### PR TITLE
Do not link to deleted branches

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -169,14 +169,9 @@
 }
 
 /* add hover underline for `content.js` linkified branch refs in pull requests */
-.commit-ref:hover,
-.commit-ref:hover span {
+a .commit-ref:hover,
+a .commit-ref:hover span {
 	text-decoration: underline !important;
-}
-
-.commit-ref.unlinked:hover,
-.commit-ref.unlinked:hover span {
-	text-decoration: none !important;
 }
 
 /* remove the "new feature" notification box */


### PR DESCRIPTION
This would prevent linking to deleted branches when wrapping head and base branches on pull request pages with links.

- Fixes #105
- Fixes #349 by using the canonical name from the title in the DOM with owner, repo name and branch

Things which this would not do or take into account, because it's not worth it:

- If a branch is deleted and subsequently restorted, it would not link to it
- If the base branch of a PR is deleted or renamed, it would still link to it