### PR TITLE
Add "Copy" button for raw file contents in single file view

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,6 +1,6 @@
 /* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants */
 'use strict';
-const [, ownerName, repoName] = location.pathname.split('/');
+const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 const repoUrl = `${ownerName}/${repoName}`;
 const getUsername = () => $('meta[name="user-login"]').attr('content');
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -207,7 +207,8 @@ function indentInput(el, size = 4) {
 }
 
 function addFileCopyButton() {
-	if ($('.copy-btn').length) {
+	// Button already added (partial page nav), or non-text file
+	if ($('.copy-btn').length || !$('[data-line-number="1"]').length) {
 		return;
 	}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,5 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton */
+
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 const repoUrl = `${ownerName}/${repoName}`;
@@ -204,39 +205,6 @@ function indentInput(el, size = 4) {
 	const indentationText = ' '.repeat(indentSize);
 	el.value = value.slice(0, selectionStart) + indentationText + value.slice(el.selectionEnd);
 	el.selectionEnd = el.selectionStart = selectionStart + indentationText.length;
-}
-
-function addFileCopyButton() {
-	// Button already added (partial page nav), or non-text file
-	if ($('.copy-btn').length || !$('[data-line-number="1"]').length) {
-		return;
-	}
-
-	const $targetSibling = $('#raw-url');
-	const fileUri = $targetSibling.attr('href');
-	// Note: Need to fetch this prior to the user-click, unfortunately.
-	// Chrome only allows the "copy" command to work within quick succession
-	// of a user-triggered event (click on "Copy" button, in this case)
-	const pendingFileContents = fetch(fileUri).then(res => res.text());
-	$(`<a href="${fileUri}" class="btn btn-sm copy-btn">Copy</a>`).insertBefore($targetSibling);
-
-	$(document).on('click', e => {
-		if (!e.target.classList.contains('copy-btn')) {
-			return;
-		}
-
-		e.preventDefault();
-		const textArea = document.createElement('textarea');
-		textArea.style.cssText = 'opacity:0; position: fixed;';
-		document.body.appendChild(textArea);
-
-		pendingFileContents.then(fileContents => {
-			textArea.value = fileContents;
-			textArea.select();
-			document.execCommand('copy');
-			document.body.removeChild(textArea);
-		});
-	});
 }
 
 // Support indent with tab key in textarea elements

--- a/extension/copy-file.js
+++ b/extension/copy-file.js
@@ -1,0 +1,29 @@
+'use strict';
+
+window.addFileCopyButton = () => {
+	// Button already added (partial page nav), or non-text file
+	if ($('.copy-btn').length || !$('[data-line-number="1"]').length) {
+		return;
+	}
+
+	const $targetSibling = $('#raw-url');
+	const fileUri = $targetSibling.attr('href');
+	$(`<a href="${fileUri}" class="btn btn-sm copy-btn">Copy</a>`).insertBefore($targetSibling);
+
+	$(document).on('click', e => {
+		if (!e.target.classList.contains('copy-btn')) {
+			return;
+		}
+
+		e.preventDefault();
+		const fileContents = $('.js-file-line-container').get(0).innerText;
+		const $textArea = $('<textarea>').css({
+			opacity: 0,
+			position: 'fixed'
+		}).appendTo('body').val(fileContents);
+		$textArea.get(0).select();
+
+		document.execCommand('copy');
+		$textArea.remove();
+	});
+};

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -31,6 +31,7 @@
 				"page-detect.js",
 				"diffheader.js",
 				"reactions-avatars.js",
+				"copy-file.js",
 				"content.js"
 			]
 		}

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -35,6 +35,8 @@ window.pageDetect = (() => {
 
 	const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());
 
+	const isSingleFile = () => isRepo() && /\/blob\//.test(getRepoPath());
+
 	return {
 		isGist,
 		isDashboard,
@@ -51,6 +53,7 @@ window.pageDetect = (() => {
 		isSingleCommit,
 		isCommit,
 		isReleases,
-		isBlame
+		isBlame,
+		isSingleFile
 	};
 })();

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -35,7 +35,16 @@ window.pageDetect = (() => {
 
 	const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());
 
-	const isSingleFile = () => isRepo() && /\/blob\//.test(getRepoPath());
+	const getOwnerAndRepo = () => {
+		const [, ownerName, repoName] = location.pathname.split('/');
+		return {ownerName, repoName};
+	};
+
+	const isSingleFile = () => {
+		const {ownerName, repoName} = getOwnerAndRepo();
+		const blobPattern = new RegExp(`/${ownerName}/${repoName}/blob/`);
+		return isRepo() && blobPattern.test(location.href);
+	};
 
 	return {
 		isGist,
@@ -54,6 +63,7 @@ window.pageDetect = (() => {
 		isCommit,
 		isReleases,
 		isBlame,
+		getOwnerAndRepo,
 		isSingleFile
 	};
 })();

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - Removes annoying hover effect in the repo file browser
 - Removes the comment box toolbar
 - Removes tooltips
+- Adds a `Copy` button for raw file contents
 
 And [lots](extension/content.css) [more...](extension/content.js)
 


### PR DESCRIPTION
Closes #62. There was a caveat to this implementation, however.

The `copy` command with `execCommand` in Chrome will only be set to `enabled` for a *very* brief period of time after a user-triggered event (in this case, a button click). I believe it's 1 second, but didn't end up spending too much more time digging into it. Because of this, I'm fetching the contents of the file prior to click, which means it happens on every page load for single-file pages.

I *think* we may be able to bypass that restriction if we do the `Copy` from a background page and request clipboard permission(s), but I'm not sure that's worth the extra complexity of adding a background page + setting up messaging between background <> content script.

Open to feedback :smile: 