### PR TITLE
Comment field tabbing improvements

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -281,37 +281,31 @@ function indentInput(el, size = 4) {
 	const fullFieldText = el.value;
 	const selection = window.getSelection().toString();
 	const {selectionStart, selectionEnd} = el;
-	const isMultiLine = /\n/.test(selection);
 	el.focus();
 
-	if (isMultiLine) {
-		const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
-		const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
+	const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
+	const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
 
-		// Find the start index of each line
-		const indexes = selectedLines.split('\n').map(line => line.length);
-		indexes.unshift(firstLineStart);
-		indexes.pop();
+	// Find the start index of each line
+	const indexes = selectedLines.split('\n').map(line => line.length);
+	indexes.unshift(firstLineStart);
+	indexes.pop();
 
-		// `indexes` contains lengths. Update them to point to each line start index
-		for (let i = 1; i < indexes.length; i++) {
-			indexes[i] += indexes[i - 1] + 1;
-		}
-
-		for (let i = indexes.length - 1; i >= 0; i--) {
-			el.setSelectionRange(indexes[i], indexes[i]);
-			document.execCommand('insertText', false, ' '.repeat(size));
-		}
-
-		// Restore selection position
-		el.setSelectionRange(
-			selectionStart + size,
-			selectionEnd + (size * indexes.length)
-		);
-	} else {
-		const indentSize = (size - (selectionEnd % size)) || size;
-		document.execCommand('insertText', false, ' '.repeat(indentSize));
+	// `indexes` contains lengths. Update them to point to each line start index
+	for (let i = 1; i < indexes.length; i++) {
+		indexes[i] += indexes[i - 1] + 1;
 	}
+
+	for (let i = indexes.length - 1; i >= 0; i--) {
+		el.setSelectionRange(indexes[i], indexes[i]);
+		document.execCommand('insertText', false, ' '.repeat(size));
+	}
+
+	// Restore selection position
+	el.setSelectionRange(
+		selectionStart + size,
+		selectionEnd + (size * indexes.length)
+	);
 }
 
 function showRecentlyPushedBranches() {

--- a/src/content.js
+++ b/src/content.js
@@ -278,9 +278,40 @@ function markMergeCommitsInList() {
 }
 
 function indentInput(el, size = 4) {
+	const fullFieldText = el.value;
+	const selection = window.getSelection().toString();
+	const {selectionStart, selectionEnd} = el;
+	const isMultiLine = /\n/.test(selection);
 	el.focus();
-	const indentSize = (size - (el.selectionEnd % size)) || size;
-	document.execCommand('insertText', false, ' '.repeat(indentSize));
+
+	if (isMultiLine) {
+		const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
+		const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
+
+		// Find the start index of each line
+		const indexes = selectedLines.split('\n').map(line => line.length);
+		indexes.unshift(firstLineStart);
+		indexes.pop();
+
+		// `indexes` contains lengths. Update them to point to each line start index
+		for (let i = 1; i < indexes.length; i++) {
+			indexes[i] += indexes[i - 1] + 1;
+		}
+
+		for (let i = indexes.length - 1; i >= 0; i--) {
+			el.setSelectionRange(indexes[i], indexes[i]);
+			document.execCommand('insertText', false, ' '.repeat(size));
+		}
+
+		// Restore selection position
+		el.setSelectionRange(
+			selectionStart + size,
+			selectionEnd + (size * indexes.length)
+		);
+	} else {
+		const indentSize = (size - (selectionEnd % size)) || size;
+		document.execCommand('insertText', false, ' '.repeat(indentSize));
+	}
 }
 
 function showRecentlyPushedBranches() {

--- a/src/content.js
+++ b/src/content.js
@@ -278,15 +278,14 @@ function markMergeCommitsInList() {
 }
 
 function indentInput(el, size = 4) {
-	const fullFieldText = el.value;
 	const selection = window.getSelection().toString();
-	const {selectionStart, selectionEnd} = el;
+	const {selectionStart, selectionEnd, value} = el;
 	const isMultiLine = /\n/.test(selection);
 	el.focus();
 
 	if (isMultiLine) {
-		const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
-		const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
+		const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;
+		const selectedLines = value.substring(firstLineStart, selectionEnd);
 
 		// Find the start index of each line
 		const indexes = selectedLines.split('\n').map(line => line.length);

--- a/src/content.js
+++ b/src/content.js
@@ -279,13 +279,8 @@ function markMergeCommitsInList() {
 
 function indentInput(el, size = 4) {
 	el.focus();
-	const value = el.value;
-	const selectionStart = el.selectionStart;
 	const indentSize = (size - (el.selectionEnd % size)) || size;
-	const indentationText = ' '.repeat(indentSize);
-	el.value = value.slice(0, selectionStart) + indentationText + value.slice(el.selectionEnd);
-	el.selectionStart = selectionStart + indentationText.length;
-	el.selectionEnd = selectionStart + indentationText.length;
+	document.execCommand('insertText', false, ' '.repeat(indentSize));
 }
 
 function showRecentlyPushedBranches() {

--- a/src/content.js
+++ b/src/content.js
@@ -279,32 +279,39 @@ function markMergeCommitsInList() {
 
 function indentInput(el, size = 4) {
 	const fullFieldText = el.value;
+	const selection = window.getSelection().toString();
 	const {selectionStart, selectionEnd} = el;
+	const isMultiLine = /\n/.test(selection);
 	el.focus();
 
-	const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
-	const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
+	if (isMultiLine) {
+		const firstLineStart = fullFieldText.lastIndexOf('\n', selectionStart) + 1;
+		const selectedLines = fullFieldText.substring(firstLineStart, selectionEnd);
 
-	// Find the start index of each line
-	const indexes = selectedLines.split('\n').map(line => line.length);
-	indexes.unshift(firstLineStart);
-	indexes.pop();
+		// Find the start index of each line
+		const indexes = selectedLines.split('\n').map(line => line.length);
+		indexes.unshift(firstLineStart);
+		indexes.pop();
 
-	// `indexes` contains lengths. Update them to point to each line start index
-	for (let i = 1; i < indexes.length; i++) {
-		indexes[i] += indexes[i - 1] + 1;
+		// `indexes` contains lengths. Update them to point to each line start index
+		for (let i = 1; i < indexes.length; i++) {
+			indexes[i] += indexes[i - 1] + 1;
+		}
+
+		for (let i = indexes.length - 1; i >= 0; i--) {
+			el.setSelectionRange(indexes[i], indexes[i]);
+			document.execCommand('insertText', false, ' '.repeat(size));
+		}
+
+		// Restore selection position
+		el.setSelectionRange(
+			selectionStart + size,
+			selectionEnd + (size * indexes.length)
+		);
+	} else {
+		const indentSize = (size - (selectionEnd % size)) || size;
+		document.execCommand('insertText', false, ' '.repeat(indentSize));
 	}
-
-	for (let i = indexes.length - 1; i >= 0; i--) {
-		el.setSelectionRange(indexes[i], indexes[i]);
-		document.execCommand('insertText', false, ' '.repeat(size));
-	}
-
-	// Restore selection position
-	el.setSelectionRange(
-		selectionStart + size,
-		selectionEnd + (size * indexes.length)
-	);
 }
 
 function showRecentlyPushedBranches() {

--- a/src/content.js
+++ b/src/content.js
@@ -281,10 +281,11 @@ function indentInput(el, size = 4) {
 	const selection = window.getSelection().toString();
 	const {selectionStart, selectionEnd, value} = el;
 	const isMultiLine = /\n/.test(selection);
+	const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;
+
 	el.focus();
 
 	if (isMultiLine) {
-		const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;
 		const selectedLines = value.substring(firstLineStart, selectionEnd);
 
 		// Find the start index of each line
@@ -308,7 +309,7 @@ function indentInput(el, size = 4) {
 			selectionEnd + (size * indexes.length)
 		);
 	} else {
-		const indentSize = (size - (selectionEnd % size)) || size;
+		const indentSize = (size - ((selectionEnd - firstLineStart) % size)) || size;
 		document.execCommand('insertText', false, ' '.repeat(indentSize));
 	}
 }

--- a/src/content.js
+++ b/src/content.js
@@ -279,7 +279,6 @@ function markMergeCommitsInList() {
 
 function indentInput(el, size = 4) {
 	const fullFieldText = el.value;
-	const selection = window.getSelection().toString();
 	const {selectionStart, selectionEnd} = el;
 	el.focus();
 


### PR DESCRIPTION
Fixes #245 

The only inconvenience with `Tab multiple lines at a time` is that the you'll have to press cmd+z as many times as the lines that have been indented. I can't find a way to make it atomic.