### PR TITLE
Update real name styling

### DIFF
--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -16,6 +16,11 @@ const addUsersName = (user, name) => {
 			$userLink.after(`<span class="comment-full-name">(${name})</span>`);
 		}
 		$userLink.addClass('has-full-name');
+		const $header = $userLink.parent().parent();
+		if ($header.hasClass('timeline-comment-header-text')) {
+			// Remove 'commented'
+			$userLink[0].parentNode.nextSibling.remove();
+		}
 	});
 };
 

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -13,11 +13,7 @@ const addUsersName = (user, name) => {
 	$usernameLinks.each((i, userLink) => {
 		const $userLink = $(userLink);
 		if (user !== name) {
-			let nameText = name;
-			if (!$userLink.parent().hasClass('timestamp-edited')) {
-				nameText += ' -';
-			}
-			$userLink.after(`<span class="comment-full-name">${nameText}</span>`);
+			$userLink.after(`<span class="comment-full-name">(${name})</span>`);
 		}
 		$userLink.closest('.timeline-comment-header-text').addClass('has-full-name');
 	});

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -9,13 +9,13 @@ const updateCachedUsers = users => {
 };
 
 const addUsersName = (user, name) => {
-	const $usernameLinks = $(`.timeline-comment-header-text:not(.has-full-name) a[href="/${user}"]`);
+	const $usernameLinks = $(`.author[href="/${user}"]:not(.has-full-name)`);
 	$usernameLinks.each((i, userLink) => {
 		const $userLink = $(userLink);
 		if (user !== name) {
 			$userLink.after(`<span class="comment-full-name">(${name})</span>`);
 		}
-		$userLink.closest('.timeline-comment-header-text').addClass('has-full-name');
+		$userLink.addClass('has-full-name');
 	});
 };
 


### PR DESCRIPTION
Per #493 update Real Name styling to have the name wrapped in ()

This adds (Real Name) behind all author links. Including:
- edited by: user (Real Name)
- user (Real Name) added <Label>
- user (Real Name) referenced this <item>

This does cause wrapping of the header sometimes, examples can be
seen here: #461 and #546. Not sure how we can avoid that though, open to suggestions.

Comment edited by @bfred-it to test the *edited by* part.

---

Fixes #493 