### PR TITLE
Simplify removeDiffSigns

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -573,8 +573,11 @@ hidden content area created to increase hover target
 .refined-github-diff-signs .blob-code-deletion:before {
 	content: '-';
 }
+
+/* prevent copy of ghost whitespace where supported (#317) */
 .refined-github-diff-signs .add-line-comment {
-	user-select: none; /* #317 */
+	-moz-user-select: none;
+	user-select: none;
 }
 
 /* restore removed space with unselectable one*/

--- a/extension/content.css
+++ b/extension/content.css
@@ -573,6 +573,9 @@ td.blob-code.blob-code-addition:before {
 td.blob-code.blob-code-deletion:before {
 	content: '-';
 }
+.soft-wrap .add-line-comment {
+	user-select: none; /* #317 */
+}
 
 /* remove "pro tip!" box on profile page (appears when name isn't set) */
 .new-user-avatar-cta {

--- a/extension/content.css
+++ b/extension/content.css
@@ -577,6 +577,12 @@ td.blob-code.blob-code-deletion:before {
 	user-select: none; /* #317 */
 }
 
+/* restore removed space with unselectable one*/
+.refined-github-diff-signs .blob-code-inner:before {
+	content: ' ' !important;
+	user-select: none;
+}
+
 /* remove "pro tip!" box on profile page (appears when name isn't set) */
 .new-user-avatar-cta {
 	display: none !important;

--- a/extension/content.css
+++ b/extension/content.css
@@ -555,8 +555,8 @@ hidden content area created to increase hover target
 }
 
 /* +/- pseudo elements on diffs */
-td.blob-code.blob-code-addition:before,
-td.blob-code.blob-code-deletion:before {
+.refined-github-diff-signs .blob-code-addition:before,
+.refined-github-diff-signs .blob-code-deletion:before {
 	display: inline-block;
 	position: absolute;
 	top: 1px;
@@ -566,14 +566,14 @@ td.blob-code.blob-code-deletion:before {
 	color: rgba(0, 0, 0, 0.3);
 }
 
-td.blob-code.blob-code-addition:before {
+.refined-github-diff-signs .blob-code-addition:before {
 	content: '+';
 }
 
-td.blob-code.blob-code-deletion:before {
+.refined-github-diff-signs .blob-code-deletion:before {
 	content: '-';
 }
-.soft-wrap .add-line-comment {
+.refined-github-diff-signs .add-line-comment {
 	user-select: none; /* #317 */
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -271,12 +271,11 @@ function addPatchDiffLinks() {
 }
 
 function removeDiffSigns() {
-	$('.blob-code-addition, .blob-code-deletion')
-		.find('.blob-code-inner:not(.refined-github-diff-signs)')
-		.each((index, element) => {
-			const $element = $(element);
-			$element.html(` ${$element.html().slice(1)}`);
-			$element.addClass('refined-github-diff-signs');
+	$('.diff-table:not(.refined-github-diff-signs)')
+		.addClass('refined-github-diff-signs')
+		.find('.blob-code-inner')
+		.each((index, el) => {
+			el.firstChild.textContent = el.firstChild.textContent.slice(1);
 		});
 }
 


### PR DESCRIPTION
The space mentioned by #317 is:

- [x] added by GitHub on every line so that +/- signs would align correctly; now removed on every line
- [ ] inside the Add Comment `<button>`; ~~now made non-selectable~~

Replaces #453
