### PR TITLE
Use bfred-it/select-dom@4.1's .exist() method

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "element-ready": "^2.0.0",
     "escape-goat": "^1.1.0",
     "github-injection": "^0.3.0",
-    "select-dom": "^4.0.0",
+    "select-dom": "^4.1.0",
     "to-semver": "^1.1.0",
     "webext-dynamic-content-scripts": "^2.0.1"
   },

--- a/src/content.js
+++ b/src/content.js
@@ -2,6 +2,7 @@ import elementReady from 'element-ready';
 import gitHubInjection from 'github-injection';
 import toSemver from 'to-semver';
 import {escape as escapeHtml} from 'escape-goat';
+import select from 'select-dom';
 import $ from './libs/vendor/jquery.slim.min';
 
 import markUnread from './libs/mark-unread';
@@ -14,7 +15,7 @@ import showRealNames from './libs/show-names';
 import filePathCopyBtnListner from './libs/copy-file-path';
 import addFileCopyButton from './libs/copy-file';
 import {linkifyCode} from './libs/linkify-urls-in-code';
-import {select, exists, issueRegex, linkifyIssueRef} from './libs/util';
+import {issueRegex, linkifyIssueRef} from './libs/util';
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
 
@@ -255,7 +256,7 @@ function linkifyIssuesInTitles() {
 }
 
 function addPatchDiffLinks() {
-	if (exists('.sha-block.patch-diff-links')) {
+	if (select.exists('.sha-block.patch-diff-links')) {
 		return;
 	}
 
@@ -313,7 +314,7 @@ function indentInput(el, size = 4) {
 
 function showRecentlyPushedBranches() {
 	// Don't duplicate on back/forward in history
-	if (exists('.recently-touched-branches-wrapper')) {
+	if (select.exists('.recently-touched-branches-wrapper')) {
 		return;
 	}
 
@@ -445,7 +446,7 @@ function addFilterCommentsByYou() {
 
 function addProjectNewLink() {
 	const projectNewLink = `<a href="/${repoUrl}/projects/new" class="btn btn-sm" id="refined-github-project-new-link">Add a project</a>`;
-	if (exists('#projects-feature:checked') && !exists('#refined-github-project-new-link')) {
+	if (select.exists('#projects-feature:checked') && !select.exists('#refined-github-project-new-link')) {
 		$(`#projects-feature ~ p.note`).after(projectNewLink);
 	}
 }

--- a/src/libs/copy-file-path.js
+++ b/src/libs/copy-file-path.js
@@ -1,6 +1,6 @@
 import copyToClipboard from 'copy-text-to-clipboard';
+import select from 'select-dom';
 import $ from './vendor/jquery.slim.min';
-import {select} from './util';
 
 function addFilePathCopyBtn() {
 	const $files = $('#files .file');

--- a/src/libs/copy-file.js
+++ b/src/libs/copy-file.js
@@ -1,10 +1,10 @@
 import copyToClipboard from 'copy-text-to-clipboard';
+import select from 'select-dom';
 import $ from './vendor/jquery.slim.min';
-import {select, exists} from './util';
 
 export default () => {
 	// Button already added (partial page nav), or non-text file
-	if (exists('.copy-btn') || !exists('[data-line-number="1"]')) {
+	if (select.exists('.copy-btn') || !select.exists('[data-line-number="1"]')) {
 		return;
 	}
 

--- a/src/libs/copy-gist.js
+++ b/src/libs/copy-gist.js
@@ -1,10 +1,10 @@
 import copyToClipboard from 'copy-text-to-clipboard';
+import select from 'select-dom';
 import $ from './vendor/jquery.slim.min';
-import {exists} from './util';
 
 export default () => {
 	// Button already added (partial page nav), or non-text file
-	if (exists('.copy-btn')) {
+	if (select.exists('.copy-btn')) {
 		return;
 	}
 

--- a/src/libs/copy-on-y.js
+++ b/src/libs/copy-on-y.js
@@ -1,5 +1,5 @@
 import copyToClipboard from 'copy-text-to-clipboard';
-import {select} from './util';
+import select from 'select-dom';
 
 const Y_KEYCODE = 89;
 

--- a/src/libs/diffheader.js
+++ b/src/libs/diffheader.js
@@ -1,6 +1,6 @@
 import debounce from 'debounce-fn';
+import select from 'select-dom';
 import $ from './vendor/jquery.slim.min';
-import {select} from './util';
 
 const diffFile = (() => {
 	let lastFile;

--- a/src/libs/linkify-urls-in-code.js
+++ b/src/libs/linkify-urls-in-code.js
@@ -1,4 +1,5 @@
-import {exists, issueRegex, linkifyIssueRef} from './util';
+import select from 'select-dom';
+import {issueRegex, linkifyIssueRef} from './util';
 
 const URLRegex = /(http(s)?(:\/\/))(www\.)?[a-zA-Z0-9-_.]+(\.[a-zA-Z0-9]{2,})([-a-zA-Z0-9:%_+.~#?&//=]*)/g;
 const linkifiedURLClass = 'rg-linkified-code';
@@ -11,7 +12,7 @@ export const findURLs = text => text.match(URLRegex) || [];
 
 export const linkifyCode = repoPath => {
 	// Don't linkify any already linkified code
-	if (exists(`.${linkifiedURLClass}`)) {
+	if (select.exists(`.${linkifiedURLClass}`)) {
 		return;
 	}
 	const codeBlobs = document.querySelectorAll('.blob-code-inner');

--- a/src/libs/mark-unread.js
+++ b/src/libs/mark-unread.js
@@ -1,5 +1,5 @@
+import select from 'select-dom';
 import $ from './vendor/jquery.slim.min';
-import {select, exists} from './util';
 import * as icons from './icons';
 import * as pageDetect from './page-detect';
 
@@ -140,7 +140,7 @@ function renderNotifications() {
 			}
 		}
 
-		const hasList = exists(`a.notifications-repo-link[title="${repository}"]`);
+		const hasList = select.exists(`a.notifications-repo-link[title="${repository}"]`);
 		if (!hasList) {
 			const list = $(`
 				<div class="boxed-group flush">
@@ -211,11 +211,11 @@ function renderNotifications() {
 }
 
 function isNotificationExist(url) {
-	return exists(`a.js-notification-target[href^="${stripHash(url)}"]`);
+	return select.exists(`a.js-notification-target[href^="${stripHash(url)}"]`);
 }
 
 function isEmptyPage() {
-	return exists('.blankslate');
+	return select.exists('.blankslate');
 }
 
 function isParticipatingPage() {
@@ -266,7 +266,7 @@ function markAllNotificationsRead(e) {
 }
 
 function addCustomAllReadBtn() {
-	const hasMarkAllReadBtnExists = exists('#notification-center a[href="#mark_as_read_confirm_box"]');
+	const hasMarkAllReadBtnExists = select.exists('#notification-center a[href="#mark_as_read_confirm_box"]');
 	if (hasMarkAllReadBtnExists || JSON.parse(localStorage.unreadNotifications || '[]').length === 0) {
 		return;
 	}

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -1,4 +1,4 @@
-import {exists} from './util';
+import select from 'select-dom';
 
 export const isGist = () => location.hostname.startsWith('gist.') || location.pathname.startsWith('gist/');
 
@@ -10,7 +10,7 @@ export const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, ''
 
 export const getRepoURL = () => location.pathname.slice(1).split('/', 2).join('/');
 
-export const isRepoRoot = () => isRepo() && /^(\/?$|\/tree\/)/.test(getRepoPath()) && exists('.repository-meta-content');
+export const isRepoRoot = () => isRepo() && /^(\/?$|\/tree\/)/.test(getRepoPath()) && select.exists('.repository-meta-content');
 
 export const isRepoTree = () => isRepo() && /\/tree\//.test(getRepoPath());
 
@@ -36,13 +36,13 @@ export const isCommitList = () => isRepo() && /^\/commits\//.test(getRepoPath())
 
 export const isSingleCommit = () => isRepo() && /^\/commit\/[0-9a-f]{5,40}/.test(getRepoPath());
 
-export const isCommit = () => isSingleCommit() || isPRCommit() || (isPRFiles() && exists('.full-commit'));
+export const isCommit = () => isSingleCommit() || isPRCommit() || (isPRFiles() && select.exists('.full-commit'));
 
 export const isCompare = () => isRepo() && /^\/compare/.test(getRepoPath());
 
-export const hasCode = () => isRepo() && exists('.blob-code-inner');
+export const hasCode = () => isRepo() && select.exists('.blob-code-inner');
 
-export const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && exists('.diff-table')));
+export const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && select.exists('.diff-table')));
 
 export const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
 
@@ -67,4 +67,4 @@ export const isSingleFile = () => {
 	return isRepo() && blobPattern.test(location.href);
 };
 
-export const hasCommentForm = () => exists('.js-previewable-comment-form');
+export const hasCommentForm = () => select.exists('.js-previewable-comment-form');

--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -1,8 +1,3 @@
-import select from 'select-dom';
-
-export {select};
-export const exists = selector => Boolean(select(selector));
-
 export const issueRegex = /([a-zA-Z0-9-_.]+\/[a-zA-Z0-9-_.]+)?#[0-9]+/;
 export const linkifyIssueRef = (repoPath, issue, attrs) => {
 	if (/\//.test(issue)) {


### PR DESCRIPTION
As requested in https://github.com/sindresorhus/refined-github/commit/c5103b6df8b786335d42997cee7844192e535050#commitcomment-22414772

Do you like `select.exists()` or do you prefer keeping it as `exists()` with the following?

```js
import select, {exists} from 'select-dom';
```
