### PR TITLE
Fix #268 - safely insert usernames into DOM in showRealNames()

### DIFF
--- a/extension/show-names.js
+++ b/extension/show-names.js
@@ -12,7 +12,7 @@ window.showRealNames = () => {
 	const addUsersName = (user, name) => {
 		const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
 		$usernameLinks.each((i, userLink) => {
-			$(`<span class="comment-full-name">(${name}) -</span>`).insertAfter(userLink);
+			$(`<span class="comment-full-name">`).text(`${name} -`).insertAfter(userLink);
 			$(userLink).closest('.timeline-comment-header-text').addClass('has-full-name');
 		});
 	};


### PR DESCRIPTION
This is a fix for #268. Thanks to @LoicMahieu for pointing out this bug!

This strips opening/closing `script` tags from usernames. There might be better solution that actually _preserves_ the `script` tag and doesn't let it execute, but I don't know that we care.

Really any time we shove some unknown string into the DOM it should be cleaned in some way, so if we want to do a comprehensive review let's do that.

// @DrewML 