### PR TITLE
Do not show new PR button on issues/pulls when repo is empty

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -201,11 +201,25 @@ function showRecentlyPushedBranches() {
 		return;
 	}
 
-	const uri = `/${repoUrl}/show_partial?partial=tree/recently_touched_branches_list`;
-	const fragMarkup = `<include-fragment src=${uri}></include-fragment>`;
-	const div = document.createElement('div');
-	div.innerHTML = fragMarkup;
-	$('.repository-content').prepend(div);
+	const codeURI = $('[data-hotkey="g c"]').attr('href');
+
+	fetch(codeURI, {
+		credentials: 'include'
+	}).then(res => res.text()).then(html => {
+		const codeDOM = new DOMParser().parseFromString(html, 'text/html');
+		const isEmpty = $(codeDOM).find('.blankslate').length;
+
+		// https://github.com/sindresorhus/refined-github/issues/216
+		if (isEmpty) {
+			return;
+		}
+
+		const uri = `/${repoUrl}/show_partial?partial=tree/recently_touched_branches_list`;
+		const fragMarkup = `<include-fragment src=${uri}></include-fragment>`;
+		const div = document.createElement('div');
+		div.innerHTML = fragMarkup;
+		$('.repository-content').prepend(div);
+	});
 }
 
 // Support indent with tab key in comments


### PR DESCRIPTION
Fixed #216 

Working on public, non-empty repo:
![image](https://cloud.githubusercontent.com/assets/5233399/16672289/d1abafc8-446a-11e6-82ff-b55d8d68db50.png)

No home page showing on empty repo:
![image](https://cloud.githubusercontent.com/assets/5233399/16672329/1527fa90-446b-11e6-9801-d583aedd621c.png)


The only reliable way I could find to do this was to do an HTTP Request. If someone knows a better way, happy to change it.
