### PR TITLE
Fix "Mark all as read" button for local notifications

### DIFF
--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -249,9 +249,36 @@ window.markUnread = (() => {
 			});
 	}
 
+	function addNotificationClearModal() {
+		const $markAllReadBtn = $('#notification-center a[href="#mark_as_read_confirm_box"]');
+		if ($markAllReadBtn.length >= 1 || JSON.parse(localStorage.unreadNotifications).length === 0) {
+			return;
+		}
+		const $tabNav = $('#notification-center .tabnav-tabs:first ');
+		const markAllBtnCustom = `
+			<div class="float-right">
+			    <a href="#mark_as_read_confirm_box" class="btn btn-sm " rel="facebox">Mark all as read</a>
+    			<div id="mark_as_read_confirm_box" style="display:none">
+	        		<h2 class="facebox-header" data-facebox-id="facebox-header">Are you sure?</h2>
+	        		<p data-facebox-id="facebox-description">Are you sure you want to mark all unread notifications as read?</p>
+	            	<div class="full-button">
+	                	<button  id="clear-local-notification" class="btn btn-block">Mark all notifications as read</button>
+	            	</div>
+    			</div>
+    		</div>`;
+
+		$tabNav.append(markAllBtnCustom);
+
+		$(document).on('click', '#clear-local-notification', () => {
+			localStorage.unreadNotifications = '[]';
+			window.location.reload();
+		});
+	}
+
 	function setup() {
 		if (pageDetect.isNotifications()) {
 			renderNotifications();
+			addNotificationClearModal();
 			$(document).on('click', '.js-mark-read', markNotificationRead);
 			$(document).on('click', '.js-mark-all-read', markAllNotificationsRead);
 			$(document).on('click', 'form[action="/notifications/mark"] button', () => {

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -255,7 +255,7 @@ window.markUnread = (() => {
 			$(document).on('click', '.js-mark-read', markNotificationRead);
 			$(document).on('click', '.js-mark-all-read', markAllNotificationsRead);
 			$(document).on('click', 'form[action="/notifications/mark"] button', () => {
-				localStorage.unreadNotifications = [];
+				localStorage.unreadNotifications = '[]';
 			});
 		} else {
 			markRead(location.href);

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -254,6 +254,9 @@ window.markUnread = (() => {
 			renderNotifications();
 			$(document).on('click', '.js-mark-read', markNotificationRead);
 			$(document).on('click', '.js-mark-all-read', markAllNotificationsRead);
+			$(document).on('click', 'form[action="/notifications/mark"] button', () => {
+				localStorage.unreadNotifications = [];
+			});
 		} else {
 			markRead(location.href);
 			addMarkUnreadButton();


### PR DESCRIPTION
### Issue
"Mark all as read" button does not clear notifications that were added using extention

### Fix
Clear localStorage.unreadNotifications when button is clicked.

### Screenshot of Fix
![screen recording 2017-05-14 at 09 05 pm](https://cloud.githubusercontent.com/assets/4201088/26035498/9f43f624-38ea-11e7-9d6a-3ca9b9e6ff5d.gif)

Fixes #291