### PR TITLE
skip linkifyBranchRefs() if fork has been removed

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -159,6 +159,11 @@
 	text-decoration: underline !important;
 }
 
+.commit-ref.unlinked:hover,
+.commit-ref.unlinked:hover span {
+	text-decoration: none !important;
+}
+
 /* remove the "new feature" notification box */
 .js-notice {
 	display: none !important;

--- a/extension/content.js
+++ b/extension/content.js
@@ -8,6 +8,7 @@ const getUsername = () => $('meta[name="user-login"]').attr('content');
 function linkifyBranchRefs() {
 	$('.commit-ref').each((i, el) => {
 		if ($(el).children().eq(0).text() === 'unknown repository') {
+			$(el).addClass('unlinked');
 			return;
 		}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -7,6 +7,10 @@ const getUsername = () => $('meta[name="user-login"]').attr('content');
 
 function linkifyBranchRefs() {
 	$('.commit-ref').each((i, el) => {
+		if ($(el).children().eq(0).text() === 'unknown repository') {
+			return;
+		}
+
 		const parts = $(el).find('.css-truncate-target');
 		const branch = encodeURIComponent(parts.eq(parts.length - 1).text());
 		let username = ownerName;

--- a/extension/content.js
+++ b/extension/content.js
@@ -7,12 +7,13 @@ const getUsername = () => $('meta[name="user-login"]').attr('content');
 
 function linkifyBranchRefs() {
 	$('.commit-ref').each((i, el) => {
-		if ($(el).children().eq(0).text() === 'unknown repository') {
-			$(el).addClass('unlinked');
+		const $el = $(el);
+		if ($el.children().eq(0).text() === 'unknown repository') {
+			$el.addClass('unlinked');
 			return;
 		}
 
-		const parts = $(el).find('.css-truncate-target');
+		const parts = $el.find('.css-truncate-target');
 		const branch = encodeURIComponent(parts.eq(parts.length - 1).text());
 		let username = ownerName;
 
@@ -21,7 +22,7 @@ function linkifyBranchRefs() {
 			username = parts.eq(0).text();
 		}
 
-		$(el).wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
+		$el.wrap(`<a href="https://github.com/${username}/${repoName}/tree/${branch}">`);
 	});
 }
 


### PR DESCRIPTION
Minor bug I've observed with the branch ref linkifications if the repository has been removed.
This change avoids linkifying a branch if the repository is unknown as this would result in broken links.