### PR TITLE
Shrink filename in sticky diff header when its too long. Fixes #122

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -296,6 +296,11 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	font-weight: bold;
 }
 
+.diff-toolbar-filename.filename-width-check {
+	visibility: hidden;
+	position: absolute;
+}
+
 /* limit width of commit title and description inputs to 50/80 chars */
 #commit-summary-input, #commit-description-textarea {
 	font-family: monospace !important;

--- a/extension/diffheader.js
+++ b/extension/diffheader.js
@@ -21,6 +21,46 @@ window.diffFileHeader = (() => {
 		};
 	})();
 
+	const maxPixelsAvailable = () => {
+		// Unfortunately can't cache this value, as it'll change with the browsers zoom level
+		const filenameLeftOffset = $('.diff-toolbar-filename').get(0).getBoundingClientRect().left;
+		const diffStatLeftOffset = $('.diff-toolbar-filename + .right').get(0).getBoundingClientRect().left;
+
+		return diffStatLeftOffset - filenameLeftOffset;
+	};
+
+	const parseFileDetails = filename => {
+		const folderCount = (filename.match(/\//g) || []).length;
+		const [, basename] = (filename.match(/(?:\/)([\w\.-]+)$/) || []);
+		const [, topDir] = (filename.match(/^([\w\.-]+)\//) || []);
+
+		return {
+			folderCount,
+			basename,
+			topDir
+		};
+	};
+
+	const updateFileLabel = val => {
+		const target = $('.diff-toolbar-filename').get(0);
+		target.classList.add('filename-width-check');
+		target.textContent = val;
+
+		const maxPixels = maxPixelsAvailable();
+		const doesOverflow = () => target.getBoundingClientRect().width > maxPixels;
+		const {basename, topDir, folderCount} = parseFileDetails(val);
+
+		if (doesOverflow() && folderCount > 1) {
+			target.textContent = `${topDir}/.../${basename}`;
+		}
+
+		if (doesOverflow()) {
+			target.textContent = basename;
+		}
+
+		target.classList.remove('filename-width-check');
+	};
+
 	const getDiffToolbarHeight = () => {
 		const el = $('.pr-toolbar.is-stuck').get(0);
 		return (el && el.clientHeight) || 0;
@@ -54,7 +94,7 @@ window.diffFileHeader = (() => {
 			return;
 		}
 
-		$('.diff-toolbar-filename').text(filename);
+		updateFileLabel(filename);
 	};
 
 	const setup = () => {


### PR DESCRIPTION
Still needs more discussion based on the conversation in #122, but I wanted to kickstart the work on this.

![screenshot](http://i.imgur.com/yi2mZ5y.gif)