### PR TITLE
Fix "Unread" count on notification page

### DIFF
--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -249,9 +249,22 @@ window.markUnread = (() => {
 			});
 	}
 
+	function countLocalNotifications() {
+		const $unreadCount = $('#notification-center .filter-list a[href="/notifications"] .count');
+		const githubNotificationsCount = Number($unreadCount.text());
+		let localNotificationsCount = 0;
+		const localNotifications = localStorage.unreadNotifications;
+
+		if (localNotifications) {
+			localNotificationsCount = JSON.parse(localNotifications).length;
+			$unreadCount.text(githubNotificationsCount + localNotificationsCount);
+		}
+	}
+
 	function setup() {
 		if (pageDetect.isNotifications()) {
 			renderNotifications();
+			countLocalNotifications();
 			$(document).on('click', '.js-mark-read', markNotificationRead);
 			$(document).on('click', '.js-mark-all-read', markAllNotificationsRead);
 		} else {


### PR DESCRIPTION
### Issue
Unread notification count doesn't include local notifications

### Fix
Add both the count and display it in the unread notification count.

### Screenshot of the Fix
![Screenshot](https://cloud.githubusercontent.com/assets/4201088/26032838/ad9b7506-38ba-11e7-9d8d-0ad0c72074b0.png)

### Note
Right now I don't have any unread github notification. So not able to test it. 
Please check that too :)

Fixes #427 
