### PR TITLE
Allow customization of the rebase title

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -424,7 +424,11 @@ function removeProjectsTab() {
 }
 
 function fixSquashAndMergeTitle() {
-	$('.btn-group-squash button[type=submit]').click(() => {
+	const btn = select('.merge-message .btn-group-squash [type=submit]');
+	if (!btn) {
+		return;
+	}
+	btn.addEventListener('click', () => {
 		const title = select('.js-issue-title').textContent;
 		const number = select('.gh-header-number').textContent;
 		select('#merge_title_field').value = `${title.trim()} (${number})`;


### PR DESCRIPTION
Related to #423

The previous selector matched both the button that shows the rebase form and the confirming rebase button. Try on this PR:

```js
document.querySelectorAll('.btn-group-squash button[type=submit]')
```

This means that the title was being reset ALSO after pressing the confirm button. This discarded any changes to the title in the form... right **after** I confirmed them. Oops.

I saw that @sindresorhus changes the title and then merges the PR. That shouldn't be the only (roundabout) way to name merge commits.

---

I replaced jQuery with select to ensure that only one element will ever be selected.