### PR TITLE
Infer GitHub user Twitter handle

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -243,7 +243,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 
 		if (!existing.length) {
-			fetch(`https://github-npm-profile.herokuapp.com/${ownerName}`)
+			fetch(`https://get-twitter-username.herokuapp.com/${ownerName}`)
 				.then(res => res.json())
 				.then(profile => sanitizedTwitterHandle(profile))
 				.then(username => {
@@ -278,9 +278,9 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 
-	function sanitizedTwitterHandle(profile) {
+	function sanitizedTwitterHandle(username) {
 		const rhandle = /^[A-z0-9_]+$/;
-		const handle = profile && profile.twitter || '';
+		const handle = username && username || '';
 		return rhandle.test(handle) ? handle : null;
 	}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -227,6 +227,33 @@ document.addEventListener('DOMContentLoaded', () => {
 		window.addEventListener('resize', infinitelyMore);
 	}
 
+	const details = $(`.vcard-details .vcard-detail`);
+	const isProfile = details.length > 0;
+	if (isProfile) {
+		const rhandle = new RegExp(`\\bhttps?:\\/\\/twitter\\.com\\/([A-z0-9_]+)\\b`, 'i');
+		const existing = details
+			.get()
+			.map(el => ({el, matches: rhandle.exec(el.innerText)}))
+			.filter(x => x.matches);
+
+		existing.forEach(x => {
+			const $el = $(x.el);
+			addTwitterProfile(x.matches[1], $el);
+			$el.remove();
+		});
+
+		if (!existing.length) {
+			fetch(`https://github-npm-profile.herokuapp.com/${ownerName}`)
+				.then(res => res.json())
+				.then(profile => sanitizedTwitterHandle(profile))
+				.then(username => {
+					if (username) {
+						addTwitterProfile(username, details.last());
+					}
+				});
+		}
+	}
+
 	if (isRepo) {
 		const isRepoRoot = location.pathname.replace(/\/$/, '') === `/${ownerName}/${repoName}` || /(\/tree\/)(\w|\d|\.)+(\/$|$)/.test(location.href);
 
@@ -249,5 +276,23 @@ document.addEventListener('DOMContentLoaded', () => {
 				addReadmeEditButton();
 			}
 		});
+	}
+
+	function sanitizedTwitterHandle(profile) {
+		const rhandle = /^[A-z0-9_]+$/;
+		const handle = profile && profile.twitter || '';
+		return rhandle.test(handle) ? handle : null;
+	}
+
+	function addTwitterProfile(username, target) {
+		const handle = `@${username}`;
+		const url = `https://twitter.com/${username}`;
+		// add proper twitter profile link
+		target.before(`
+			<li class="vcard-detail py-1 css-truncate css-truncate-target">
+				<svg aria-hidden="true" class="octicon octicon-mention" height="16" role="img" version="1.1" viewBox="0 0 335 276" width="14"><path d="m302 70a195 195 0 0 1 -299 175 142 142 0 0 0 97 -30 70 70 0 0 1 -58 -47 70 70 0 0 0 31 -2 70 70 0 0 1 -57 -66 70 70 0 0 0 28 5 70 70 0 0 1 -18 -90 195 195 0 0 0 141 72 67 67 0 0 1 116 -62 117 117 0 0 0 43 -17 65 65 0 0 1 -31 38 117 117 0 0 0 39 -11 65 65 0 0 1 -32 35"/></svg>
+				<a class="url" href="${url}" rel="nofollow me">${handle}</a>
+			</li>
+		`);
 	}
 });


### PR DESCRIPTION
Here's a fix for #46. Uses [an external API service](https://github.com/bevacqua/github-npm-profile) because the dependencies don't work browserified _(and would be too large anyways, `cheerio` is among them for instance)_

- Only runs on user profiles
- If user already has Twitter links in profile they are beautified
  - This works regardless of them having a configured npm profile
  - No requests are sent to the service in this case
- Looks up GitHub user on npm
- Pulls Twitter handle from npm profile
- Removes any previous vcard details which included a link to their Twitter handle
- Appends Twitter handle link before the last item in the info list which is always the join date

Before:

<img width="249" alt="screen shot 2016-03-04 at 13 08 05" src="https://cloud.githubusercontent.com/assets/934293/13532426/36d4a3dc-e20a-11e5-94c5-b6c96697ab78.png">

After:

<img width="195" alt="screen shot 2016-03-04 at 14 14 28" src="https://cloud.githubusercontent.com/assets/934293/13534341/70625b9a-e213-11e5-8b79-8a17a9edd097.png">
