### PR TITLE
Add patch and diff links to commit pages

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -254,3 +254,13 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	font-weight: bold;
 	color: inherit !important;
 }
+
+/* remove margin for added patch and diff links */
+.commit-meta span.right .sha-block {
+	margin-left: 5px;
+}
+
+.commit-meta span.right .sha-block:first-child,
+.commit-meta span.right .sha-block:last-child {
+	margin-left: 0;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -251,6 +251,20 @@ function linkifyIssuesInTitles() {
 	}
 }
 
+function addPatchDiffLinks() {
+	const commitUrl = location.href.replace(/\/$/, '');
+	const commitMeta = $('.commit-meta span.right').get(0);
+
+	$(commitMeta).append(`
+		<span class="sha-block">
+			<a href="${commitUrl}.patch" class="sha">[.patch]</a>
+			</span>
+		<span class="sha-block">
+			<a href="${commitUrl}.diff" class="sha">[.diff]</a>
+		</span>
+	`);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
 	const username = getUsername();
 
@@ -276,6 +290,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	if (isRepo) {
 		const isRepoRoot = location.pathname.replace(/\/$/, '') === `/${ownerName}/${repoName}` || /(\/tree\/)(\w|\d|\.)+(\/$|$)/.test(location.href);
+		const isCommit = path.split('/')[3] === 'commit';
 
 		gitHubInjection(window, () => {
 			addReleasesTab();
@@ -297,6 +312,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (isRepoRoot) {
 				addReadmeEditButton();
+			}
+
+			if (isCommit) {
+				addPatchDiffLinks();
 			}
 		});
 	}

--- a/extension/content.js
+++ b/extension/content.js
@@ -257,10 +257,8 @@ function addPatchDiffLinks() {
 
 	$(commitMeta).append(`
 		<span class="sha-block">
-			<a href="${commitUrl}.patch" class="sha">[.patch]</a>
-			</span>
-		<span class="sha-block">
-			<a href="${commitUrl}.diff" class="sha">[.diff]</a>
+			<a href="${commitUrl}.patch" class="sha">.patch</a>
+			<a href="${commitUrl}.diff" class="sha">.diff</a>
 		</span>
 	`);
 }

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ My hope is that GitHub will notice and implement some of these much needed impro
 - [Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)
 - [Adds a shortcut to quickly delete a forked repo](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
 - [Adds ability to minimize/maximize files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13552719/ccadcae0-e3a0-11e5-8b27-8b860c225d9f.png)
+- [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13604862/d285d0de-e512-11e5-8679-7cabc85bf5a5.png)
 - Automagically expands the news feed when you scroll down
 - Hides other users starring/forking your repos from the newsfeed
 - Removes tooltips

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ My hope is that GitHub will notice and implement some of these much needed impro
 - [Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)
 - [Adds a shortcut to quickly delete a forked repo](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
 - [Adds ability to minimize/maximize files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13552719/ccadcae0-e3a0-11e5-8b27-8b860c225d9f.png)
-- [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13604862/d285d0de-e512-11e5-8679-7cabc85bf5a5.png)
+- [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - Automagically expands the news feed when you scroll down
 - Hides other users starring/forking your repos from the newsfeed
 - Removes tooltips


### PR DESCRIPTION
This PR closes #63.

With this update there is now a link to the patch and diff for each commit on the commit page immediately after the full commit hash.

![patch-diff-links](https://cloud.githubusercontent.com/assets/737065/13604862/d285d0de-e512-11e5-8679-7cabc85bf5a5.png)
