### PR TITLE
Added 'light' font weight for Operator font

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -21,7 +21,7 @@ tt,
 .gollum-editor .gollum-editor-body,
 .input-monospace,
 .wiki-wrapper .wiki-history .commit-meta code {
-	font-family: 'Operator Mono SSm', 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
+	font-family: 'Operator Mono SSm Light', 'Operator Mono Light', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }
 
 .CodeMirror-lines pre.CodeMirror-line {


### PR DESCRIPTION
Explicitly added the 'Light' variant for Operator Mono, since Windows is dumb and renders the bold variant.