### PR TITLE
Improve branch name assignment

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -16,7 +16,8 @@ function linkifyBranchRefs() {
 		let branch = parts.eq(1).text();
 
 		// forked repos can have their name changed; grab it from first commit in PR
-		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
+		// the regex matches '/[any word]/' at the beginning, or '/commit/[40 char hash]' at the end of the string
+		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').replace(/(^\/\w+\/)|(\/(commit)\/\w{40}$)/g, '');
 
 		// both branches are from the current repo
 		if (!branch) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -20,8 +20,7 @@ function linkifyBranchRefs() {
 		}
 
 		// forked repos can have their name changed; grab it from first commit in PR
-		// the regex matches '/[any word]/' at the beginning, or '/commit/[40 char hash]' at the end of the string
-		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').replace(/(^\/\w+\/)|(\/(commit)\/\w{40}$)/g, '');
+		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
 
 		// both branches are from the current repo
 		if (!branch) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -33,7 +33,7 @@ function addReleasesTab() {
 	const hasReleases = $releasesTab.length > 0;
 
 	if (!hasReleases) {
-		$releasesTab = $(`<a href="/${username}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${username}/${repoName}/releases">
+		$releasesTab = $(`<a href="/${ownername}/${repoName}/releases" class="reponav-item" data-hotkey="g r" data-selected-links="repo_releases /${ownername}/${repoName}/releases">
 			<svg class="octicon octicon-tag" height="16" version="1.1" viewBox="0 0 14 16" width="14"><path d="M6.73 2.73c-0.47-0.47-1.11-0.73-1.77-0.73H2.5C1.13 2 0 3.13 0 4.5v2.47c0 0.66 0.27 1.3 0.73 1.77l6.06 6.06c0.39 0.39 1.02 0.39 1.41 0l4.59-4.59c0.39-0.39 0.39-1.02 0-1.41L6.73 2.73zM1.38 8.09c-0.31-0.3-0.47-0.7-0.47-1.13V4.5c0-0.88 0.72-1.59 1.59-1.59h2.47c0.42 0 0.83 0.16 1.13 0.47l6.14 6.13-4.73 4.73L1.38 8.09z m0.63-4.09h2v2H2V4z"></path></svg>
 			Releases
 		</a>`);

--- a/extension/content.js
+++ b/extension/content.js
@@ -3,7 +3,7 @@
 const path = location.pathname;
 const isDashboard = path === '/';
 const isRepo = /^\/[^/]+\/[^/]+/.test(path);
-const username = path.split('/')[1];
+const ownername = path.split('/')[1];
 const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
@@ -13,20 +13,15 @@ function linkifyBranchRefs() {
 	$('.commit-ref').each((i, el) => {
 		const parts = $(el).find('.css-truncate-target');
 		let branch = parts.eq(parts.length - 1).text();
+		let username = ownername;
 
 		// if there are two parts the first part is the username
 		if (parts.length > 1) {
-			let username = parts.eq(0).text();
+			username = parts.eq(0).text();
 		}
 
 		// forked repos can have their name changed; grab it from first commit in PR
 		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
-
-		// both branches are from the current repo
-		if (!branch) {
-			branch = username;
-			username = getUsername();
-		}
 
 		$(el).wrap(`<a href="https://github.com/${username}/${branchRepo}/tree/${branch}">`);
 	});

--- a/extension/content.js
+++ b/extension/content.js
@@ -12,8 +12,12 @@ const getUsername = () => $('meta[name="user-login"]').attr('content');
 function linkifyBranchRefs() {
 	$('.commit-ref').each((i, el) => {
 		const parts = $(el).find('.css-truncate-target');
-		let username = parts.eq(0).text();
-		let branch = parts.eq(1).text();
+		let branch = parts.eq(parts.length - 1).text();
+
+		// if there are two parts the first part is the username
+		if (parts.length > 1) {
+			let username = parts.eq(0).text();
+		}
 
 		// forked repos can have their name changed; grab it from first commit in PR
 		// the regex matches '/[any word]/' at the beginning, or '/commit/[40 char hash]' at the end of the string


### PR DESCRIPTION
This was a red herring that I tried to murder with regex. Sorry for the mess.

Fixes #18.

Basically, in your own repo the `branch` var assignment was incorrect, leading to bad URLs in the linkified repos at the top of a PR. This PR should be evidence of the fix.