### PR TITLE
Updated 'created repository' style

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -242,17 +242,45 @@ forked a repo
 remove padding from body of simple news alerts in Dashboard since some will be hidden
 we will add it back on for the simple news alerts we decide to show
 */
+/* - Disabled because these rules were overwriting other padding rules, breaking the layout. -
 .news .alert.create.simple,
 .news .alert.create.simple .body {
 	padding-top: 0;
 	padding-bottom: 0;
 }
+*/
 
 /* add padding back to the contents of simple news alerts in Dashboard */
+/* - Disabled because these rules were overwriting other padding rules, breaking the layout. -
 .news .alert.create.simple .body .title,
 .news .alert.create.simple .body .time {
 	padding-top: 1em;
 	padding-bottom: 1em;
+}
+*/
+
+/* increase visibility of news item when someone create a repo */
+.created.simple .body {
+	min-height: 55px;
+}
+
+svg.octicon.octicon-repo.dashboard-event-icon {
+	height: 32px !important;
+	width: 28px !important;
+}
+
+.created .time {
+	position: absolute;
+	top: 10px;
+	left: 45px;
+}
+
+.created.simple.alert .simple .title {
+	position: absolute;
+	top: 26px;
+	font-size: 14px !important;
+	font-weight: bold;
+	color: inherit !important;
 }
 
 /* don't show contents of simple news alert in Dashboard when you create a branch */

--- a/extension/content.css
+++ b/extension/content.css
@@ -260,7 +260,7 @@ we will add it back on for the simple news alerts we decide to show
 */
 
 /* increase visibility of news item when someone create a repo */
-.created.simple .body {
+.create.simple .body {
 	min-height: 55px;
 }
 
@@ -269,13 +269,13 @@ svg.octicon.octicon-repo.dashboard-event-icon {
 	width: 28px !important;
 }
 
-.created .time {
+.create .time {
 	position: absolute;
 	top: 10px;
 	left: 45px;
 }
 
-.created.simple.alert .simple .title {
+.create.simple.alert .simple .title {
 	position: absolute;
 	top: 26px;
 	font-size: 14px !important;


### PR DESCRIPTION
Added the rules for display the `user created repository user/repo` news as the others.
*I've commented some rules because they were overwriting the correct style.*

I've made all the work with the Chrome dev tools and for me everything is ok, but it's better if you check it as well. 😄 