### PR TITLE
Remove the markdown helper text from inline comment boxes

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -77,7 +77,7 @@
 }
 
 /* remove top buttons on comment box */
-.timeline-comment-wrapper .tabnav-extra {
+.timeline-comment-wrapper .tabnav-extra, .inline-comment-form-container .tabnav-extra {
 	display: none !important;
 }
 


### PR DESCRIPTION
The last "fix" for the comment boxes was over-specific and missed inline comment boxes.