### PR TITLE
Restore Open in Desktop button

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -2,11 +2,6 @@
 	highly opinionated changes
 */
 
-/* remove clone/open in desktop buttons */
-a[href^="github-mac"] {
-	display: none !important;
-}
-
 /* remove "Pulse" repo tab */
 .reponav a[href$="/pulse"] {
 	display: none !important;


### PR DESCRIPTION
The button was moved inside a combined download/clone popup. Hiding it in there now just leaves empty space inside a button that says "**Clone** or download"

Current:

<img width="384" alt="current" src="https://cloud.githubusercontent.com/assets/1402241/22850834/95f43598-efc5-11e6-9a7b-a3c8597f6f87.png">

After this PR:

<img width="404" alt="after" src="https://cloud.githubusercontent.com/assets/1402241/22850836/9bac6cf8-efc5-11e6-8a4d-bebf3ca6325a.png">
