### PR TITLE
Align Issue/PR List Labels to the Right

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -610,6 +610,11 @@ Hidden content area created to increase hover target
 	margin-left: 5px;
 }
 
+/* Align labels in Issue/PR list to the right */
+.js-issue-row .labels {
+	float: right;
+}
+
 /* Move "close issue" and "cancel" buttons on authoring comments to the left */
 
 /* ...in issue comment form */


### PR DESCRIPTION
This aligns the labels in the Issue/PR list to the right per #523. We
need the `js-issue-row` selector to prevent the labels being floated right on
the individual Issue/PR page itself.