### PR TITLE
Add min-height to newsfeed

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -259,6 +259,11 @@ forked a repo
 	display: none !important;
 }
 
+/* ensure the news feed is still shown once the items above have been hidden */
+.news {
+	min-height: 1px;
+}
+
 /*
 remove padding from body of simple news alerts in Dashboard since some will be hidden
 we will add it back on for the simple news alerts we decide to show


### PR DESCRIPTION
To ensure the newsfeed is shown even when it’s empty. This keeps the
repository column in place and avoids the following problem for those of us where there's not a lot going on...
![screen shot 2016-07-13 at 18 32 18](https://cloud.githubusercontent.com/assets/219017/16811575/51fcab88-4929-11e6-942c-7aabf5d5af07.png)
