### PR TITLE
Fix broken patch/diff links on commit PRs. Fixes #104

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -270,7 +270,10 @@ function linkifyIssuesInTitles() {
 }
 
 function addPatchDiffLinks() {
-	const commitUrl = location.href.replace(/\/$/, '');
+	let commitUrl = location.href.replace(/\/$/, '');
+	if (isPRCommit()) {
+		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
+	}
 	const commitMeta = $('.commit-meta span.right').get(0);
 
 	$(commitMeta).append(`


### PR DESCRIPTION
Note: Once #99 goes in, it would make sense to switch out the `prCommit` regex local to this function with the `isPRCommit` regex (the one that will be moving to the URL utils file shortly).