### PR TITLE
Fix display of "out of date" and "stale" warnings in sticky header

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -304,6 +304,16 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	display: none;
 }
 
+.js-sticky-offset-scroll.is-stuck .subset-files-tab,
+.js-sticky-offset-scroll.is-stuck .stale-files-tab {
+	width: 100%;
+	text-align: center;
+	padding-top: 1px;
+	padding-bottom: 1px;
+	font-size: 11px;
+	margin-top: 5px;
+}
+
 .diff-toolbar-filename {
 	font-weight: bold;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -306,12 +306,10 @@ svg.octicon.octicon-star.dashboard-event-icon {
 
 .js-sticky-offset-scroll.is-stuck .subset-files-tab,
 .js-sticky-offset-scroll.is-stuck .stale-files-tab {
-	width: 100%;
+	width: 120%;
 	text-align: center;
-	padding-top: 1px;
-	padding-bottom: 1px;
-	font-size: 11px;
 	margin-top: 5px;
+	margin-left: -11%;
 }
 
 .diff-toolbar-filename {


### PR DESCRIPTION
Fixes #139 

![image](https://cloud.githubusercontent.com/assets/5233399/14340265/4153026c-fc4b-11e5-9b78-db059d0b9f29.png)

![image](https://cloud.githubusercontent.com/assets/5233399/14340275/510adc7a-fc4b-11e5-954d-51999e42f262.png)

My design skills are *weak*, so let me know if you can think of a better alternative.
