### PR TITLE
Fix text formatting for name of post editor

### DIFF
--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -13,14 +13,15 @@ const updateCachedUsers = users => {
 const addUsersName = (user, name) => {
 	const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
 	$usernameLinks.each((i, userLink) => {
+		const $userLink = $(userLink);
 		if (user !== name) {
 			let nameText = name;
-			if (!$(userLink).parent().is('span.timestamp')) {
+			if (!$userLink.parent().hasClass('timestamp-edited')) {
 				nameText += ' -';
 			}
-			$(`<span class="comment-full-name">`).text(nameText).insertAfter(userLink);
+			$userLink.after(`<span class="comment-full-name">${nameText}</span>`);
 		}
-		$(userLink).closest('.timeline-comment-header-text').addClass('has-full-name');
+		$userLink.closest('.timeline-comment-header-text').addClass('has-full-name');
 	});
 };
 

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -14,7 +14,11 @@ const addUsersName = (user, name) => {
 	const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
 	$usernameLinks.each((i, userLink) => {
 		if (user !== name) {
-			$(`<span class="comment-full-name">`).text(`${name} -`).insertAfter(userLink);
+			let nameText = name;
+			if (!$(userLink).parent().is('span.timestamp')) {
+				nameText += ' -';
+			}
+			$(`<span class="comment-full-name">`).text(nameText).insertAfter(userLink);
 		}
 		$(userLink).closest('.timeline-comment-header-text').addClass('has-full-name');
 	});


### PR DESCRIPTION
This fixes a small bug where showing the full name of an edited issue/PR post would show a stray dash at the end like:

> WanderMax commented 5 hours ago • edited by arkon Eugene Cheung -

See https://github.com/kabouzeid/Phonograph/issues/195 for an example.