### PR TITLE
Force JS files to checkout as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
 *.ai binary
+*.js text eol=lf
 readme.md merge=union
 extension/content.css merge=union


### PR DESCRIPTION
Currently if you checkout the code on Windows the JS files will have CRLF and will automatically fail in ESLint when running 'npm test'