### PR TITLE
Use union merge for readme and CSS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto
 *.ai binary
+readme.md merge=union
+extension/content.css merge=union


### PR DESCRIPTION
There are two lists-like sections in the readme:
- Highlights
- Related

When there are multiple pull requests adding to the lists whichever is merged first would cause conflicts in the rest.

The union merge cause Git to try to resolve the conflicts automatically by keeping both additions.

Read more here: https://about.gitlab.com/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/

I think this is also useful for the CSS file where it would be common separate rules to be added to the bottom in different pull requests.