### PR TITLE
Let jQuery do innerHTML once

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -279,10 +279,7 @@ function showRecentlyPushedBranches() {
 		}
 
 		const uri = `/${repoUrl}/show_partial?partial=tree/recently_touched_branches_list`;
-		const fragMarkup = `<include-fragment src=${uri}></include-fragment>`;
-		const div = document.createElement('div');
-		div.innerHTML = fragMarkup;
-		$('.repository-content').prepend(div);
+		$(`<include-fragment src=${uri}></include-fragment>`).prependTo('.repository-content');
 	});
 }
 


### PR DESCRIPTION
Creating the `div` beforehand doesn't seem to be necessary. jQuery handles the `include-fragment` fine.