### PR TITLE
Restore cross-OS build compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
 	"scripts": {
-		"test": "xo && BABEL_ENV=testing ava && run-s build minify",
+		"test": "xo && cross-env BABEL_ENV=testing ava && run-s build minify",
 		"build": "webpack",
 		"watch": "webpack --watch",
 		"watch:sourcemap": "webpack --watch --devtool eval-cheap-module-source-map",
-		"minify": "BABEL_ENV=production babel --out-dir . extension/content.js",
+		"minify": "cross-env BABEL_ENV=production babel --out-dir . extension/content.js",
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
-		"release": "BABEL_ENV=production run-s build minify update-version release:*",
+		"release": "run-s build minify update-version release:*",
 		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
 	},
 	"dependencies": {
@@ -36,6 +36,7 @@
 		"babel-preset-babili": "^0.1.4",
 		"chrome-webstore-upload-cli": "^1.0.0",
 		"common-tags": "^1.4.0",
+		"cross-env": "^5.0.1",
 		"dot-json": "^1.0.3",
 		"npm-run-all": "^4.0.2",
 		"webext": "^1.9.1-with-submit.1",


### PR DESCRIPTION
Uses cross-env like it was used before by Windows user @jgierer12 in https://github.com/sindresorhus/refined-github/commit/ffe599b8ba16a7276e51e941a17d0d10cbfafda2

Drops an unnecessary ENV since it does not change the output size.