### PR TITLE
Add support for GitHub Enterprise

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,3 @@
+/* globals injectContentScripts */
+
+injectContentScripts();

--- a/extension/content.js
+++ b/extension/content.js
@@ -467,7 +467,7 @@ $(document).on('pjax:end', () => {
 	}
 });
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
 	const username = getUsername();
 
 	markUnread.unreadIndicatorIcon();
@@ -601,8 +601,14 @@ document.addEventListener('DOMContentLoaded', () => {
 			}
 		});
 	}
-});
+}
 
 if (!pageDetect.isGist()) {
 	addTrendingMenuItem();
+}
+
+if (document.readyState === 'complete') {
+	init();
+} else {
+	document.addEventListener('DOMContentLoaded', init);
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,8 +8,23 @@
 	"permissions": [
 		"storage"
 	],
+	"optional_permissions": [
+		"http://*/*",
+		"https://*/*"
+	],
 	"icons": {
 		"128": "icon.png"
+	},
+	"options_ui": {
+		"chrome_style": true,
+		"page": "options/index.html"
+	},
+	"background": {
+		"scripts": [
+			"vendor/webext-dynamic-content-scripts.js",
+			"background.js"
+		],
+		"persistent": false
 	},
 	"content_scripts": [
 		{
@@ -26,6 +41,7 @@
 				"vendor/jquery.slim.min.js",
 				"vendor/element-ready.js",
 				"vendor/gh-injection.js",
+				"vendor/webext-dynamic-content-scripts.js",
 				"util.js",
 				"page-detect.js",
 				"icons.js",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -52,10 +52,10 @@
 				"copy-gist.js",
 				"copy-on-y.js",
 				"show-names.js",
-				"content.js",
 				"mark-unread.js",
 				"linkify-urls-in-code.js",
-				"upload-button.js"
+				"upload-button.js",
+				"content.js"
 			]
 		}
 	]

--- a/extension/options/index.css
+++ b/extension/options/index.css
@@ -1,0 +1,6 @@
+html {
+	font-family: sans-serif;
+}
+input {
+	font: inherit;
+}

--- a/extension/options/index.html
+++ b/extension/options/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Refined GitHub options</title>
+<link rel="stylesheet" href="index.css">
+<form id="custom-domain">
+	<h2>GitHub Enterprise support</h2>
+	<p>
+		<label>Authorize your own domain:
+			<input type="url" placeholder="https://fullurl.example.com" size="23" required id="custom-domain-origin">
+		</label>
+		<button type="submit">Add</button>
+	</p>
+</form>
+<script src="index.js"></script>

--- a/extension/options/index.html
+++ b/extension/options/index.html
@@ -5,10 +5,8 @@
 <form id="custom-domain">
 	<h2>GitHub Enterprise support</h2>
 	<p>
-		<label>Authorize your own domain:
-			<input type="url" placeholder="https://fullurl.example.com" size="23" required id="custom-domain-origin">
-		</label>
-		<button type="submit">Add</button>
+		<input type="url" placeholder="https://github.yourdomain.com" size="30" required id="custom-domain-origin">
+		<button type="submit">Authorize</button>
 	</p>
 </form>
 <script src="index.js"></script>

--- a/extension/options/index.html
+++ b/extension/options/index.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<meta charset="UTF-8">
+<!doctype html>
+<meta charset="utf-8">
 <title>Refined GitHub options</title>
 <link rel="stylesheet" href="index.css">
 <form id="custom-domain">

--- a/extension/options/index.js
+++ b/extension/options/index.js
@@ -1,0 +1,25 @@
+const cdForm = document.querySelector('#custom-domain');
+const cdInput = document.querySelector('#custom-domain-origin');
+
+if (!chrome.permissions) {
+	cdForm.disabled = true;
+	cdForm.querySelector('p').textContent = 'Your browser doesn’t support the Permission API required.';
+}
+
+cdForm.addEventListener('submit', e => {
+	e.preventDefault();
+
+	const origin = new URL(cdInput.value).origin;
+
+	if (origin) {
+		chrome.permissions.request({
+			origins: [
+				origin + '/*'
+			]
+		}, granted => {
+			if (granted) {
+				cdForm.reset();
+			}
+		});
+	}
+});

--- a/extension/options/index.js
+++ b/extension/options/index.js
@@ -3,18 +3,18 @@ const cdInput = document.querySelector('#custom-domain-origin');
 
 if (!chrome.permissions) {
 	cdForm.disabled = true;
-	cdForm.querySelector('p').textContent = 'Your browser doesn’t support the Permission API required.';
+	cdForm.querySelector('p').textContent = 'Your browser doesn’t support the required Permission API.';
 }
 
