### PR TITLE
Add `Releases` tab to the repo page

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3,8 +3,10 @@
 const path = location.pathname;
 const isDashboard = path === '/';
 const isRepo = /^\/[^/]+\/[^/]+/.test(path);
+const vendorName = path.split('/')[1];
 const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
+const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/releases/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 
 function linkifyBranchRefs() {
@@ -24,6 +26,28 @@ function linkifyBranchRefs() {
 
 		$(el).wrap(`<a href="https://github.com/${username}/${branchRepo}/tree/${branch}">`);
 	});
+}
+
+function addReleasesTab() {
+	const releasesTabTemplate = '<span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">' +
+		`<a href="/${vendorName}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${vendorName}/${repoName}/releases" itemprop="url">` +
+			'<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>' +
+			'&nbsp;<span itemprop="name">Releases</span>' +
+			'<meta itemprop="position" content="6">' +
+		'</a>' +
+	'</span>';
+	const $releasesTab = $(releasesTabTemplate);
+	const $repoNav = $('.js-repo-nav');
+
+	if (isReleases()) {
+		$releasesTab.children('a')
+			.addClass('js-selected-navigation-item selected');
+
+		$repoNav.find('.selected')
+			.removeClass('js-selected-navigation-item selected');
+	}
+
+	$repoNav.append($releasesTab);
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -59,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	if (isRepo) {
 		gitHubInjection(window, () => {
+			addReleasesTab();
 			if (isPR()) {
 				linkifyBranchRefs();
 			}

--- a/extension/content.js
+++ b/extension/content.js
@@ -29,13 +29,18 @@ function linkifyBranchRefs() {
 }
 
 function addReleasesTab() {
+	const $repoNav = $('.js-repo-nav');
+
+	if ($repoNav.children('[data-selected-links~="repo_releases"]').length > 0) {
+		return;
+	}
+
 	const releasesTabTemplate = `<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
 		<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
 		&nbsp;<span itemprop="name">Releases</span>
 		<meta itemprop="position" content="6">
 	</a>`;
 	const $releasesTab = $(releasesTabTemplate);
-	const $repoNav = $('.js-repo-nav');
 
 	if (isReleases()) {
 		$releasesTab.addClass('js-selected-navigation-item selected');

--- a/extension/content.js
+++ b/extension/content.js
@@ -29,19 +29,16 @@ function linkifyBranchRefs() {
 }
 
 function addReleasesTab() {
-	const releasesTabTemplate = '<span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">' +
-		`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">` +
-			'<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>' +
-			'&nbsp;<span itemprop="name">Releases</span>' +
-			'<meta itemprop="position" content="6">' +
-		'</a>' +
-	'</span>';
+	const releasesTabTemplate = `<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
+		<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
+		&nbsp;<span itemprop="name">Releases</span>
+		<meta itemprop="position" content="6">
+	</a>`;
 	const $releasesTab = $(releasesTabTemplate);
 	const $repoNav = $('.js-repo-nav');
 
 	if (isReleases()) {
-		$releasesTab.children('a')
-			.addClass('js-selected-navigation-item selected');
+		$releasesTab.addClass('js-selected-navigation-item selected');
 
 		$repoNav.find('.selected')
 			.removeClass('js-selected-navigation-item selected');

--- a/extension/content.js
+++ b/extension/content.js
@@ -3,7 +3,7 @@
 const path = location.pathname;
 const isDashboard = path === '/';
 const isRepo = /^\/[^/]+\/[^/]+/.test(path);
-const vendorName = path.split('/')[1];
+const username = path.split('/')[1];
 const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/releases/.test(location.pathname);
@@ -30,7 +30,7 @@ function linkifyBranchRefs() {
 
 function addReleasesTab() {
 	const releasesTabTemplate = '<span itemscope="" itemtype="http://schema.org/ListItem" itemprop="itemListElement">' +
-		`<a href="/${vendorName}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${vendorName}/${repoName}/releases" itemprop="url">` +
+		`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">` +
 			'<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>' +
 			'&nbsp;<span itemprop="name">Releases</span>' +
 			'<meta itemprop="position" content="6">' +

--- a/extension/content.js
+++ b/extension/content.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	if (isRepo) {
-		gitHubInjection(window, () => {
+		gitHubInjection(window, {wait: 1}, () => {
 			addReleasesTab();
 			if (isPR()) {
 				linkifyBranchRefs();

--- a/extension/content.js
+++ b/extension/content.js
@@ -35,11 +35,10 @@ function addReleasesTab() {
 		return;
 	}
 
-	const releasesTabTemplate = `<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
+	const $releasesTab = $(`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
 		<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
 		Releases
-	</a>`;
-	const $releasesTab = $(releasesTabTemplate);
+	</a>`);
 
 	if (isReleases()) {
 		$releasesTab.addClass('js-selected-navigation-item selected');

--- a/extension/content.js
+++ b/extension/content.js
@@ -6,7 +6,7 @@ const isRepo = /^\/[^/]+\/[^/]+/.test(path);
 const username = path.split('/')[1];
 const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
-const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/releases/.test(location.pathname);
+const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 
 function linkifyBranchRefs() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -37,8 +37,7 @@ function addReleasesTab() {
 
 	const releasesTabTemplate = `<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
 		<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
-		&nbsp;<span itemprop="name">Releases</span>
-		<meta itemprop="position" content="6">
+		Releases
 	</a>`;
 	const $releasesTab = $(releasesTabTemplate);
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -30,24 +30,26 @@ function linkifyBranchRefs() {
 
 function addReleasesTab() {
 	const $repoNav = $('.js-repo-nav');
+	let $releasesTab = $repoNav.children('[data-selected-links~="repo_releases"]')
+	const hasReleases = $releasesTab.length > 0
 
-	if ($repoNav.children('[data-selected-links~="repo_releases"]').length > 0) {
-		return;
+	if (!hasReleases) {
+		$releasesTab = $(`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
+			<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
+			Releases
+		</a>`);
 	}
-
-	const $releasesTab = $(`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases" itemprop="url">
-		<svg aria-hidden="true" class="octicon octicon-tag" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
-		Releases
-	</a>`);
 
 	if (isReleases()) {
-		$releasesTab.addClass('js-selected-navigation-item selected');
-
 		$repoNav.find('.selected')
 			.removeClass('js-selected-navigation-item selected');
+
+		$releasesTab.addClass('js-selected-navigation-item selected');
 	}
 
-	$repoNav.append($releasesTab);
+	if (!hasReleases) {
+		$repoNav.append($releasesTab);
+	}
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Closes #8

I've successfully added a releases tab.
However I have some concerns which I hope I'd be able to address with your help.

- Adding just `<span class="octicon octicon-tag">` does not render an icon. I needed to add a full SVG markup like the rest of the icons I could found on github.com.
- Appending the *Releases* tab and activating it instead of *Code* is rather slow and you could visually see the change after the page loads. Feedback appreciated.
- If you have an idea how to easily count the number of releases (or tags) to put next to the label on the tab, that would be great.

P.S. This also adds a new shortcut `g r` for navigating to the releases page of a repo :smiley_cat: 