### PR TITLE
custom.css: Add "Fira Code" monospace font-family for code ligatures

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -25,5 +25,5 @@ tt,
 .gollum-editor .gollum-editor-body,
 .input-monospace,
 .wiki-wrapper .wiki-history .commit-meta code {
-	font-family: 'Ubuntu Mono', 'Droid Sans Mono', 'Operator Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
+	font-family: 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Operator Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }


### PR DESCRIPTION
This PR adds [Fira Code](https://github.com/tonsky/FiraCode) to the list of mono-space fonts to enable the use of code ligatures.

Before:

![bildschirmfoto 2016-09-08 um 09 46 29](https://cloud.githubusercontent.com/assets/141300/18341332/d09b5b7c-75a9-11e6-9cd1-c8392d3606d0.png)

After:

![bildschirmfoto 2016-09-08 um 09 46 08](https://cloud.githubusercontent.com/assets/141300/18341333/d24bd6a4-75a9-11e6-9197-24f6f29195d6.png)
