### PR TITLE
Add avatars for reactions participants

### DIFF
--- a/extension/addreactionparticipants.js
+++ b/extension/addreactionparticipants.js
@@ -8,13 +8,6 @@ const addReactionParticipants = currentUser => {
 		const $reactionButtons = $reactionsContainer.find('.comment-reactions-options .reaction-summary-item[aria-label]');
 
 		$reactionButtons.each((index, element) => {
-			element.addEventListener('click', () => {
-				const applyReactions = setInterval(() => {
-					addReactionParticipants(currentUser);
-					clearInterval(applyReactions);
-				}, 1000);
-			});
-
 			const reactionEmoji = $(element).html().replace(element.innerHTML.split('/g-emoji>')[1], '');
 			const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
 			const participants = element.getAttribute('aria-label')
@@ -57,4 +50,14 @@ const addReactionParticipants = currentUser => {
 			}
 		});
 	});
+};
+
+const reapplyReactionParticipants = (event, currentUser) => {
+	if(!$(event.target).closest('button').not('.add-reaction-btn').is('.add-reactions-options-item, .reaction-summary-item')) {
+		return;
+	}
+	const applyReactions = setInterval(() => {
+		addReactionParticipants(currentUser);
+		clearInterval(applyReactions);
+	}, 1000);
 };

--- a/extension/addreactionparticipants.js
+++ b/extension/addreactionparticipants.js
@@ -1,0 +1,60 @@
+const addReactionParticipants = currentUser => {
+	$('.comment-reactions').each((index, reactionsContainer) => {
+		const $reactionsContainer = $(reactionsContainer);
+		if (!$reactionsContainer.hasClass('has-reactions')) {
+			return;
+		}
+
+		const $reactionButtons = $reactionsContainer.find('.comment-reactions-options .reaction-summary-item[aria-label]');
+
+		$reactionButtons.each((index, element) => {
+			element.addEventListener('click', () => {
+				const applyReactions = setInterval(() => {
+					addReactionParticipants(currentUser);
+					clearInterval(applyReactions);
+				}, 1000);
+			});
+
+			const reactionEmoji = $(element).html().replace(element.innerHTML.split('/g-emoji>')[1], '');
+			const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
+			const participants = element.getAttribute('aria-label')
+				.replace(/,? and /, ', ')
+				.replace(/, \d+ more/, '')
+				.split(', ');
+			const userPosition = participants.indexOf(currentUser);
+
+			// if the user is the only participant, leave as is
+			if (participantCount === 1 && userPosition > -1) {
+				return;
+			}
+
+			// get rid of existing count
+			$(element).html(reactionEmoji);
+
+			// add participant container
+			if ($(element).find('div.participants-container').length === 0) {
+				$(element).append('<div class="participants-container">');
+			}
+
+			// remove self from participant list so you don't see your own avatar
+			if (userPosition > -1) {
+				participants.splice(userPosition, 1);
+			}
+
+			const firstThreeParticipants = participants.slice(0, 3);
+			const participantsContainer = $(element).find('.participants-container').get(0);
+			const remainder = participantCount - firstThreeParticipants.length;
+
+			// clear any existing avatars and remainder count
+			$(participantsContainer).html('');
+
+			for (const participant of firstThreeParticipants) {
+				$(participantsContainer).append(`<img src="https://github.com/${participant}.png">`);
+			}
+
+			if (remainder > 0) {
+				$(participantsContainer).append(`<span>+${remainder}</span>`);
+			}
+		});
+	});
+};

