### PR TITLE
Hide Upload files button from file navigation in the repo

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -158,3 +158,8 @@
 #dashboard .alert.git_hub {
 	display: none !important;
 }
+
+/* remove Upload files button; drag and drop is available anyway */
+.file-navigation a[href$="/upload"] {
+	display: none !important;
+}


### PR DESCRIPTION
The uploading of files directly is nice, but the drag-n-drop ability is enough.

This of course could be merged a bit later once it has rolled out and people are familiar the upload feature is available. One could of course say users of this extension would not care about that feature.