### PR TITLE
Hide some news feed items, increase visibility of starred repos

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -197,3 +197,41 @@
 #refined-github-delete-fork-link a {
 	color: #df3e3e;
 }
+
+/* hide news items when people pushed to a branch */
+.news .alert.push {
+	display: none;
+}
+
+/* hide news items when people create a branch */
+.news .alert.create.simple {
+	display: none;
+}
+
+/* hide news items when people delete a branch */
+.news .alert.delete.simple {
+	display: none;
+}
+
+/* increase visibility of news item when someone stars a repo */
+.watch_started.simple .body {
+	min-height: 40px;
+}
+
+svg.octicon.octicon-star.dashboard-event-icon {
+	height: 32px !important;
+	width: 28px !important;
+}
+
+.watch_started .time {
+	position: absolute;
+	top: 10px;
+	left: 45px;
+}
+
+.watch_started.simple.alert .simple .title {
+	position: absolute;
+	top: 26px;
+	font-size: 14px !important;
+	font-weight: bold;
+}


### PR DESCRIPTION
This is fixes #44 with CSS and no additions to the UI.

The update does the following:
* Hides news feed items for pushing to a branch, deleting a branch, creating a branch. These seem like pretty pointless updates to me, and while they're using the `.simple` class and very small, I never read them.
* Increase the visibility of items relating to a user starring a repo. This is a good discovery tool for me, and it's the main reason I follow another GH user. It should be easier to see.

Here is a screenshot that has a PR, starred repo, and comment in order:
![screenshot-starred-news-visibility](https://cloud.githubusercontent.com/assets/737065/13552028/70e65b60-e31d-11e5-828d-1e2688826768.png)

Here is the same section of my feed without the plugin (you can see a pushed commit that was hidden by the extension):
![without-extension](https://cloud.githubusercontent.com/assets/737065/13552049/7fa90912-e31e-11e5-8316-9ce4e16b77ca.png)
