### PR TITLE
Semantically select a head commit for the compare tab

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -52,13 +52,13 @@ function addCompareTab() {
 	let head = '';
 
 	if (pageDetect.isRepoRoot() || pageDetect.isRepoTree()) {
-		const matches = $('title').text().match(/^([^\/]+\/[^\/]+) at (\S+)$/);
+		const matches = $('title').text().match(/^([^/]+\/[^/]+) at (\S+)$/);
 		if (matches) {
 			head = matches[2];
 		}
 	}
 	if (pageDetect.isRepoTree()) {
-		const matches = $('title').text().match(/^(.+) at (\S+) · ([^\/]+\/[^\/]+)$/);
+		const matches = $('title').text().match(/^(.+) at (\S+) · ([^/]+\/[^/]+)$/);
 		if (matches) {
 			head = matches[2];
 		}

--- a/extension/content.js
+++ b/extension/content.js
@@ -49,12 +49,39 @@ function cacheReleasesCount() {
 }
 
 function addCompareTab() {
+	let head = '';
+
+	if (pageDetect.isRepoRoot() || pageDetect.isRepoTree()) {
+		const matches = $('title').text().match(/^([^\/]+\/[^\/]+) at (\S+)$/);
+		if (matches) {
+			head = matches[2];
+		}
+	}
+	if (pageDetect.isRepoTree()) {
+		const matches = $('title').text().match(/^(.+) at (\S+) · ([^\/]+\/[^\/]+)$/);
+		if (matches) {
+			head = matches[2];
+		}
+	}
+	if (pageDetect.isPR()) {
+		head = $('.head-ref').text();
+	}
+	if (pageDetect.isCommit()) {
+		head = $('.sha-block:last-child .sha').text();
+	}
+	if (pageDetect.isCommitList()) {
+		const commits = $('.commits-list-item');
+		if (commits.length > 0) {
+			head = $(commits[0]).find('.zeroclipboard-button').data('clipboard-text');
+		}
+	}
+
 	const $repoNav = $('.js-repo-nav');
 
 	if ($repoNav.find('.refined-github-compare-tab').length > 0) {
 		return;
 	}
-	const $compareTab = $(`<a href="/${repoUrl}/compare" class="reponav-item refined-github-compare-tab">
+	const $compareTab = $(`<a href="/${repoUrl}/compare/${head}" class="reponav-item refined-github-compare-tab">
 		${icons.compare}
 		<span>Compare</span>
 	</a>`);

--- a/extension/content.js
+++ b/extension/content.js
@@ -105,7 +105,7 @@ function addReleasesTab() {
 		</a>`);
 	}
 
-	if (pageDetect.isReleases()) {
+	if (pageDetect.isReleaseList() || pageDetect.isRelease()) {
 		$repoNav.find('.selected')
 			.removeClass('js-selected-navigation-item selected');
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -75,6 +75,15 @@ function addCompareTab() {
 			head = $(commits[0]).find('.zeroclipboard-button').data('clipboard-text');
 		}
 	}
+	if (pageDetect.isReleaseList()) {
+		const latestRelease = $('.release-timeline .release .tag-references li:first-child .css-truncate-target')[0] || $('.release-timeline-tags li .tag-name, .releases-tag-list tr .tag-name')[0];
+		if (latestRelease) {
+			head = $(latestRelease).text();
+		}
+	}
+	if (pageDetect.isRelease()) {
+		head = $('.tag-references li:first-child .css-truncate-target').text();
+	}
 
 	const $repoNav = $('.js-repo-nav');
 

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -37,7 +37,9 @@ window.pageDetect = (() => {
 
 	const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && $('.diff-table').length > 0));
 
-	const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
+	const isReleaseList = () => isRepo() && /^\/(releases|tags)\/?$/.test(getRepoPath());
+
+	const isRelease = () => isRepo() && /^\/releases\/tag/.test(getRepoPath());
 
 	const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());
 
@@ -81,7 +83,8 @@ window.pageDetect = (() => {
 		isCompare,
 		hasCode,
 		hasDiff,
-		isReleases,
+		isReleaseList,
+		isRelease,
 		isBlame,
 		isNotifications,
 		getOwnerAndRepo,

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -135,11 +135,18 @@ test('isSingleCommit', urlMatcherMacro, pageDetect.isSingleCommit, [
 	'https://github.com/sindresorhus/refined-github/branches'
 ]);
 
-test('isReleases', urlMatcherMacro, pageDetect.isReleases, [
+test('isReleaseList', urlMatcherMacro, pageDetect.isReleaseList, [
 	'https://github.com/sindresorhus/refined-github/releases'
 ], [
 	'https://github.com/sindresorhus/refined-github',
 	'https://github.com/sindresorhus/refined-github/graphs'
+]);
+
+test('isRelease', urlMatcherMacro, pageDetect.isRelease, [
+	'https://github.com/sindresorhus/refined-github/releases/tag/1.2.3'
+], [
+	'https://github.com/sindresorhus/refined-github',
+	'https://github.com/sindresorhus/refined-github/releases'
 ]);
 
 test('isBlame', urlMatcherMacro, pageDetect.isBlame, [


### PR DESCRIPTION
Apart from the "Compare" tab that #399  introduced, #267 also proposes a "semantic" selection of the head commit. Based on the current page type, the head is chosen like this (checked items are implemented):
- [x] PR -> Compare against upstream branch
- [x] Commit -> Compare against that commit
- [x] Comit list -> Compare against latest of these commits
- [x] Non-default branch on repo root or file tree -> Compare against that branch
- [x] Release -> Compare against that release
- [x] Release list -> Compare against latest of these releases

Anything else just points to the default compare page.

Often, it would make more sense to semantically set the base instead and compare against master. Perhaps we can automatically "click" the "switch the base" link (as seen on https://github.com/sindresorhus/refined-github/compare/8778310c6ac7149b707bb55d6b1324650a326b26) if it exists?

Closes #267.