### PR TITLE
Hide repo description when it's empty

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -683,6 +683,6 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 }
 
 /* Hide empty description of repo */
-.repository-meta-content > em {
-	display: none !important;
+.repository-meta.mb-3 > .repository-meta-content > em {
+  display: none !important;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -684,5 +684,5 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 
 /* Hide empty description of repo */
 .repository-meta.mb-3 > .repository-meta-content > em {
-  display: none !important;
+	display: none !important;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -681,3 +681,8 @@ tt,
 a.tabnav-extra[href$="mastering-markdown/"] {
 	display: none !important;
 }
+
+/* Hide empty description of repo */
+.repository-meta-content > em {
+	display: none !important;
+}

--- a/src/content.js
+++ b/src/content.js
@@ -106,6 +106,15 @@ function renameInsightsDropdown() {
 	}
 }
 
+function hideEmptyMeta() {
+	if (pageDetect.isRepoRoot()) {
+		const meta = select('.repository-meta');
+		if (select.exists('em', meta) && !select.exists('.js-edit-repo-meta-button')) {
+			meta.style.display = 'none';
+		}
+	}
+}
+
 function addReleasesTab() {
 	const $repoNav = $('.js-repo-nav');
 	let $releasesTab = $repoNav.children('[data-selected-links~="repo_releases"]');
@@ -518,6 +527,7 @@ function init(options) {
 
 	if (pageDetect.isRepo()) {
 		gitHubInjection(window, () => {
+			hideEmptyMeta();
 			addReleasesTab();
 			removeProjectsTab();
 			addCompareLink();


### PR DESCRIPTION
# Issue

This is an attempt to solve https://github.com/sindresorhus/refined-github/issues/549

# Code

I tried doing it with jQuery but [you do notice the jump](https://github.com/sindresorhus/refined-github/issues/549#issuecomment-311532819) from visible to hidden.

The only thing I could come up with in css is a rule to hide the empty message.

# Results

## Admins with empty description

The problem here is that it hides the message even for admins, so it's a little weird after the change:

![description-admin](https://user-images.githubusercontent.com/4324982/27657765-b70269c2-5c1b-11e7-93b7-730dc30bfb1d.jpg)

![arr1](https://cdn2.iconfinder.com/data/icons/navigation-set-arrows-part-two/32/Arrow_Download-128.png)

![empty-admin](https://user-images.githubusercontent.com/4324982/27657622-48644e22-5c1b-11e7-8590-89822b2bbd5f.jpg)

## Non-admins with empty description

Here we can see that the UI is much cleaner after the change:

![description-non-admin](https://user-images.githubusercontent.com/4324982/27657793-cb06fb40-5c1b-11e7-8b6c-3623c1f2230c.jpg)

![arr2](https://cdn2.iconfinder.com/data/icons/navigation-set-arrows-part-two/32/Arrow_Download-128.png)

![empty-non-admin](https://user-images.githubusercontent.com/4324982/27657801-d3489ba6-5c1b-11e7-94b8-0f3c8dcb7769.jpg)


