### PR TITLE
Implement like / dislike count

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -48,8 +48,19 @@ function commentIsUseless(type, el) {
 }
 
 function renderVoteCount(type, count) {
+	let iconUrl;
+	if (type === 'upvote') {
+		iconUrl = 'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44d.png';
+	}
+	if (type === 'downvote') {
+		iconUrl = 'https://assets-cdn.github.com/images/icons/emoji/unicode/1f44e.png';
+	}
 	const $sidebar = $('#partial-discussion-sidebar');
-	$sidebar.append(`<div class="discussion-sidebar-item"><h3 class="discussion-sidebar-heading">${count} ${type}</h3></div>`);
+	$sidebar.append(`<div class="discussion-sidebar-item">
+			<h3 class="discussion-sidebar-heading">
+				${count} <img class="emoji" alt="${type}" height="20" width="20" align="absmiddle" src="${iconUrl}">
+			</h3>
+		</div>`);
 }
 
 function moveVotes() {
@@ -67,10 +78,10 @@ function moveVotes() {
 		}
 	});
 	if (upCount > 0) {
-		renderVoteCount('upvotes', upCount);
+		renderVoteCount('upvote', upCount);
 	}
 	if (downCount > 0) {
-		renderVoteCount('downvotes', downCount);
+		renderVoteCount('downvote', downCount);
 	}
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -8,8 +8,8 @@ const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 const uselessContent = {
-	like: {text: ['+1\n'], emoji: [':+1:']},
-	dislike: {text: ['-1\n'], emoji: [':-1:']}
+	upvote: {text: ['+1\n'], emoji: [':+1:']},
+	downvote: {text: ['-1\n'], emoji: [':-1:']}
 };
 
 function linkifyBranchRefs() {
@@ -45,38 +45,38 @@ function commentIsUseless(type, el) {
 	}
 }
 
