### PR TITLE
Add option to disable font override (#556)

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -647,24 +647,8 @@ div.inline-comment-form .form-actions,
 }
 
 /* Alternate monospace font stack, sorted by least popular so you're most likely to get the font you want */
-code,
-kbd,
-pre,
-tt,
-.CodeMirror-lines,
-.ace_editor.ace-github-light,
-.blob-code-inner,
-.export-phrase pre,
-.file-editor-textarea,
-.gollum-editor .expanded textarea,
-.gollum-editor .gollum-editor-body,
-.input-monospace,
-.wiki-wrapper .wiki-history .commit-meta code {
+.override-fonts {
 	font-family: 'Operator Mono SSm', 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
-}
-
-.default-fonts {
-	font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
 }
 
 .CodeMirror-lines pre.CodeMirror-line {

--- a/extension/content.css
+++ b/extension/content.css
@@ -663,6 +663,10 @@ tt,
 	font-family: 'Operator Mono SSm', 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }
 
+.default-fonts {
+	font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+}
+
 .CodeMirror-lines pre.CodeMirror-line {
 	font-variant-ligatures: normal;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -647,7 +647,19 @@ div.inline-comment-form .form-actions,
 }
 
 /* Alternate monospace font stack, sorted by least popular so you're most likely to get the font you want */
-.override-fonts {
+.override-fonts code,
+.override-fonts kbd,
+.override-fonts pre,
+.override-fonts tt,
+.override-fonts .CodeMirror-lines,
+.override-fonts .ace_editor.ace-github-light,
+.override-fonts .blob-code-inner,
+.override-fonts .export-phrase pre,
+.override-fonts .file-editor-textarea,
+.override-fonts .gollum-editor .expanded textarea,
+.override-fonts .gollum-editor .gollum-editor-body,
+.override-fonts .input-monospace,
+.override-fonts .wiki-wrapper .wiki-history .commit-meta code {
 	font-family: 'Operator Mono SSm', 'Operator Mono', 'Fira Code', 'Ubuntu Mono', 'Droid Sans Mono', 'Liberation Mono', 'Source Code Pro', Menlo, Consolas, Courier, monospace !important;
 }
 

--- a/extension/options/index.html
+++ b/extension/options/index.html
@@ -10,6 +10,13 @@
 			Hide other users starring/forking your repos
 		</label>
 	</p>
+	<h2>Code</h2>
+	<p>
+		<label>
+			<input type="checkbox" name="overrideFonts">
+			Override fonts
+		</label>
+	</p>
 </form>
 <form id="custom-domain">
 	<h2>GitHub Enterprise support</h2>

--- a/src/background.js
+++ b/src/background.js
@@ -4,7 +4,8 @@ import injectContentScripts from 'webext-dynamic-content-scripts';
 // Define defaults
 new OptionsSync().define({
 	defaults: {
-		hideStarsOwnRepos: true
+		hideStarsOwnRepos: true,
+		overrideFonts: true
 	},
 	migrations: [
 		OptionsSync.migrations.removeUnused

--- a/src/content.js
+++ b/src/content.js
@@ -453,21 +453,7 @@ function addTitleToEmojis() {
 }
 
 function overrideCodeFonts() {
-	$(`
-	code,
-	kbd,
-	pre,
-	tt,
-	.CodeMirror-lines,
-	.ace_editor.ace-github-light,
-	.blob-code-inner,
-	.export-phrase pre,
-	.file-editor-textarea,
-	.gollum-editor .expanded textarea,
-	.gollum-editor .gollum-editor-body,
-	.input-monospace,
-	.wiki-wrapper .wiki-history .commit-meta code`)
-	.addClass('override-fonts');
+	$('body').addClass('override-fonts');
 }
 
 function init() {

--- a/src/content.js
+++ b/src/content.js
@@ -518,6 +518,24 @@ async function onDomReady() {
 		addGistCopyButton();
 	}
 
+	if (!options.overrideFonts) {
+		$(`
+		code,
+		kbd,
+		pre,
+		tt,
+		.CodeMirror-lines,
+		.ace_editor.ace-github-light,
+		.blob-code-inner,
+		.export-phrase pre,
+		.file-editor-textarea,
+		.gollum-editor .expanded textarea,
+		.gollum-editor .gollum-editor-body,
+		.input-monospace,
+		.wiki-wrapper .wiki-history .commit-meta code`)
+		.addClass('default-fonts');
+	}
+
 	if (pageDetect.isDashboard()) {
 		// Hide other users starring/forking your repos
 		const hideStarsOwnRepos = () => {

--- a/src/content.js
+++ b/src/content.js
@@ -452,6 +452,24 @@ function addTitleToEmojis() {
 	}
 }
 
+function overrideCodeFonts() {
+	$(`
+	code,
+	kbd,
+	pre,
+	tt,
+	.CodeMirror-lines,
+	.ace_editor.ace-github-light,
+	.blob-code-inner,
+	.export-phrase pre,
+	.file-editor-textarea,
+	.gollum-editor .expanded textarea,
+	.gollum-editor .gollum-editor-body,
+	.input-monospace,
+	.wiki-wrapper .wiki-history .commit-meta code`)
+	.addClass('override-fonts');
+}
+
 function init() {
 	if (select.exists('html.refined-github')) {
 		console.count('Refined GitHub was loaded multiple times: https://github.com/sindresorhus/refined-github/issues/479');
@@ -518,22 +536,8 @@ async function onDomReady() {
 		addGistCopyButton();
 	}
 
-	if (!options.overrideFonts) {
-		$(`
-		code,
-		kbd,
-		pre,
-		tt,
-		.CodeMirror-lines,
-		.ace_editor.ace-github-light,
-		.blob-code-inner,
-		.export-phrase pre,
-		.file-editor-textarea,
-		.gollum-editor .expanded textarea,
-		.gollum-editor .gollum-editor-body,
-		.input-monospace,
-		.wiki-wrapper .wiki-history .commit-meta code`)
-		.addClass('default-fonts');
+	if (options.overrideFonts) {
+		overrideCodeFonts();
 	}
 
 	if (pageDetect.isDashboard()) {


### PR DESCRIPTION
I agree with https://github.com/sindresorhus/refined-github/issues/556 cause I prefer the new default SF Mono than Fira Code (which was the one I had with the extension)