### PR TITLE
Close bracket of a[href^=/username] selector

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -141,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		{
 			const hideStarsOwnRepos = () => {
 				$('#dashboard .news .watch_started, #dashboard .news .fork')
-					.has(`.title a[href^="/${username}"`)
+					.has(`.title a[href^="/${username}"]`)
 					.css('display', 'none');
 			};
 


### PR DESCRIPTION
Not sure if this was intentionally left like that, just checking.