### PR TITLE
Improve upvote / downvote comment handling

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -73,13 +73,13 @@ function moveVotes() {
 	const downVoters = new Set();
 	$('.js-comment-body').each((i, el) => {
 		// this is a comment not in the usual container - found on inline comments
-		if (!el.closest('.js-comment-container')) {
+		if (!$(el).closest('.js-comment-container')) {
 			return;
 		}
 
 		const isUp = commentIsUseless('upvote', el);
 		const isDown = commentIsUseless('downvote', el);
-		const commenter = el.closest('.js-comment-container').getElementsByClassName('author')[0].innerHTML;
+		const commenter = $(el).closest('.js-comment-container').find('.author').get(0).innerHTML;
 
 		if (isUp || isDown) {
 			// remove from both arrays

--- a/extension/content.js
+++ b/extension/content.js
@@ -10,7 +10,7 @@ const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 const uselessContent = {
-	upvote: {text: ['+1\n'], emoji: [':+1:', ':100:']},
+	upvote: {text: ['+1\n'], emoji: [':+1:', ':100:', ':ok_hand:']},
 	downvote: {text: ['-1\n'], emoji: [':-1:']}
 };
 
@@ -72,6 +72,11 @@ function moveVotes() {
 	const upVoters = new Set();
 	const downVoters = new Set();
 	$('.js-comment-body').each((i, el) => {
+		// this is a comment not in the usual container - found on inline comments
+		if (!el.closest('.js-comment-container')) {
+			return;
+		}
+
 		const isUp = commentIsUseless('upvote', el);
 		const isDown = commentIsUseless('downvote', el);
 		const commenter = el.closest('.js-comment-container').getElementsByClassName('author')[0].innerHTML;

--- a/extension/content.js
+++ b/extension/content.js
@@ -10,7 +10,7 @@ const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => isRepo && /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 const uselessContent = {
-	upvote: {text: ['+1\n'], emoji: [':+1:']},
+	upvote: {text: ['+1\n'], emoji: [':+1:', ':100:']},
 	downvote: {text: ['-1\n'], emoji: [':-1:']}
 };
 
@@ -48,6 +48,8 @@ function commentIsUseless(type, el) {
 			}
 		}
 	}
+
+	return false;
 }
 
 function renderVoteCount(type, count) {
@@ -67,24 +69,36 @@ function renderVoteCount(type, count) {
 }
 
 function moveVotes() {
-	let upCount = 0;
-	let downCount = 0;
+	const upVoters = new Set();
+	const downVoters = new Set();
 	$('.js-comment-body').each((i, el) => {
 		const isUp = commentIsUseless('upvote', el);
 		const isDown = commentIsUseless('downvote', el);
+		const commenter = el.closest('.js-comment-container').getElementsByClassName('author')[0].innerHTML;
 
 		if (isUp || isDown) {
-			el.closest('.js-comment-container').remove();
+			// remove from both arrays
+			upVoters.delete(commenter);
+			downVoters.delete(commenter);
 
-			upCount += isUp ? 1 : 0;
-			downCount += isDown ? 1 : 0;
+			// add to upvoters if it's an upvote
+			if (isUp) {
+				upVoters.add(commenter);
+			}
+
+			// add to upvoters if it's an upvote
+			if (isDown) {
+				downVoters.add(commenter);
+			}
+
+			el.closest('.js-comment-container').remove();
 		}
 	});
-	if (upCount > 0) {
-		renderVoteCount('upvote', upCount);
+	if (upVoters.size > 0) {
+		renderVoteCount('upvote', upVoters.size);
 	}
-	if (downCount > 0) {
-		renderVoteCount('downvote', downCount);
+	if (downVoters.size > 0) {
+		renderVoteCount('downvote', downVoters.size);
 	}
 }
 


### PR DESCRIPTION
This is a WIP to fix #32. It solves 2 of the 3 items, but I don't know how to solve the last one perfectly. If we decide to omit it then maybe this PR is done.

- [x] Smarter emoji detection

As of the opening of this PR :100: is an acceptable emoji to upvote. To add more acceptable emoji (or text) it can just be added to those arrays. @SpaceK33z set it up that way to begin with.

- [x] Count one vote per user. In a PR, a user can first down vote, but after some changes up vote. Only the up vote should count in this scenario.

Now each upvote/downvote is only counted once per user. If the same user upvotes, then downvotes, then upvotes, it should effectively count as a single upvote. Voting 100 times in either direction counts as 1 vote.

Not done:

- ~~If the upvote / downvote is followed by some text, don't remove the comment but let it count.~~

edit: not doing this since there are too many circumstances to consider. A comment with just a vote and nothing else is a vote. Everything else should stay.

It's not even just following text that's what you'll find. Sometimes the emoji can be at the end of the text. It can also be in the middle some place. And if you look at [this issue](https://github.com/dear-github/dear-github/issues/113) you can see that there's even people complaining out all the +1's with no content, and those aren't votes, just arguing about voting. Not sure how to solve that one.