### PR TITLE
Add support for gist.github.com in the diff file collapse feature

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -366,7 +366,11 @@ $(document).on('click', event => {
 		return;
 	}
 
+	// Github PR's
 	$target.closest('.js-details-container').toggleClass('refined-github-minimized');
+	// Gist code snippets & markdown files
+	$target.closest('.blob').toggleClass('refined-github-minimized');
+	$target.closest('.blob-wrapper').toggleClass('refined-github-minimized');
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/extension/content.js
+++ b/extension/content.js
@@ -366,9 +366,9 @@ $(document).on('click', event => {
 		return;
 	}
 
-	// Github PR's
+	// GitHub PRs
 	$target.closest('.js-details-container').toggleClass('refined-github-minimized');
-	// Gist code snippets & markdown files
+	// Gist code snippets and Markdown files
 	$target.closest('.blob').toggleClass('refined-github-minimized');
 	$target.closest('.blob-wrapper').toggleClass('refined-github-minimized');
 });


### PR DESCRIPTION
I have some Gist's with many files and I get lost quite often.