### PR TITLE
Create observer only if we have elements to observe

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -457,7 +457,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
-				new MutationObserver(removeDiffSigns).observe($('.js-discussion, #files')[0], {childList: true, subtree: true});
+				const $diffElements = $('.js-discussion, #files');
+				if ($diffElements.length > 0) {
+					new MutationObserver(removeDiffSigns).observe($diffElements[0], {childList: true, subtree: true});
+				}
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {


### PR DESCRIPTION
This fixes issue #400. Currently if you visit the compare page,
https://github.com/sindresorhus/refined-github/compare/ you'll get a JS
error because the element list has no items.