### PR TITLE
Linkify URLs and issues in code comments

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, showRealNames, markUnread */
+/* globals gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, showRealNames, markUnread, linkifyURLsInCode */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -429,6 +429,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isMilestone()) {
 				addMilestoneNavigation();
+			}
+
+			if (pageDetect.hasCode()) {
+				linkifyURLsInCode.linkifyCode(repoUrl);
 			}
 		});
 	}

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -1,10 +1,17 @@
 window.linkifyURLsInCode = (() => {
-	const issueRegex = /#[0-9]+/;
+	const issueRegex = /([a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+)?#[0-9]+/;
 	const URLRegex = /(http(s)?(:\/\/))(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/;
-	const linkifyIssue = (repoPath, issue) => `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}" target="_blank">${issue}</a>`;
+	const linkifyIssue = (repoPath, issue) => {
+		if (/\//.test(issue)) {
+			const issueParts = issue.split('#');
+			return `<a href="https://github.com/${issueParts[0]}/issues/${issueParts[1]}" target="_blank">${issue}</a>`;
+		}
+		return `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}" target="_blank">${issue}</a>`;
+	};
 	const linkifyURL = url => `<a href="${url}" target="_blank">${url}</a>`;
 
 	const hasIssue = text => issueRegex.test(text);
+	const hasCommentClass = text => /<span.+class="pl-c".+/.test(text);
 	const hasURL = text => URLRegex.test(text);
 
 	const linkifyCode = repoPath => {
@@ -20,9 +27,12 @@ window.linkifyURLsInCode = (() => {
 				blobHTML = blobHTML.replace(URLmatch, linkifyURL(URLmatch));
 			}
 
+			// Hacky way to ensure only issue number inside a comment, even starting midline
 			if (hasIssue(blobHTML)) {
 				const issueMatch = blobHTML.match(issueRegex)[0];
-				blobHTML = blobHTML.replace(issueMatch, linkifyIssue(repoPath, issueMatch));
+				if (hasCommentClass(blobHTML.toString().split(issueMatch)[0])) {
+					blobHTML = blobHTML.replace(issueMatch, linkifyIssue(repoPath, issueMatch));
+				}
 			}
 
 			blob.innerHTML = blobHTML;
@@ -31,6 +41,7 @@ window.linkifyURLsInCode = (() => {
 
 	return {
 		hasIssue,
+		hasCommentClass,
 		hasURL,
 		linkifyCode
 	};

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -1,6 +1,6 @@
 window.linkifyURLsInCode = (() => {
 	const issueRegex = /#[0-9]+/;
-	const URLRegex = /(http(s)?(:\/\/))?(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/;
+	const URLRegex = /(http(s)?(:\/\/))(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/;
 	const linkifyIssue = (repoPath, issue) => `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}">${issue}</a>`;
 	const linkifyURL = url => `<a href="${url}">${url}</a>`;
 

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -1,8 +1,8 @@
 window.linkifyURLsInCode = (() => {
 	const issueRegex = /#[0-9]+/;
 	const URLRegex = /(http(s)?(:\/\/))(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/;
-	const linkifyIssue = (repoPath, issue) => `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}">${issue}</a>`;
-	const linkifyURL = url => `<a href="${url}">${url}</a>`;
+	const linkifyIssue = (repoPath, issue) => `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}" target="_blank">${issue}</a>`;
+	const linkifyURL = url => `<a href="${url}" target="_blank">${url}</a>`;
 
 	const hasIssue = text => issueRegex.test(text);
 	const hasURL = text => URLRegex.test(text);

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -4,9 +4,9 @@ window.linkifyURLsInCode = (() => {
 	const linkifyIssue = (repoPath, issue) => {
 		if (/\//.test(issue)) {
 			const issueParts = issue.split('#');
-			return `<a href="https://github.com/${issueParts[0]}/issues/${issueParts[1]}" target="_blank">${issue}</a>`;
+			return `<a href="https://github.com/${issueParts[0]}/issues/${issueParts[1]}" target="_blank" class="rg-linkified-code">${issue}</a>`;
 		}
-		return `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}" target="_blank">${issue}</a>`;
+		return `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}" target="_blank" class="rg-linkified-code">${issue}</a>`;
 	};
 	const linkifyURL = url => `<a href="${url}" target="_blank">${url}</a>`;
 
@@ -14,6 +14,10 @@ window.linkifyURLsInCode = (() => {
 	const hasURL = text => URLRegex.test(text);
 
 	const linkifyCode = repoPath => {
+		// Don't linkify any already linkified code
+		if ($('.rg-linkified-code').length > 0) {
+			return;
+		}
 		const codeBlobs = $('.blob-code-inner');
 		const commentCodeBlobs = $('.blob-code-inner span.pl-c');
 

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -11,37 +11,36 @@ window.linkifyURLsInCode = (() => {
 	const linkifyURL = url => `<a href="${url}" target="_blank">${url}</a>`;
 
 	const hasIssue = text => issueRegex.test(text);
-	const hasCommentClass = text => /<span.+class="pl-c".+/.test(text);
 	const hasURL = text => URLRegex.test(text);
 
 	const linkifyCode = repoPath => {
-		const codeBlobs = $('.blob-code-inner');
+		const codeBlobs = $('.blob-code-inner span');
+		const commentCodeBlobs = $('.blob-code-inner span.pl-c');
 
 		$(codeBlobs)
 		.toArray()
 		.forEach(blob => {
-			let blobHTML = blob.innerHTML;
+			const blobHTML = blob.innerHTML;
 			if (hasURL(blobHTML)) {
 				// Match URLs and remove < or > from beginning or end
 				const URLmatch = blobHTML.match(URLRegex)[0].replace(/(^&lt)|(&gt$)/, '');
-				blobHTML = blobHTML.replace(URLmatch, linkifyURL(URLmatch));
+				blob.innerHTML = blobHTML.replace(URLmatch, linkifyURL(URLmatch));
 			}
+		});
 
-			// Hacky way to ensure only issue number inside a comment, even starting midline
+		$(commentCodeBlobs)
+		.toArray()
+		.forEach(blob => {
+			const blobHTML = blob.innerHTML;
 			if (hasIssue(blobHTML)) {
 				const issueMatch = blobHTML.match(issueRegex)[0];
-				if (hasCommentClass(blobHTML.toString().split(issueMatch)[0])) {
-					blobHTML = blobHTML.replace(issueMatch, linkifyIssue(repoPath, issueMatch));
-				}
+				blob.innerHTML = blobHTML.replace(issueMatch, linkifyIssue(repoPath, issueMatch));
 			}
-
-			blob.innerHTML = blobHTML;
 		});
 	};
 
 	return {
 		hasIssue,
-		hasCommentClass,
 		hasURL,
 		linkifyCode
 	};

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -1,0 +1,37 @@
+window.linkifyURLsInCode = (() => {
+	const issueRegex = /#[0-9]+/;
+	const URLRegex = /(http(s)?(:\/\/))?(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/;
+	const linkifyIssue = (repoPath, issue) => `<a href="https://github.com/${repoPath}/issues/${issue.replace('#', '')}">${issue}</a>`;
+	const linkifyURL = url => `<a href="${url}">${url}</a>`;
+
+	const hasIssue = text => issueRegex.test(text);
+	const hasURL = text => URLRegex.test(text);
+
+	const linkifyCode = repoPath => {
+		const codeBlobs = $('.blob-code-inner');
+
+		$(codeBlobs)
+		.toArray()
+		.forEach(blob => {
+			let blobHTML = blob.innerHTML;
+			if (hasURL(blobHTML)) {
+				// Match URLs and remove < or > from beginning or end
+				const URLmatch = blobHTML.match(URLRegex)[0].replace(/(^&lt)|(&gt$)/, '');
+				blobHTML = blobHTML.replace(URLmatch, linkifyURL(URLmatch));
+			}
+
+			if (hasIssue(blobHTML)) {
+				const issueMatch = blobHTML.match(issueRegex)[0];
+				blobHTML = blobHTML.replace(issueMatch, linkifyIssue(repoPath, issueMatch));
+			}
+
+			blob.innerHTML = blobHTML;
+		});
+	};
+
+	return {
+		hasIssue,
+		hasURL,
+		linkifyCode
+	};
+})();

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -14,7 +14,7 @@ window.linkifyURLsInCode = (() => {
 	const hasURL = text => URLRegex.test(text);
 
 	const linkifyCode = repoPath => {
-		const codeBlobs = $('.blob-code-inner span');
+		const codeBlobs = $('.blob-code-inner');
 		const commentCodeBlobs = $('.blob-code-inner span.pl-c');
 
 		$(codeBlobs)

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -37,7 +37,8 @@
 				"copy-on-y.js",
 				"show-names.js",
 				"content.js",
-				"mark-unread.js"
+				"mark-unread.js",
+				"linkify-urls-in-code.js"
 			]
 		}
 	]

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -33,6 +33,8 @@ window.pageDetect = (() => {
 
 	const isCompare = () => isRepo() && /^\/compare\//.test(getRepoPath());
 
+	const hasCode = () => isRepo() && $('.blob-code-inner').length > 0;
+
 	const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && $('.diff-table').length > 0));
 
 	const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
@@ -73,6 +75,7 @@ window.pageDetect = (() => {
 		isSingleCommit,
 		isCommit,
 		isCompare,
+		hasCode,
 		hasDiff,
 		isReleases,
 		isBlame,

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - Removes tooltips
 - Copy canonical link to file when [the `y` hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) is used
 - ~~[Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)~~ [Implemented by GitHub](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view)
+- [Linkifies URLs and issue references in code](https://github.com/sindresorhus/refined-github/issues/380)
 
 And [lots](extension/content.css) [more...](extension/content.js)
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - Removes tooltips
 - Copy canonical link to file when [the `y` hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) is used
 - ~~[Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)~~ [Implemented by GitHub](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view)
-- [Linkifies URLs and issue references in code](https://github.com/sindresorhus/refined-github/issues/380)
+- [Linkifies URLs and issue references in code](https://cloud.githubusercontent.com/assets/737065/25365902/f407f964-2939-11e7-9c66-7d48f31c5576.png)
 
 And [lots](extension/content.css) [more...](extension/content.js)
 
@@ -64,6 +64,9 @@ And [lots](extension/content.css) [more...](extension/content.js)
 
 <img src="screenshot-comment-box.png" width="795">
 
+### URLs and issue references in code
+
+![](https://cloud.githubusercontent.com/assets/737065/25365902/f407f964-2939-11e7-9c66-7d48f31c5576.png)
 
 ## Install
 

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Mark issues and pull requests as unread](https://cloud.githubusercontent.com/assets/170270/18231475/bdf83e26-72e4-11e6-958f-9ce9431d80eb.png) *(They will reappear in Notifications)*
 - [Linkifies branch references in pull requests](https://github.com/sindresorhus/refined-github/issues/1)
 - [Linkifies issue/PR references in issue/PR titles](https://cloud.githubusercontent.com/assets/170270/13597190/bd487ec4-e549-11e5-9521-419fa284512c.png)
+- [Linkifies URLs in code](https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png)
+- [Linkifies issue references in code comments](https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png)
 - [Adds a 'Releases' tab to repos](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png) *(<kbd>g</kbd> <kbd>r</kbd> hotkey)*
 - [Adds user avatars to Reactions](screenshot-reactions.png)
 - [Adds a quick edit button to the readme](https://cloud.githubusercontent.com/assets/170270/13379292/61cd4c42-de54-11e5-8829-f4b82ba8c2bc.png)
@@ -41,7 +43,6 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - Removes tooltips
 - Copy canonical link to file when [the `y` hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) is used
 - ~~[Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)~~ [Implemented by GitHub](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view)
-- [Linkifies URLs and issue references in code](https://cloud.githubusercontent.com/assets/737065/25365902/f407f964-2939-11e7-9c66-7d48f31c5576.png)
 
 And [lots](extension/content.css) [more...](extension/content.js)
 
@@ -64,9 +65,9 @@ And [lots](extension/content.css) [more...](extension/content.js)
 
 <img src="screenshot-comment-box.png" width="795">
 
-### URLs and issue references in code
+### Linkified URLs and issue references in code
 
-![](https://cloud.githubusercontent.com/assets/737065/25365902/f407f964-2939-11e7-9c66-7d48f31c5576.png)
+![](https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png)
 
 ## Install
 

--- a/test/linkify-urls-in-code.js
+++ b/test/linkify-urls-in-code.js
@@ -1,0 +1,40 @@
+import test from 'ava';
+import Window from './fixtures/window';
+
+global.window = new Window();
+global.location = window.location;
+
+require('../extension/linkify-urls-in-code.js'); // eslint-disable-line import/no-unassigned-import
+
+const {linkifyURLsInCode} = window;
+
+function batchTestText(t, detectFn, shouldMatch = [], shouldNotMatch = []) {
+	for (const text of shouldMatch) {
+		t.true(detectFn(text));
+	}
+
+	for (const text of shouldNotMatch) {
+		t.false(detectFn(text));
+	}
+}
+
+test('isIssue', batchTestText, linkifyURLsInCode.hasIssue, [
+	'#1',
+	'#12',
+	'an issue in the middle #123 of some text'
+], [
+	'#a',
+	'1234'
+]);
+
+test('isURL', batchTestText, linkifyURLsInCode.hasURL, [
+	'http://github.com/',
+	'https://www.github.com',
+	'github.com',
+	'https://github.com/orgs/test/dashboard',
+	'a long string of text with a url at the end: https://github.com/dashboard?param=test'
+], [
+	'https://github',
+	'github',
+	'github/whatever/text'
+]);

--- a/test/linkify-urls-in-code.js
+++ b/test/linkify-urls-in-code.js
@@ -27,6 +27,13 @@ test('isIssue', batchTestText, linkifyURLsInCode.hasIssue, [
 	'1234'
 ]);
 
+test('isIssueInComment', batchTestText, linkifyURLsInCode.hasCommentClass, [
+	'Whatever <span class="pl-c">some/repo#1</span>',
+	'<span class="pl-c">#123</span>'
+], [
+	'<span class="pl-v">#123</span>'
+]);
+
 test('isURL', batchTestText, linkifyURLsInCode.hasURL, [
 	'http://github.com/',
 	'https://www.github.com',

--- a/test/linkify-urls-in-code.js
+++ b/test/linkify-urls-in-code.js
@@ -27,13 +27,6 @@ test('isIssue', batchTestText, linkifyURLsInCode.hasIssue, [
 	'1234'
 ]);
 
-test('isIssueInComment', batchTestText, linkifyURLsInCode.hasCommentClass, [
-	'Whatever <span class="pl-c">some/repo#1</span>',
-	'<span class="pl-c">#123</span>'
-], [
-	'<span class="pl-v">#123</span>'
-]);
-
 test('isURL', batchTestText, linkifyURLsInCode.hasURL, [
 	'http://github.com/',
 	'https://www.github.com',

--- a/test/linkify-urls-in-code.js
+++ b/test/linkify-urls-in-code.js
@@ -30,11 +30,11 @@ test('isIssue', batchTestText, linkifyURLsInCode.hasIssue, [
 test('isURL', batchTestText, linkifyURLsInCode.hasURL, [
 	'http://github.com/',
 	'https://www.github.com',
-	'github.com',
 	'https://github.com/orgs/test/dashboard',
 	'a long string of text with a url at the end: https://github.com/dashboard?param=test'
 ], [
 	'https://github',
 	'github',
+	'github.com',
 	'github/whatever/text'
 ]);

--- a/test/linkify-urls-in-code.js
+++ b/test/linkify-urls-in-code.js
@@ -21,7 +21,7 @@ function batchTestText(t, detectFn, shouldMatch = [], shouldNotMatch = []) {
 test('isIssue', batchTestText, linkifyURLsInCode.hasIssue, [
 	'#1',
 	'#12',
-	'an issue in the middle #123 of some text'
+	'an issue in the middle #123 of some text' // Only link to issues in comments, see #381
 ], [
 	'#a',
 	'1234'


### PR DESCRIPTION
Closes #380 

This linkifies numbered issues (i.e. `#123`) and URLs found in code comments. You can take a look at this page to see it in action: https://github.com/contao/core/blob/549738f9a41974d963bd09a3a83ae0f46f887f01/system/modules/core/pages/PageForward.php#L51

In that page there is a URL and there are a few issues linked.

Should work on any page with code, so a PR with inline comments works: https://github.com/sindresorhus/refined-github/pull/346

The files on a PR: https://github.com/sindresorhus/refined-github/pull/346/files

And the code for individual files/commits: https://github.com/sindresorhus/refined-github/commit/2d0c354b66556cd15ac9f1fc5f775a313f026f96#diff-0730bb7c2e8f9ea2438b52e419dd86c9

// @Loilo