-function renderLikeCount(type, count) {
+function renderVoteCount(type, count) {
 	const sidebar = document.querySelector('#partial-discussion-sidebar');
-	const likeElement = document.createElement('div');
-	const likeHeading = document.createElement('h3');
+	const voteElement = document.createElement('div');
+	const voteHeading = document.createElement('h3');
 
-	likeElement.className = 'discussion-sidebar-item';
-	likeHeading.className = 'discussion-sidebar-heading';
-	likeHeading.textContent = count + ' ' + type;
-	likeElement.appendChild(likeHeading);
-	sidebar.appendChild(likeElement);
+	voteElement.className = 'discussion-sidebar-item';
+	voteHeading.className = 'discussion-sidebar-heading';
+	voteHeading.textContent = count + ' ' + type;
+	voteElement.appendChild(voteHeading);
+	sidebar.appendChild(voteElement);
 }
 
-function moveLikes() {
-	let likeCount = 0;
-	let dislikeCount = 0;
+function moveVotes() {
+	let upCount = 0;
+	let downCount = 0;
 	$('.js-comment-body').each((i, el) => {
-		const isLike = commentIsUseless('like', el);
-		const isDislike = commentIsUseless('dislike', el);
+		const isUp = commentIsUseless('upvote', el);
+		const isDown = commentIsUseless('downvote', el);
 
-		if (isLike || isDislike) {
+		if (isUp || isDown) {
 			const commentContainer = el.closest('.js-comment-container');
 			commentContainer.parentNode.removeChild(commentContainer);
 
-			likeCount += isLike ? 1 : 0;
-			dislikeCount += isDislike ? 1 : 0;
+			upCount += isUp ? 1 : 0;
+			downCount += isDown ? 1 : 0;
 		}
 	});
-	if (likeCount > 0) {
-		renderLikeCount('likes', likeCount);
+	if (upCount > 0) {
+		renderVoteCount('upvotes', upCount);
 	}
-	if (dislikeCount > 0) {
-		renderLikeCount('dislikes', dislikeCount);
+	if (downCount > 0) {
+		renderVoteCount('downvotes', downCount);
 	}
 }
 
@@ -117,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				linkifyBranchRefs();
 			}
 			if (isPR() || isIssue()) {
-				moveLikes();
+				moveVotes();
 			}
 		});
 	}

--- a/extension/content.js
+++ b/extension/content.js
@@ -37,12 +37,16 @@ function commentIsUseless(type, el) {
 	if (uselessContent[type].text.includes(el.innerText)) {
 		return true;
 	}
-	// check if there is exactly one child element, that has one other child node
-	// using `childNodes` because this also includes text
-	if (el.children.length === 1 && el.children[0].childNodes.length === 1) {
-		const onlyChild = el.children[0].childNodes[0];
-		if (onlyChild.tagName === 'IMG' && uselessContent[type].emoji.includes(onlyChild.title)) {
-			return true;
+	// check if there is exactly one child element, that has one or two child nodes;
+	// sometimes a second child node can contain a useless space
+	// using `childNodes` because this also includes text nodes
+	if (el.children.length === 1) {
+		const children = el.children[0].childNodes;
+		if (children.length === 1 || (children.length === 2 && !children[1].textContent.trim())) {
+			const onlyChild = children[0];
+			if (onlyChild.tagName === 'IMG' && uselessContent[type].emoji.includes(onlyChild.title)) {
+				return true;
+			}
 		}
 	}
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -34,29 +34,22 @@ function linkifyBranchRefs() {
 }
 
 function commentIsUseless(type, el) {
-	if (uselessContent[type].text.indexOf(el.innerText) >= 0) {
+	if (uselessContent[type].text.includes(el.innerText)) {
 		return true;
 	}
 	// check if there is exactly one child element, that has one other child node
 	// using `childNodes` because this also includes text
 	if (el.children.length === 1 && el.children[0].childNodes.length === 1) {
 		const onlyChild = el.children[0].childNodes[0];
-		if (onlyChild.tagName === 'IMG' && uselessContent[type].emoji.indexOf(onlyChild.title) >= 0) {
+		if (onlyChild.tagName === 'IMG' && uselessContent[type].emoji.includes(onlyChild.title)) {
 			return true;
 		}
 	}
 }
 
 function renderVoteCount(type, count) {
-	const sidebar = document.querySelector('#partial-discussion-sidebar');
-	const voteElement = document.createElement('div');
-	const voteHeading = document.createElement('h3');
-
-	voteElement.className = 'discussion-sidebar-item';
-	voteHeading.className = 'discussion-sidebar-heading';
-	voteHeading.textContent = count + ' ' + type;
-	voteElement.appendChild(voteHeading);
-	sidebar.appendChild(voteElement);
+	const $sidebar = $('#partial-discussion-sidebar');
+	$sidebar.append(`<div class="discussion-sidebar-item"><h3 class="discussion-sidebar-heading">${count} ${type}</h3></div>`);
 }
 
 function moveVotes() {
@@ -67,8 +60,7 @@ function moveVotes() {
 		const isDown = commentIsUseless('downvote', el);
 
 		if (isUp || isDown) {
-			const commentContainer = el.closest('.js-comment-container');
-			commentContainer.parentNode.removeChild(commentContainer);
+			el.closest('.js-comment-container').remove();
 
 			upCount += isUp ? 1 : 0;
 			downCount += isDown ? 1 : 0;


### PR DESCRIPTION
Comments that contain only `+1` or :+1: will be treated as a like. For dislike `-1` and :-1:.
The count of the likes / dislikes will be shown in the sidebar of an issue or PR, like this:

![add_explicit_ _1 _feature_for_issues_that_isn_t_a_comment_ _issue__9_ _isaacs_github](https://cloud.githubusercontent.com/assets/533616/13126811/5eb2fc0e-d5cc-11e5-92f6-8b3ed5d82988.png)

Fixes #15. In #15 I showed a screenshot that also shows user avatars; I've decided not to this for now (maybe later).

Personally I've no use for this feature, but I've much sympathy for huge open-source project maintainers and hope to help them :).