### PR TITLE
Fix created repo style

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -290,26 +290,26 @@ svg.octicon.octicon-star.dashboard-event-icon {
 
 /* Created repository style in dashboard */
 .news .create.simple.alert .body {
-    min-height: 69px;
+	min-height: 69px;
 }
 
 svg.octicon.octicon-repo.dashboard-event-icon {
-    height: 32px !important;
-    width: 28px !important;
+	height: 32px !important;
+	width: 28px !important;
 }
 
 .create.simple.alert .simple .title {
-    position: absolute;
-    top: 10px;
-    font-size: 14px !important;
-    font-weight: bold;
-    color: inherit !important;
+	position: absolute;
+	top: 10px;
+	font-size: 14px !important;
+	font-weight: bold;
+	color: inherit !important;
 }
 
 .create.simple.alert .simple .time {
-    position: absolute;
-    top: -2px;
-    left: 45px;
+	position: absolute;
+	top: -2px;
+	left: 45px;
 }
 
 /* decrease font-size on commit details so our custom patch and diff links fit */
@@ -598,8 +598,8 @@ td.blob-code.blob-code-deletion:before {
 
 /* ...in comment edit form */
 div.previewable-edit .previewable-comment-form .form-actions {
-    float: none;
-    margin-left: 10px;
+	float: none;
+	margin-left: 10px;
 }
 
 .previewable-edit .previewable-comment-form .form-actions .btn.js-comment-cancel-button {

--- a/extension/content.css
+++ b/extension/content.css
@@ -288,6 +288,30 @@ svg.octicon.octicon-star.dashboard-event-icon {
 	color: inherit !important;
 }
 
+/* Created repository style in dashboard */
+.news .create.simple.alert .body {
+    min-height: 69px;
+}
+
+svg.octicon.octicon-repo.dashboard-event-icon {
+    height: 32px !important;
+    width: 28px !important;
+}
+
+.create.simple.alert .simple .title {
+    position: absolute;
+    top: 10px;
+    font-size: 14px !important;
+    font-weight: bold;
+    color: inherit !important;
+}
+
+.create.simple.alert .simple .time {
+    position: absolute;
+    top: -2px;
+    left: 45px;
+}
+
 /* decrease font-size on commit details so our custom patch and diff links fit */
 .commit .sha-block {
 	margin-left: 7px !important;


### PR DESCRIPTION
### Fix
Styling for created repos in dashboard. (Make it look like stared repos)

### Screenshot
![image](https://cloud.githubusercontent.com/assets/4201088/26323041/00db908e-3f4b-11e7-9132-5d1175604226.png)

### Note
I tried to avoid overriding other styles (#215)

Not sure if it still has any side effects / covers all use cases.

Please let me know if I've missed anything :)

Fixes (#213)