### PR TITLE
Fix delete fork button for merged PRs

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -128,7 +128,7 @@ function addDeleteForkLink() {
 
 	if ($postMergeContainer.length > 0) {
 		const $postMergeDescription = $postMergeContainer.find('.merge-branch-description');
-		const forkPath = $postMergeContainer.attr('data-channel').split(':')[0];
+		const forkPath = `${getUsername()}/${repoName}`;
 
 		if (forkPath !== repoUrl) {
 			$postMergeDescription.append(

--- a/extension/content.js
+++ b/extension/content.js
@@ -128,7 +128,7 @@ function addDeleteForkLink() {
 
 	if ($postMergeContainer.length > 0) {
 		const $postMergeDescription = $postMergeContainer.find('.merge-branch-description');
-		const forkPath = `${getUsername()}/${repoName}`;
+		const forkPath = $postMergeDescription.find('.commit-ref.current-branch')[0].title.split(':')[0];
 
 		if (forkPath !== repoUrl) {
 			$postMergeDescription.append(


### PR DESCRIPTION
This fixes #298.

I changed the method of making the fork path to use an `attr` found in the DOM that has the fork's user and repo name. It seems like this is appropriate for creating the path to the settings for the fork, and the existing tests (not the original repo, is merged, etc.) remained intact.