### PR TITLE
Sort milestones by closest due date

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ GitHub Enterprise is also supported by [authorizing your own domain in the optio
 - Easier copy-pasting from diffs by making +/- signs unselectable
 - Automagically expands the news feed when you scroll down
 - Shows the reactions popover on hover instead of click
+- Changes the default sort order of milestones to "Closest due date"
 
 And [lots](extension/content.css) [more...](src/content.js)
 

--- a/src/content.js
+++ b/src/content.js
@@ -473,10 +473,15 @@ function addTitleToEmojis() {
 	}
 }
 
-function sortMileStonesByClosestDueDate() {
-	const milestoneTab = select('.subnav-item[href$="/milestones"]');
-	if (milestoneTab) {
-		milestoneTab.setAttribute('href', `/${repoUrl}/milestones?direction=asc&sort=due_date`);
+function sortMilestonesByClosestDueDate() {
+	for (const a of select.all('a[href$="/milestones"], a[href*="/milestones?"]')) {
+		const url = new URL(a.href);
+		// Only if they aren't explicitly sorted differently
+		if (!url.searchParams.get('direction') && !url.searchParams.get('sort')) {
+			url.searchParams.set('direction', 'asc');
+			url.searchParams.set('sort', 'due_date');
+			a.href = url;
+		}
 	}
 }
 
@@ -643,12 +648,6 @@ async function onDomReady() {
 				addMilestoneNavigation();
 			}
 
-			if (pageDetect.isPRList() || pageDetect.isIssueList() ||
-				pageDetect.isMilestoneList() || pageDetect.isMilestone() ||
-				pageDetect.isLabelList() || pageDetect.isLabel()) {
-				sortMileStonesByClosestDueDate();
-			}
-
 			if (pageDetect.hasCode()) {
 				linkifyCode();
 			}
@@ -656,6 +655,8 @@ async function onDomReady() {
 			if (pageDetect.isRepoSettings()) {
 				addProjectNewLink();
 			}
+
+			sortMilestonesByClosestDueDate(); // Needs to be after addMilestoneNavigation
 		});
 	}
 }

--- a/src/content.js
+++ b/src/content.js
@@ -473,6 +473,13 @@ function addTitleToEmojis() {
 	}
 }
 
+function sortMileStonesByClosestDueDate() {
+	const milestoneTab = select('.subnav-item[href$="/milestones"]');
+	if (milestoneTab) {
+		milestoneTab.setAttribute('href', `/${repoUrl}/milestones?direction=asc&sort=due_date`);
+	}
+}
+
 function init() {
 	if (select.exists('html.refined-github')) {
 		console.count('Refined GitHub was loaded multiple times: https://github.com/sindresorhus/refined-github/issues/479');
@@ -634,6 +641,12 @@ async function onDomReady() {
 
 			if (pageDetect.isMilestone()) {
 				addMilestoneNavigation();
+			}
+
+			if (pageDetect.isPRList() || pageDetect.isIssueList() ||
+				pageDetect.isMilestoneList() || pageDetect.isMilestone() ||
+				pageDetect.isLabelList() || pageDetect.isLabel()) {
+				sortMileStonesByClosestDueDate();
 			}
 
 			if (pageDetect.hasCode()) {

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -30,7 +30,13 @@ export const isPRFiles = () => isRepo() && /^\/pull\/\d+\/files/.test(getRepoPat
 
 export const isPRCommit = () => isRepo() && /^\/pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(getRepoPath());
 
+export const isMilestoneList = () => isRepo() && /^\/milestones\/?$/.test(getRepoPath());
+
 export const isMilestone = () => isRepo() && /^\/milestone\/\d+/.test(getRepoPath());
+
+export const isLabelList = () => isRepo() && /^\/labels\/?(((?=\?).*)|$)/.test(getRepoPath());
+
+export const isLabel = () => isRepo() && /^\/labels\/\w+/.test(getRepoPath());
 
 export const isCommitList = () => isRepo() && /^\/commits\//.test(getRepoPath());
 


### PR DESCRIPTION
The default sorting of milestones in github is pretty frustrating. Milestones are used to manage releases; where as the closest one is often more important than the last updated one.

This PR fixes the default sorting, so they are sorted by closest due date, instead of recently updated.