### PR TITLE
Add blame parent links next to each commit

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -8,6 +8,7 @@ const repoName = path.split('/')[2];
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+$/.test(location.pathname);
 const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
+const isBlame = () => isRepo && /^\/[^/]+\/[^/]+\/blame\//.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 const uselessContent = {
 	upvote: {text: ['+1\n'], emoji: [':+1:']},
@@ -133,6 +134,23 @@ function infinitelyMore() {
 	}
 }
 
+function addBlameParentLinks() {
+	$('.blame-sha').each((index, commitLink) => {
+		const $commitLink = $(commitLink);
+		const $blameParentLink = $commitLink.clone();
+		const commitSha = /\w{40}$/.exec(commitLink.href)[0];
+
+		$blameParentLink
+			.text('Blame ^')
+			.prop('href', location.pathname.replace(
+				/(\/blame\/)[^\/]+/,
+				'$1' + commitSha + encodeURI('^')
+			));
+
+		$commitLink.nextAll('.blame-commit-meta').append($blameParentLink);
+	});
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 	const username = getUsername();
 
@@ -165,6 +183,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 			if (isPR() || isIssue()) {
 				moveVotes();
+			}
+			if (isBlame()) {
+				addBlameParentLinks();
 			}
 		});
 	}

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ My hope is that GitHub will notice and implement some of these much needed impro
 - Removes annoying hover effect in the repo file browser
 - Removes the comment box toolbar
 - Moves the dashboard organization switcher to the right column
+- Adds blame links for parent commits in blame view
 
 And [lots](extension/content.css) [more...](extension/content.js)
 


### PR DESCRIPTION
Fixes #2.

Note this produces links which sometimes can lead to 404 when there is no parent commit.