### PR TITLE
Auto deploy to Chrome Webstore on new git tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
 branches:
   only:
     - master
-before_install: npm install -g grunt-cli
 after_success: ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
 branches:
   only:
     - master
+before_install: npm install -g grunt-cli
+after_success: ./deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,9 @@ node_js:
 branches:
   only:
     - master
-after_success: ./deploy.sh
+deploy:
+  provider: script
+  script: ./deploy.sh
+  on:
+    branch: master
+    tags: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,15 +1,15 @@
-var zipFileName = 'extension.zip';
+const zipFileName = 'extension.zip';
 module.exports = function (grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		webstoreUpload: {
 			accounts: {
 				default: {
-					cli_auth: true,
+					cli_auth: true, // eslint-disable-line
 					publish: true,
-					client_id: process.env.CLIENT_ID,
-					client_secret: process.env.CLIENT_SECRET,
-					refresh_token: process.env.REFRESH_TOKEN
+					client_id: process.env.CLIENT_ID, // eslint-disable-line
+					client_secret: process.env.CLIENT_SECRET, // eslint-disable-line
+					refresh_token: process.env.REFRESH_TOKEN // eslint-disable-line
 				}
 			},
 			extensions: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,4 @@
-var archiveName = '/extension.zip';
+var zipFileName = 'extension.zip';
 module.exports = function (grunt) {
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
@@ -14,9 +14,9 @@ module.exports = function (grunt) {
 			},
 			extensions: {
 				refinedGitHub: {
-					appID: 'hlepfoohegkhhmjieoechaddaejaokhf', // edit with your App ID from chrome webstore
+					appID: 'hlepfoohegkhhmjieoechaddaejaokhf', // App ID from chrome webstore
 					publish: true,
-					zip: process.env.TRAVIS_BUILD_DIR + archiveName
+					zip: zipFileName
 				}
 			}
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,27 @@
+var archiveName = '/extension.zip';
+module.exports = function (grunt) {
+	grunt.initConfig({
+		pkg: grunt.file.readJSON('package.json'),
+		webstoreUpload: {
+			accounts: {
+				default: {
+					cli_auth: true,
+					publish: true,
+					client_id: process.env.CLIENT_ID,
+					client_secret: process.env.CLIENT_SECRET,
+					refresh_token: process.env.REFRESH_TOKEN
+				}
+			},
+			extensions: {
+				refinedGitHub: {
+					appID: 'hlepfoohegkhhmjieoechaddaejaokhf', // edit with your App ID from chrome webstore
+					publish: true,
+					zip: process.env.TRAVIS_BUILD_DIR + archiveName
+				}
+			}
+		}
+	});
+
+	grunt.loadNpmTasks('grunt-webstore-upload');
+	grunt.registerTask('default', ['webstoreUpload']);
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  echo `zip -r extension.zip extension/`
+  echo `grunt`
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -ev
-echo `zip -r extension.zip extension/`
-echo `grunt`
+zip -r extension.zip extension/
+grunt

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 set -ev
-if ([ "$TRAVIS_BRANCH" == "master" ] || [ ! -z "$TRAVIS_TAG" ]) && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
-  echo `zip -r extension.zip extension/`
-  echo `grunt`
-fi
+echo `zip -r extension.zip extension/`
+echo `grunt`

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
       "webextensions"
     ],
     "ignores": [
-      "extension/vendor/**",
-      "Gruntfile.js"
+      "extension/vendor/**"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "scripts": {
     "test": "xo"
   },
-  "devDependencies": {
-    "xo": "*"
-  },
   "dependencies": {
     "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
     "grunt-webstore-upload": "^0.8.10"
+  },
+  "devDependencies": {
+    "xo": "*"
   },
   "xo": {
     "esnext": true,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "devDependencies": {
     "xo": "*"
   },
+  "dependencies": {
+    "grunt": "^1.0.1",
+    "grunt-webstore-upload": "^0.8.10"
+  },
   "xo": {
     "esnext": true,
     "envs": [
@@ -13,7 +17,8 @@
       "webextensions"
     ],
     "ignores": [
-      "extension/vendor/**"
+      "extension/vendor/**",
+      "Gruntfile.js"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "scripts": {
     "test": "xo"
   },
-  "dependencies": {
+  "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
-    "grunt-webstore-upload": "^0.8.10"
-  },
-  "devDependencies": {
+    "grunt-webstore-upload": "^0.8.10",
     "xo": "*"
   },
   "xo": {


### PR DESCRIPTION
@sindresorhus This will not work without some steps from you, and as of right not we can't test until it's merged into `master`. I hope you don't mind helping with this PR.

To get this working we need to set some environment variables for Travis CI. You can do this by adding encrypted credentials to the .travis.yml file, or through the Travis CI website. I documented it a bit here https://github.com/paulmolluzzo/test-deploy-chrome

Once that is done, we actually need to have this in `master` because the bash script is going to check that we're on that branch when it runs the script. You can test this outside of `master` by removing the checks in `./deploy.sh`, but you'll want to put them back in so we aren't deploying non-master branches or PRs, which are likely WIP or something.