### PR TITLE
Faster selections (big PR)

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -167,7 +167,7 @@ function infinitelyMore() {
 
 function addReadmeEditButton() {
 	const readmeContainer = utils.el('#readme');
-	if (readmeContainer) {
+	if (!readmeContainer) {
 		return;
 	}
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -3,7 +3,7 @@
 'use strict';
 const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 const repoUrl = `${ownerName}/${repoName}`;
-const getUsername = () => utils.el('meta[name="user-login"]').getAttribute('content');
+const getUsername = () => utils.select('meta[name="user-login"]').getAttribute('content');
 
 function getCanonicalBranchFromRef($element) {
 	const refSelector = '.commit-ref, .head-ref, .base-ref';
@@ -147,7 +147,7 @@ function addYoursMenuItem() {
 }
 
 function infinitelyMore() {
-	const btn = utils.el('.ajax-pagination-btn');
+	const btn = utils.select('.ajax-pagination-btn');
 
 	// If there's no more button remove unnecessary event listeners
 	if (!btn) {
@@ -166,14 +166,14 @@ function infinitelyMore() {
 }
 
 function addReadmeEditButton() {
-	const readmeContainer = utils.el('#readme');
+	const readmeContainer = utils.select('#readme');
 	if (!readmeContainer) {
 		return;
 	}
 
-	const readmeName = utils.el('#readme > h3').textContent.trim();
+	const readmeName = utils.select('#readme > h3').textContent.trim();
 	const path = $('.js-repo-root ~ .js-path-segment, .final-path').get().map(el => el.textContent).join('/');
-	const selectMenuButton = utils.el('.file-navigation .select-menu.float-left button.select-menu-button');
+	const selectMenuButton = utils.select('.file-navigation .select-menu.float-left button.select-menu-button');
 	const currentBranch = selectMenuButton.getAttribute('title') || selectMenuButton.querySelector('span').textContent;
 	const editHref = `/${repoUrl}/edit/${currentBranch}/${path ? `${path}/` : ''}${readmeName}`;
 	const editButtonHtml = `<div id="refined-github-readme-edit-link">
@@ -186,7 +186,7 @@ function addReadmeEditButton() {
 }
 
 function addDeleteForkLink() {
-	const postMergeDescription = utils.el('#partial-pull-merging .merge-branch-description');
+	const postMergeDescription = utils.select('#partial-pull-merging .merge-branch-description');
 
 	if (postMergeDescription) {
 		const currentBranch = postMergeDescription.querySelector('.commit-ref.current-branch');
@@ -206,7 +206,7 @@ function addDeleteForkLink() {
 }
 
 function linkifyIssuesInTitles() {
-	const title = utils.el('.js-issue-title');
+	const title = utils.select('.js-issue-title');
 	const titleText = utils.escapeHtml(title.textContent);
 	const issueRegex = utils.issueRegex;
 
@@ -281,7 +281,7 @@ function showRecentlyPushedBranches() {
 		return;
 	}
 
-	const codeURI = utils.el('[data-hotkey="g c"]').getAttribute('href');
+	const codeURI = utils.select('[data-hotkey="g c"]').getAttribute('href');
 
 	fetch(codeURI, {
 		credentials: 'include'
@@ -348,7 +348,7 @@ function addOPLabels() {
 		let op;
 
 		if (pageDetect.isPR()) {
-			const title = utils.el('title').textContent;
+			const title = utils.select('title').textContent;
 			const titleRegex = /^(.+) by (\S+) · Pull Request #(\d+) · (\S+)\/(\S+)$/;
 			op = titleRegex.exec(title)[2];
 		} else {
@@ -410,7 +410,7 @@ function addProjectNewLink() {
 }
 
 function removeProjectsTab() {
-	const projectsTab = utils.el('.js-repo-nav .reponav-item[data-selected-links^="repo_projects"]');
+	const projectsTab = utils.select('.js-repo-nav .reponav-item[data-selected-links^="repo_projects"]');
 	if (projectsTab && projectsTab.querySelector('.Counter, .counter').textContent === '0') {
 		projectsTab.remove();
 	}
@@ -418,9 +418,9 @@ function removeProjectsTab() {
 
 function fixSquashAndMergeTitle() {
 	$('.btn-group-squash button[type=submit]').click(() => {
-		const title = utils.el('.js-issue-title').textContent;
-		const number = utils.el('.gh-header-number').textContent;
-		utils.el('#merge_title_field').value = `${title.trim()} (${number})`;
+		const title = utils.select('.js-issue-title').textContent;
+		const number = utils.select('.gh-header-number').textContent;
+		utils.select('#merge_title_field').value = `${title.trim()} (${number})`;
 	});
 }
 
@@ -481,7 +481,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		hideStarsOwnRepos();
 
 		new MutationObserver(() => hideStarsOwnRepos())
-			.observe(utils.el('#dashboard .news'), {childList: true});
+			.observe(utils.select('#dashboard .news'), {childList: true});
 
 		$(window).on('scroll.infinite resize.infinite', infinitelyMore);
 	}
@@ -495,11 +495,11 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isNotifications()) {
 				markUnread.setup();
 			}
-		}).observe(utils.el('#js-pjax-container'), {childList: true});
+		}).observe(utils.select('#js-pjax-container'), {childList: true});
 	}
 
 	addUploadBtn();
-	new MutationObserver(addUploadBtn).observe(utils.el('div[role=main]'), {childList: true, subtree: true});
+	new MutationObserver(addUploadBtn).observe(utils.select('div[role=main]'), {childList: true, subtree: true});
 
 	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
 		addYoursMenuItem();
@@ -540,7 +540,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 			if (pageDetect.hasDiff()) {
 				removeDiffSigns();
-				const diffElements = utils.el('.js-discussion, #files');
+				const diffElements = utils.select('.js-discussion, #files');
 				if (diffElements) {
 					new MutationObserver(removeDiffSigns).observe(diffElements, {childList: true, subtree: true});
 				}
@@ -578,7 +578,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			if (pageDetect.isIssue() || pageDetect.isPR()) {
 				addOPLabels();
 
-				new MutationObserver(addOPLabels).observe(utils.el('.new-discussion-timeline'), {childList: true, subtree: true});
+				new MutationObserver(addOPLabels).observe(utils.select('.new-discussion-timeline'), {childList: true, subtree: true});
 			}
 
 			if (pageDetect.isMilestone()) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -182,7 +182,7 @@ function addReadmeEditButton() {
 		</a>
 	</div>`;
 
-	readmeContainer.append(editButtonHtml);
+	$(editButtonHtml).appendTo(readmeContainer);
 }
 
 function addDeleteForkLink() {

--- a/extension/content.js
+++ b/extension/content.js
@@ -12,7 +12,7 @@ function getCanonicalBranchFromRef($element) {
 }
 
 function getSettingsTab() {
-	return $('.js-repo-nav').children('[data-selected-links~="repo_settings"]');
+	return $('.js-repo-nav > [data-selected-links~="repo_settings"]');
 }
 
 const hasSettings = () => getSettingsTab().length > 0;
@@ -187,10 +187,9 @@ function addReadmeEditButton() {
 }
 
 function addDeleteForkLink() {
-	const $postMergeContainer = $('#partial-pull-merging');
+	const $postMergeDescription = $('#partial-pull-merging .merge-branch-description');
 
-	if ($postMergeContainer.length > 0) {
-		const $postMergeDescription = $postMergeContainer.find('.merge-branch-description');
+	if ($postMergeDescription.length > 0) {
 		const $currentBranch = $postMergeDescription.find('.commit-ref.current-branch')[0];
 		const forkPath = $currentBranch ? $currentBranch.title.split(':')[0] : null;
 
@@ -333,7 +332,7 @@ function addDiffViewWithoutWhitespaceOption(type) {
 	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace');
 
 	if (type === 'pr') {
-		$('.diff-options-content').find('.dropdown-item:last-of-type').after(optionElement);
+		$('.diff-options-content .dropdown-item:last-of-type').after(optionElement);
 		optionElementObject.addClass('dropdown-item');
 	} else {
 		$('.btn-group .selected[href*="diff="]').after(optionElement);
@@ -398,7 +397,7 @@ function addFilterCommentsByYou() {
 				Everything commented by you
 			</div>
 		</a>`;
-	const lastFilter = $('.subnav-search-context').find('.select-menu-list > a:last-child');
+	const lastFilter = $('.subnav-search-context .select-menu-list > a:last-child');
 	if (!lastFilter.prev().hasClass('refined-github-filter')) {
 		lastFilter.before(newFilter);
 	}
@@ -412,7 +411,7 @@ function addProjectNewLink() {
 }
 
 function removeProjectsTab() {
-	const projectsTab = $('.js-repo-nav').find('.reponav-item[data-selected-links^="repo_projects"]');
+	const projectsTab = $('.js-repo-nav .reponav-item[data-selected-links^="repo_projects"]');
 	if (projectsTab.length > 0 && projectsTab.find('.Counter, .counter').text() === '0') {
 		projectsTab.remove();
 	}

--- a/extension/content.js
+++ b/extension/content.js
@@ -301,12 +301,12 @@ function showRecentlyPushedBranches() {
 
 // Add option for viewing diffs without whitespace changes
 function addDiffViewWithoutWhitespaceOption(type) {
-	if (!utils.exists('.diff-options-content') && !utils.exists('.btn-group .selected[href*="diff="]')) {
+	if ($('.diff-options-content').length < 1 && $('.btn-group .selected[href*="diff="]').length < 1) {
 		return;
 	}
 
 	// Return if element already exists in DOM (history actions)
-	if (utils.exists('.refined-github-toggle-whitespace')) {
+	if ($('.refined-github-toggle-whitespace').length > 0) {
 		return;
 	}
 
@@ -331,7 +331,7 @@ function addDiffViewWithoutWhitespaceOption(type) {
 	optionElementObject.html(optionElementContent).attr('href', optionHref).attr('data-hotkey', 'd w').attr('class', 'refined-github-toggle-whitespace');
 
 	if (type === 'pr') {
-		$('.diff-options-content .dropdown-item:last-of-type').after(optionElement);
+		$('.diff-options-content').find('.dropdown-item:last-of-type').after(optionElement);
 		optionElementObject.addClass('dropdown-item');
 	} else {
 		$('.btn-group .selected[href*="diff="]').after(optionElement);

--- a/extension/copy-file-path.js
+++ b/extension/copy-file-path.js
@@ -6,12 +6,12 @@ window.addFilePathCopyBtn = () => {
 	const $files = $('#files .file');
 	$files.each((i, el) => {
 		// Button already added
-		if ($(el).find('.copy-filepath-btn').length > 0) {
+		if (el.querySelector('.copy-filepath-btn')) {
 			return;
 		}
 
-		const $fileUri = $(el).find('.file-header .file-info a');
-		const filePath = $fileUri.attr('title');
+		const fileUri = el.querySelector('.file-header .file-info a');
+		const filePath = fileUri.getAttribute('title');
 		const copyButton = `
 			<button id="rg-copy-filepath-btn" class="btn-octicon tooltipped tooltipped-nw btn btn-sm copy-filepath-btn">
 				<svg aria-hidden="true" class="octicon octicon-clippy" height="16" version="1.1" viewBox="0 0 14 16" width="14" aria-label="Copy to clipboard">
@@ -20,7 +20,7 @@ window.addFilePathCopyBtn = () => {
 				</svg>
 			</button>`;
 		$(copyButton)
-			.insertAfter($fileUri)
+			.insertAfter(fileUri)
 			.mouseenter(e => {
 				$(e.currentTarget).attr('aria-label', 'Copy file path');
 			})
@@ -33,6 +33,6 @@ window.addFilePathCopyBtn = () => {
 };
 
 window.filePathCopyBtnListner = () => {
-	const $filesBucket = $('#files_bucket #files');
-	new MutationObserver(addFilePathCopyBtn).observe($filesBucket[0], {childList: true, subtree: true});
+	const filesBucket = utils.el('#files_bucket #files');
+	new MutationObserver(addFilePathCopyBtn).observe(filesBucket, {childList: true, subtree: true});
 };

--- a/extension/copy-file-path.js
+++ b/extension/copy-file-path.js
@@ -33,6 +33,6 @@ window.addFilePathCopyBtn = () => {
 };
 
 window.filePathCopyBtnListner = () => {
-	const filesBucket = utils.el('#files_bucket #files');
+	const filesBucket = utils.select('#files_bucket #files');
 	new MutationObserver(addFilePathCopyBtn).observe(filesBucket, {childList: true, subtree: true});
 };

--- a/extension/copy-file.js
+++ b/extension/copy-file.js
@@ -4,17 +4,17 @@
 
 window.addFileCopyButton = () => {
 	// Button already added (partial page nav), or non-text file
-	if ($('.copy-btn').length > 0 || $('[data-line-number="1"]').length === 0) {
+	if (utils.exists('.copy-btn') || !utils.exists('[data-line-number="1"]')) {
 		return;
 	}
 
-	const $targetSibling = $('#raw-url');
-	const fileUri = $targetSibling.attr('href');
-	$(`<a href="${fileUri}" class="btn btn-sm BtnGroup-item copy-btn">Copy</a>`).insertBefore($targetSibling);
+	const targetSibling = utils.el('#raw-url');
+	const fileUri = targetSibling.getAttribute('href');
+	$(`<a href="${fileUri}" class="btn btn-sm BtnGroup-item copy-btn">Copy</a>`).insertBefore(targetSibling);
 
 	$(document).on('click', '.copy-btn', e => {
 		e.preventDefault();
-		const fileContents = $('.js-file-line-container').get(0).innerText;
+		const fileContents = utils.el('.js-file-line-container').innerText;
 		utils.copyToClipboard(fileContents);
 	});
 };

--- a/extension/copy-file.js
+++ b/extension/copy-file.js
@@ -8,13 +8,13 @@ window.addFileCopyButton = () => {
 		return;
 	}
 
-	const targetSibling = utils.el('#raw-url');
+	const targetSibling = utils.select('#raw-url');
 	const fileUri = targetSibling.getAttribute('href');
 	$(`<a href="${fileUri}" class="btn btn-sm BtnGroup-item copy-btn">Copy</a>`).insertBefore(targetSibling);
 
 	$(document).on('click', '.copy-btn', e => {
 		e.preventDefault();
-		const fileContents = utils.el('.js-file-line-container').innerText;
+		const fileContents = utils.select('.js-file-line-container').innerText;
 		utils.copyToClipboard(fileContents);
 	});
 };

--- a/extension/copy-gist.js
+++ b/extension/copy-gist.js
@@ -4,7 +4,7 @@
 
 window.addGistCopyButton = () => {
 	// Button already added (partial page nav), or non-text file
-	if ($('.copy-btn').length > 0) {
+	if (utils.exists('.copy-btn')) {
 		return;
 	}
 

--- a/extension/copy-on-y.js
+++ b/extension/copy-on-y.js
@@ -7,7 +7,7 @@ const Y_KEYCODE = 89;
 window.enableCopyOnY = (() => {
 	const handler = ({keyCode, target}) => {
 		if (keyCode === Y_KEYCODE && target.nodeName !== 'INPUT') {
-			const commitIsh = $('.commit-tease-sha').text().trim();
+			const commitIsh = utils.el('.commit-tease-sha').textContent.trim();
 			const uri = location.href.replace(/\/blob\/[\w-]+\//, `/blob/${commitIsh}/`);
 
 			utils.copyToClipboard(uri);

--- a/extension/copy-on-y.js
+++ b/extension/copy-on-y.js
@@ -7,7 +7,7 @@ const Y_KEYCODE = 89;
 window.enableCopyOnY = (() => {
 	const handler = ({keyCode, target}) => {
 		if (keyCode === Y_KEYCODE && target.nodeName !== 'INPUT') {
-			const commitIsh = utils.el('.commit-tease-sha').textContent.trim();
+			const commitIsh = utils.select('.commit-tease-sha').textContent.trim();
 			const uri = location.href.replace(/\/blob\/[\w-]+\//, `/blob/${commitIsh}/`);
 
 			utils.copyToClipboard(uri);

--- a/extension/diffheader.js
+++ b/extension/diffheader.js
@@ -25,8 +25,8 @@ window.diffFileHeader = (() => {
 
 	const maxPixelsAvailable = () => {
 		// Unfortunately can't cache this value, as it'll change with the browsers zoom level
-		const filenameLeftOffset = utils.el('.diff-toolbar-filename').getBoundingClientRect().left;
-		const diffStatLeftOffset = utils.el('.diffbar > .diffstat').getBoundingClientRect().left;
+		const filenameLeftOffset = utils.select('.diff-toolbar-filename').getBoundingClientRect().left;
+		const diffStatLeftOffset = utils.select('.diffbar > .diffstat').getBoundingClientRect().left;
 
 		return diffStatLeftOffset - filenameLeftOffset;
 	};
@@ -63,7 +63,7 @@ window.diffFileHeader = (() => {
 	};
 
 	const getDiffToolbarHeight = () => {
-		const el = utils.el('.pr-toolbar.is-stuck');
+		const el = utils.select('.pr-toolbar.is-stuck');
 		return (el && el.clientHeight) || 0;
 	};
 
@@ -95,7 +95,7 @@ window.diffFileHeader = (() => {
 		}
 
 		if (isResize) {
-			const target = utils.el('.diff-toolbar-filename');
+			const target = utils.select('.diff-toolbar-filename');
 			if (target.getBoundingClientRect().width < maxPixelsAvailable()) {
 				return;
 			}

--- a/extension/diffheader.js
+++ b/extension/diffheader.js
@@ -25,8 +25,8 @@ window.diffFileHeader = (() => {
 
 	const maxPixelsAvailable = () => {
 		// Unfortunately can't cache this value, as it'll change with the browsers zoom level
-		const filenameLeftOffset = $('.diff-toolbar-filename').get(0).getBoundingClientRect().left;
-		const diffStatLeftOffset = $('.diffbar > .diffstat').get(0).getBoundingClientRect().left;
+		const filenameLeftOffset = utils.el('.diff-toolbar-filename').getBoundingClientRect().left;
+		const diffStatLeftOffset = utils.el('.diffbar > .diffstat').getBoundingClientRect().left;
 
 		return diffStatLeftOffset - filenameLeftOffset;
 	};
@@ -63,7 +63,7 @@ window.diffFileHeader = (() => {
 	};
 
 	const getDiffToolbarHeight = () => {
-		const el = $('.pr-toolbar.is-stuck').get(0);
+		const el = utils.el('.pr-toolbar.is-stuck');
 		return (el && el.clientHeight) || 0;
 	};
 
@@ -88,14 +88,14 @@ window.diffFileHeader = (() => {
 			return;
 		}
 
-		const filename = $(targetDiffFile).find('.file-header').attr('data-path');
+		const filename = targetDiffFile.querySelector('.file-header').dataset.path;
 
 		if (!diffFile.hasChanged(filename) && !isResize) {
 			return;
 		}
 
 		if (isResize) {
-			const target = $('.diff-toolbar-filename').get(0);
+			const target = utils.el('.diff-toolbar-filename');
 			if (target.getBoundingClientRect().width < maxPixelsAvailable()) {
 				return;
 			}

--- a/extension/diffheader.js
+++ b/extension/diffheader.js
@@ -111,7 +111,7 @@ window.diffFileHeader = (() => {
 
 		$('.diffbar > .diffstat').insertAfter('.pr-review-tools');
 
-		$(`<span class="diffbar-item diff-toolbar-filename"></span>`).insertAfter($('.toc-select'));
+		$(`<span class="diffbar-item diff-toolbar-filename"></span>`).insertAfter('.toc-select');
 		diffFile.reset();
 	};
 

--- a/extension/linkify-urls-in-code.js
+++ b/extension/linkify-urls-in-code.js
@@ -1,3 +1,5 @@
+/* globals utils */
+
 window.linkifyURLsInCode = (() => {
 	const issueRegex = window.utils.issueRegex;
 	const URLRegex = /(http(s)?(:\/\/))(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/g;
@@ -11,7 +13,7 @@ window.linkifyURLsInCode = (() => {
 
 	const linkifyCode = repoPath => {
 		// Don't linkify any already linkified code
-		if ($(`.${linkifiedURLClass}`).length > 0) {
+		if (utils.exists(`.${linkifiedURLClass}`)) {
 			return;
 		}
 		const codeBlobs = document.querySelectorAll('.blob-code-inner');

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -1,4 +1,4 @@
-/* globals pageDetect, icons */
+/* globals pageDetect, icons, utils */
 
 'use strict';
 
@@ -38,7 +38,7 @@ window.markUnread = (() => {
 
 		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const repository = `${ownerName}/${repoName}`;
-		const title = $('.js-issue-title').text().trim();
+		const title = utils.el('.js-issue-title').textContent.trim();
 		const type = pageDetect.isPR() ? 'pull-request' : 'issue';
 		const url = stripHash(location.href);
 
@@ -140,7 +140,7 @@ window.markUnread = (() => {
 				}
 			}
 
-			const hasList = $(`a.notifications-repo-link[title="${repository}"]`).length > 0;
+			const hasList = utils.exists(`a.notifications-repo-link[title="${repository}"]`);
 			if (!hasList) {
 				const list = $(`
 					<div class="boxed-group flush">
@@ -211,11 +211,11 @@ window.markUnread = (() => {
 	}
 
 	function isNotificationExist(url) {
-		return $(`a.js-notification-target[href^="${stripHash(url)}"]`).length > 0;
+		return utils.exists(`a.js-notification-target[href^="${stripHash(url)}"]`);
 	}
 
 	function isEmptyPage() {
-		return $('.blankslate').length > 0;
+		return utils.exists('.blankslate');
 	}
 
 	function isParticipatingPage() {
@@ -223,7 +223,7 @@ window.markUnread = (() => {
 	}
 
 	function getUserName() {
-		return $('#user-links a.name img').attr('alt').slice(1);
+		return utils.el('#user-links a.name img').getAttribute('alt').slice(1);
 	}
 
 	function unreadIndicatorIcon() {
@@ -266,8 +266,8 @@ window.markUnread = (() => {
 	}
 
 	function addCustomAllReadBtn() {
-		const $markAllReadBtn = $('#notification-center a[href="#mark_as_read_confirm_box"]');
-		if ($markAllReadBtn.length >= 1 || JSON.parse(localStorage.unreadNotifications || '[]').length === 0) {
+		const hasMarkAllReadBtnExists = utils.exists('#notification-center a[href="#mark_as_read_confirm_box"]');
+		if (hasMarkAllReadBtnExists || JSON.parse(localStorage.unreadNotifications || '[]').length === 0) {
 			return;
 		}
 
@@ -293,14 +293,14 @@ window.markUnread = (() => {
 	}
 
 	function countLocalNotifications() {
-		const $unreadCount = $('#notification-center .filter-list a[href="/notifications"] .count');
-		const githubNotificationsCount = Number($unreadCount.text());
+		const unreadCount = utils.el('#notification-center .filter-list a[href="/notifications"] .count');
+		const githubNotificationsCount = Number(unreadCount.textContent);
 		let localNotificationsCount = 0;
 		const localNotifications = localStorage.unreadNotifications;
 
 		if (localNotifications) {
 			localNotificationsCount = JSON.parse(localNotifications).length;
-			$unreadCount.text(githubNotificationsCount + localNotificationsCount);
+			unreadCount.textContent = githubNotificationsCount + localNotificationsCount;
 		}
 	}
 

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -211,10 +211,7 @@ window.markUnread = (() => {
 	}
 
 	function isNotificationExist(url) {
-		return $('a.js-notification-target')
-			.toArray()
-			.filter(link => stripHash($(link).attr('href')) === stripHash(url))
-			.length > 0;
+		return $(`a.js-notification-target[href^="${stripHash(url)}"]`).length > 0;
 	}
 
 	function isEmptyPage() {

--- a/extension/mark-unread.js
+++ b/extension/mark-unread.js
@@ -38,7 +38,7 @@ window.markUnread = (() => {
 
 		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const repository = `${ownerName}/${repoName}`;
-		const title = utils.el('.js-issue-title').textContent.trim();
+		const title = utils.select('.js-issue-title').textContent.trim();
 		const type = pageDetect.isPR() ? 'pull-request' : 'issue';
 		const url = stripHash(location.href);
 
@@ -223,7 +223,7 @@ window.markUnread = (() => {
 	}
 
 	function getUserName() {
-		return utils.el('#user-links a.name img').getAttribute('alt').slice(1);
+		return utils.select('#user-links a.name img').getAttribute('alt').slice(1);
 	}
 
 	function unreadIndicatorIcon() {
@@ -293,7 +293,7 @@ window.markUnread = (() => {
 	}
 
 	function countLocalNotifications() {
-		const unreadCount = utils.el('#notification-center .filter-list a[href="/notifications"] .count');
+		const unreadCount = utils.select('#notification-center .filter-list a[href="/notifications"] .count');
 		const githubNotificationsCount = Number(unreadCount.textContent);
 		let localNotificationsCount = 0;
 		const localNotifications = localStorage.unreadNotifications;

--- a/extension/page-detect.js
+++ b/extension/page-detect.js
@@ -1,3 +1,5 @@
+/* globals utils */
+
 window.pageDetect = (() => {
 	const isGist = () => location.hostname === 'gist.github.com';
 
@@ -7,7 +9,7 @@ window.pageDetect = (() => {
 
 	const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, '');
 
-	const isRepoRoot = () => isRepo() && /^(\/?$|\/tree\/)/.test(getRepoPath()) && $('.repository-meta-content').length > 0;
+	const isRepoRoot = () => isRepo() && /^(\/?$|\/tree\/)/.test(getRepoPath()) && utils.exists('.repository-meta-content');
 
 	const isRepoTree = () => isRepo() && /\/tree\//.test(getRepoPath());
 
@@ -33,13 +35,13 @@ window.pageDetect = (() => {
 
 	const isSingleCommit = () => isRepo() && /^\/commit\/[0-9a-f]{5,40}/.test(getRepoPath());
 
-	const isCommit = () => isSingleCommit() || isPRCommit() || (isPRFiles() && $('.full-commit').length > 0);
+	const isCommit = () => isSingleCommit() || isPRCommit() || (isPRFiles() && utils.exists('.full-commit'));
 
 	const isCompare = () => isRepo() && /^\/compare/.test(getRepoPath());
 
-	const hasCode = () => isRepo() && $('.blob-code-inner').length > 0;
+	const hasCode = () => isRepo() && utils.exists('.blob-code-inner');
 
-	const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && $('.diff-table').length > 0));
+	const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && utils.exists('.diff-table')));
 
 	const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
 
@@ -64,7 +66,7 @@ window.pageDetect = (() => {
 		return isRepo() && blobPattern.test(location.href);
 	};
 
-	const hasCommentForm = () => $('.js-previewable-comment-form').length > 0;
+	const hasCommentForm = () => utils.exists('.js-previewable-comment-form');
 
 	return {
 		isGist,

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -20,7 +20,7 @@ const addReactionParticipants = {
 				}
 
 				// Add participant container
-				if (element.querySelector('div.participants-container') === undefined) {
+				if (!element.querySelector('div.participants-container')) {
 					$element.append('<div class="participants-container">');
 				}
 
@@ -47,7 +47,7 @@ const addReactionParticipants = {
 	},
 
 	reapply(event, currentUser) {
-		if (!$(event.target).closest('.add-reactions-options-item, .reaction-summary-item').not('.add-reaction-btn')) {
+		if ($(event.target).closest('.add-reactions-options-item, .reaction-summary-item').not('.add-reaction-btn').length === 0) {
 			return;
 		}
 

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -47,7 +47,7 @@ const addReactionParticipants = {
 	},
 
 	reapply(event, currentUser) {
-		if (!$(event.target).closest('button').not('.add-reaction-btn').is('.add-reactions-options-item, .reaction-summary-item')) {
+		if (!$(event.target).closest('.add-reactions-options-item, .reaction-summary-item').not('.add-reaction-btn')) {
 			return;
 		}
 

--- a/extension/reactions-avatars.js
+++ b/extension/reactions-avatars.js
@@ -20,7 +20,7 @@ const addReactionParticipants = {
 				}
 
 				// Add participant container
-				if ($element.find('div.participants-container').length === 0) {
+				if (element.querySelector('div.participants-container') === undefined) {
 					$element.append('<div class="participants-container">');
 				}
 

--- a/extension/util.js
+++ b/extension/util.js
@@ -47,6 +47,6 @@
 		return escape.innerHTML;
 	};
 
-	exports.el = selector => document.querySelector(selector);
+	exports.select = selector => document.querySelector(selector);
 	exports.exists = selector => Boolean(document.querySelector(selector));
 })(window.utils = {});

--- a/extension/util.js
+++ b/extension/util.js
@@ -46,4 +46,7 @@
 		escape.textContent = html;
 		return escape.innerHTML;
 	};
+
+	exports.el = selector => document.querySelector(selector);
+	exports.exists = selector => Boolean(document.querySelector(selector));
 })(window.utils = {});


### PR DESCRIPTION
The easiest part was merging sequential selections like `$('a').find('span')` that most of the time were better written as `$('a span')`.

`$()` selects multiple elements but RG often only needs one element. Sometimes we forget that vanilla DOM methods are less awkward than `$('a')[0]` or even `$('a').toArray()[1]`

Since `document.querySelector` is a mouthful I was going to use a local `select()` function, but then I ended up saving it as `utils.el`.

Also often `$(selector).length > 0` was used to detect the existence of an element. I initially replaced it with `utils.el(selector)` but thought it'd be more explicit as `utils.exists(selector)`

Wherever `$()` was dropped in these places, I also switched to plain DOM APIs; e.g. `.textContent` instead of `.text()`

---

I avoided these changes where they brought big diffs or were impractical (e.g. `$existingVar[0].querySelector()` instead of leaving it as `$existingVar.find()`)