### PR TITLE
Limit indenting of textarea contents to the comment field only

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -233,7 +233,9 @@ function showRecentlyPushedBranches() {
 // Support indent with tab key in textarea elements
 $(document).on('keydown', event => {
 	// Check event.target instead of using a delegate, because Sprint doesn't support them
-	if (!$(event.target).is('textarea')) {
+	const $target = $(event.target);
+	// Limit indenting to just the textarea in comments
+	if (!($target.is('textarea') && $target.hasClass('js-comment-field'))) {
 		return;
 	}
 


### PR DESCRIPTION
The current behavior conflicts with `OctoEdit`, and it's a bit of a pain.

There is still discussion in #195 about whether we should have this feature in the extension at all. Since that discussion may take a bit, would be nice to get this in for now.