### PR TITLE
blame parent links should link to specific line

### DIFF
--- a/extension/add-blame-parent-links.js
+++ b/extension/add-blame-parent-links.js
@@ -1,0 +1,46 @@
+'use strict';
+
+window.addBlameParentLinks = (() => {
+	const getFirstAndLastAffectedLineOfBlame = $commitLink => {
+		const $lines = $commitLink.parent().parent().nextUntil('.blame-commit');
+		const $firstAndLast = [];
+		$firstAndLast.push($lines.eq(0));
+		if ($lines.length > 1) {
+			$firstAndLast.push($lines.eq($lines.length - 1));
+		}
+
+		return $firstAndLast;
+	};
+
+	const parseAffectedLines = $commitLink => {
+		return getFirstAndLastAffectedLineOfBlame($commitLink)
+			.map(item => item.children().eq(1).attr('id').replace(/^L(\d+)$/, '$1'))
+			.reduce((prev, cur, i) => [prev, cur].join(i === 0 ? '' : '-'), 'L');
+	};
+
+	return () => {
+		$('.blame-sha:not(.js-blame-parent)').each((index, commitLink) => {
+			const $commitLink = $(commitLink);
+
+			const $blameMetaContainer = $commitLink.nextAll('.blame-commit-meta');
+			if ($blameMetaContainer.find('.js-blame-parent').length > 0) {
+				return;
+			}
+
+			const blameTargets = parseAffectedLines($commitLink);
+			const $blameParentLink = $commitLink.clone();
+			const commitSha = /\w{40}$/.exec(commitLink.href)[0];
+			const href = location.pathname.replace(
+				/(\/blame\/)[^\/]+/,
+				`$1${commitSha}`
+			);
+
+			$blameParentLink
+				.text('Blame ^')
+				.addClass('js-blame-parent')
+				.prop('href', `${href}#${blameTargets}`);
+
+			$blameMetaContainer.append($blameParentLink);
+		});
+	};
+})();

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY, showRealNames */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY, addBlameParentLinks, showRealNames */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -97,29 +97,6 @@ function infinitelyMore() {
 	if (wScroll > (btnOffset - wHeight)) {
 		btn.click();
 	}
-}
-
-function addBlameParentLinks() {
-	$('.blame-sha:not(.js-blame-parent)').each((index, commitLink) => {
-		const $commitLink = $(commitLink);
-		const $blameMetaContainer = $commitLink.nextAll('.blame-commit-meta');
-		if ($blameMetaContainer.find('.js-blame-parent').length > 0) {
-			return;
-		}
-
-		const $blameParentLink = $commitLink.clone();
-		const commitSha = /\w{40}$/.exec(commitLink.href)[0];
-
-		$blameParentLink
-			.text('Blame ^')
-			.addClass('js-blame-parent')
-			.prop('href', location.pathname.replace(
-				/(\/blame\/)[^\/]+/,
-				`$1${commitSha}${encodeURI('^')}`
-			));
-
-		$blameMetaContainer.append($blameParentLink);
-	});
 }
 
 function addReadmeEditButton() {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -34,7 +34,8 @@
 				"copy-file.js",
 				"copy-on-y.js",
 				"show-names.js",
-				"content.js"
+				"content.js",
+				"add-blame-parent-links.js"
 			]
 		}
 	]


### PR DESCRIPTION
Fixes #208 

This PR traverses over the DOM in the ``git blame`` table in the UI in order to find all lines affected by a change and adds them as hash URLs. Old ``#L123`` will be removed