### PR TITLE
Fix diff indentation

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -542,12 +542,12 @@ Hidden content area created to increase hover target
 /* +/- Pseudo elements on diffs */
 .refined-github-diff-signs .blob-code-addition:before,
 .refined-github-diff-signs .blob-code-deletion:before {
-	position: relative;
-	top: -1px;
-	left: -8px;
+	display: inline-block;
+	position: absolute;
+	top: 1px;
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
-	line-height: 0; /* Avoids extra vertical space */
 	font-size: 11px;
+	text-indent: -8px;
 	color: rgba(0, 0, 0, 0.3);
 }
 
@@ -562,6 +562,12 @@ Hidden content area created to increase hover target
 /* Prevent copy of ghost whitespace where supported (#317) */
 .refined-github-diff-signs .add-line-comment {
 	-moz-user-select: none;
+	user-select: none;
+}
+
+/* Restore removed space with unselectable one*/
+.refined-github-diff-signs .blob-code-inner:before {
+	content: ' ' !important;
 	user-select: none;
 }
 

--- a/extension/content.css
+++ b/extension/content.css
@@ -565,7 +565,7 @@ Hidden content area created to increase hover target
 	user-select: none;
 }
 
-/* Restore removed space with unselectable one*/
+/* Restore removed space with unselectable one */
 .refined-github-diff-signs .blob-code-inner:before {
 	content: ' ' !important;
 	user-select: none;

--- a/extension/content.css
+++ b/extension/content.css
@@ -542,12 +542,12 @@ Hidden content area created to increase hover target
 /* +/- Pseudo elements on diffs */
 .refined-github-diff-signs .blob-code-addition:before,
 .refined-github-diff-signs .blob-code-deletion:before {
-	display: inline-block;
-	position: absolute;
-	top: 1px;
+	position: relative;
+	top: -1px;
+	left: -8px;
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+	line-height: 0; /* Avoids extra vertical space */
 	font-size: 11px;
-	text-indent: -8px;
 	color: rgba(0, 0, 0, 0.3);
 }
 
@@ -557,10 +557,6 @@ Hidden content area created to increase hover target
 
 .refined-github-diff-signs .blob-code-deletion:before {
 	content: '-';
-}
-.refined-github-diff-signs .blob-code-addition .blob-code-inner,
-.refined-github-diff-signs .blob-code-deletion .blob-code-inner {
-	padding-left: 1ch;
 }
 
 /* Prevent copy of ghost whitespace where supported (#317) */

--- a/src/content.js
+++ b/src/content.js
@@ -275,10 +275,7 @@ function addPatchDiffLinks() {
 function removeDiffSigns() {
 	$('.diff-table:not(.refined-github-diff-signs)')
 		.addClass('refined-github-diff-signs')
-		.find(`
-			.blob-code-addition .blob-code-inner,
-			.blob-code-deletion .blob-code-inner
-		`)
+		.find('.blob-code-inner')
 		.each((index, el) => {
 			el.firstChild.textContent = el.firstChild.textContent.slice(1);
 		});

--- a/src/content.js
+++ b/src/content.js
@@ -272,6 +272,16 @@ function addPatchDiffLinks() {
 	);
 }
 
+function removeSelectableWhiteSpaceFromDiffs() {
+	for (const commentBtn of select.all('.add-line-comment')) {
+		for (const node of commentBtn.childNodes) {
+			if (node.nodeType === Node.TEXT_NODE) {
+				node.remove();
+			}
+		}
+	}
+}
+
 /* Lasciate ogne speranza, voi ch'intrate. */
 function removeDiffSigns() {
 	for (const line of select.all('tr:not(.refined-github-diff-signs)')) {
@@ -289,6 +299,7 @@ function removeDiffSigns() {
 }
 
 function removeDiffSignsAndWatchExpansions() {
+	removeSelectableWhiteSpaceFromDiffs();
 	removeDiffSigns();
 	for (const file of $('.diff-table:not(.rgh-watching-lines)').has('.diff-expander')) {
 		file.classList.add('rgh-watching-lines');

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -22,7 +22,7 @@ export const observeEl = (el, listener, options = {childList: true}) => {
 	}
 
 	// Run first
-	listener();
+	listener([]);
 
 	// Run on updates
 	return new MutationObserver(listener).observe(el, options);


### PR DESCRIPTION
Fixes #612 

Manual tests:
- #601 alignment on Windows/Linux:
  https://github.com/dunst-project/dunst/commit/717c747a8caf0f823da0e4e45bbb632ef46c68ee
- #590 indentation of ajax-loaded diffs:
  https://github.com/rob3n/yard-frontend/pull/4/files (scroll all the way down)
- #557 indentation of expanded code:
  https://github.com/npmhub/npmhub/pull/63/files?diff=unified (click to expand collapsed code)
- https://github.com/sindresorhus/refined-github/pull/607#issuecomment-314142245 indentation of whatever regression
  [sindresorhus/eslint-plugin-unicorn/pull/99/files#diff](https://github.com/sindresorhus/eslint-plugin-unicorn/pull/99/files#diff-2d660eee44e5e1d2a779ac70f6ad47a6R22)
- https://github.com/sindresorhus/refined-github/pull/607#issuecomment-314150451 no spaces added *inside* the line:
  [sindresorhus/eslint-plugin-unicorn/pull/100/files#diff](https://github.com/sindresorhus/eslint-plugin-unicorn/pull/100/files#diff-126eaa52c8d3f2872d9763009c8365e3R6)

Additionally:

- try to copy across changed lines, unchanged lines, and expanded code (from line 82 to 92)
  https://github.com/npmhub/npmhub/pull/63/files?diff=unified

Fixes #317 for good measure 🎉 