### PR TITLE
Leverage Operator Mono ScreenSmart variant

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -21,7 +21,7 @@ tt,
 .gollum-editor .gollum-editor-body,
 .input-monospace,
 .wiki-wrapper .wiki-history .commit-meta code {
-	font-family: 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
+	font-family: 'Operator Mono SSm', 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }
 
 .CodeMirror-lines pre.CodeMirror-line {


### PR DESCRIPTION
Some Operator Mono users install the ScreenSmart variant, sometimes exclusively (due to what license they bought), so it would be nice to have the relevant font name in the overridden code font family.

Here goes.