### PR TITLE
Prevent domify from making unnecessary network requests

### DIFF
--- a/src/libs/domify.js
+++ b/src/libs/domify.js
@@ -2,6 +2,13 @@ export default html => {
 	const fragment = document.createElement('template');
 	fragment.innerHTML = html;
 
+	const content = fragment.content;
+
+	// If it's a single element, return just the element
+	if (content.firstChild === content.lastChild) {
+		return content.firstChild;
+	}
+
 	// Return template for querying
-	return fragment;
+	return content;
 };

--- a/src/libs/domify.js
+++ b/src/libs/domify.js
@@ -1,9 +1,7 @@
 export default html => {
-	const fragment = document.createRange().createContextualFragment(html);
+	const fragment = document.createElement('template');
+	fragment.innerHTML = html;
 
-	// If it's a single element, return just the element
-	if (fragment.firstChild === fragment.lastChild) {
-		return fragment.firstChild;
-	}
+	// Return template for querying
 	return fragment;
 };

--- a/src/libs/domify.js
+++ b/src/libs/domify.js
@@ -1,14 +1,14 @@
 export default html => {
-	const fragment = document.createElement('template');
-	fragment.innerHTML = html;
+	const template = document.createElement('template');
+	template.innerHTML = html;
 
-	const content = fragment.content;
+	const fragment = template.content;
 
 	// If it's a single element, return just the element
-	if (content.firstChild === content.lastChild) {
-		return content.firstChild;
+	if (fragment.firstChild === fragment.lastChild) {
+		return fragment.firstChild;
 	}
 
-	// Return template for querying
-	return content;
+	// Return fragment for querying
+	return fragment;
 };

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -27,7 +27,7 @@ const fetchName = async username => {
 
 export default async () => {
 	const myUsername = getUsername();
-	const cache = (await getCachedUsers())[storageKey];
+	const cache = (await getCachedUsers())[storageKey] || {};
 
 	// {sindresorhus: [a.author, a.author], otheruser: [a.author]}
 	const selector = `.js-discussion .author:not(.refined-github-fullname)`;

--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -27,7 +27,7 @@ const fetchName = async username => {
 
 export default async () => {
 	const myUsername = getUsername();
-	const cache = (await getCachedUsers())[storageKey] || {};
+	const cache = (await getCachedUsers())[storageKey];
 
 	// {sindresorhus: [a.author, a.author], otheruser: [a.author]}
 	const selector = `.js-discussion .author:not(.refined-github-fullname)`;


### PR DESCRIPTION
`document.createRange().createContextualFragment` helps in creating a document fragment by parsing HTML but additionally loads resources linked from the HTML.

This is solved by using the HTML `template` tag.