### PR TITLE
Fix repeated appending of patch/diff links to commits

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -270,6 +270,10 @@ function linkifyIssuesInTitles() {
 }
 
 function addPatchDiffLinks() {
+	if ($('.sha-block.patch-diff-links').length > 0) {
+		return;
+	}
+
 	let commitUrl = location.href.replace(/\/$/, '');
 	if (isPRCommit()) {
 		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
@@ -277,7 +281,7 @@ function addPatchDiffLinks() {
 	const commitMeta = $('.commit-meta span.right').get(0);
 
 	$(commitMeta).append(`
-		<span class="sha-block">
+		<span class="sha-block patch-diff-links">
 			<a href="${commitUrl}.patch" class="sha">.patch</a>
 			<a href="${commitUrl}.diff" class="sha">.diff</a>
 		</span>


### PR DESCRIPTION
This is a fix to close #135.

Checks if there are links and doesn't add them if there are.