### PR TITLE
fix error on voting count when there are inline comments

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -74,7 +74,7 @@ function moveVotes() {
 	const downVoters = new Set();
 	$('.js-comment-body').each((i, el) => {
 		// this is a comment not in the usual container - found on inline comments
-		if (!$(el).closest('.js-comment-container')) {
+		if ($(el).closest('.js-comment-container').find('.author').length === 0) {
 			return;
 		}
 


### PR DESCRIPTION
I noticed this when looking at the last PR. (Test with `master` here: https://github.com/sindresorhus/refined-github/pull/41)

There's an error in the console because the test is if there's a container not an author, but we really need to be sure there's an author.

Error:
```
Uncaught TypeError: Cannot read property 'innerHTML' of undefined
```