### PR TITLE
Skip wrapper for console.error()

### DIFF
--- a/extension/show-names.js
+++ b/extension/show-names.js
@@ -54,6 +54,6 @@ window.showRealNames = () => {
 			}
 
 			updateCachedUsers(Object.assign({}, users, userCache));
-		}).catch(err => console.error(err));
+		}).catch(console.error);
 	});
 };


### PR DESCRIPTION
`console.error` is bound in the latest versions of Chrome and Firefox, no need to wrap it or bind it.