### PR TITLE
Fix narrow diff view on navigation

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -206,7 +206,7 @@
     cursor: zoom-in !important;
 }
 
-.refined-github-minimized .data {
+.refined-github-minimized .data tbody {
 	display: none !important;
 }
 /* style for delete fork link */


### PR DESCRIPTION
This fixes #176.

The only "bad" thing about this solution is that it doesn't preserver the collapsed state on navigating. I don't think there's a way around it though. I tried switching the class to an `attr` and the issue persisted, so it's something about the DOM being different than expected.