### PR TITLE
Show Saved Replies in Comment Toolbar

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -82,8 +82,17 @@
 }
 
 /* remove commentbox toolbar */
-.toolbar-commenting {
-	display: none !important;
+.toolbar-group {
+    display: none;
+}
+.toolbar-group:last-child {
+    display: inline-block;
+}
+.toolbar-group .toolbar-item {
+    display: none;
+}
+.toolbar-group .js-saved-reply-container {
+	display: block;
 }
 
 /* remove upload message on comment box */


### PR DESCRIPTION
This fixes #115. Only the Saved Replies button is shown in the comment toolbar now.