--- a/extension/addreactionparticipants.js
+++ b/extension/addreactionparticipants.js
@@ -1,63 +1,65 @@
-const addReactionParticipants = currentUser => {
-	$('.comment-reactions').each((index, reactionsContainer) => {
-		const $reactionsContainer = $(reactionsContainer);
-		if (!$reactionsContainer.hasClass('has-reactions')) {
-			return;
-		}
-
-		const $reactionButtons = $reactionsContainer.find('.comment-reactions-options .reaction-summary-item[aria-label]');
-
-		$reactionButtons.each((index, element) => {
-			const reactionEmoji = $(element).html().replace(element.innerHTML.split('/g-emoji>')[1], '');
-			const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
-			const participants = element.getAttribute('aria-label')
-				.replace(/,? and /, ', ')
-				.replace(/, \d+ more/, '')
-				.split(', ');
-			const userPosition = participants.indexOf(currentUser);
-
-			// if the user is the only participant, leave as is
-			if (participantCount === 1 && userPosition > -1) {
+const addReactionParticipants = {
+	add(currentUser) {
+		$('.comment-reactions').each((index, reactionsContainer) => {
+			const $reactionsContainer = $(reactionsContainer);
+			if (!$reactionsContainer.hasClass('has-reactions')) {
 				return;
 			}
 
-			// get rid of existing count
-			$(element).html(reactionEmoji);
+			const $reactionButtons = $reactionsContainer.find('.comment-reactions-options .reaction-summary-item[aria-label]');
 
-			// add participant container
-			if ($(element).find('div.participants-container').length === 0) {
-				$(element).append('<div class="participants-container">');
-			}
+			$reactionButtons.each((index, element) => {
+				const reactionEmoji = $(element).html().replace(element.innerHTML.split('/g-emoji>')[1], '');
+				const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
+				const participants = element.getAttribute('aria-label')
+					.replace(/,? and /, ', ')
+					.replace(/, \d+ more/, '')
+					.split(', ');
+				const userPosition = participants.indexOf(currentUser);
 
-			// remove self from participant list so you don't see your own avatar
-			if (userPosition > -1) {
-				participants.splice(userPosition, 1);
-			}
+				// if the user is the only participant, leave as is
+				if (participantCount === 1 && userPosition > -1) {
+					return;
+				}
 
-			const firstThreeParticipants = participants.slice(0, 3);
-			const participantsContainer = $(element).find('.participants-container').get(0);
-			const remainder = participantCount - firstThreeParticipants.length;
+				// get rid of existing count
+				$(element).html(reactionEmoji);
 
-			// clear any existing avatars and remainder count
-			$(participantsContainer).html('');
+				// add participant container
+				if ($(element).find('div.participants-container').length === 0) {
+					$(element).append('<div class="participants-container">');
+				}
 
-			for (const participant of firstThreeParticipants) {
-				$(participantsContainer).append(`<img src="https://github.com/${participant}.png">`);
-			}
+				// remove self from participant list so you don't see your own avatar
+				if (userPosition > -1) {
+					participants.splice(userPosition, 1);
+				}
 
-			if (remainder > 0) {
-				$(participantsContainer).append(`<span>+${remainder}</span>`);
-			}
+				const firstThreeParticipants = participants.slice(0, 3);
+				const participantsContainer = $(element).find('.participants-container').get(0);
+				const remainder = participantCount - firstThreeParticipants.length;
+
+				// clear any existing avatars and remainder count
+				$(participantsContainer).html('');
+
+				for (const participant of firstThreeParticipants) {
+					$(participantsContainer).append(`<img src="https://github.com/${participant}.png">`);
+				}
+
+				if (remainder > 0) {
+					$(participantsContainer).append(`<span>+${remainder}</span>`);
+				}
+			});
 		});
-	});
-};
+	},
 
-const reapplyReactionParticipants = (event, currentUser) => {
-	if(!$(event.target).closest('button').not('.add-reaction-btn').is('.add-reactions-options-item, .reaction-summary-item')) {
-		return;
+	reapply(event, currentUser) {
+		if (!$(event.target).closest('button').not('.add-reaction-btn').is('.add-reactions-options-item, .reaction-summary-item')) {
+			return;
+		}
+		const applyReactions = setInterval(() => {
+			addReactionParticipants.add(currentUser);
+			clearInterval(applyReactions);
+		}, 1000);
 	}
-	const applyReactions = setInterval(() => {
-		addReactionParticipants(currentUser);
-		clearInterval(applyReactions);
-	}, 1000);
 };

--- a/extension/addreactionparticipants.js
+++ b/extension/addreactionparticipants.js
@@ -1,15 +1,10 @@
 const addReactionParticipants = {
 	add(currentUser) {
-		$('.comment-reactions').each((index, reactionsContainer) => {
+		$('.comment-reactions.has-reactions').each((index, reactionsContainer) => {
 			const $reactionsContainer = $(reactionsContainer);
-			if (!$reactionsContainer.hasClass('has-reactions')) {
-				return;
-			}
-
 			const $reactionButtons = $reactionsContainer.find('.comment-reactions-options .reaction-summary-item[aria-label]');
 
 			$reactionButtons.each((index, element) => {
-				const reactionEmoji = $(element).html().replace(element.innerHTML.split('/g-emoji>')[1], '');
 				const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
 				const participants = element.getAttribute('aria-label')
 					.replace(/,? and /, ', ')
@@ -21,9 +16,6 @@ const addReactionParticipants = {
 				if (participantCount === 1 && userPosition > -1) {
 					return;
 				}
-
-				// get rid of existing count
-				$(element).html(reactionEmoji);
 
 				// add participant container
 				if ($(element).find('div.participants-container').length === 0) {
@@ -37,17 +29,12 @@ const addReactionParticipants = {
 
 				const firstThreeParticipants = participants.slice(0, 3);
 				const participantsContainer = $(element).find('.participants-container').get(0);
-				const remainder = participantCount - firstThreeParticipants.length;
 
 				// clear any existing avatars and remainder count
 				$(participantsContainer).html('');
 
 				for (const participant of firstThreeParticipants) {
 					$(participantsContainer).append(`<img src="https://github.com/${participant}.png">`);
-				}
-
-				if (remainder > 0) {
-					$(participantsContainer).append(`<span>+${remainder}</span>`);
 				}
 			});
 		});
@@ -60,6 +47,6 @@ const addReactionParticipants = {
 		const applyReactions = setInterval(() => {
 			addReactionParticipants.add(currentUser);
 			clearInterval(applyReactions);
-		}, 1000);
+		}, 500);
 	}
 };

--- a/extension/content.css
+++ b/extension/content.css
@@ -340,7 +340,7 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	height: 200px !important;
 }
 
-/* styles for reaction avatars */
+/* styles for avatars Refined GitHub adds to Reactions */
 .reaction-summary-item {
 	padding-left: 10px !important;
 	padding-right: 10px !important;

--- a/extension/content.css
+++ b/extension/content.css
@@ -339,3 +339,29 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .comment-form-textarea {
 	height: 200px !important;
 }
+
+/* styles for reaction avatars */
+.reaction-summary-item {
+	padding-left: 10px !important;
+	padding-right: 10px !important;
+}
+
+.reaction-summary-item.add-reaction-btn {
+	padding-right: 0 !important;
+}
+
+.reaction-summary-item div,
+.reaction-summary-item div img {
+	display: inline-block;
+}
+
+.reaction-summary-item div img,
+.reaction-summary-item div span {
+	width: 20px;
+	height: 20px;
+	margin-left: 3px;
+	vertical-align: middle;
+}
+.reaction-summary-item div img {
+	border-radius: 3px;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -378,8 +378,6 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isPR() || pageDetect.isIssue()) {
 				moveVotes();
 				linkifyIssuesInTitles();
-				addReactionParticipants.add(username);
-				addReactionParticipants.addListener(username);
 			}
 
 			if (pageDetect.isBlame()) {
@@ -392,6 +390,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isCommit()) {
 				addPatchDiffLinks();
+			}
+
+			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
 				addReactionParticipants.add(username);
 				addReactionParticipants.addListener(username);
 			}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants */
 'use strict';
 const [, ownerName, repoName] = location.pathname.split('/');
 const repoUrl = `${ownerName}/${repoName}`;
@@ -372,6 +372,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isPR() || pageDetect.isIssue()) {
 				moveVotes();
 				linkifyIssuesInTitles();
+				addReactionParticipants(username);
 			}
 
 			if (pageDetect.isBlame()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -373,6 +373,9 @@ document.addEventListener('DOMContentLoaded', () => {
 				moveVotes();
 				linkifyIssuesInTitles();
 				addReactionParticipants(username);
+				document.addEventListener('click', event => {
+					reapplyReactionParticipants(event, username)
+				});
 			}
 
 			if (pageDetect.isBlame()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -372,9 +372,9 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isPR() || pageDetect.isIssue()) {
 				moveVotes();
 				linkifyIssuesInTitles();
-				addReactionParticipants(username);
+				addReactionParticipants.add(username);
 				document.addEventListener('click', event => {
-					reapplyReactionParticipants(event, username)
+					addReactionParticipants.reapply(event, username);
 				});
 			}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -373,9 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				moveVotes();
 				linkifyIssuesInTitles();
 				addReactionParticipants.add(username);
-				document.addEventListener('click', event => {
-					addReactionParticipants.reapply(event, username);
-				});
+				addReactionParticipants.addListener(username);
 			}
 
 			if (pageDetect.isBlame()) {
@@ -388,6 +386,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isCommit()) {
 				addPatchDiffLinks();
+				addReactionParticipants.add(username);
+				addReactionParticipants.addListener(username);
 			}
 
 			if (pageDetect.isCommitList()) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -29,7 +29,7 @@
 				"vendor/gh-injection.js",
 				"page-detect.js",
 				"diffheader.js",
-				"addreactionparticipants.js",
+				"reactions-avatars.js",
 				"content.js"
 			]
 		}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -29,6 +29,7 @@
 				"vendor/gh-injection.js",
 				"page-detect.js",
 				"diffheader.js",
+				"addreactionparticipants.js",
 				"content.js"
 			]
 		}

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -48,5 +48,11 @@ const addReactionParticipants = {
 			addReactionParticipants.add(currentUser);
 			clearInterval(applyReactions);
 		}, 500);
+	},
+
+	addListener(username) {
+		document.addEventListener('click', event => {
+			addReactionParticipants.reapply(event, username);
+		});
 	}
 };

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -50,9 +50,9 @@ const addReactionParticipants = {
 		}, 500);
 	},
 
