### PR TITLE
remove diff signs

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -483,3 +483,19 @@ hidden content area created to increase hover target
 	font-weight: normal;
 	margin-left: 4px;
 }
+
+/* +/- pseudo elements on diffs */
+td.blob-code.blob-code-addition:before,
+td.blob-code.blob-code-deletion:before {
+	display: inline-block;
+	position: absolute;
+	color: rgba(0, 0, 0, 0.3);
+}
+
+td.blob-code.blob-code-addition:before {
+	content: '+';
+}
+
+td.blob-code.blob-code-deletion:before {
+	content: '-';
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -170,6 +170,14 @@ function addPatchDiffLinks() {
 	`);
 }
 
+function removeDiffSigns() {
+	$('.blob-code-deletion .blob-code-inner, .blob-code-addition .blob-code-inner').each((index, element) => {
+		const textNode = element.childNodes[0];
+
+		textNode.nodeValue = textNode.nodeValue.replace(/^[+-]/, ' ');
+	});
+}
+
 function markMergeCommitsInList() {
 	$('.commit.commits-list-item.table-list-item:not(.refined-github-merge-commit)').each((index, element) => {
 		const $element = $(element);
@@ -301,6 +309,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isCommit()) {
 				addPatchDiffLinks();
+			}
+
+			if (pageDetect.isCommit() || pageDetect.isPRFiles()) {
+				removeDiffSigns();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/readme.md
+++ b/readme.md
@@ -25,6 +25,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds ability to collapse/expand files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
 - [Adds links to patch and diff for each commit](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
 - [Differentiates merge commits from regular commits](https://cloud.githubusercontent.com/assets/170270/14101222/2fe2c24a-f5bd-11e5-8b1f-4e589917d4c4.png)
+- +/- signs on diffs are not selectable, making it easier to copy and paste
 - Shows the reactions popover on hover instead of click
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - Automagically expands the news feed when you scroll down


### PR DESCRIPTION
I feel like the red and green backgrounds on diffs are explanatory enough, and the +/- just make things messier.

## Before
![screenshot from 2016-06-22 23 48 35](https://cloud.githubusercontent.com/assets/5340692/16293141/a7ec27a4-38d4-11e6-86e1-a71d341a750d.png)

## After
![screenshot from 2016-06-22 23 49 11](https://cloud.githubusercontent.com/assets/5340692/16293148/ae641cea-38d4-11e6-9e9c-24e5dae54008.png)
