### PR TITLE
Show real names next to usernames in comments. Closes #250

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -478,3 +478,8 @@ hidden content area created to increase hover target
 	padding-top: 0 !important;
 	border-top: none !important;
 }
+
+.comment-full-name {
+	font-weight: normal;
+	margin-left: 4px;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY */
+/* globals gitHubInjection, pageDetect, diffFileHeader, addReactionParticipants, addFileCopyButton, enableCopyOnY, showRealNames */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -343,6 +343,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
 				addReactionParticipants.add(username);
 				addReactionParticipants.addListener(username);
+				showRealNames();
 			}
 
 			if (pageDetect.isCommitList()) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,6 +33,7 @@
 				"reactions-avatars.js",
 				"copy-file.js",
 				"copy-on-y.js",
+				"show-names.js",
 				"content.js"
 			]
 		}

--- a/extension/show-names.js
+++ b/extension/show-names.js
@@ -1,0 +1,59 @@
+window.showRealNames = () => {
+	const storageKey = 'cachedNames';
+
+	const getCachedUsers = cb => {
+		chrome.storage.local.get(storageKey, data => cb(data[storageKey]));
+	};
+
+	const updateCachedUsers = users => {
+		chrome.storage.local.set({[storageKey]: users});
+	};
+
+	const addUsersName = (user, name) => {
+		const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
+		$usernameLinks.each((i, userLink) => {
+			$(`<span class="comment-full-name">(${name}) -</span>`).insertAfter(userLink);
+			$(userLink).closest('.timeline-comment-header-text').addClass('has-full-name');
+		});
+	};
+
+	getCachedUsers((users = {}) => {
+		const usersOnPage = $('.js-discussion .author').dom.map(el => el.innerText);
+		const uniqueUsers = new Set(usersOnPage);
+
+		// Add cached users to DOM first, since the calls for everyone else will be slow
+		for (const user of uniqueUsers) {
+			const cachedName = users[user];
+			if (cachedName) {
+				addUsersName(user, cachedName);
+				uniqueUsers.delete(user);
+			}
+		}
+
+		const userUrl = user => `https://github.com/${user}/following`;
+		const requests = Array.from(uniqueUsers).map(username => {
+			const req = fetch(userUrl(username));
+			return req.then(res => res.text()).then(profile => ({
+				username,
+				profile
+			}));
+		});
+
+		Promise.all(requests).then(profiles => {
+			const userCache = {};
+
+			for (const {username, profile} of profiles) {
+				const profileDOM = new DOMParser().parseFromString(profile, 'text/html');
+				const fullname = $(profileDOM.querySelector('h1 strong')).text().slice(1, -1);
+
+				// Possible for a user to not set a name
+				if (fullname) {
+					userCache[username] = fullname;
+					addUsersName(username, fullname);
+				}
+			}
+
+			updateCachedUsers(Object.assign({}, users, userCache));
+		}).catch(err => console.error(err));
+	});
+};

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds ability to collapse/expand files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
+- [Show user's full name in comments](https://cloud.githubusercontent.com/assets/5233399/16167507/80a09148-34bb-11e6-960a-515157fd28c8.png)
 - Shows the reactions popover on hover instead of click
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - Automagically expands the news feed when you scroll down


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5233399/16139367/019c6066-340c-11e6-82e8-2127a6dd0fbb.png)

I made the decision to cache all users real names in `chrome.storage.local`, since I don't think it's super common for people to change their name. Let me know if anyone has any strong opinions here.

So far, I've verified this works in the following places/scenarios:

1. Comments on issues
2. Comments on PRs
3. "Outdated" comments in PRs (after clicking to expand)
4. On partial page nav back/forward

[Here is a good issue to use as a test case](https://github.com/isaacs/github/issues/9). Note the second refresh (after all names load) is much faster. Pretty happy that `chrome.storage` is async, or we'd be having a baddd time.

Note: I did this directly with native DOM APIs, but happy to switch the implementation over to Sprint if desired.