### PR TITLE
Include gist.github.com to affected pages

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4,8 +4,9 @@ const path = location.pathname;
 const ownerName = path.split('/')[1];
 const repoName = path.split('/')[2];
 const repoUrl = `${ownerName}/${repoName}`;
+const isGist = location.hostname === 'gist.github.com';
 const isDashboard = () => location.pathname === '/' || /(^\/(dashboard))/.test(location.pathname) || /(^\/(orgs)\/)(\w|-)+\/(dashboard)/.test(location.pathname);
-const isRepo = () => /^\/[^/]+\/[^/]+/.test(location.pathname);
+const isRepo = () => !isGist && /^\/[^/]+\/[^/]+/.test(location.pathname);
 const isRepoRoot = () => location.pathname.replace(/\/$/, '') === `/${repoUrl}` || (/\/tree\/$/.test(location.href) && $('.repository-meta-content').length);
 const isPR = () => /^\/[^/]+\/[^/]+\/pull\/\d+/.test(location.pathname) || /^\/[^/]+\/[^/]+\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(location.pathname);
 const isCommit = () => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,6 +7,7 @@
 	"minimum_chrome_version": "48",
 	"permissions": [
 		"https://github.com/*",
+		"https://gist.github.com/*",
 		"storage"
 	],
 	"icons": {
@@ -16,7 +17,8 @@
 		{
 			"run_at": "document_start",
 			"matches": [
-				"https://github.com/*"
+				"https://github.com/*",
+				"https://gist.github.com/*"
 			],
 			"css": [
 				"content.css",


### PR DESCRIPTION
This way the extension adds some of its goodies on GitHub Gists as well:
- [x] hides GitHub Desktop download links
- [x] hides top buttons on comment box
- [x] add collapsing functionality to GitHub Gist revision pages

TODO:
- [x] Releases tab should not be added to GitHub Gists.