### PR TITLE
Fix the toolbar top margin

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -117,6 +117,9 @@ body {
 .toolbar-group .js-saved-reply-container {
 	display: block;
 }
+.toolbar-commenting {
+	margin-top: 4px;
+}
 
 /* remove upload message on comment box */
 .write-content .drag-and-drop {


### PR DESCRIPTION
This PR fixes the toolbar's top margin.

### Before

![before](https://cloud.githubusercontent.com/assets/1192057/16802030/a1aad324-48fe-11e6-969f-8ddad52b3750.png)

### After

![after](https://cloud.githubusercontent.com/assets/1192057/16802053/bfdd1690-48fe-11e6-8618-d8b41f6cf186.png)
