### PR TITLE
Show current filename in sticky pull request header

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -291,3 +291,12 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	width: 16px !important;
 	height: 16px !important;
 }
+
+/* Hide current filename in PR header when not sticky (top of page) */
+.js-sticky-offset-scroll:not(.is-stuck) .diff-toolbar-filename {
+	display: none;
+}
+
+.diff-toolbar-filename {
+	font-weight: bold;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection */
+/* globals gitHubInjection, diffFileHeader */
 'use strict';
 const path = location.pathname;
 const ownerName = path.split('/')[1];
@@ -9,8 +9,9 @@ const isDashboard = () => location.pathname === '/' || /(^\/(dashboard))/.test(l
 const isRepo = () => !isGist && /^\/[^/]+\/[^/]+/.test(location.pathname);
 const isRepoRoot = () => location.pathname.replace(/\/$/, '') === `/${repoUrl}` || (/\/tree\/$/.test(location.href) && $('.repository-meta-content').length);
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname);
+const isPRCommit = () => /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname);
 const isCommit = () => {
-	if (/^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{5,40}/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname)) {
+	if (/^\/[^/]+\/[^/]+\/commit\/[0-9a-f]{5,40}/.test(location.pathname) || isPRCommit()) {
 		return true;
 	}
 
@@ -20,6 +21,7 @@ const isCommitList = () => /^\/[^/]+\/[^/]+\/commits\//.test(location.pathname);
 const isIssue = () => /^\/[^/]+\/[^/]+\/issues\/\d+$/.test(location.pathname);
 const isReleases = () => /^\/[^/]+\/[^/]+\/(releases|tags)/.test(location.pathname);
 const isBlame = () => /^\/[^/]+\/[^/]+\/blame\//.test(location.pathname);
+const isPRFiles = () => /pull\/\d+\/files/.test(location.pathname);
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 
 const uselessContent = {
@@ -349,6 +351,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	if (isRepo()) {
 		gitHubInjection(window, () => {
 			addReleasesTab();
+			diffFileHeader.destroy();
 
 			if (isPR()) {
 				linkifyBranchRefs();
@@ -374,6 +377,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (isCommitList()) {
 				markMergeCommitsInList();
+			}
+
+			if (isPRFiles() || isPRCommit()) {
+				diffFileHeader.setup();
 			}
 		});
 	}

--- a/extension/diffheader.js
+++ b/extension/diffheader.js
@@ -1,0 +1,78 @@
+window.diffFileHeader = (() => {
+	const diffFile = (() => {
+		let lastFile;
+
+		const hasChanged = nextFile => {
+			if (nextFile !== lastFile) {
+				lastFile = nextFile;
+				return true;
+			}
+
+			return false;
+		};
+
+		const reset = () => {
+			lastFile = '';
+		};
+
+		return {
+			hasChanged,
+			reset
+		};
+	})();
+
+	const getDiffToolbarHeight = () => {
+		const el = $('.pr-toolbar.is-stuck').get(0);
+		return (el && el.clientHeight) || 0;
+	};
+
+	const isFilePartlyVisible = (fileEl, offset) => {
+		const {bottom} = fileEl.getBoundingClientRect();
+		return bottom >= offset;
+	};
+
+	const getHighestVisibleDiffFilename = () => {
+		const toolbarHeight = getDiffToolbarHeight();
+		if (!toolbarHeight) {
+			return;
+		}
+
+		// Note: Not using $.each, because Sprint doesn't allow bailing out early
+		const files = $('.file.js-details-container').dom;
+		return files.find(el => isFilePartlyVisible(el, toolbarHeight));
+	};
+
+	const diffHeaderFilename = () => {
+		const targetDiffFile = getHighestVisibleDiffFilename();
+		if (!targetDiffFile) {
+			return;
+		}
+
+		const filename = $(targetDiffFile).find('.file-header').attr('data-path');
+
+		if (!diffFile.hasChanged(filename)) {
+			return;
+		}
+
+		$('.diff-toolbar-filename').text(filename);
+	};
+
+	const setup = () => {
+		const events = ['scroll', 'resize'];
+		events.forEach(event => window.addEventListener(event, diffHeaderFilename));
+		$(`<span class="diff-toolbar-filename"></span>`)
+				.insertAfter($('.toc-select'));
+		diffFile.reset();
+	};
+
+	const destroy = () => {
+		const events = ['scroll', 'resize'];
+		events.forEach(event => window.removeEventListener(event, diffHeaderFilename));
+		$('.diff-toolbar-filename').remove();
+	};
+
+	return {
+		setup,
+		destroy
+	};
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -27,6 +27,7 @@
 			"js": [
 				"vendor/sprint.min.js",
 				"vendor/gh-injection.js",
+				"diffheader.js",
 				"content.js"
 			]
 		}


### PR DESCRIPTION
Ref: Issue #98 

Todo:
- [x] Unbind scroll/resize listeners on partial page nav to non-PR page
- [x] Only update file name label in DOM when it's changed from previous val
- [x] Hide filename in header when not sticky (top of page)
- [x] Enable on Commit pages (currently only PR pages)
- [x] Determine desired behavior [when sticky header will never reach last commit ](https://github.com/sindresorhus/refined-github/issues/98#issuecomment-200637951)