### PR TITLE
Linkify issue and PR refs in issue and PR titles

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -239,6 +239,18 @@ function addDeleteForkLink() {
 	}
 }
 
+function linkifyIssuesInTitles() {
+	const $title = $('.js-issue-title');
+	const titleText = $title.text();
+
+	if (/(#\d+)/.test(titleText)) {
+		$title.html(titleText.replace(
+			/#(\d+)/g,
+			`<a href="https://github.com/${ownerName}/${repoName}/issues/$1">#$1</a>`
+		));
+	}
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 	const username = getUsername();
 
@@ -276,6 +288,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (isPR() || isIssue()) {
 				moveVotes();
+				linkifyIssuesInTitles();
 			}
 
 			if (isBlame()) {

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ My hope is that GitHub will notice and implement some of these much needed impro
 - Removes annoying hover effect in the repo file browser
 - Removes the comment box toolbar
 - Moves the dashboard organization switcher to the right column
+- Links issue and PR references in issue and PR titles
 
 And [lots](extension/content.css) [more...](extension/content.js)
 


### PR DESCRIPTION
See https://github.com/isaacs/github/issues/568

This aims to fix the most common case in a simple manner.

- It links to PRs using GitHub redirect from issues/1 to pull/1
- It does not re-link when you edit a title unless you reload the page
- It links when the issue or PR does not exist
- It does not show title of issue/PR on hover like other issue/PR links
- It does not check permissions
- It links even text like #1foo
- It does not support cross-repo and cross-fork links