### PR TITLE
Resize source pane to fit into viewport

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, addBlameParentLinks, showRealNames, markUnread */
+/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, addBlameParentLinks, showRealNames, markUnread, resizeSourcePane */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -354,6 +354,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		}).observe($('#js-pjax-container').get(0), {childList: true});
 	}
 
+	resizeSourcePane.destroy();
 	if (pageDetect.isRepo()) {
 		gitHubInjection(window, () => {
 			addReleasesTab();
@@ -372,6 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isBlame()) {
 				addBlameParentLinks();
+				resizeSourcePane.setup();
 			}
 
 			if (pageDetect.isRepoRoot() || pageDetect.isRepoTree()) {
@@ -412,6 +414,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isSingleFile()) {
 				addFileCopyButton();
 				enableCopyOnY.setup();
+				resizeSourcePane.setup();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue()) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -38,7 +38,8 @@
 				"show-names.js",
 				"content.js",
 				"add-blame-parent-links.js",
-				"mark-unread.js"
+				"mark-unread.js",
+				"resize-source-pane.js"
 			]
 		}
 	]

--- a/extension/resize-source-pane.js
+++ b/extension/resize-source-pane.js
@@ -1,0 +1,36 @@
+window.resizeSourcePane = (() => {
+	function _resizePane() {
+		const blobWrapper = $('.file > .blob-wrapper');
+		if (blobWrapper[0].clientWidth >= blobWrapper[0].scrollWidth) { // do not resize if no horizontal scroll
+			blobWrapper.css({
+				'overflow-y': '',
+				'max-height': ''
+			});
+			return;
+		}
+
+		const fileHeaderBottom = $('.file > .file-header')[0].getBoundingClientRect().bottom;
+		let availHeight = window.innerHeight - fileHeaderBottom - 20;
+		if (availHeight <= 100) {
+			availHeight = 100;
+		}
+		blobWrapper.css({
+			'overflow-y': 'auto',
+			'max-height': availHeight + 'px'
+		});
+	}
+
+	const setup = () => {
+		_resizePane();
+		$(window).on('resize.filepane', _resizePane);
+	};
+
+	const destroy = () => {
+		$(window).off('resize.filepane');
+	};
+
+	return {
+		setup,
+		destroy
+	};
+})();


### PR DESCRIPTION
This is helpful when viewing a large source file, hundreds of lines and maybe some lines are too long to view it. Without this, you might need to scroll to bottom to find the horizontal scrollbar and then move it right...
Now, this feature sets `max-height` of the source pane element (`.blob-wrapper`) to a proper value so that the horizontal scrollbar is shown in the viewport and vertical scrolling is also enabled via `overflow-y: auto`. In addition, it does nothing if no horizontal scrolling (source is properly formatted).