### PR TITLE
Consider PR files listing with 1 commit to be a commit view

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -8,7 +8,13 @@ const isRepo = () => /^\/[^/]+\/[^/]+/.test(location.pathname);
 const isRepoRoot = () => location.pathname.replace(/\/$/, '') === `/${ownerName}/${repoName}` || /(\/tree\/)(\w|\d|\.)+(\/$|$)/.test(location.href);
 const isCompare = () => /^\/[^/]+\/[^/]+\/compare/.test(location.pathname);
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname);
-const isCommit = () => /^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{5,40}/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname);
+const isCommit = () => {
+	if (/^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{5,40}/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname)) {
+		return true;
+	}
+
+	return /^\/[^/]+\/[^/]+\/pull\/\d+\/files/.test(location.pathname) && $('.full-commit').length > 0;
+};
 const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const isBlame = () => /^\/[^/]+\/[^/]+\/blame\//.test(location.pathname);


### PR DESCRIPTION
This is a follow-up after #86 to catch cases such as https://github.com/sindresorhus/refined-github/pull/86/files to be a commit view as GitHub now shows just the single commit info there.