### PR TITLE
Allow collapse of all file diffs

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -206,7 +206,7 @@
     cursor: zoom-in !important;
 }
 
-.refined-github-minimized .data tbody {
+.refined-github-minimized .data {
 	display: none !important;
 }
 /* style for delete fork link */


### PR DESCRIPTION
Allow other types of file diffs to be hidden, not just ones with tables.

Note: This will set the entire div to `display: none`

Example of a diff that can't be collapsed:
![image](https://cloud.githubusercontent.com/assets/581684/16506056/4ae817e8-3edd-11e6-9043-7e673115cd6d.png)
