### PR TITLE
Fix textarea resizing not working

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -367,7 +367,7 @@ svg.octicon.octicon-star.dashboard-event-icon {
 
 /* larger comment box */
 .comment-form-textarea {
-	height: 200px !important;
+	min-height: 200px !important;
 }
 
 /* styles for avatars Refined GitHub adds to Reactions */


### PR DESCRIPTION
The resize handler in the right-bottom didn't work because we force the textarea to be bigger by default.

Fixes #203