### PR TITLE
Update readme.md link to content.js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ GitHub Enterprise is also supported by [authorizing your own domain in the optio
 - ~~[Adds blame links for parent commits in blame view](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)~~ [Implemented by GitHub](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view)
 - ~~[Adds ability to collapse/expand files in a pull request diff](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)~~ [Implemented by GitHub](https://cloud.githubusercontent.com/assets/170270/25772137/6a6b678e-3296-11e7-97c7-02e31ef17743.png)
 
-And [lots](extension/content.css) [more...](extension/content.js)
+And [lots](extension/content.css) [more...](src/content.js)
 
 
 ## Screenshots


### PR DESCRIPTION
In https://github.com/sindresorhus/refined-github/pull/465, the link to `content.js` broke as it moved. This commit changes the path to point to its new location under `/src/`.