### PR TITLE
Fix Project tab displaying on GHE with 0 Projects

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -353,7 +353,7 @@ function addProjectNewLink() {
 
 function removeProjectsTab() {
 	const projectsTab = $('.js-repo-nav').find('.reponav-item[data-selected-links^="repo_projects"]');
-	if (projectsTab.length > 0 && projectsTab.find('.Counter').text() === '0') {
+	if (projectsTab.length > 0 && projectsTab.find('.Counter, .counter').text() === '0') {
 		projectsTab.remove();
 	}
 }


### PR DESCRIPTION
GHE uses a class of 'counter' instead of 'Counter'
Fixes #418