### PR TITLE
Fix releases counter class name

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -31,7 +31,7 @@ function appendReleasesCount(count) {
 		return;
 	}
 
-	$('.reponav-releases').append(`<span class="counter">${count}</span>`);
+	$('.reponav-releases').append(`<span class="Counter">${count}</span>`);
 }
 
 function cacheReleasesCount() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -17,7 +17,7 @@ function linkifyBranchRefs() {
 		const branch = encodeURIComponent(parts.eq(parts.length - 1).text());
 		let username = ownerName;
 
-		// if there are two parts the first part is the username
+		// If there are two parts the first part is the username
 		if (parts.length > 1) {
 			username = parts.eq(0).text();
 		}
@@ -87,18 +87,18 @@ function addTrendingMenuItem() {
 function infinitelyMore() {
 	const $btn = $('.ajax-pagination-btn');
 
-	// if there's no more button remove unnecessary event listeners
+	// If there's no more button remove unnecessary event listeners
 	if ($btn.length === 0) {
 		$(window).off('scroll.infinite resize.infinite', infinitelyMore);
 		return;
 	}
 
-	// grab dimensions to see if we should load
+	// Grab dimensions to see if we should load
 	const wHeight = window.innerHeight;
 	const wScroll = window.pageYOffset || document.scrollTop;
 	const btnOffset = $btn.offset().top;
 
-	// smash the button if it's coming close to being in view
+	// Smash the button if it's coming close to being in view
 	if (wScroll > (btnOffset - wHeight)) {
 		$btn.click();
 	}
@@ -207,7 +207,8 @@ function indentInput(el, size = 4) {
 	const indentSize = (size - (el.selectionEnd % size)) || size;
 	const indentationText = ' '.repeat(indentSize);
 	el.value = value.slice(0, selectionStart) + indentationText + value.slice(el.selectionEnd);
-	el.selectionEnd = el.selectionStart = selectionStart + indentationText.length;
+	el.selectionStart = selectionStart + indentationText.length;
+	el.selectionEnd = selectionStart + indentationText.length;
 }
 
 function showRecentlyPushedBranches() {
@@ -280,7 +281,7 @@ function addDiffViewWithoutWhitespaceOption(type) {
 // Support indent with tab key in comments
 $(document).on('keydown', '.js-comment-field', event => {
 	if (event.which === 9 && !event.shiftKey) {
-		// don't indent if the suggester box is active
+		// Don't indent if the suggester box is active
 		if ($('.suggester').hasClass('active')) {
 			return;
 		}
@@ -328,7 +329,7 @@ document.addEventListener('DOMContentLoaded', () => {
 	}
 
 	if (pageDetect.isDashboard()) {
-		// hide other users starring/forking your repos
+		// Hide other users starring/forking your repos
 		const hideStarsOwnRepos = () => {
 			$('#dashboard .news .watch_started, #dashboard .news .fork')
 				.has(`.title a[href^="/${username}"]`)

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -14,17 +14,17 @@ const addReactionParticipants = {
 					.split(', ');
 				const userPosition = participants.indexOf(currentUser);
 
-				// if the user is the only participant, leave as is
+				// If the user is the only participant, leave as is
 				if (participantCount === 1 && userPosition > -1) {
 					return;
 				}
 
-				// add participant container
+				// Add participant container
 				if ($element.find('div.participants-container').length === 0) {
 					$element.append('<div class="participants-container">');
 				}
 
-				// remove self from participant list so you don't see your own avatar
+				// Remove self from participant list so you don't see your own avatar
 				if (userPosition > -1) {
 					participants.splice(userPosition, 1);
 				}
@@ -32,7 +32,7 @@ const addReactionParticipants = {
 				const firstThreeParticipants = participants.slice(0, 3);
 				const $participantsContainer = $element.find('.participants-container');
 
-				// clear any existing avatars and remainder count
+				// Clear any existing avatars and remainder count
 				$participantsContainer.html('');
 
 				for (const participant of firstThreeParticipants) {


### PR DESCRIPTION
Today I noticed the release counter looks weird. It turns out that GitHub has for some reason capitalized the class name responsible for applying proper styling for this element.

**Before changes:**
<img width="434" alt="dom-before" src="https://cloud.githubusercontent.com/assets/11782/25204456/e67468b2-255d-11e7-8bbf-4099abecf185.png">
<img width="616" alt="ui-before" src="https://cloud.githubusercontent.com/assets/11782/25204455/e67253ce-255d-11e7-8120-f1140b69c217.png">

**After changes:**
<img width="704" alt="after" src="https://cloud.githubusercontent.com/assets/11782/25204457/e676037a-255d-11e7-8e4c-389b84ba383e.png">
