### PR TITLE
Fix problem with initial retrieval of `cachedNames`

### DIFF
--- a/src/libs/show-names.js
+++ b/src/libs/show-names.js
@@ -27,7 +27,7 @@ const fetchName = async username => {
 
 export default async () => {
 	const myUsername = getUsername();
-	const cache = (await getCachedUsers())[storageKey];
+	const cache = (await getCachedUsers())[storageKey] || {};
 
 	// {sindresorhus: [a.author, a.author], otheruser: [a.author]}
 	const selector = `.js-discussion .author:not(.refined-github-fullname)`;


### PR DESCRIPTION
Fix issue where initial retrieval of `cachedNames` returns an empty object which is considered to have a property with the same name