### PR TITLE
Fix minimizing images in pull request diffs

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -224,6 +224,7 @@ body {
     cursor: zoom-in !important;
 }
 
+/* style for collapse/expand feature; images are rendered in .render-wrapper, not in .data */
 .refined-github-minimized .data,
 .refined-github-minimized .render-wrapper {
 	display: none !important;

--- a/extension/content.css
+++ b/extension/content.css
@@ -224,7 +224,8 @@ body {
     cursor: zoom-in !important;
 }
 
-.refined-github-minimized .data {
+.refined-github-minimized .data,
+.refined-github-minimized .render-wrapper {
 	display: none !important;
 }
 /* style for delete fork link */


### PR DESCRIPTION
Images are rendered in a `.render-wrapper` instead of a `.data` element

<img width="569" alt="gh-image-render-wrapper" src="https://cloud.githubusercontent.com/assets/12849807/18164628/42a2780e-7041-11e6-9b58-47df3b4a2fa9.png">
