### PR TITLE
Move mark-unread to browser.storage.local

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
 		"webext-dynamic-content-scripts": "^2.0.1",
-		"webext-options-sync": "^0.11.0"
+		"webext-options-sync": "^0.11.0",
+		"webextension-polyfill": "^0.1.1"
 	},
 	"devDependencies": {
 		"ava": "*",

--- a/src/libs/mark-unread.js
+++ b/src/libs/mark-unread.js
@@ -313,6 +313,20 @@ function updateLocalNotificationsCount() {
 	}
 }
 
+// Migrate old localStorage.unreadNotifications to new storage.
+// For extra safety, keep the old notifications under a different name.
+// Drop function in mid August and drop the new key as well.
+function migrateOldStorage() {
+	const oldStorage = localStorage.getItem('unreadNotifications');
+	if (oldStorage) {
+		const list = JSON.parse(oldStorage);
+		console.log('Migrating old unreadNotifications storage', list);
+		storage.set(list);
+		localStorage.setItem('_unreadNotifications_migrated', JSON.stringify(list));
+		localStorage.removeItem('unreadNotifications');
+	}
+}
+
 async function setup() {
 	storage = await new SynchronousStorage(
 		() => {
@@ -324,6 +338,7 @@ async function setup() {
 			return browser.storage.local.set({unreadNotifications});
 		}
 	);
+	migrateOldStorage();
 	gitHubInjection(window, () => {
 		destroy();
 

--- a/src/libs/synchronous-storage.js
+++ b/src/libs/synchronous-storage.js
@@ -1,0 +1,43 @@
+/**
+ * Allows usage of async get/set API synchronously.
+ * Requirements:
+ * - SynchronousStorage must be the only way to get/set the storage
+ * - The source API must be promised
+ * - The first call must be awaited to make sure the value has been loaded
+ *
+ * Usage:
+
+import SynchronousStorage from './synchronous-storage';
+
+const storage = await new SynchronousStorage(
+	() => browser.storage.local.get('name'),
+	va => browser.storage.local.set({name: va})
+);
+
+console.log(storage.get()); // {}
+storage.set('Federico');
+console.log(storage.get()); // {name: 'Federico'}
+
+ *
+ * Caveats:
+ * - .set() returns a promise that you can use to catch write errors.
+ *   However if an error happens, SynchronousStorage will no longer match the real cache.
+ */
+export default class SynchronousStorage {
+	constructor(get, set) {
+		this._get = get;
+		this._set = set;
+		return get().then(value => {
+			this._cache = value;
+			return this;
+		});
+	}
+	get() {
+		return this._cache;
+	}
+	set(value) {
+		this._cache = value;
+		return this._set(value);
+	}
+}
+


### PR DESCRIPTION
`mark-unread` is the only piece that uses localStorage, which I just realized it's shared across all extensions enabled on github.com and can end up being fuller than we expect.

This PR moves `mark-unread` to `chrome.storage.local` and, while at it, it tries the promised `browser.*` polyfill by Mozilla as mentioned in #495

There's one minor issue though: `chrome.storage.local` is async and `mark-unread` makes a lot of synchronous queries to the storage. I thought of just using `async`/`await` but that meant that literally almost every function would have to be `async` and therefore `await`ed. It got messy quickly.

An _ok_ alternative solution was to provide a local asynchronous cache that responded synchronously: `SynchronousStorage`. I tried to keep it as small as possible. API improvements or alternative solutions are welcome. 

## Testing

Because this tries to migrate data across the storages, it's best to be tested while you have some items _marked as unread_ **before** you load this new version. The migration happens on the first GitHub pageload after the extension update.

1. Mark this PR as unread
2. Open [Notifications](https://github.com/notifications) + see the unread item
3. Reload the extension
4. Reload your Notifications page
5. See the unread item + see the migration log in the console