### PR TITLE
Fix organisation dashboard pagehead nav

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -153,7 +153,7 @@ body {
 	padding-top: 50px;
 }
 /* organization dashboard */
-.orgpage .pagehead-nav {
+.orgpage .underline-nav {
 	float: left !important;
 }
 .orgpage .account-switcher {


### PR DESCRIPTION
GitHub must've updated the CSS class on the nav.

### Before
![image](https://cloud.githubusercontent.com/assets/2037851/17701555/df243862-63fc-11e6-9d4c-2c018758bfc4.png)

### After
![image](https://cloud.githubusercontent.com/assets/2037851/17701605/05b0c806-63fd-11e6-9cd2-ce57b510a2ac.png)
