### PR TITLE
Push comment options on the right

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -84,6 +84,7 @@
 /* remove commentbox toolbar */
 .toolbar-group {
     display: none;
+    margin-left: 0 !important;
 }
 .toolbar-group:last-child {
     display: inline-block;


### PR DESCRIPTION
This commit pushes the comment options on the right. Refined Github
makes the gitHub interface better by removing useless features and by
organizing in an smarter way the other ones. Before this commit, if you
used an extension on the comment menu it was could be not properly
aligned. By removing the "margin-left" all options are pushed on the
right.

resolves #133