### PR TITLE
Move Operator Mono to top of font stack

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -26,7 +26,7 @@ tt,
 .gollum-editor .gollum-editor-body,
 .input-monospace,
 .wiki-wrapper .wiki-history .commit-meta code {
-	font-family: 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Operator Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
+	font-family: 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }
 
 .CodeMirror-lines pre.CodeMirror-line {


### PR DESCRIPTION
Since Operator Mono is a $200 font, I think it being installed is much more likely to indicate that it's preferred by the user. Thoughts?