### PR TITLE
Fix real names not being fetched in Firefox

### DIFF
--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -34,7 +34,7 @@ export default () => {
 			}
 		}
 
-		const userUrl = user => `/${user}/following`;
+		const userUrl = user => `${window.location.origin}/${user}/following`;
 		const requests = Array.from(uniqueUsers).map(username => {
 			const req = fetch(userUrl(username));
 			return req.then(res => res.text()).then(profile => ({

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -34,7 +34,7 @@ export default () => {
 			}
 		}
 
-		const userUrl = user => `${window.location.origin}/${user}/following`;
+		const userUrl = user => `${location.origin}/${user}/following`;
 		const requests = Array.from(uniqueUsers).map(username => {
 			const req = fetch(userUrl(username));
 			return req.then(res => res.text()).then(profile => ({


### PR DESCRIPTION
Closes #489 

Since Firefox doesn't seem to allow `fetch`ing relative URLs (even though it's in their own [docs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)), we now use an absolute URL.