### PR TITLE
Lighter bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"babel-cli": "^6.24.1",
 		"babel-core": "^6.25.0",
 		"babel-loader": "^7.1.1",
-		"babel-plugin-jsx": "^1.2.0",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 		"babel-plugin-transform-react-jsx": "^6.24.1",
 		"chrome-webstore-upload-cli": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
 		"build": "webpack",
 		"watch": "webpack --watch",
 		"watch:sourcemap": "webpack --watch --devtool eval-cheap-module-source-map",
-		"reduce-size": "babel --out-dir . --no-comments extension/*.js",
+		"reduce-size": "BABEL_ENV=production babel --out-dir . extension/content.js",
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
-		"release": "run-s build update-version release:* reduce-size",
+		"release": "BABEL_ENV=production run-s build reduce-size update-version release:*",
 		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
 	},
 	"dependencies": {
@@ -72,7 +72,6 @@
 		]
 	},
 	"babel": {
-		"comments": false,
 		"plugins": [
 			[
 				"transform-react-jsx",
@@ -86,6 +85,22 @@
 			"testing": {
 				"plugins": [
 					"transform-es2015-modules-commonjs"
+				]
+			},
+			"production": {
+				"minified": false,
+				"presets": [
+					[
+						"babili",
+						{
+							"deadcode": {
+								"optimizeRawSize": true
+							},
+							"mangle": false,
+							"removeConsole": false,
+							"simplify": false
+						}
+					]
 				]
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"scripts": {
-		"test": "xo && ava && npm run build",
+		"test": "xo && BABEL_ENV=testing ava && npm run build",
 		"build": "webpack",
 		"watch": "webpack --watch",
 		"watch:sourcemap": "webpack --watch --devtool eval-cheap-module-source-map",
@@ -75,7 +75,6 @@
 	"babel": {
 		"comments": false,
 		"plugins": [
-			"transform-es2015-modules-commonjs",
 			[
 				"transform-react-jsx",
 				{
@@ -83,6 +82,13 @@
 					"useBuiltIns": true
 				}
 			]
-		]
+		],
+		"env": {
+			"testing": {
+				"plugins": [
+					"transform-es2015-modules-commonjs"
+				]
+			}
+		}
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,9 @@ module.exports = {
 		options: './src/options'
 	},
 	plugins: [
+		new webpack.DefinePlugin({
+			process: '0'
+		}),
 		new webpack.optimize.ModuleConcatenationPlugin()
 	],
 	output: {


### PR DESCRIPTION
* Drop process shim: 6KB (4%)
* Optimize code via babili: 18KB (12%)

This is almost minimization but the code remains readable because mangling and  `simplify` are disabled.

You can see the diff of the resulting `content.js` by checking out:

```
https://gist.github.com/afa017a7c81dd5f5eeefc963593088b4.git
```