### PR TITLE
Only add the Edit/Tag buttons on repo pages

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -172,7 +172,7 @@ function addYoursMenuItem() {
 }
 
 function addReadmeButtons() {
-	const readmeContainer = select('#readme.readme');
+	const readmeContainer = select('.repository-content > #readme');
 	if (!readmeContainer) {
 		return;
 	}


### PR DESCRIPTION
This page was also matched (and it failed): https://github.com/sindresorhus/refined-github/blob/master/readme.md

<img width="773" alt="screen shot 2017-07-18 at 15 27 19" src="https://user-images.githubusercontent.com/1402241/28305271-9a930afa-6bcd-11e7-81c9-fde7d63d2793.png">
