### PR TITLE
Don't break 'copy' if copy-markdown fails

### DIFF
--- a/src/libs/copy-markdown.js
+++ b/src/libs/copy-markdown.js
@@ -70,8 +70,10 @@ export default event => {
 
 	const markdown = getSmarterMarkdown(holder.innerHTML);
 
-	copyToClipboard(markdown);
-
-	event.stopImmediatePropagation();
-	event.preventDefault();
+	if (copyToClipboard(markdown)) {
+		event.stopImmediatePropagation();
+		event.preventDefault();
+	} else {
+		console.warn('Refined GitHub: copy-markdown failed');
+	}
 };


### PR DESCRIPTION
Fixes #635 

Untested. Will be running this for a while but I think we can merge it preventively if it doesn't break anything itself.