### PR TITLE
Make commit message inputs monospaced

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -295,3 +295,16 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .diff-toolbar-filename {
 	font-weight: bold;
 }
+
+/* limit width of commit title and description inputs to 50/80 chars */
+#commit-summary-input, #commit-description-textarea {
+	font-family: monospace !important;
+}
+
+#commit-summary-input {
+	width: 410px !important;
+}
+
+#commit-description-textarea {
+	width: 645px !important;
+}


### PR DESCRIPTION
- Make input and textarea when writing a commit message monospaced
- Limit input to about 50 chars so you see when you are close to the warning
- Limit textarea to about 80 chars ~~and turn off wrapping~~.

This simulates the behaviour of Vim when writing a Git commit message.
Unfortunately implementing autowrapping like Vim is harder and quite more opinionated.

Before:

![screen shot 2016-03-30 at 22 29 52](https://cloud.githubusercontent.com/assets/506129/14154773/03d1be80-f6c7-11e5-9e11-1027e7c5e186.png)


After:


![screen shot 2016-03-30 at 22 29 38](https://cloud.githubusercontent.com/assets/506129/14154774/03f43546-f6c7-11e5-83cc-d94e52ed33ea.png)
