### PR TITLE
allow default behavior in textareas

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -300,7 +300,7 @@ $(document).on('keydown', event => {
 		return;
 	}
 
-	if (event.which === 9) {
+	if (event.which === 9 && !event.shiftKey) {
 		event.preventDefault();
 		indentInput(event.target);
 		return false;

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
 - [Hides :+1: :-1: comments and shows their count in the sidebar](https://cloud.githubusercontent.com/assets/170270/13241396/0b708ae8-da1d-11e5-8c01-94eae501034c.png)
-- Supports indenting with the tab key in textareas like the comment box
+- Supports indenting with the tab key in textareas like the comment box (use <kbd>shift</kbd>+<kbd>tab</kbd> for original behavior)
 - Automagically expands the news feed when you scroll down
 - Hides other users starring/forking your repos from the newsfeed
 - Prompts you when pressing `Cancel` on an inline comment in case it was a mistake


### PR DESCRIPTION
I often use the <kbd>tab</kbd> key to move on in github forms. I understand the desire to have it indent text, but I'd really like a workaround. I think allowing the user to enter <kbd>alt</kbd> + <kbd>tab</kbd> to get default behavior is reasonable as long as this doesn't interfere with some other common key binding I'm unfamiliar with. (Totally just tripped up again trying to submit this pull request by hitting <kbd>tab</kbd>...)

Definitely open to other ways to enable this...