### PR TITLE
Add shortcuts to access patch/diff - fix #220

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY, patchDiffShortcuts */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -173,25 +173,6 @@ function linkifyIssuesInTitles() {
 	}
 }
 
-function addPatchDiffLinks() {
-	if ($('.sha-block.patch-diff-links').length > 0) {
-		return;
-	}
-
-	let commitUrl = location.pathname.replace(/\/$/, '');
-	if (pageDetect.isPRCommit()) {
-		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
-	}
-	const commitMeta = $('.commit-meta span.right').get(0);
-
-	$(commitMeta).append(`
-		<span class="sha-block patch-diff-links">
-			<a href="${commitUrl}.patch" class="sha">.patch</a>
-			<a href="${commitUrl}.diff" class="sha">.diff</a>
-		</span>
-	`);
-}
-
 function markMergeCommitsInList() {
 	$('.commit.commits-list-item.table-list-item:not(.refined-github-merge-commit)').each((index, element) => {
 		const $element = $(element);
@@ -334,7 +315,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (pageDetect.isCommit()) {
-				addPatchDiffLinks();
+				patchDiffShortcuts();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,6 +33,7 @@
 				"reactions-avatars.js",
 				"copy-file.js",
 				"copy-on-y.js",
+				"patch-diff-shortcuts.js",
 				"content.js"
 			]
 		}

--- a/extension/patch-diff-shortcuts.js
+++ b/extension/patch-diff-shortcuts.js
@@ -1,0 +1,33 @@
+/* globals pageDetect */
+
+'use strict';
+
+const PLUS_EQUAL_KEYCODE = 187;
+
+window.patchDiffShortcuts = () => {
+	$(document).on('keyup', e => {
+		let commitUrl = location.pathname.replace(/\/$|\.diff$|\.patch$/, '');
+		if (pageDetect.isPRCommit()) {
+			commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
+		}
+
+		// the plus/equal sign and the shift key and alt key go to original commit url
+		// not using the meta key because Chrome uses those keys to zoom
+		if (e.which === PLUS_EQUAL_KEYCODE && e.shiftKey && e.altKey) {
+			location.href = commitUrl;
+			return;
+		}
+
+		// the plus/equal sign and the shift key together make +
+		if (e.which === PLUS_EQUAL_KEYCODE && e.shiftKey) {
+			location.href = `${commitUrl}.patch`;
+			return;
+		}
+
+		// the plus/equal sign and no shift key is =
+		if (e.which === PLUS_EQUAL_KEYCODE && !e.shiftKey) {
+			location.href = `${commitUrl}.diff`;
+			return;
+		}
+	});
+};

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds a 'Copy' button to the file view](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
 - [Adds a shortcut to quickly delete a forked repo](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
 - [Adds ability to collapse/expand files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
-- [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
+- Adds keyboard shortcuts links to patch and diff for each commit (on a commit page, <kbd>=</kbd> for the diff, <kbd>+</kbd> for the patch, <kbd>Alt</kbd>+<kbd>+</kbd> for usual commit)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
 - Shows the reactions popover on hover instead of click
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)


### PR DESCRIPTION
This is a fix for #220 that removes the patch/diff links on commit pages introduced in #66 and replaces them with keyboard shortcuts.

To use this PR, on a commit page you press the<kbd>shift</kbd>+<kbd>+/=</kbd> to view the patch, or <kbd>+/=</kbd> to view the diff or <kbd>shift</kbd>+<kbd>alt</kbd>+<kbd>+/=</kbd> to view the original. 

~~This is a WIP because of failing `ava` tests.~~

These tests only fail locally I guess. If anyone else has failures please comment.