### PR TITLE
Fix expanded diffs alignment

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -556,7 +556,7 @@ Hidden content area created to increase hover target
 	top: -1px;
 	left: -8px;
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
-	line-height: 0; /* avoids extra vertical space */
+	line-height: 0; /* Avoids extra vertical space */
 	font-size: 11px;
 	color: rgba(0, 0, 0, 0.3);
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -552,12 +552,12 @@ Hidden content area created to increase hover target
 /* +/- Pseudo elements on diffs */
 .refined-github-diff-signs .blob-code-addition:before,
 .refined-github-diff-signs .blob-code-deletion:before {
-	display: inline-block;
-	position: absolute;
-	top: 1px;
+	position: relative;
+	top: -1px;
+	left: -8px;
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+	line-height: 0; /* avoids extra vertical space */
 	font-size: 11px;
-	text-indent: -8px;
 	color: rgba(0, 0, 0, 0.3);
 }
 
@@ -572,12 +572,6 @@ Hidden content area created to increase hover target
 /* Prevent copy of ghost whitespace where supported (#317) */
 .refined-github-diff-signs .add-line-comment {
 	-moz-user-select: none;
-	user-select: none;
-}
-
-/* Restore removed space with unselectable one*/
-.refined-github-diff-signs .blob-code-inner:before {
-	content: ' ' !important;
 	user-select: none;
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -256,7 +256,10 @@ function addPatchDiffLinks() {
 function removeDiffSigns() {
 	$('.diff-table:not(.refined-github-diff-signs)')
 		.addClass('refined-github-diff-signs')
-		.find('.blob-code-inner')
+		.find(`
+			.blob-code-addition .blob-code-inner,
+			.blob-code-deletion .blob-code-inner
+		`)
 		.each((index, el) => {
 			el.firstChild.textContent = el.firstChild.textContent.slice(1);
 		});


### PR DESCRIPTION
Fixes #557

I made sure that the position of the +/- stayed the same (Chrome, OSX, retina), try it on your computer. 

<img width="189" alt="demo" src="https://user-images.githubusercontent.com/1402241/27815159-a29a196a-60b4-11e7-867b-876600cee3b9.png">
