### PR TITLE
Hide every github-mac:// link

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -2,8 +2,8 @@
 	highly opinionated changes
 */
 
-/* remove clone in desktop button */
-.file-navigation-options a[href^="github-mac"] {
+/* remove clone/open in desktop buttons */
+a[href^="github-mac"] {
 	display: none !important;
 }
 


### PR DESCRIPTION
- Hides Clone in Desktop links for both the repo and the wiki.
- Hides Open in Desktop link for files

This is an alternative, more generic version of #37. Closes #37.