### PR TITLE
Show reactions popover menu on hover

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -373,3 +373,9 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .reaction-summary-item div img {
 	border-radius: 3px;
 }
+
+/* hide reaction popover text */
+.reaction-popover-form.js-pick-reaction span.js-reaction-description,
+.reaction-popover-form.js-pick-reaction .dropdown-divider {
+	display: none;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, showReactionsMenu */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -317,6 +317,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
+				showReactionsMenu.init();
 				addReactionParticipants.add(username);
 				addReactionParticipants.addListener(username);
 			}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -30,6 +30,7 @@
 				"util.js",
 				"page-detect.js",
 				"diffheader.js",
+				"show-reactions-menu.js",
 				"reactions-avatars.js",
 				"copy-file.js",
 				"content.js"

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -1,3 +1,5 @@
+/* globals showReactionsMenu */
+
 const addReactionParticipants = {
 	add(currentUser) {
 		$('.comment-reactions.has-reactions').each((index, reactionsContainer) => {
@@ -47,6 +49,7 @@ const addReactionParticipants = {
 		}
 
 		const applyReactions = setInterval(() => {
+			showReactionsMenu.init();
 			addReactionParticipants.add(currentUser);
 			clearInterval(applyReactions);
 		}, 500);

--- a/extension/show-reactions-menu.js
+++ b/extension/show-reactions-menu.js
@@ -1,0 +1,53 @@
+let addReactionContainer;
+let reactionButton;
+let reactionPopover;
+let deactivateInterval;
+let isHovering = false;
+
+const showReactionsMenu = { // eslint-disable-line
+	init() {
+		// set the properties related to DOM elements
+		addReactionContainer = $('.reaction-popover-container');
+		reactionButton = $(addReactionContainer).find('button.timeline-comment-action, button.add-reaction-btn');
+		reactionPopover = $(addReactionContainer).find('.add-reaction-popover');
+
+		// apply the event listeners
+		this.mouseEnter();
+		this.mouseLeave();
+	},
+	activatePopover(event) {
+		clearInterval(deactivateInterval);
+		deactivateInterval = null;
+		isHovering = true;
+
+		if ($(event.target).closest('.js-reaction-popover-container').hasClass('active')) {
+			return;
+		}
+		$(event.target).closest('.js-reaction-popover-container').addClass('active');
+	},
+	setDeactivateTimer(event) {
+		isHovering = false;
+
+		if (deactivateInterval) {
+			return;
+		}
+		deactivateInterval = setInterval(() => {
+			clearInterval(deactivateInterval);
+			deactivateInterval = null;
+
+			if (isHovering) {
+				return;
+			}
+
+			$(event.target).closest('.js-reaction-popover-container').removeClass('active');
+		}, 1500);
+	},
+	mouseEnter() {
+		reactionButton.on('mouseenter', this.activatePopover);
+		reactionPopover.on('mouseenter', this.activatePopover);
+	},
+	mouseLeave() {
+		reactionButton.on('mouseleave', this.setDeactivateTimer);
+		reactionPopover.on('mouseleave', this.setDeactivateTimer);
+	}
+};


### PR DESCRIPTION
This fixes #170.

This could be overwrought, but basically it adds event listeners to show/hide the reactions popover menu when hovering over the button that you normally click. I've also added CSS to remove the extra text per: https://github.com/sindresorhus/refined-github/issues/170#issuecomment-207055077