### PR TITLE
Restore command line instructions panel

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -71,11 +71,6 @@
 	visibility: hidden;
 }
 
-/* remove useless message on the right side of the PR merge box */
-.alt-merge-options {
-	display: none !important;
-}
-
 /* remove top buttons on comment box */
 .timeline-comment-wrapper .tabnav-extra, .inline-comment-form-container .tabnav-extra {
 	display: none !important;


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8056274/15448098/9afecef2-1f89-11e6-836f-81c7d305c98f.png)

Saying the command line instructions panel (and its content, as shown above) is [useless](https://github.com/sindresorhus/refined-github/commit/07ecc75e81cbc466d6bc98a12505ae58fec68d59#diff-83ab1d10d74dc75c62ac9cf612cfce51R57) is debatable. I would argue that the panel serves its purpose, at least for immediate-level developers. I, for one, would always copy and paste the commands provided with it to test a PR instead of having to remember and type all of them down. 

Also, by default the panel is hidden and doesn't take any space, so hiding it doesn't gain anything, but instead removes a (possibly) useful feature.