### PR TITLE
Add parens back to real name in comments

### DIFF
--- a/extension/show-names.js
+++ b/extension/show-names.js
@@ -12,7 +12,7 @@ window.showRealNames = () => {
 	const addUsersName = (user, name) => {
 		const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
 		$usernameLinks.each((i, userLink) => {
-			$(`<span class="comment-full-name">`).text(`${name} -`).insertAfter(userLink);
+			$(`<span class="comment-full-name">`).text(`(${name}) -`).insertAfter(userLink);
 			$(userLink).closest('.timeline-comment-header-text').addClass('has-full-name');
 		});
 	};


### PR DESCRIPTION
We dropped the parens in #269, but I don't think it was intentional.