-cdForm.addEventListener('submit', e => {
-	e.preventDefault();
+cdForm.addEventListener('submit', event => {
+	event.preventDefault();
 
 	const origin = new URL(cdInput.value).origin;
 
 	if (origin) {
 		chrome.permissions.request({
 			origins: [
-				origin + '/*'
+				`${origin}/*`
 			]
 		}, granted => {
 			if (granted) {

--- a/extension/vendor/webext-dynamic-content-scripts.js
+++ b/extension/vendor/webext-dynamic-content-scripts.js
@@ -1,0 +1,114 @@
+// https://github.com/bfred-it/webext-dynamic-content-scripts 1.0.0
+
+var injectContentScripts = (function () {
+'use strict';
+
+function createCommonjsModule(fn, module) {
+	return module = { exports: {} }, fn(module, module.exports), module.exports;
+}
+
+var webextContentScriptPing = createCommonjsModule(function (module, exports) {
+// https://github.com/bfred-it/webext-content-script-ping
+
+function pingContentScript(tabId) {
+	return new Promise((resolve, reject) => {
+		setTimeout(reject, 300);
+		chrome.tabs.sendMessage(tabId, chrome.runtime.id, {
+			// Only the main frame is necessary;
+			// if that isn't loaded, no other iframe is
+			frameId: 0
+		}, response => {
+			if (response === chrome.runtime.id) {
+				resolve();
+			} else {
+				reject();
+			}
+		});
+	});
+}
+
+if (!chrome.runtime.getBackground) {
+	// Respond to pings
+	chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+		if (request === chrome.runtime.id) {
+			sendResponse(chrome.runtime.id);
+		}
+	});
+}
+
+if (typeof exports === 'object') {
+	exports.pingContentScript = pingContentScript;
+}
+});
+
+var pingContentScript = webextContentScriptPing.pingContentScript;
+
+function logRuntimeErrors() {
+	if (chrome.runtime.lastError) {
+		console.error(chrome.runtime.lastError);
+	}
+}
+
+async function injectContentScript(script, tabId) {
+	const allFrames = script.all_frames;
+	const runAt = script.run_at;
+
+	// Flatten file list
+	const list = [
+		...script.css.map(file => ({file, fn: 'insertCSS'})),
+		...script.js.map(file => ({file, fn: 'executeScript'}))
+	];
+
+	// Guarantee execution order
+	for (const {file, fn} of list) {
+		/* eslint no-await-in-loop: 0 */ // We actually need the loop to wait
+		await new Promise(resolve => chrome.tabs[fn](tabId, {file, allFrames, runAt}, resolve));
+		logRuntimeErrors(); // TODO: should errors stop the execution instead?
+	}
+}
+
+async function injectContentScripts(tab) {
+	// Exit if already injected
+	try {
+		return await pingContentScript(tab.id || tab);
+	} catch (err) {}
+
+	// Get the tab object if we don't have it already
+	if (!tab.id) {
+		tab = await new Promise(resolve => chrome.tabs.get(tab, resolve));
+		logRuntimeErrors();
+	}
+
+	// Verify that we have permission to the current tab
+	// Url is available only with `tabs` permission.
+	// If that's missing, you'll see errors in background.js's console.
+	// It's fine.
+	if (tab.url) {
+		const isPermitted = await new Promise(resolve => chrome.permissions.contains({
+			origins: [new URL(tab.url).origin + '/']
+		}, resolve));
+		logRuntimeErrors();
+
+		if (!isPermitted) {
+			return;
+		}
+	}
+
+	chrome.runtime.getManifest().content_scripts.forEach(s => injectContentScript(s, tab.id));
+}
+
+var index = function (tab = false) {
+	if (tab === false) {
+		chrome.tabs.onUpdated.addListener((tabId, {status}) => {
+			if (status === 'loading') {
+				injectContentScripts(tabId);
+			}
+		});
+	} else {
+		injectContentScripts(tab);
+	}
+};
+
+return index;
+
+}());


### PR DESCRIPTION
Fixes #315 

New domains can be specified in GH's options view, which can also help #193, should that ever materialize.

<img width="444" alt="options view" src="https://cloud.githubusercontent.com/assets/1402241/26502379/32dadf14-426f-11e7-8bb7-835527f07c5f.png">

To test this without access to GHE:

1. remove all the permissions to `github.com` in `manifest.json`
42. disable and re-enable the extension (don't just reload it)
369. Verify the permissions, `github.com` should not be there
9001. Add `https://github.com` via the form