### PR TITLE
Remove minimise/maximise all buttons

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -186,10 +186,7 @@
 	opacity: 1;
 }
 
-/* style for minimize/maximize button group */
-.btn-group.refined-github-btn-group {
-    margin-right: 25px;
-}
+/* indicate collapsible file headers with zoom cursor */
 .file-header[data-path], .file-header[data-path] .diffstat {
     cursor: zoom-out !important;
 }


### PR DESCRIPTION
Keep the collapse behaviour when clicking file headers using a click handler.
No need for `isCompare()` check anymore.
Simplify other click delegate event a bit using Sprint and keep code-style consistent.

Closes #85