### PR TITLE
Bring back Pulse tab

### DIFF
--- a/extension/custom.css
+++ b/extension/custom.css
@@ -2,11 +2,6 @@
 	highly opinionated changes
 */
 
-/* remove "Pulse" repo tab */
-.reponav a[href$="/pulse"] {
-	display: none !important;
-}
-
 /* alternate monospace font stack, sorted by least popular so you're most likely to get the font you want */
 code,
 kbd,


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/433

Now when the Insights tab drop down holds Graphs and Pulse we can stop hiding Pulse.