### PR TITLE
Limit reaction avatars when there are too many

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -393,19 +393,20 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	padding-left: 10px !important;
 	padding-right: 10px !important;
 }
-.reaction-summary-item a {
-	display: inline-block;
-	transition: margin-left 0.2s;
-	padding-left: 3px;
-}
 
 .reaction-summary-item.add-reaction-btn {
 	padding-right: 0 !important;
 }
 
 .reaction-summary-item div,
+.reaction-summary-item div a,
 .reaction-summary-item div img {
 	display: inline-block;
+}
+
+.reaction-summary-item div a {
+	transition: margin-left 0.2s;
+	padding-left: 3px;
 }
 
 .reaction-summary-item div img,
@@ -414,6 +415,7 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	height: 20px;
 	vertical-align: middle;
 }
+
 .reaction-summary-item div img {
 	color: #FFF; /* affects box-shadow */
 	box-shadow: 0 0 0 2px;
@@ -430,11 +432,13 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	padding-left: 0;
 	margin-left: -12px;
 }
+
 /* un-overlap on hover */
 .reaction-summary-item:first-child:nth-last-child(n+5):hover a:nth-child(n+2),
 .reaction-summary-item:first-child:nth-last-child(n+5) ~ *:hover a:nth-child(n+2) {
 	margin-left: -2px;
 }
