### PR TITLE
Show created repositories

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -227,13 +227,11 @@
 
 /* hide news items when people:
 pushed to a branch
-created a branch
 deleted a branch
 added someone as a collaborator
 forked a repo
 */
 .news .alert.push,
-.news .alert.create.simple,
 .news .alert.delete.simple,
 .news .member_add,
 .news .alert.fork.simple {

--- a/extension/content.js
+++ b/extension/content.js
@@ -276,9 +276,20 @@ document.addEventListener('DOMContentLoaded', () => {
 				.css('display', 'none');
 		};
 
-		hideStarsOwnRepos();
+		const hideCreatedBranches = () => {
+			$('#dashboard .news .alert.create.simple')
+				.css('display', 'none')
+				.has('.octicon-repo')
+				.css('display', 'block');
+		};
 
-		new MutationObserver(() => hideStarsOwnRepos())
+		hideStarsOwnRepos();
+		hideCreatedBranches();
+
+		new MutationObserver(() => {
+			hideStarsOwnRepos();
+			hideCreatedBranches();
+		})
 			.observe($('#dashboard .news').get(0), {childList: true});
 
 		// event binding for infinite scroll


### PR DESCRIPTION
Had to remove the CSS rule too because it took precedence over the one set in JS (since the stylesheet is injected), and apparently you can't set `.css('display', 'block !important')` either.

Fixes #184.