### PR TITLE
Load more news until the screen is full

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "refined-github@sindresorhus.com",
-			"strict_min_version": "55.0"
+			"strict_min_version": "52.0"
 		}
 	},
 	"permissions": [

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "refined-github@sindresorhus.com",
-			"strict_min_version": "52.0"
+			"strict_min_version": "55.0"
 		}
 	},
 	"permissions": [

--- a/src/content.js
+++ b/src/content.js
@@ -18,6 +18,7 @@ import filePathCopyBtnListner from './libs/copy-file-path';
 import addFileCopyButton from './libs/copy-file';
 import linkifyCode, {editTextNodes} from './libs/linkify-urls-in-code';
 import shortenLinks from './libs/shorten-links';
+import autoLoadMoreNews from './libs/auto-load-more-news';
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
 
@@ -150,25 +151,6 @@ function addYoursMenuItem() {
 	}
 
 	$menu.append(yoursMenuItem);
-}
-
-function infinitelyMore() {
-	const btn = select('.ajax-pagination-btn');
-
-	// If there's no more button remove unnecessary event listeners
-	if (!btn) {
-		$(window).off('scroll.infinite resize.infinite', infinitelyMore);
-		return;
-	}
-
-	// Grab dimensions to see if we should load
-	const wHeight = window.innerHeight;
-	const btnOffset = btn.getBoundingClientRect().top;
-
-	// Smash the button if it's coming close to being in view
-	if (wHeight > btnOffset) {
-		btn.click();
-	}
 }
 
 function addReadmeButtons() {
@@ -511,7 +493,7 @@ function init() {
 		new MutationObserver(() => hideStarsOwnRepos())
 			.observe(select('#dashboard .news'), {childList: true});
 
-		$(window).on('scroll.infinite resize.infinite', infinitelyMore);
+		autoLoadMoreNews();
 	}
 
 	if (pageDetect.isNotifications()) {

--- a/src/libs/auto-load-more-news.js
+++ b/src/libs/auto-load-more-news.js
@@ -1,0 +1,52 @@
+import select from 'select-dom';
+import debounce from 'debounce-fn';
+import feedUpdates from './on-feed-update';
+
+let btn;
+
+const loadMore = debounce(() => {
+	btn.click();
+
+	// If GH hasn't loaded the JS, the click will not load anything.
+	// We can detect if it worked by looking at the button's state,
+	// and then trying again (auto-debounced)
+	if (!btn.disabled) {
+		loadMore();
+	}
+}, {wait: 200});
+
+const inView = new IntersectionObserver(([{isIntersecting}]) => {
+	if (isIntersecting) {
+		loadMore();
+	}
+});
+
+const findButton = () => {
+	// If the old button is still there, leave
+	if (btn && document.contains(btn)) {
+		return;
+	}
+
+	// Forget the old button
+	inView.disconnect();
+
+	// Watch the new button, or stop everything
+	btn = select('.ajax-pagination-btn');
+	if (btn) {
+		inView.observe(btn);
+	} else {
+		feedUpdates.off(findButton);
+	}
+};
+
+export default () => {
+	const form = select('.ajax-pagination-form');
+	if (form) {
+		// If GH hasn't loaded the JS,
+		// the fake click will submit the form without ajax.
+		form.addEventListener('submit', e => e.preventDefault());
+
+		feedUpdates.on(findButton);
+		findButton();
+	}
+};

--- a/src/libs/auto-load-more-news.js
+++ b/src/libs/auto-load-more-news.js
@@ -15,6 +15,25 @@ const loadMore = debounce(() => {
 	}
 }, {wait: 200});
 
+// Delete after Firefox 55 goes stable
+// Also update applications.gecko.strict_min_version to 55.0 in manifest.json
+const IntersectionObserver = window.IntersectionObserver || class IntersectionObserverLocalfill {
+	maybeLoadMore() {
+		if (window.innerHeight > btn.getBoundingClientRect().top) {
+			loadMore();
+		}
+	}
+	observe() {
+		window.addEventListener('scroll', this.maybeLoadMore);
+		window.addEventListener('resize', this.maybeLoadMore);
+		this.maybeLoadMore();
+	}
+	disconnect() {
+		window.removeEventListener('scroll', this.maybeLoadMore);
+		window.removeEventListener('resize', this.maybeLoadMore);
+	}
+};
+
 const inView = new IntersectionObserver(([{isIntersecting}]) => {
 	if (isIntersecting) {
 		loadMore();

--- a/src/libs/auto-load-more-news.js
+++ b/src/libs/auto-load-more-news.js
@@ -19,7 +19,7 @@ const loadMore = debounce(() => {
 // Also update applications.gecko.strict_min_version to 55.0 in manifest.json
 const IntersectionObserver = window.IntersectionObserver || class IntersectionObserverLocalfill {
 	maybeLoadMore() {
-		if (window.innerHeight > btn.getBoundingClientRect().top) {
+		if (window.innerHeight > btn.getBoundingClientRect().top - 500) {
 			loadMore();
 		}
 	}
@@ -38,6 +38,8 @@ const inView = new IntersectionObserver(([{isIntersecting}]) => {
 	if (isIntersecting) {
 		loadMore();
 	}
+}, {
+	rootMargin: '500px' // https://github.com/sindresorhus/refined-github/pull/505#issuecomment-309273098
 });
 
 const findButton = () => {

--- a/src/libs/on-feed-update.js
+++ b/src/libs/on-feed-update.js
@@ -1,0 +1,29 @@
+const callbacks = new Set();
+const observer = new MutationObserver(records => {
+	for (const cb of callbacks) {
+		cb(records, observer);
+	}
+});
+
+export default {
+	on(cb) {
+		if (typeof cb !== 'function') {
+			throw new TypeError('cb must be a function');
+		}
+		if (callbacks.size === 0) {
+			observer.observe(document.querySelector('#dashboard .news'), {
+				childList: true
+			});
+		}
+		callbacks.add(cb);
+	},
+	off(cb) {
+		if (typeof cb !== 'function') {
+			throw new TypeError('cb must be a function');
+		}
+		callbacks.delete(cb);
+		if (callbacks.size === 0) {
+			observer.disconnect();
+		}
+	}
+};


### PR DESCRIPTION
- Automatically start loading new content if the button is visible, without scrolling
- Keep loading new content until the button is no longer visible
- If GH's JS was slow to load, clicking the button would trigger a full-page reload because of the non-ajax form submission. _No more!_

Fixes #256

~~Firefox 55+ because of IntersectionObserver. It'll land in September, IIRC.~~ Edit: semi-ponyfill added.

Demo (using [GitHub Clean Feed](https://github.com/bfred-it/github-clean-feed) to hide most content)

![demo](https://user-images.githubusercontent.com/1402241/27258456-6d069442-542d-11e7-9c6d-8433ca709fd2.gif)
