### PR TITLE
Make "diff copy" feature work with lazy-loaded diffs

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -182,7 +182,7 @@ function removeDiffSigns() {
 	const lines = $('.blob-code .blob-code-inner:not(.refined-github-diff-signs)');
 	lines.each((index, element) => {
 		const $element = $(element);
-		$element.text($element.text().replace(/^[+-]/, ''));
+		$element.html($element.html().replace(/^[+-]/, ''));
 	});
 	lines.addClass('refined-github-diff-signs');
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -179,11 +179,13 @@ function addPatchDiffLinks() {
 }
 
 function removeDiffSigns() {
-	$('.blob-code .blob-code-inner:not(.refined-github-diff-signs)').each((index, element) => {
-		const $element = $(element);
-		$element.html($element.html().replace(/^[+-]/, ''));
-		$element.addClass('refined-github-diff-signs');
-	});
+	$('.blob-code-addition, .blob-code-deletion')
+		.find('.blob-code-inner:not(.refined-github-diff-signs)')
+		.each((index, element) => {
+			const $element = $(element);
+			$element.html($element.html().slice(1));
+			$element.addClass('refined-github-diff-signs');
+		});
 }
 
 function markMergeCommitsInList() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -179,12 +179,11 @@ function addPatchDiffLinks() {
 }
 
 function removeDiffSigns() {
-	const lines = $('.blob-code .blob-code-inner:not(.refined-github-diff-signs)');
-	lines.each((index, element) => {
+	$('.blob-code .blob-code-inner:not(.refined-github-diff-signs)').each((index, element) => {
 		const $element = $(element);
 		$element.html($element.html().replace(/^[+-]/, ''));
+		$element.addClass('refined-github-diff-signs');
 	});
-	lines.addClass('refined-github-diff-signs');
 }
 
 function markMergeCommitsInList() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -418,7 +418,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
-				new MutationObserver(removeDiffSigns).observe($('#files')[0], {childList: true, subtree: true});
+				new MutationObserver(removeDiffSigns).observe($('.js-discussion, .js-diff-progressive-container')[0], {childList: true, subtree: true});
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -419,7 +419,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
-				$(document).on('scroll', removeDiffSigns);
+				new MutationObserver(removeDiffSigns).observe($('#files')[0], {childList: true, subtree: true});
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -179,10 +179,12 @@ function addPatchDiffLinks() {
 }
 
 function removeDiffSigns() {
-	$('.blob-code-deletion .blob-code-inner, .blob-code-addition .blob-code-inner').each((index, element) => {
-		const textNode = element.childNodes[0];
-		textNode.nodeValue = textNode.nodeValue.replace(/^[+-]/, ' ');
+	const lines = $('.blob-code .blob-code-inner:not(.refined-github-diff-signs)');
+	lines.each((index, element) => {
+		const $element = $(element);
+		$element.text($element.text().replace(/^[+-]/, ''));
 	});
+	lines.addClass('refined-github-diff-signs');
 }
 
 function markMergeCommitsInList() {
@@ -397,6 +399,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
+				$(document).on('scroll', removeDiffSigns);
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -437,7 +437,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
-				new MutationObserver(removeDiffSigns).observe($('.js-discussion, .js-diff-progressive-container')[0], {childList: true, subtree: true});
+				new MutationObserver(removeDiffSigns).observe($('.js-discussion, #files')[0], {childList: true, subtree: true});
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {


### PR DESCRIPTION
Fixes #377. ~Definitely not the nicest solution to re-run the function on scroll, but I can't think of any other solution.~ ~Also not sure how to handle https://github.com/sindresorhus/refined-github/issues/377#issuecomment-296781677~