-	addListener(username) {
+	addListener(currentUser) {
 		document.addEventListener('click', event => {
-			addReactionParticipants.reapply(event, username);
+			addReactionParticipants.reapply(event, currentUser);
 		});
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
 - [Hides :+1: :-1: comments and shows their count in the sidebar](https://cloud.githubusercontent.com/assets/170270/13241396/0b708ae8-da1d-11e5-8c01-94eae501034c.png)
+- [Adds User avatars to Reactions](https://cloud.githubusercontent.com/assets/737065/14269443/c80ae418-fab2-11e5-93f7-d776f40a5b25.png)
 - Supports indenting with the tab key in textareas like the comment box
 - Automagically expands the news feed when you scroll down
 - Hides other users starring/forking your repos from the newsfeed

--- a/readme.md
+++ b/readme.md
@@ -21,8 +21,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
 - [Hides :+1: :-1: comments and shows their count in the sidebar](https://cloud.githubusercontent.com/assets/170270/13241396/0b708ae8-da1d-11e5-8c01-94eae501034c.png)
-- [Adds User avatars to Reactions](https://cloud.githubusercontent.com/assets/737065/14269443/c80ae418-fab2-11e5-93f7-d776f40a5b25.png)
-- Supports indenting with the tab key in textareas like the comment box
+- [Adds user avatars to Reactions](https://cloud.githubusercontent.com/assets/737065/14269443/c80ae418-fab2-11e5-93f7-d776f40a5b25.png)
 - Supports indenting with the tab key in textareas like the comment box (use <kbd>shift</kbd>+<kbd>tab</kbd> for original behavior)
 - Automagically expands the news feed when you scroll down
 - Hides other users starring/forking your repos from the newsfeed

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
 - [Hides :+1: :-1: comments and shows their count in the sidebar](https://cloud.githubusercontent.com/assets/170270/13241396/0b708ae8-da1d-11e5-8c01-94eae501034c.png)
-- [Adds user avatars to Reactions](https://cloud.githubusercontent.com/assets/737065/14269443/c80ae418-fab2-11e5-93f7-d776f40a5b25.png)
+- [Adds user avatars to Reactions](https://cloud.githubusercontent.com/assets/737065/14320233/53fa3624-fbe2-11e5-8a77-6b493d9b9d84.png)
 - Supports indenting with the tab key in textareas like the comment box (use <kbd>shift</kbd>+<kbd>tab</kbd> for original behavior)
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - Automagically expands the news feed when you scroll down


### PR DESCRIPTION
Hat tip to @hkdobrev for getting this started and finding the way to get GH user avatars.

This extends the work @hkdobrev did on a new branch that is also up to date with `master`. Basically, it takes the avatars of people who add a reaction to a comment and appends their avatar. I am only appending the first 3 (or less) avatars because it quickly gets crazy, and then just add `+${remainder}` at the end.

Suggestions on the design are welcome. I'm thinking we can even get rid of the original number, but not sure.

Example:
![reaction-avatars](https://cloud.githubusercontent.com/assets/737065/14230374/ca390f4a-f921-11e5-92a8-c1d81ce51b4c.png)
