### PR TITLE
Add Collapse All/Expand All button to PR diffs. Closes #226

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, addBlameParentLinks, showRealNames, markUnread */
+/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, addBlameParentLinks, showRealNames, markUnread, toggleDiffChanges */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -406,6 +406,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 				diffFileHeader.setup();
+				toggleDiffChanges.init();
 				addDiffViewWithoutWhitespaceOption('pr');
 			}
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -36,6 +36,7 @@
 				"copy-gist.js",
 				"copy-on-y.js",
 				"show-names.js",
+				"toggle-diff-changes.js",
 				"content.js",
 				"add-blame-parent-links.js",
 				"mark-unread.js"

--- a/extension/toggle-diff-changes.js
+++ b/extension/toggle-diff-changes.js
@@ -1,0 +1,26 @@
+'use strict';
+
+window.toggleDiffChanges = (() => {
+	const init = () => {
+		if ($('.js-collapse-all').length > 0) {
+			return;
+		}
+
+		const html = `<button type="button" class="btn btn-sm js-collapse-all">Collapse All</button>`;
+		const $btn = $(html).appendTo('.gh-header-actions');
+
+		let allCollapsed = false;
+		$btn.click(() => {
+			$('.file-header').click();
+			if (allCollapsed) {
+				$btn.text('Collapse All');
+			} else {
+				$btn.text('Expand All');
+			}
+
+			allCollapsed = !allCollapsed;
+		});
+	};
+
+	return {init};
+})();

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - Removes the comment box toolbar
 - Removes tooltips
 - Copy canonical link to file when [the `y` hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) is used
+- Collapse All/Expand All buttons added to diffs on pull requests
 
 And [lots](extension/content.css) [more...](extension/content.js)
 


### PR DESCRIPTION
Really painful to review PRs in `Babylon` like [this one](https://github.com/babel/babylon/pull/213/files) when a large number of fixture files have changed in the same commit, but I just want to start by skimming the code. This helps.

Let me know if anyone wants to change the placement of the button. I didn't put it in the diffbar (the one that floats on scroll) because we are already tight on space for the feature that shows the file currently being viewed.

![collaprseexpand](https://cloud.githubusercontent.com/assets/5233399/21746266/515854b8-d504-11e6-8b49-96b58e983a76.gif)
