### PR TITLE
Fix unread "undefined" icon

### DIFF
--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -42,18 +42,18 @@ window.markUnread = (() => {
 		const type = pageDetect.isPR() ? 'pull-request' : 'issue';
 		const url = stripHash(location.href);
 
-		const stateLabel = $('.gh-header-meta .state');
+		const stateLabel = $('.gh-header-meta .State');
 		let state;
 
-		if (stateLabel.hasClass('state-open')) {
+		if (stateLabel.hasClass('State--green')) {
 			state = 'open';
 		}
 
-		if (stateLabel.hasClass('state-merged')) {
+		if (stateLabel.hasClass('State--purple')) {
 			state = 'merged';
 		}
 
-		if (stateLabel.hasClass('state-closed')) {
+		if (stateLabel.hasClass('State--red')) {
 			state = 'closed';
 		}
 


### PR DESCRIPTION
### Issue
Seems like GitHub changed some class names 😜

As a result of this **state** field ended up undefined.

### Fix

Have updated those class names.

Here's screenshot of the fixed issue

![Screenshot](https://cloud.githubusercontent.com/assets/4201088/26028395/1aa22f7e-383d-11e7-861f-01207da7ada2.png)

Fixes #424 