+
 /* limit reaction avatars when there are 6 types of reactions */
 .reaction-summary-item:first-child:nth-last-child(6) a:nth-child(n+3),
 .reaction-summary-item:first-child:nth-last-child(6) ~ * a:nth-child(n+3) {

--- a/extension/content.css
+++ b/extension/content.css
@@ -409,6 +409,7 @@ svg.octicon.octicon-star.dashboard-event-icon {
 }
 
 .reaction-summary-item div a {
+	margin-left: -2px;
 	transition: margin-left 0.2s;
 }
 
@@ -430,15 +431,9 @@ svg.octicon.octicon-star.dashboard-event-icon {
 }
 
 /* overlap reaction avatars when there are 5+ types of reactions */
-.reaction-summary-item:first-child:nth-last-child(n+5) a:nth-child(n+2),
-.reaction-summary-item:first-child:nth-last-child(n+5) ~ * a:nth-child(n+2) {
+.reaction-summary-item:first-child:nth-last-child(n+5):not(:hover) a:nth-child(n+2),
+.reaction-summary-item:first-child:nth-last-child(n+5) ~ *:not(:hover) a:nth-child(n+2) {
 	margin-left: -12px;
-}
-
-/* un-overlap on hover */
-.reaction-summary-item:first-child:nth-last-child(n+5):hover a:nth-child(n+2),
-.reaction-summary-item:first-child:nth-last-child(n+5) ~ *:hover a:nth-child(n+2) {
-	margin-left: -2px;
 }
 
 /* limit reaction avatars when there are 6 types of reactions */

--- a/extension/content.css
+++ b/extension/content.css
@@ -412,11 +412,16 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .reaction-summary-item div span {
 	width: 20px;
 	height: 20px;
-	box-shadow: 0 0 0 2px #fff;
 	vertical-align: middle;
 }
 .reaction-summary-item div img {
+	color: #FFF; /* affects box-shadow */
+	box-shadow: 0 0 0 2px;
 	border-radius: 3px;
+}
+
+.reaction-summary-item.user-has-reacted div img {
+	color: #f2f8fa;
 }
 
 /* overlap reaction avatars when there are 5+ types of reactions */

--- a/extension/content.css
+++ b/extension/content.css
@@ -408,10 +408,22 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	width: 20px;
 	height: 20px;
 	margin-left: 3px;
+	box-shadow: 0 0 0 2px #fff;
 	vertical-align: middle;
 }
 .reaction-summary-item div img {
 	border-radius: 3px;
+}
+
+/* overlap reaction avatars when there are 5+ types of reactions */
+.reaction-summary-item:first-child:nth-last-child(n+5) a:nth-child(n+2),
+.reaction-summary-item:first-child:nth-last-child(n+5) ~ * a:nth-child(n+2) {
+	margin-left: -15px;
+}
+/* limit reaction avatars when there are 6 types of reactions */
+.reaction-summary-item:first-child:nth-last-child(6) a:nth-child(n+3),
+.reaction-summary-item:first-child:nth-last-child(6) ~ * a:nth-child(n+3) {
+	display: none;
 }
 
 /* hide reaction popover text */

--- a/extension/content.css
+++ b/extension/content.css
@@ -389,6 +389,10 @@ svg.octicon.octicon-star.dashboard-event-icon {
 }
 
 /* styles for avatars Refined GitHub adds to Reactions */
+.participants-container {
+	margin-left: 4px;
+}
+
 .reaction-summary-item {
 	padding-left: 10px !important;
 	padding-right: 10px !important;
@@ -406,7 +410,6 @@ svg.octicon.octicon-star.dashboard-event-icon {
 
 .reaction-summary-item div a {
 	transition: margin-left 0.2s;
-	padding-left: 3px;
 }
 
 .reaction-summary-item div img,
@@ -429,7 +432,6 @@ svg.octicon.octicon-star.dashboard-event-icon {
 /* overlap reaction avatars when there are 5+ types of reactions */
 .reaction-summary-item:first-child:nth-last-child(n+5) a:nth-child(n+2),
 .reaction-summary-item:first-child:nth-last-child(n+5) ~ * a:nth-child(n+2) {
-	padding-left: 0;
 	margin-left: -12px;
 }
 

--- a/extension/content.css
+++ b/extension/content.css
@@ -393,6 +393,9 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	padding-left: 10px !important;
 	padding-right: 10px !important;
 }
+.reaction-summary-item a {
+	transition: margin-left 0.2s;
+}
 
 .reaction-summary-item.add-reaction-btn {
 	padding-right: 0 !important;
@@ -419,6 +422,11 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .reaction-summary-item:first-child:nth-last-child(n+5) a:nth-child(n+2),
 .reaction-summary-item:first-child:nth-last-child(n+5) ~ * a:nth-child(n+2) {
 	margin-left: -15px;
+}
+/* un-overlap on hover */
+.reaction-summary-item:first-child:nth-last-child(n+5):hover a:nth-child(n+2),
+.reaction-summary-item:first-child:nth-last-child(n+5) ~ *:hover a:nth-child(n+2) {
+	margin-left: -5px;
 }
 /* limit reaction avatars when there are 6 types of reactions */
 .reaction-summary-item:first-child:nth-last-child(6) a:nth-child(n+3),

--- a/extension/content.css
+++ b/extension/content.css
@@ -394,7 +394,9 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	padding-right: 10px !important;
 }
 .reaction-summary-item a {
+	display: inline-block;
 	transition: margin-left 0.2s;
+	padding-left: 3px;
 }
 
 .reaction-summary-item.add-reaction-btn {
@@ -410,7 +412,6 @@ svg.octicon.octicon-star.dashboard-event-icon {
 .reaction-summary-item div span {
 	width: 20px;
 	height: 20px;
-	margin-left: 3px;
 	box-shadow: 0 0 0 2px #fff;
 	vertical-align: middle;
 }
@@ -421,12 +422,13 @@ svg.octicon.octicon-star.dashboard-event-icon {
 /* overlap reaction avatars when there are 5+ types of reactions */
 .reaction-summary-item:first-child:nth-last-child(n+5) a:nth-child(n+2),
 .reaction-summary-item:first-child:nth-last-child(n+5) ~ * a:nth-child(n+2) {
-	margin-left: -15px;
+	padding-left: 0;
+	margin-left: -12px;
 }
 /* un-overlap on hover */
 .reaction-summary-item:first-child:nth-last-child(n+5):hover a:nth-child(n+2),
 .reaction-summary-item:first-child:nth-last-child(n+5) ~ *:hover a:nth-child(n+2) {
-	margin-left: -5px;
+	margin-left: -2px;
 }
 /* limit reaction avatars when there are 6 types of reactions */
 .reaction-summary-item:first-child:nth-last-child(6) a:nth-child(n+3),


### PR DESCRIPTION
Fixes #362 

# 4 reactions (untouched)

<img width="705" alt="" src="https://cloud.githubusercontent.com/assets/1402241/23577753/a1bde032-007c-11e7-8b70-0302d9ef1776.png">

# 5 reactions (overlap)

<img width="707" alt="" src="https://cloud.githubusercontent.com/assets/1402241/23577758/b0be8b4a-007c-11e7-9c28-8c871db4365a.png">

# 6 reactions (overlap and limit to 2)

<img width="706" alt="" src="https://cloud.githubusercontent.com/assets/1402241/23577766/ca2afe42-007c-11e7-9094-3ade922b47b5.png">

The solution differs from what I suggested initially because that didn't take into consideration this little guy  <img width="30" alt="add reaction button" src="https://cloud.githubusercontent.com/assets/1402241/23577773/f47cbeb0-007c-11e7-9a35-ab9d33e617a3.png">


The long selector is a [Quantity Query](https://alistapart.com/article/quantity-queries-for-css). It can be done via JS but I promised it would be CSS-only