### PR TITLE
Remove "Open this file in GitHub Desktop" link as well

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -2,8 +2,8 @@
 	highly opinionated changes
 */
 
-/* remove clone in desktop button */
-.file-navigation-options a[href^="github-mac"] {
+/* remove clone / open in desktop buttons */
+.file-navigation-options a[href^="github-mac"], .file-actions a[href^="github-mac"] {
 	display: none !important;
 }
 


### PR DESCRIPTION
This link is visible in the top right of a file view next to edit and delete forms.

P.S. Looking deeper I think the alternative PR to this in #38 is better.