### PR TITLE
Show "Recently pushed branches" in more places than just the repo root

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -307,7 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
 				addReadmeEditButton();
 			}
 
-			if (!pageDetect.isRepoRoot()) {
+			if (pageDetect.isPRList() || pageDetect.isIssueList()) {
 				showRecentPushedBranches();
 			}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -206,6 +206,19 @@ function indentInput(el, size = 4) {
 	el.selectionEnd = el.selectionStart = selectionStart + indentationText.length;
 }
 
+function showRecentPushedBranches() {
+	// Don't duplicate on back/forward in history
+	if ($('.recently-touched-branches-wrapper').length) {
+		return;
+	}
+
+	const uri = `/${repoUrl}/show_partial?partial=tree/recently_touched_branches_list`;
+	const fragMarkup = `<include-fragment src=${uri}></include-fragment>`;
+	const div = document.createElement('div');
+	div.innerHTML = fragMarkup;
+	$('.repository-content').prepend(div);
+}
+
 // Support indent with tab key in textarea elements
 $(document).on('keydown', event => {
 	// Check event.target instead of using a delegate, because Sprint doesn't support them
@@ -292,6 +305,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isRepoRoot() || pageDetect.isRepoTree()) {
 				addReadmeEditButton();
+			}
+
+			if (!pageDetect.isRepoRoot()) {
+				showRecentPushedBranches();
 			}
 
 			if (pageDetect.isCommit()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -206,7 +206,7 @@ function indentInput(el, size = 4) {
 	el.selectionEnd = el.selectionStart = selectionStart + indentationText.length;
 }
 
-function showRecentPushedBranches() {
+function showRecentlyPushedBranches() {
 	// Don't duplicate on back/forward in history
 	if ($('.recently-touched-branches-wrapper').length) {
 		return;
@@ -308,7 +308,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (pageDetect.isPRList() || pageDetect.isIssueList()) {
-				showRecentPushedBranches();
+				showRecentlyPushedBranches();
 			}
 
 			if (pageDetect.isCommit()) {


### PR DESCRIPTION
Resolves #140 

I have a sneaking suspicion that, for super active users, showing this on *every* page of the repo may become a bit of a pain. Maybe we limit it to just "List" pages, like the PR list or the issues list, rather than individual issue/PR pages. Would love feedback/input.