### PR TITLE
Move page detection checks to a separate file

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,7 @@
 	"description": "Simplifies the GitHub interface and adds useful features",
 	"homepage_url": "https://github.com/sindresorhus/refined-github",
 	"manifest_version": 2,
-	"minimum_chrome_version": "48",
+	"minimum_chrome_version": "49",
 	"permissions": [
 		"https://github.com/*",
 		"https://gist.github.com/*",
@@ -27,6 +27,7 @@
 			"js": [
 				"vendor/sprint.min.js",
 				"vendor/gh-injection.js",
+				"page-detect.js",
 				"diffheader.js",
 				"content.js"
 			]

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -1,0 +1,53 @@
+window.pageDetect = (() => {
+	const isGistCheck = location.hostname === 'gist.github.com';
+
+	const isGist = () => isGistCheck;
+
+	const isDashboard = () => location.pathname === '/' || /^(\/orgs\/[^\/]+)?\/dashboard/.test(location.pathname);
+
+	const isRepo = () => !isGist() && /^\/[^/]+\/[^/]+/.test(location.pathname);
+
+	const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, '');
+
+	const isRepoRoot = () => isRepo() && /^(\/?$|\/tree\/)/.test(getRepoPath()) && $('.repository-meta-content').length > 0;
+
+	const isIssueList = () => isRepo() && /^\/issues\/?$/.test(getRepoPath());
+
+	const isIssue = () => isRepo() && /^\/issues\/\d+/.test(getRepoPath());
+
+	const isPRList = () => isRepo() && /^\/pulls\/?$/.test(getRepoPath());
+
+	const isPR = () => isRepo() && /^\/pull\/\d+/.test(getRepoPath());
+
+	const isPRFiles = () => isRepo() && /^\/pull\/\d+\/files/.test(getRepoPath());
+
+	const isPRCommit = () => isRepo() && /^\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(getRepoPath());
+
+	const isCommitList = () => isRepo() && /^\/commits\//.test(getRepoPath());
+
+	const isSingleCommit = () => isRepo() && /^\/commit\/[0-9a-f]{5,40}/.test(getRepoPath());
+
+	const isCommit = () => isSingleCommit() || isPRCommit() || (isPRFiles() && $('.full-commit').length > 0);
+
+	const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
+
+	const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());
+
+	return {
+		isGist,
+		isDashboard,
+		isRepo,
+		isRepoRoot,
+		isIssueList,
+		isIssue,
+		isPRList,
+		isPR,
+		isPRFiles,
+		isPRCommit,
+		isCommitList,
+		isSingleCommit,
+		isCommit,
+		isReleases,
+		isBlame
+	};
+})();


### PR DESCRIPTION
Closes #120.

In this change I've tried to improve readability and consistency and not focus so much on performance as microoptimisations in these checks are not worth it.

Except for moving the checks to a separate file I've unified them a bit and made some fixes:

- simplified and unified dashboard regular expressions
- made all regex checks nested under a repo consistent
- re-used as much as possible especially for commit checks
- simplified repo root check
- fixed repo root check with `tree` in the regex for repositories like https://github.com/react-component/tree
- tried to use consistent naming and order of the methods
- fixed a few regular expressions not taking trailing slash in the URL into account