### PR TITLE
Fix linkifyURLs bug in some code

### DIFF
--- a/src/libs/linkify-urls-in-code.js
+++ b/src/libs/linkify-urls-in-code.js
@@ -20,7 +20,8 @@ const options = {
 };
 
 export const editTextNodes = (fn, el) => {
-	for (const textNode of getTextNodes(el)) {
+	// Spread required because the elements will change and the TreeWalker will break
+	for (const textNode of [...getTextNodes(el)]) {
 		if (fn === linkifyUrls && textNode.textContent.length < 11) { // Shortest url: http://j.mp
 			continue;
 		}


### PR DESCRIPTION
Bug example: https://github.com/treycordova/nativejsx/issues/26

Notice the w3.org URLs: the first one is linkified, the second one isn't, because TreeWalker completely drops out when the first element is replaced. Not sure why it worked elsewhere but not here.

<img width="633" alt="" src="https://user-images.githubusercontent.com/1402241/27975090-5d206740-6393-11e7-9b6d-344366e5f1d4.png">
