### PR TITLE
Add missing BtnGroup-item class to copy button

### DIFF
--- a/extension/copy-file.js
+++ b/extension/copy-file.js
@@ -10,7 +10,7 @@ window.addFileCopyButton = () => {
 
 	const $targetSibling = $('#raw-url');
 	const fileUri = $targetSibling.attr('href');
-	$(`<a href="${fileUri}" class="btn btn-sm copy-btn">Copy</a>`).insertBefore($targetSibling);
+	$(`<a href="${fileUri}" class="btn btn-sm BtnGroup-item copy-btn">Copy</a>`).insertBefore($targetSibling);
 
 	$(document).on('click', '.copy-btn', e => {
 		e.preventDefault();


### PR DESCRIPTION
Adds an extra class (`BtnGroup-item`) to the copy button to fix the look.

## Before
![image](https://cloud.githubusercontent.com/assets/2037851/18622604/35b4a91a-7e64-11e6-913e-697196aaa3c6.png)

## After
![image](https://cloud.githubusercontent.com/assets/2037851/18622602/2ea81972-7e64-11e6-9c16-e63bfbe6216d.png)
