### PR TITLE
Avoid hiding the jobs ad

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -187,11 +187,6 @@ body {
 	display: none !important;
 }
 
-/* hide jobs ads from the dashboard */
-.github-jobs-promotion {
-	display: none !important;
-}
-
 /* remove useless tip in the organization news feed */
 #dashboard .alert.git_hub {
 	display: none !important;


### PR DESCRIPTION
GitHub is a great free service, I feel bad to hide the only unobtrusive and relevant ad they have. It's there only when you [mark yourself](https://github.com/settings/profile#user_profile_hireable) as "Available for hire"

<img width="460" alt="github jobs" src="https://cloud.githubusercontent.com/assets/1402241/17031818/e26b956a-4f2a-11e6-90a2-afabfac3b4c7.png">
