### PR TITLE
Remove duplicate permissions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,8 +6,6 @@
 	"manifest_version": 2,
 	"minimum_chrome_version": "49",
 	"permissions": [
-		"https://github.com/*",
-		"https://gist.github.com/*",
 		"storage"
 	],
 	"icons": {


### PR DESCRIPTION
Those domains are implied since they appear in `content_scripts.matches`