### PR TITLE
Change default issue sort

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -430,6 +430,13 @@ function addTitleToEmojis() {
 	}
 }
 
+function sortIssuesByUpdateTime() {
+	const issuesTab = document.querySelector('.reponav-item[href$="issues"');
+	if (issuesTab) {
+		issuesTab.href += '?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc';
+	}
+}
+
 // Support indent with tab key in comments
 $(document).on('keydown', '.js-comment-field', event => {
 	if (event.which === 9 && !event.shiftKey) {
@@ -517,6 +524,7 @@ document.addEventListener('DOMContentLoaded', () => {
 			addCompareTab();
 			removeProjectsTab();
 			addTitleToEmojis();
+			sortIssuesByUpdateTime();
 
 			diffFileHeader.destroy();
 			enableCopyOnY.destroy();

--- a/extension/content.js
+++ b/extension/content.js
@@ -435,6 +435,11 @@ function sortIssuesByUpdateTime() {
 	if (issuesTab) {
 		issuesTab.href += '?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc';
 	}
+
+	const prTab = document.querySelector('.reponav-item[href$="pulls"');
+	if (prTab) {
+		prTab.href += '?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc';
+	}
 }
 
 // Support indent with tab key in comments


### PR DESCRIPTION
Simplistic approach to the change requested in #80. It just updates the two tabs/links to default to the Recently Updated order.

Closes #80 