### PR TITLE
Remove renamed fork support from branch name links

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -28,10 +28,7 @@ function linkifyBranchRefs() {
 			username = parts.eq(0).text();
 		}
 
-		// forked repos can have their name changed; grab it from first commit in PR
-		const branchRepo = path.includes(username) ? repoName : $('.commit-id').attr('href').split('/')[2];
-
-		$(el).wrap(`<a href="https://github.com/${username}/${branchRepo}/tree/${branch}">`);
+		$(el).wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
 	});
 }
 


### PR DESCRIPTION
- GitHub changed some DOM in https://github.com/blog/2123-more-code-review-tools The `.commit-id` is still matching elements on the page, but they are not anchors.
- I have tried changing the selector and making it future proof by checking the href attribute, but actually they have changed links to the commits in a PR as well. They now use `/<source owner>/<source repo>/pull/<PR id>/commits/<commit sha>`.

That said I think we should remove the correct branch links across forks as it produces JS error.
We can restore it if we find another solution.

On top of that the links to a renamed fork are redirect unless there is another repo with the same name so the branch links would work in most cases even without handling the renamed forks case.