### PR TITLE
fix #30 - make hiding markdown helpers more specific

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -77,7 +77,7 @@
 }
 
 /* remove top buttons on comment box */
-.tabnav-extra {
+.timeline-comment-wrapper .tabnav-extra {
 	display: none !important;
 }
 


### PR DESCRIPTION
This is more specific so it doesn't hide the count of lines added/deleted in the diff on a PR.