### PR TITLE
Differentiate merge commits from regular commits

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -266,3 +266,23 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .page-profile .member-badge {
 	display: none !important;
 }
+
+/* fade out merge commits from commit list */
+.refined-github-merge-commit .commit-title {
+	font-size: 12px !important;
+	margin-top: 4px !important;
+}
+
+.refined-github-merge-commit .commit-author-section {
+	font-size: 11.4px !important;
+}
+
+.refined-github-merge-commit .commit-avatar-cell svg {
+	color: #4078c0;
+	margin-left: 9px;
+}
+
+.refined-github-merge-commit .avatar-parent-child img.avatar-child {
+	width: 16px !important;
+	height: 16px !important;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -15,6 +15,7 @@ const isCommit = () => {
 
 	return /^\/[^/]+\/[^/]+\/pull\/\d+\/files/.test(location.pathname) && $('.full-commit').length > 0;
 };
+const isCommitList = () => /^\/[^/]+\/[^/]+\/commits\//.test(location.pathname);
 const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const isBlame = () => /^\/[^/]+\/[^/]+\/blame\//.test(location.pathname);
@@ -277,6 +278,16 @@ function addPatchDiffLinks() {
 	`);
 }
 
+function markMergeCommitsInList() {
+	$('.commit.commits-list-item.table-list-item').each((index, element) => {
+		const $element = $(element);
+		const messageText = $element.find('.commit-title').text();
+		if (/Merge pull request #/.test(messageText)) {
+			$element.addClass('refined-github-merge-commit');
+		}
+	});
+}
+
 // Prompt user to confirm erasing a comment with the Cancel button
 $(document).on('click', event => {
 	// Check event.target instead of using a delegate, because Sprint doesn't support them
@@ -353,6 +364,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (isCommit()) {
 				addPatchDiffLinks();
+			}
+
+			if (isCommitList()) {
+				markMergeCommitsInList();
 			}
 		});
 	}

--- a/extension/content.js
+++ b/extension/content.js
@@ -283,7 +283,12 @@ function markMergeCommitsInList() {
 		const $element = $(element);
 		const messageText = $element.find('.commit-title').text();
 		if (/Merge pull request #/.test(messageText)) {
-			$element.addClass('refined-github-merge-commit');
+			$element
+				.addClass('refined-github-merge-commit')
+				.find('.commit-avatar-cell')
+					.prepend('<svg aria-hidden="true" class="octicon octicon-git-pull-request" height="36" role="img" version="1.1" viewBox="0 0 12 16" width="27"><path d="M11 11.28c0-1.73 0-6.28 0-6.28-0.03-0.78-0.34-1.47-0.94-2.06s-1.28-0.91-2.06-0.94c0 0-1.02 0-1 0V0L4 3l3 3V4h1c0.27 0.02 0.48 0.11 0.69 0.31s0.3 0.42 0.31 0.69v6.28c-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72z m-1 2.92c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2zM4 3c0-1.11-0.89-2-2-2S0 1.89 0 3c0 0.73 0.41 1.38 1 1.72 0 1.55 0 5.56 0 6.56-0.59 0.34-1 0.98-1 1.72 0 1.11 0.89 2 2 2s2-0.89 2-2c0-0.73-0.41-1.38-1-1.72V4.72c0.59-0.34 1-0.98 1-1.72z m-0.8 10c0 0.66-0.55 1.2-1.2 1.2s-1.2-0.55-1.2-1.2 0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2z m-1.2-8.8c-0.66 0-1.2-0.55-1.2-1.2s0.55-1.2 1.2-1.2 1.2 0.55 1.2 1.2-0.55 1.2-1.2 1.2z"></path></svg>')
+					.find('img')
+						.addClass('avatar-child');
 		}
 	});
 }


### PR DESCRIPTION
Closes #94

@sindresorhus I've made this PR to close #94, but seeing this live I am not sure I need/want this. Merge commits are important to see in the commits list marking a point when something was merged (or released if a web app is deployed when pushed to master).

![Faded out merge commits in commit list](https://cloud.githubusercontent.com/assets/506129/13969470/cba319a0-f08b-11e5-935c-09869446c7bf.png)
