### PR TITLE
Add a copy button next to the branch name. Closes #77.

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -149,6 +149,11 @@
 	text-decoration: underline !important;
 }
 
+/* No padding around the clippy icons added to branch names */
+.gh-header-meta .zeroclipboard-button {
+	padding: 0 3px !important;
+}
+
 /* remove the "new feature" notification box */
 .js-notice {
 	display: none !important;

--- a/extension/content.js
+++ b/extension/content.js
@@ -17,7 +17,7 @@ const uselessContent = {
 	downvote: {text: ['-1\n'], emoji: [':-1:']}
 };
 
-function linkifyBranchRefs() {
+function linkifyBranchRefsAndAddCopyButtons() {
 	$('.commit-ref').each((i, el) => {
 		const parts = $(el).find('.css-truncate-target');
 		const branch = parts.eq(parts.length - 1).text();
@@ -32,6 +32,10 @@ function linkifyBranchRefs() {
 		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
 
 		$(el).wrap(`<a href="https://github.com/${username}/${branchRepo}/tree/${branch}">`);
+
+		$(el).parent().after(`
+			<button aria-label="Copy the branch name" class="js-zeroclipboard btn btn-outline zeroclipboard-button tooltipped tooltipped-s" data-clipboard-text="${branch}" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M2 12h4v1H2v-1z m5-6H2v1h5v-1z m2 3V7L6 10l3 3V11h5V9H9z m-4.5-1H2v1h2.5v-1zM2 11h2.5v-1H2v1z m9 1h1v2c-0.02 0.28-0.11 0.52-0.3 0.7s-0.42 0.28-0.7 0.3H1c-0.55 0-1-0.45-1-1V3c0-0.55 0.45-1 1-1h3C4 0.89 4.89 0 6 0s2 0.89 2 2h3c0.55 0 1 0.45 1 1v5h-1V5H1v9h10V12zM2 4h8c0-0.55-0.45-1-1-1h-1c-0.55 0-1-0.45-1-1s-0.45-1-1-1-1 0.45-1 1-0.45 1-1 1h-1c-0.55 0-1 0.45-1 1z"></path></svg></button>
+		`)
 	});
 }
 
@@ -295,7 +299,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			addReleasesTab();
 
 			if (isPR()) {
-				linkifyBranchRefs();
+				linkifyBranchRefsAndAddCopyButtons();
 				addDeleteForkLink();
 			}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -35,7 +35,7 @@ function linkifyBranchRefsAndAddCopyButtons() {
 
 		$(el).parent().after(`
 			<button aria-label="Copy the branch name" class="js-zeroclipboard btn btn-outline zeroclipboard-button tooltipped tooltipped-s" data-clipboard-text="${branch}" data-copied-hint="Copied!" type="button"><svg aria-hidden="true" class="octicon octicon-clippy" height="16" role="img" version="1.1" viewBox="0 0 14 16" width="14"><path d="M2 12h4v1H2v-1z m5-6H2v1h5v-1z m2 3V7L6 10l3 3V11h5V9H9z m-4.5-1H2v1h2.5v-1zM2 11h2.5v-1H2v1z m9 1h1v2c-0.02 0.28-0.11 0.52-0.3 0.7s-0.42 0.28-0.7 0.3H1c-0.55 0-1-0.45-1-1V3c0-0.55 0.45-1 1-1h3C4 0.89 4.89 0 6 0s2 0.89 2 2h3c0.55 0 1 0.45 1 1v5h-1V5H1v9h10V12zM2 4h8c0-0.55-0.45-1-1-1h-1c-0.55 0-1-0.45-1-1s-0.45-1-1-1-1 0.45-1 1-0.45 1-1 1h-1c-0.55 0-1 0.45-1 1z"></path></svg></button>
-		`)
+		`);
 	});
 }
 


### PR DESCRIPTION
See #77 for details.

I'm not sure about the padding on the copy button at the moment, it makes the target a bit small. But let me know what you think.

<img width="853" alt="add_a_copy_button_next_to_the_branch_name__closes__77__by_edhgoose_ _pull_request__78_ _sindresorhus_refined-github" src="https://cloud.githubusercontent.com/assets/1108173/13730919/544da574-e955-11e5-906a-6f785512611d.png">
