### PR TITLE
Improve linkifying branches by using repo name from fork URL

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3,7 +3,7 @@
 const path = location.pathname;
 const isDashboard = path === '/';
 const isRepo = /^\/[^/]+\/[^/]+/.test(path);
-let repoName = path.split('/')[2];
+const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 
@@ -14,7 +14,7 @@ function linkifyBranchRefs() {
 		let branch = parts.eq(1).text();
 
 		// forked repos can have their name changed; grab it from first commit in PR
-		const forkName = document.querySelectorAll('.commit-id')[0].href.split('/')[4];
+		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
 
 		// both branches are from the current repo
 		if (!branch) {
@@ -22,12 +22,7 @@ function linkifyBranchRefs() {
 			username = getUsername();
 		}
 
-		// if this is the forked version, use the forked repo's name
-		if (!path.includes(username)) {
-			repoName = forkName;
-		}
-
-		$(el).wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
+		$(el).wrap(`<a href="https://github.com/${username}/${branchRepo}/tree/${branch}">`);
 	});
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -23,8 +23,9 @@ function linkifyBranchRefs() {
 		}
 
 		// if this is the forked version, use the forked repo's name
-		if (!path.includes(username))
-			repoName = forkName
+		if (!path.includes(username)) {
+			repoName = forkName;
+		}
 
 		$(el).wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
 	});

--- a/extension/content.js
+++ b/extension/content.js
@@ -3,7 +3,7 @@
 const path = location.pathname;
 const isDashboard = path === '/';
 const isRepo = /^\/[^/]+\/[^/]+/.test(path);
-const repoName = path.split('/')[2];
+let repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 
@@ -13,11 +13,18 @@ function linkifyBranchRefs() {
 		let username = parts.eq(0).text();
 		let branch = parts.eq(1).text();
 
+		// forked repos can have their name changed; grab it from first commit in PR
+		const forkName = document.querySelectorAll('.commit-id')[0].href.split('/')[4];
+
 		// both branches are from the current repo
 		if (!branch) {
 			branch = username;
 			username = getUsername();
 		}
+
+		// if this is the forked version, use the forked repo's name
+		if (!path.includes(username))
+			repoName = forkName
 
 		$(el).wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
 	});


### PR DESCRIPTION
You can change the name of a repo that's a fork of another repo. If you do this, the current implementation of `linkifyBranchRefs()` won't work because the `repoName` isn't the same for both repos. This is at best a corner case, and I doubt anyone would have an issue but ¯\_(ツ)_/¯

This update grabs the fork repo name from the URL of the first commit and uses that if it's not the same user as the current URL.

I changed my fork's repo name so you can test in this PR.
