### PR TITLE
Show "Unread" indicator for local notifications

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -605,3 +605,9 @@ div.inline-comment-form .form-actions,
 #refined-github-project-new-link {
 	margin-top: 5px;
 }
+
+/* Display notification bell icon for bookmarked Issues/PR */
+.notification-indicator .mail-status.local-unread{
+	display: inline-block;
+}
+

--- a/extension/content.js
+++ b/extension/content.js
@@ -410,6 +410,8 @@ $(document).on('click', '.js-hide-inline-comment-form', event => {
 document.addEventListener('DOMContentLoaded', () => {
 	const username = getUsername();
 
+	markUnread.unreadIndicatorIcon();
+
 	if (pageDetect.isGist()) {
 		addGistCopyButton();
 	} else {

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -231,16 +231,11 @@ window.markUnread = (() => {
 
 	function unreadIndicatorIcon() {
 		const $notificationIndicator = $('.header-nav-link.notification-indicator');
-		const $notificationStatus = $($notificationIndicator).find('.mail-status');
+		const $notificationStatus = $notificationIndicator.find('.mail-status');
 
 		const localNotifications = localStorage.unreadNotifications;
-		let hasLocalNotification = false;
-
-		if (JSON.parse(localNotifications).length > 0) {
-			hasLocalNotification = true;
-		}
 		let notificationsLabel = '';
-		if (hasLocalNotification) {
+		if (JSON.parse(localNotifications).length > 0) {
 			notificationsLabel = 'You have unread notifications';
 			$notificationStatus.addClass('local-unread');
 		} else {

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -233,16 +233,15 @@ window.markUnread = (() => {
 		const $notificationIndicator = $('.header-nav-link.notification-indicator');
 		const $notificationStatus = $notificationIndicator.find('.mail-status');
 
-		const localNotifications = localStorage.unreadNotifications;
-		let notificationsLabel = '';
-		if (JSON.parse(localNotifications).length > 0) {
-			notificationsLabel = 'You have unread notifications';
+		let hasNotifications = $notificationStatus.hasClass('unread');
+		if (JSON.parse(localStorage.unreadNotifications).length > 0) {
+			hasNotifications = true;
 			$notificationStatus.addClass('local-unread');
 		} else {
 			$notificationStatus.removeClass('local-unread');
-			notificationsLabel = ($notificationStatus.hasClass('unread')) ? 'You have unread notifications' : 'You have no unread notifications';
 		}
-		$notificationIndicator.attr('aria-label', notificationsLabel);
+
+		$notificationIndicator.attr('aria-label', hasNotifications ? 'You have unread notifications' : 'You have no unread notifications');
 	}
 
 	function markNotificationRead(e) {

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -228,12 +228,33 @@ window.markUnread = (() => {
 		return $('#user-links a.name img').attr('alt').slice(1);
 	}
 
+	function unreadIndicatorIcon() {
+		const $notificationIndicator = $('.header-nav-link.notification-indicator');
+		const $notificationStatus = $($notificationIndicator).find('.mail-status');
+
+		const localNotifications = localStorage.unreadNotifications;
+		let hasLocalNotification = false;
+
+		if (localNotifications !== '[]' && JSON.parse(localNotifications).length > 0) {
+			hasLocalNotification = true;
+		}
+
+		if (hasLocalNotification) {
+			$notificationIndicator.attr('aria-label', 'You have unread notifications');
+			$notificationStatus.addClass('local-unread');
+		} else {
+			$notificationStatus.removeClass('local-unread');
+		}
+	}
+
 	function markNotificationRead(e) {
 		const notification = $(e.target).parents('li.js-notification');
 		notification.addClass('read');
 
 		const url = notification.find('a.js-notification-target').attr('href');
 		markRead(url);
+
+		unreadIndicatorIcon();
 	}
 
 	function markAllNotificationsRead(e) {
@@ -247,6 +268,7 @@ window.markUnread = (() => {
 				$(el).parents('.js-notification').removeClass('unread').addClass('read');
 				markRead(el.href);
 			});
+		unreadIndicatorIcon();
 	}
 
 	function setup() {
@@ -266,5 +288,5 @@ window.markUnread = (() => {
 		$('.js-mark-unread').remove();
 	}
 
-	return {setup, destroy};
+	return {setup, destroy, unreadIndicatorIcon};
 })();

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -74,6 +74,7 @@ window.markUnread = (() => {
 		});
 
 		localStorage.unreadNotifications = JSON.stringify(unreadNotifications);
+		unreadIndicatorIcon();
 	}
 
 	function renderNotifications() {
@@ -235,16 +236,18 @@ window.markUnread = (() => {
 		const localNotifications = localStorage.unreadNotifications;
 		let hasLocalNotification = false;
 
-		if (localNotifications !== '[]' && JSON.parse(localNotifications).length > 0) {
+		if (JSON.parse(localNotifications).length > 0) {
 			hasLocalNotification = true;
 		}
-
+		let notificationsLabel = '';
 		if (hasLocalNotification) {
-			$notificationIndicator.attr('aria-label', 'You have unread notifications');
+			notificationsLabel = 'You have unread notifications';
 			$notificationStatus.addClass('local-unread');
 		} else {
 			$notificationStatus.removeClass('local-unread');
+			notificationsLabel = ($notificationStatus.hasClass('unread')) ? 'You have unread notifications' : 'You have no unread notifications';
 		}
+		$notificationIndicator.attr('aria-label', notificationsLabel);
 	}
 
 	function markNotificationRead(e) {


### PR DESCRIPTION
### Issue
Unread indicator on the bell icon is displayed only for github notification. Not the local notifications that we have bookmarked.

### Fix
Include local notifications too

### Screenshot of Fix
<img width="1041" alt="screen shot 2017-05-14 at 7 16 07 pm" src="https://cloud.githubusercontent.com/assets/4201088/26034428/f2a5f62a-38d9-11e7-8fed-336e36a6487a.png">

### Note
Not sure I've covered all the use cases. If I've missed something, please let me know 😄 

Fixes #292