### PR TITLE
Only deploy on cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ deploy:
   script: npm run release
   on:
     branch: master
+    # Only deploy on cronjobs + if the last commit was within the last day ± 1 hour.
+    # Temporarily comment out this condition to let any commits be deployed.
+    condition: $TRAVIS_EVENT_TYPE = cron &&  $(git log -1 --pretty=format:%ct) -gt $(gdate --date='26 hours ago' +%s)


### PR DESCRIPTION
Related to #595 

I'm not 100% sure that this condition works (although it seems to work locally) but it should:

* Only deploy on cronjobs
* Only deploy if there was a commit in the last 26 hours

**26 hours** should help with Travis' cronjob irregularities. It might occasionally let some commits be deployed again, but at least it shouldn't *miss* any commits.

Next steps:
1. [add daily cronjob](https://travis-ci.org/sindresorhus/refined-github/settings) + 24 hour option.
2. Perhaps change the version from `y.m.d.hmm` to `y.m.dhh` since we don't expect this to be deployed more than once per hour, even if an urgent version should be let in.