### PR TITLE
Fix alignment of the comment body for PR reviews

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -532,3 +532,8 @@ td.blob-code.blob-code-deletion:before {
 .diffbar > .diffstat {
 	float: right;
 }
+
+/* fix padding for comment-body when reviewing a PR */
+.review-comment .comment-body {
+	padding-left: 44px;
+}


### PR DESCRIPTION
Extremely annoying, especially for a front-end developer… 😡

See the attached screenshot (red vertical line is just for showing the wrong alignment):
![github](https://cloud.githubusercontent.com/assets/11782/20102731/7601fc90-a5c7-11e6-9dd2-9b55734020a8.jpg)
