### PR TITLE
Add window.$ and window.select to simplify debugging

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -24,6 +24,10 @@ import autoLoadMoreNews from './libs/auto-load-more-news';
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
 
+// Add globals for easier debugging
+window.$ = $;
+window.select = select;
+
 const repoUrl = pageDetect.getRepoURL();
 
 const getUsername = () => select('meta[name="user-login"]').getAttribute('content');


### PR DESCRIPTION
The build wraps jQuery and `select` into an IIFE, hiding it from the console. This makes it harder to debug some code by copying and pasting it in the console.