### PR TITLE
Fix recently pushed branches duplication

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -24,7 +24,6 @@ import autoLoadMoreNews from './libs/auto-load-more-news';
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
 import {getUsername, observeEl} from './libs/utils';
-import domify from './libs/domify';
 
 // Add globals for easier debugging
 window.$ = $;
@@ -323,8 +322,7 @@ async function showRecentlyPushedBranches() {
 	}).then(res => res.text());
 
 	// https://github.com/sindresorhus/refined-github/issues/216
-	const isEmpty = select.exists('.blankslate, .js-git-clone-help-container', domify(html));
-	if (!isEmpty) {
+	if (html.includes(fragmentURL)) {
 		select('.repository-content').prepend(<include-fragment src={fragmentURL}></include-fragment>);
 	}
 }

--- a/src/content.js
+++ b/src/content.js
@@ -310,7 +310,7 @@ function indentInput(el, size = 4) {
 
 function showRecentlyPushedBranches() {
 	// Don't duplicate on back/forward in history
-	if (select.exists('.recently-touched-branches-wrapper')) {
+	if (select.exists('[data-url$=recently_touched_branches_list]')) {
 		return;
 	}
 


### PR DESCRIPTION
1. I think GitHub recently stopped using the `recently-touched-branches-wrapper` class we were testing for.
2. I think we can avoid parsing the DOM for unrelated elements and just look for the specific element in the string.

Extracted from #586 