### PR TITLE
Add search filter for "Everything commented by you"

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -331,6 +331,19 @@ function addMilestoneNavigation() {
 	`);
 }
 
+function addFilterCommentsByYou() {
+	const newFilter = `
+		<a href="/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}" class="select-menu-item js-navigation-item refined-github-filter">
+			<div class="select-menu-item-text">
+				Everything commented by you
+			</div>
+		</a>`;
+	const lastFilter = $('.subnav-search-context').find('.select-menu-list > a:last-child');
+	if (!lastFilter.prev().hasClass('refined-github-filter')) {
+		lastFilter.before(newFilter);
+	}
+}
+
 // Support indent with tab key in comments
 $(document).on('keydown', '.js-comment-field', event => {
 	if (event.which === 9 && !event.shiftKey) {
@@ -434,6 +447,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (pageDetect.isPRList() || pageDetect.isIssueList()) {
+				addFilterCommentsByYou();
 				showRecentlyPushedBranches();
 			}
 

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds a `Copy` button to gist files](https://cloud.githubusercontent.com/assets/170270/21074840/5dc37578-bf03-11e6-9fd9-501d73edef87.png)
 - [Adds labels to comments by the original poster](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
 - [Adds navigation to milestone pages](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
+- [Adds search filter for 'Everything commented by you'](https://cloud.githubusercontent.com/assets/940070/25518367/cb917d3e-2c36-11e7-8475-c4e6dbe0ed6c.png)
 - Easier copy-pasting from diffs by making +/- signs unselectable
 - Shows the reactions popover on hover instead of click
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)


### PR DESCRIPTION
Fixes #389

This adds a new search filter on issues/PR pages with the text of
'Everything commented by you' with the filter of 'is:open
commenter:<username>'