### PR TITLE
Link to restored branches

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -174,6 +174,11 @@ a .commit-ref:hover span {
 	text-decoration: underline !important;
 }
 
+/* The extra span on branch names interferes with a possible deletion line-through */
+.commit-ref span {
+	text-decoration: inherit;
+}
+
 /* Remove the "new feature" notification box */
 .dashboard-sidebar .octofication {
 	display: none !important;

--- a/src/content.js
+++ b/src/content.js
@@ -41,7 +41,7 @@ function linkifyBranchRefs() {
 		deletedBranch = lastBranchAction.title;
 	}
 
-	for (const el of select.all('.base-ref, .head-ref')) {
+	for (const el of select.all('.commit-ref[title], .base-ref[title], .head-ref[title]')) {
 		if (el.textContent === 'unknown repository') {
 			continue;
 		}

--- a/src/content.js
+++ b/src/content.js
@@ -31,36 +31,22 @@ window.select = select;
 
 const repoUrl = pageDetect.getRepoURL();
 
-function getCanonicalBranchFromRef($element) {
-	const refSelector = '.commit-ref, .head-ref, .base-ref';
-
-	return $element.find(refSelector).addBack(refSelector).filter('[title]').attr('title');
-}
-
 function linkifyBranchRefs() {
-	let deletedBranchName = null;
-	const $deletedBranchInTimeline = $('.discussion-item-head_ref_deleted');
-	if ($deletedBranchInTimeline.length > 0) {
-		deletedBranchName = getCanonicalBranchFromRef($deletedBranchInTimeline);
+	const deletedBranch = (select('.discussion-item-head_ref_deleted .head-ref') || {}).title;
+
+	for (const el of select.all('.base-ref, .head-ref')) {
+		if (el.textContent === 'unknown repository') {
+			continue;
+		}
+
+		if (el.title === deletedBranch) {
+			el.title = 'Deleted: ' + el.title;
+			continue;
+		}
+
+		const branchUrl = '/' + el.title.replace(':', '/tree/');
+		$(el).closest('.commit-ref').wrap(<a href={branchUrl}></a>);
 	}
-
-	$('.commit-ref').each((i, el) => {
-		if (el.firstElementChild.textContent === 'unknown repository') {
-			return;
-		}
-
-		const $el = $(el);
-		const canonicalBranch = getCanonicalBranchFromRef($el);
-
-		if (deletedBranchName && canonicalBranch === deletedBranchName) {
-			$el.attr('title', 'Deleted: ' + canonicalBranch);
-			return;
-		}
-
-		const branchUrl = canonicalBranch.replace(':', '/tree/');
-
-		$el.wrap(<a href={`/${branchUrl}`}></a>);
-	});
 }
 
 function appendReleasesCount(count) {

--- a/src/content.js
+++ b/src/content.js
@@ -48,7 +48,7 @@ function linkifyBranchRefs() {
 
 		if (el.title === deletedBranch) {
 			el.title = 'Deleted: ' + el.title;
-			el.style.textDecoration: 'line-through';
+			el.style.textDecoration = 'line-through';
 			continue;
 		}
 

--- a/src/content.js
+++ b/src/content.js
@@ -48,6 +48,7 @@ function linkifyBranchRefs() {
 
 		if (el.title === deletedBranch) {
 			el.title = 'Deleted: ' + el.title;
+			el.style.textDecoration: 'line-through';
 			continue;
 		}
 

--- a/src/content.js
+++ b/src/content.js
@@ -32,7 +32,14 @@ window.select = select;
 const repoUrl = pageDetect.getRepoURL();
 
 function linkifyBranchRefs() {
-	const deletedBranch = (select('.discussion-item-head_ref_deleted .head-ref') || {}).title;
+	let deletedBranch = false;
+	const lastBranchAction = select.all(`
+		.discussion-item-head_ref_deleted .head-ref,
+		.discussion-item-head_ref_restored .head-ref
+	`).pop();
+	if (lastBranchAction && lastBranchAction.closest('.discussion-item-head_ref_deleted')) {
+		deletedBranch = lastBranchAction.title;
+	}
 
 	for (const el of select.all('.base-ref, .head-ref')) {
 		if (el.textContent === 'unknown repository') {


### PR DESCRIPTION
> If a branch is deleted and subsequently restored, it would not link to it
> @hkdobrev in #422 

* Fixes the above
* Cleans up the function
* Fixes the below (title not showing on `user deleted the xxx branch` event)

<img width="342" alt="screen shot 2017-07-08 at 01 03 38" src="https://user-images.githubusercontent.com/1402241/27968407-75e0af16-6379-11e7-9912-a6921d13fa28.png">
<img width="685" alt="screen shot 2017-07-08 at 01 03 27" src="https://user-images.githubusercontent.com/1402241/27968408-75e3df88-6379-11e7-8292-4b1ff724589a.png">
