### PR TITLE
Avoid jump when adding Trending link

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1,4 +1,4 @@
-/* globals utils, gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, showRealNames, markUnread, linkifyURLsInCode, addUploadBtn, filePathCopyBtnListner */
+/* globals utils, gitHubInjection, pageDetect, icons, diffFileHeader, addReactionParticipants, addFileCopyButton, addGistCopyButton, enableCopyOnY, showRealNames, markUnread, linkifyURLsInCode, addUploadBtn, filePathCopyBtnListner, elementReady */
 
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
@@ -118,10 +118,10 @@ function addReleasesTab() {
 	}
 }
 
-function addTrendingMenuItem() {
-	const $secondListItem = $('.header-nav.float-left .header-nav-item:nth-child(2)');
+async function addTrendingMenuItem() {
+	const secondListItem = await elementReady('.header-nav.float-left .header-nav-item:nth-child(2)');
 
-	$secondListItem.after(`
+	$(secondListItem).after(`
 		<li class="header-nav-item">
 			<a href="/trending" class="header-nav-link" data-hotkey="g t">Trending</a>
 		</li>
@@ -446,8 +446,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 	if (pageDetect.isGist()) {
 		addGistCopyButton();
-	} else {
-		addTrendingMenuItem();
 	}
 
 	if (pageDetect.isDashboard()) {
@@ -571,3 +569,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	}
 });
+
+if (!pageDetect.isGist()) {
+	addTrendingMenuItem();
+}

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -26,6 +26,7 @@
 			],
 			"js": [
 				"vendor/jquery.slim.min.js",
+				"vendor/element-ready.js",
 				"vendor/gh-injection.js",
 				"util.js",
 				"page-detect.js",

--- a/extension/vendor/element-ready.js
+++ b/extension/vendor/element-ready.js
@@ -1,0 +1,36 @@
+// https://github.com/sindresorhus/element-ready/blob/master/index.js 1.0.0
+'use strict';
+
+const selectorCache = new Map();
+
+window.elementReady = selector => {
+	if (selectorCache.has(selector)) {
+		return selectorCache.get(selector);
+	}
+
+	const promise = new Promise(resolve => {
+		const el = document.querySelector(selector);
+
+		// Shortcut if the element already exists
+		if (el) {
+			resolve(el);
+			selectorCache.delete(selector);
+			return;
+		}
+
+		// Interval to keep checking for it to come into the DOM
+		const awaitElement = setInterval(() => {
+			const el = document.querySelector(selector);
+
+			if (el) {
+				resolve(el);
+				clearInterval(awaitElement);
+				selectorCache.delete(selector);
+			}
+		}, 50);
+	});
+
+	selectorCache.set(selector, promise);
+
+	return promise;
+};


### PR DESCRIPTION
Issue before this PR: the Trending link is added on domready, which happens after the first paint.

![trending link is added too late](https://cloud.githubusercontent.com/assets/1402241/26481027/c7e30d3e-4210-11e7-9f00-3602f0bd83d8.gif)

This change can probably be applied to more jumpy parts at some point, but this is the most visible on every page.