### PR TITLE
Tabs in code fence (alternative fix to #162)

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -291,11 +291,10 @@ function markMergeCommitsInList() {
 
 function indentInput(el, size = 4) {
 	el.focus();
-	const value = el.value;
-	const selectionStart = el.selectionStart;
-	const indentSize = (size - el.selectionEnd % size) || size;
+	const {selectionStart, value, selectionEnd} = el;
+	const indentSize = (size - selectionEnd % size) || size;
 	const indentationText = ' '.repeat(indentSize);
-	el.value = value.slice(0, selectionStart) + indentationText + value.slice(el.selectionEnd);
+	el.value = value.slice(0, selectionStart) + indentationText + value.slice(selectionEnd);
 	el.selectionEnd = el.selectionStart = selectionStart + indentationText.length;
 }
 


### PR DESCRIPTION
Suggestion from @hkdobrev https://github.com/sindresorhus/refined-github/issues/162#issuecomment-206524661

This will only insert a tab character when your selection is inside of a GFM code fence.

Caveat: A tab will *not* be inserted if you're typing in an unclosed block. We *could* attempt to catch if you're in an open one, but that is going to be fairly difficult.