### PR TITLE
Add `Yours` issue/PR search tab

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -631,3 +631,7 @@ div.inline-comment-form .form-actions,
 	display: inline-block;
 }
 
+/* Decrease the size of the search box to fit 'Yours' menu item */
+.subnav-search-input[aria-label="Search all issues"] {
+	width: 420px;
+}

--- a/extension/content.js
+++ b/extension/content.js
@@ -129,17 +129,17 @@ function addTrendingMenuItem() {
 }
 
 function addYoursMenuItem() {
-	const [, page] = location.pathname.split('/');
+	const pageName = pageDetect.isIssueSearch() ? 'issues' : 'pulls';
 	const username = getUsername();
 	const $menu = $('.subnav-links');
 
-	if ($(`.subnav-item[href="/${page}?q=is%3Aopen+is%3Aissue+user%3A${username}"]`).length > 0) {
+	if ($menu.find('.refined-github-yours').length > 0) {
 		return;
 	}
 
-	const yoursMenuItem = $(`<a href="/${page}?q=is%3Aopen+is%3Aissue+user%3A${username}" class="subnav-item">Yours</a>`).dom[0];
+	const yoursMenuItem = $(`<a href="/${pageName}?q=is%3Aopen+is%3Aissue+user%3A${username}" class="subnav-item refined-github-yours">Yours</a>`);
 
-	if ($('.subnav-links.selected').length === 0 && /user%3A[username]/.test(location.search)) {
+	if ($('.subnav-links .selected').length === 0 && location.search.includes(`user%3A${username}`)) {
 		yoursMenuItem.addClass('selected');
 	}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -128,6 +128,24 @@ function addTrendingMenuItem() {
 	`);
 }
 
+function addYoursMenuItem() {
+	const [, page] = location.pathname.split('/');
+	const username = getUsername();
+	const $menu = $('.subnav-links');
+
+	if ($(`.subnav-item[href="/${page}?q=is%3Aopen+is%3Aissue+user%3A${username}"]`).length > 0) {
+		return;
+	}
+
+	const yoursMenuItem = $(`<a href="/${page}?q=is%3Aopen+is%3Aissue+user%3A${username}" class="subnav-item">Yours</a>`).dom[0];
+
+	if ($('.subnav-links.selected').length === 0 && /user%3A[username]/.test(location.search)) {
+		yoursMenuItem.addClass('selected');
+	}
+
+	$menu.append(yoursMenuItem);
+}
+
 function infinitelyMore() {
 	const $btn = $('.ajax-pagination-btn');
 
@@ -439,6 +457,13 @@ $(document).on('click', '.js-hide-inline-comment-form', event => {
 	}
 });
 
+// Handle issue list ajax
+$(document).on('pjax:end', () => {
+	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
+		addYoursMenuItem();
+	}
+});
+
 document.addEventListener('DOMContentLoaded', () => {
 	const username = getUsername();
 
@@ -480,6 +505,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	addUploadBtn();
 	new MutationObserver(addUploadBtn).observe($('div[role=main]')[0], {childList: true, subtree: true});
+
+	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
+		addYoursMenuItem();
+	}
 
 	if (pageDetect.isRepo()) {
 		gitHubInjection(window, () => {

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -11,13 +11,13 @@ window.pageDetect = (() => {
 
 	const isRepoTree = () => isRepo() && /\/tree\//.test(getRepoPath());
 
-	const isIssueSearch = () => location.pathname.indexOf('/issues') === 0;
+	const isIssueSearch = () => location.pathname.startsWith('/issues');
 
 	const isIssueList = () => isRepo() && /^\/issues\/?$/.test(getRepoPath());
 
 	const isIssue = () => isRepo() && /^\/issues\/\d+/.test(getRepoPath());
 
-	const isPRSearch = () => location.pathname.indexOf('/pulls') === 0;
+	const isPRSearch = () => location.pathname.startsWith('/pulls');
 
 	const isPRList = () => isRepo() && /^\/pulls\/?$/.test(getRepoPath());
 

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -11,9 +11,13 @@ window.pageDetect = (() => {
 
 	const isRepoTree = () => isRepo() && /\/tree\//.test(getRepoPath());
 
+	const isIssueSearch = () => location.pathname.indexOf('/issues') === 0;
+
 	const isIssueList = () => isRepo() && /^\/issues\/?$/.test(getRepoPath());
 
 	const isIssue = () => isRepo() && /^\/issues\/\d+/.test(getRepoPath());
+
+	const isPRSearch = () => location.pathname.indexOf('/pulls') === 0;
 
 	const isPRList = () => isRepo() && /^\/pulls\/?$/.test(getRepoPath());
 
@@ -68,8 +72,10 @@ window.pageDetect = (() => {
 		isRepo,
 		isRepoRoot,
 		isRepoTree,
+		isIssueSearch,
 		isIssueList,
 		isIssue,
+		isPRSearch,
 		isPRList,
 		isPR,
 		isPRFiles,

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ Our hope is that GitHub will notice and implement some of these much needed impr
 - [Adds navigation to milestone pages](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
 - [Adds search filter for 'Everything commented by you'](https://cloud.githubusercontent.com/assets/940070/25518367/cb917d3e-2c36-11e7-8475-c4e6dbe0ed6c.png)
 - [Moves destructive buttons ("Close issue", "Cancel") in commenting forms away from primary button](#comment-box)
+- [Adds `Yours` button to Issues/Pull Requests page](https://cloud.githubusercontent.com/assets/1282980/14636384/0d8770e4-0623-11e6-8520-2054bece2771.png)
 - Easier copy-pasting from diffs by making +/- signs unselectable
 - Shows the reactions popover on hover instead of click
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -58,6 +58,13 @@ test('isRepoTree', urlMatcherMacro, pageDetect.isRepoTree, [
 	'https://github.com/sindresorhus/refined-github'
 ]);
 
+test('isIssueSearch', urlMatcherMacro, pageDetect.isIssueSearch, [
+	'https://github.com/issues'
+], [
+	'https://github.com/sindresorhus/refined-github/issues',
+	'https://github.com/sindresorhus/refined-github/issues/170'
+]);
+
 test('isIssueList', urlMatcherMacro, pageDetect.isIssueList, [
 	'http://github.com/sindresorhus/ava/issues'
 ], [
@@ -72,6 +79,13 @@ test('isIssue', urlMatcherMacro, pageDetect.isIssue, [
 	'http://github.com/sindresorhus/ava',
 	'https://github.com',
 	'https://github.com/sindresorhus/refined-github/issues'
+]);
+
+test('isPRSearch', urlMatcherMacro, pageDetect.isPRSearch, [
+	'https://github.com/pulls'
+], [
+	'https://github.com/sindresorhus/refined-github/pulls',
+	'https://github.com/sindresorhus/refined-github/pull/148'
 ]);
 
 test('isPRList', urlMatcherMacro, pageDetect.isPRList, [


### PR DESCRIPTION
Add a 'Yours' menu tab to the top navigation. This does a Github search
for all open items created by yourself, which includes PRs and Issues.
Fixes #183 

Shortcut is 'g y' and appears after Issues in the menu.