### PR TITLE
[CSS] Hide `new-user-avatar-cta` protip box

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -533,3 +533,8 @@ td.blob-code.blob-code-addition:before {
 td.blob-code.blob-code-deletion:before {
 	content: '-';
 }
+
+/* remove "pro tip!" box on profile page (appears when name isn't set) */
+.new-user-avatar-cta {
+	display: none !important;
+}


### PR DESCRIPTION
Hides the annoying 'Pro Tip! Updating your profile...' box on the personal profile page (appears whenever your name isn't set)