### PR TITLE
Fix reaction avatars with changed GitHub copy

### DIFF
--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -7,6 +7,7 @@ const addReactionParticipants = {
 			$reactionButtons.each((index, element) => {
 				const participantCount = Number(element.innerHTML.split('/g-emoji>')[1]);
 				const participants = element.getAttribute('aria-label')
+					.replace(/ reacted with.*/, '')
 					.replace(/,? and /, ', ')
 					.replace(/, \d+ more/, '')
 					.split(', ');


### PR DESCRIPTION
Fixes #178

GitHub added "reacted with ... emoji" which we add to the last username and add an invalid avatar.

/cc @DrewML 