### PR TITLE
Hide edit README links floating over the delete button on blobs

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -170,6 +170,10 @@
 }
 
 /* style for edit README button */
+#readme.blob #refined-github-readme-edit-link {
+	display: none;
+}
+
 #refined-github-readme-edit-link {
 	position: absolute;
 	top: 10px;


### PR DESCRIPTION
This fixes #64 with CSS. The edit README link should not be visible on blobs for MD files, and the links that were visible were bad links anyway. This hides links in those scenarios.