### PR TITLE
Optimize addReadmeButtons

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -185,12 +185,14 @@ function addReadmeButtons() {
 	/**
 	 * Generate Edit button
 	 */
-	const readmeName = select('#readme > h3').textContent.trim();
-	const path = select('.breadcrumb').textContent.trim().split('/').slice(1).join('/');
-	const currentBranch = select('.branch-select-menu .select-menu-item.selected').textContent.trim();
-	const editButton = domify(`<a class="tooltipped tooltipped-nw" aria-label="Edit this file">${icons.edit}</a>`);
-	editButton.href = `/${repoUrl}/edit/${currentBranch}/${path}${readmeName}`;
-	buttons.appendChild(editButton);
+	if (select('.branch-select-menu i').textContent === 'Branch:') {
+		const readmeName = select('#readme > h3').textContent.trim();
+		const path = select('.breadcrumb').textContent.trim().split('/').slice(1).join('/');
+		const currentBranch = select('.branch-select-menu .select-menu-item.selected').textContent.trim();
+		const button = domify(`<a class="tooltipped tooltipped-nw" aria-label="Edit this file">${icons.edit}</a>`);
+		button.href = `/${repoUrl}/edit/${currentBranch}/${path}${readmeName}`;
+		buttons.appendChild(button);
+	}
 
 	readmeContainer.appendChild(buttons);
 }

--- a/src/libs/domify.js
+++ b/src/libs/domify.js
@@ -1,2 +1,9 @@
-// Get DOM node from HTML
-export default html => document.createRange().createContextualFragment(html);
+export default html => {
+	const fragment = document.createRange().createContextualFragment(html);
+
+	// If it's a single element, return just the element
+	if (fragment.firstChild === fragment.lastChild) {
+		return fragment.firstChild;
+	}
+	return fragment;
+};


### PR DESCRIPTION
* shorten selectors
* avoid unnecessary operations
* skip jQuery
* get user content out of innerHTML (XSS)
* various code shortcuts

Tested on the pages:

* base branch: https://github.com/sindresorhus/refined-github
* custom branch: https://github.com/sindresorhus/refined-github/tree/badges
* long branch name: https://github.com/bfred-it/sandbox/tree/what-do-you-think-the-maximum-branch-name-length-is-question-mark-i-think-there's-no-limit-so-i'm-just-gonna-keep-going-until-github-throws-up-or-i-get-tired-of-typing-nonsense-omg-why-are-you-still-reading
* 1-level deep readme: https://github.com/GhostText/GhostText/tree/master/browser
* multi-level deep readme: https://github.com/babel/babel/tree/7.0/packages/babel-cli
* commit view (no edits allowed): https://github.com/sindresorhus/refined-github/tree/83e6bd82746327654fe7a8dd089ba3a132a84c4e
* tag view (no edits allowed): https://github.com/sindresorhus/refined-github/tree/1.17.0
