### PR TITLE
Fix whitespace diff option button

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -262,7 +262,7 @@ function showRecentlyPushedBranches() {
 
 // Add option for viewing diffs without whitespace changes
 function addDiffViewWithoutWhitespaceOption(type) {
-	if ($('.diff-options-content').length < 1 && $('.btn-group .selected[href*="diff="]').length < 1) {
+	if ($('.pr-review-tools .BtnGroup').length < 1 && $('.pr-review-tools .BtnGroup .tooltipped[href*="diff="]').length < 1) {
 		return;
 	}
 
@@ -274,30 +274,23 @@ function addDiffViewWithoutWhitespaceOption(type) {
 	const optionElement = document.createElement('a');
 	const urlParams = new URLSearchParams(window.location.search);
 	const urlHash = window.location.hash || '';
-	const svgIcon = icons.check;
 	const optionElementObject = $(optionElement);
 	let optionIsSet = false;
 
 	if (urlParams.get('w') === '1') {
 		optionIsSet = true;
 		urlParams.delete('w');
-		optionElementObject.addClass('selected');
 	} else {
 		urlParams.set('w', 1);
 	}
 
-	const optionElementContent = `${optionIsSet ? svgIcon : ''} Ignore whitespace`;
+	const optionElementContent = `${optionIsSet ? 'Show' : 'Ignore'} whitespace`;
 	const optionHref = `${window.location.origin + window.location.pathname}?${urlParams.toString() + urlHash}`;
 
 	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace');
 
-	if (type === 'pr') {
-		$('.diff-options-content').find('.dropdown-item:last-of-type').after(optionElement);
-		optionElementObject.addClass('dropdown-item');
-	} else {
-		$('.btn-group .selected[href*="diff="]').after(optionElement);
-		optionElementObject.addClass('btn btn-sm');
-	}
+	$('.pr-review-tools .BtnGroup *:last-child').after(optionElement);
+	optionElementObject.addClass('btn btn-sm btn-outline BtnGroup-item');
 }
 
 function addOPLabels() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -262,7 +262,7 @@ function showRecentlyPushedBranches() {
 
 // Add option for viewing diffs without whitespace changes
 function addDiffViewWithoutWhitespaceOption(type) {
-	if ($('.pr-review-tools .BtnGroup').length < 1 && $('.pr-review-tools .BtnGroup .tooltipped[href*="diff="]').length < 1) {
+	if ($('.pr-review-tools .BtnGroup').length < 1 && $('.Details .BtnGroup').length < 1 && $('.pr-review-tools .BtnGroup .tooltipped[href*="diff="]').length < 1) {
 		return;
 	}
 
@@ -289,8 +289,15 @@ function addDiffViewWithoutWhitespaceOption(type) {
 
 	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace');
 
-	$('.pr-review-tools .BtnGroup *:last-child').after(optionElement);
-	optionElementObject.addClass('btn btn-sm btn-outline BtnGroup-item');
+	if ($('.Details .BtnGroup').length > 0) {
+		$('.Details .BtnGroup *:last-child').after(optionElement);
+		optionElementObject.addClass('btn btn-sm BtnGroup-item');
+	};
+
+	if ($('.pr-review-tools .BtnGroup').length > 0 ) {
+		$('.pr-review-tools .BtnGroup *:last-child').after(optionElement)
+		optionElementObject.addClass('btn btn-sm btn-outline BtnGroup-item');
+	};
 }
 
 function addOPLabels() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -262,7 +262,12 @@ function showRecentlyPushedBranches() {
 
 // Add option for viewing diffs without whitespace changes
 function addDiffViewWithoutWhitespaceOption() {
-	if ($('.pr-review-tools .BtnGroup').length < 1 && $('.Details .BtnGroup').length < 1 && $('.pr-review-tools .BtnGroup .tooltipped[href*="diff="]').length < 1) {
+	const detailsButtonGroup = $('.table-of-contents.Details .BtnGroup:first-child');
+	const detailsButtonGroupLength = detailsButtonGroup.length;
+	const prReviewTools = $('.pr-review-tools > .diffbar-item:first-child');
+	const prReviewToolsLength = prReviewTools.length;
+
+	if (prReviewToolsLength < 1 && detailsButtonGroupLength < 1 && prReviewTools.find('.tooltipped[href*="diff="]').length < 1) {
 		return;
 	}
 
@@ -271,7 +276,7 @@ function addDiffViewWithoutWhitespaceOption() {
 		return;
 	}
 
-	const optionElement = document.createElement('a');
+	const optionElement = document.createElement('div');
 	const urlParams = new URLSearchParams(window.location.search);
 	const urlHash = window.location.hash || '';
 	const svgIcon = icons.check;
@@ -285,19 +290,22 @@ function addDiffViewWithoutWhitespaceOption() {
 		urlParams.set('w', 1);
 	}
 
-	const optionElementContent = `${optionIsSet ? svgIcon + ' ' : ''}No Whitespace`;
-	const optionHref = `${window.location.origin + window.location.pathname}?${urlParams.toString() + urlHash}`;
+	optionElementObject.html(
+		`<a href=${window.location.origin + window.location.pathname}?${urlParams.toString() + urlHash}
+		   data-hotkey="d w"
+		   class="refined-github-toggle-whitespace btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${optionIsSet ? 'bg-gray-light text-gray-light' : ''}"
+		   title="Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}"
+		   aria-label="Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}">
+			${optionIsSet ? svgIcon + ' ' : ''}No Whitespace
+		</a>`).addClass('diffbar-item');
 
-	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace').attr('title', `Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}`);
-
-	if ($('.Details .BtnGroup').length > 0) {
-		$('.Details .BtnGroup *:last-child').after(optionElement);
-		optionElementObject.addClass('btn btn-sm BtnGroup-item');
+	if (detailsButtonGroupLength > 0) {
+		detailsButtonGroup.after(optionElement);
+		optionElementObject.addClass('float-right');
 	}
 
-	if ($('.pr-review-tools .BtnGroup').length > 0) {
-		$('.pr-review-tools .BtnGroup *:last-child').after(optionElement);
-		optionElementObject.addClass('btn btn-sm btn-outline BtnGroup-item');
+	if (prReviewToolsLength > 0) {
+		prReviewTools.after(optionElement);
 	}
 }
 
@@ -504,7 +512,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 				diffFileHeader.setup();
-				addDiffViewWithoutWhitespaceOption();
 				filePathCopyBtnListner();
 			}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -262,25 +262,14 @@ function showRecentlyPushedBranches() {
 
 // Add option for viewing diffs without whitespace changes
 function addDiffViewWithoutWhitespaceOption() {
-	const detailsButtonGroup = $('.table-of-contents.Details .BtnGroup:first-child');
-	const detailsButtonGroupLength = detailsButtonGroup.length;
-	const prReviewTools = $('.pr-review-tools > .diffbar-item:first-child');
-	const prReviewToolsLength = prReviewTools.length;
+	const $detailsButtonGroup = $('.table-of-contents.Details .BtnGroup:first-child');
+	const $prReviewTools = $('.pr-review-tools > .diffbar-item:first-child');
 
-	if (prReviewToolsLength < 1 && detailsButtonGroupLength < 1 && prReviewTools.find('.tooltipped[href*="diff="]').length < 1) {
+	if (($detailsButtonGroup.length === 0 && $prReviewTools.length === 0) || $('.refined-github-toggle-whitespace').length > 0) {
 		return;
 	}
 
-	// Return if element already exists in DOM (history actions)
-	if ($('.refined-github-toggle-whitespace').length > 0) {
-		return;
-	}
-
-	const optionElement = document.createElement('div');
 	const urlParams = new URLSearchParams(window.location.search);
-	const urlHash = window.location.hash || '';
-	const svgIcon = icons.check;
-	const optionElementObject = $(optionElement);
 	let optionIsSet = false;
 
 	if (urlParams.get('w') === '1') {
@@ -290,22 +279,29 @@ function addDiffViewWithoutWhitespaceOption() {
 		urlParams.set('w', 1);
 	}
 
-	optionElementObject.html(
-		`<a href=${window.location.origin + window.location.pathname}?${urlParams.toString() + urlHash}
-		   data-hotkey="d w"
-		   class="refined-github-toggle-whitespace btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${optionIsSet ? 'bg-gray-light text-gray-light' : ''}"
-		   title="Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}"
-		   aria-label="Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}">
-			${optionIsSet ? svgIcon + ' ' : ''}No Whitespace
-		</a>`).addClass('diffbar-item');
+	let url = window.location.pathname;
+	if (String(urlParams)) {
+		url += '?' + String(urlParams);
+	}
+	url += window.location.hash || '';
 
-	if (detailsButtonGroupLength > 0) {
-		detailsButtonGroup.after(optionElement);
-		optionElementObject.addClass('float-right');
+	const optionHtml = `
+		<div class="diffbar-item ${$detailsButtonGroup.length > 0 ? 'float-right' : ''}">
+			<a href="${url}"
+				data-hotkey="d w"
+				class="refined-github-toggle-whitespace btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${optionIsSet ? 'bg-gray-light text-gray-light' : ''}"
+				aria-label="${optionIsSet ? 'Show' : 'Hide'} whitespace in diffs">
+				${optionIsSet ? icons.check + ' ' : ''}No Whitespace
+			</a>
+		</div>
+	`;
+
+	if ($detailsButtonGroup.length > 0) {
+		$detailsButtonGroup.after(optionHtml);
 	}
 
-	if (prReviewToolsLength > 0) {
-		prReviewTools.after(optionElement);
+	if ($prReviewTools.length > 0) {
+		$prReviewTools.after(optionHtml);
 	}
 }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -261,7 +261,7 @@ function showRecentlyPushedBranches() {
 }
 
 // Add option for viewing diffs without whitespace changes
-function addDiffViewWithoutWhitespaceOption(type) {
+function addDiffViewWithoutWhitespaceOption() {
 	if ($('.pr-review-tools .BtnGroup').length < 1 && $('.Details .BtnGroup').length < 1 && $('.pr-review-tools .BtnGroup .tooltipped[href*="diff="]').length < 1) {
 		return;
 	}
@@ -274,6 +274,7 @@ function addDiffViewWithoutWhitespaceOption(type) {
 	const optionElement = document.createElement('a');
 	const urlParams = new URLSearchParams(window.location.search);
 	const urlHash = window.location.hash || '';
+	const svgIcon = icons.check;
 	const optionElementObject = $(optionElement);
 	let optionIsSet = false;
 
@@ -284,20 +285,20 @@ function addDiffViewWithoutWhitespaceOption(type) {
 		urlParams.set('w', 1);
 	}
 
-	const optionElementContent = `${optionIsSet ? 'Show' : 'Ignore'} whitespace`;
+	const optionElementContent = `${optionIsSet ? svgIcon + ' ' : ''}No Whitespace`;
 	const optionHref = `${window.location.origin + window.location.pathname}?${urlParams.toString() + urlHash}`;
 
-	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace');
+	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace').attr('title', `Click here to turn whitespace in diffs ${optionIsSet ? 'on' : 'off'}`);
 
 	if ($('.Details .BtnGroup').length > 0) {
 		$('.Details .BtnGroup *:last-child').after(optionElement);
 		optionElementObject.addClass('btn btn-sm BtnGroup-item');
-	};
+	}
 
-	if ($('.pr-review-tools .BtnGroup').length > 0 ) {
-		$('.pr-review-tools .BtnGroup *:last-child').after(optionElement)
+	if ($('.pr-review-tools .BtnGroup').length > 0) {
+		$('.pr-review-tools .BtnGroup *:last-child').after(optionElement);
 		optionElementObject.addClass('btn btn-sm btn-outline BtnGroup-item');
-	};
+	}
 }
 
 function addOPLabels() {
@@ -494,7 +495,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 
 			if (pageDetect.hasDiff()) {
-				addDiffViewWithoutWhitespaceOption('commit');
+				addDiffViewWithoutWhitespaceOption();
 			}
 
 			if (pageDetect.isCommitList()) {
@@ -503,7 +504,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 				diffFileHeader.setup();
-				addDiffViewWithoutWhitespaceOption('pr');
+				addDiffViewWithoutWhitespaceOption();
 				filePathCopyBtnListner();
 			}
 


### PR DESCRIPTION
This fixes #322.

TL;DR: Github changed the markup from a select optionbox
to a tablist. This change re-implements the whitespace
diff toggle option as third tab-item on diff view pages.

## Screenshots of new layout:
![screen shot 2017-05-13 at 17 20 39](https://cloud.githubusercontent.com/assets/399345/26026728/6562ee1a-37f0-11e7-9605-59f210e1a5ad.png)
![screen shot 2017-05-13 at 17 20 47](https://cloud.githubusercontent.com/assets/399345/26026729/6565b30c-37f0-11e7-8e76-8e13801fbe53.png)
