### PR TITLE
Fix Trending menu item and "g + t" shortcut disappearance and hide Marketplace menu item

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -674,7 +674,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 }
 
 /* Hide marketplace navbar button */
-.header-nav-item > a[href='/marketplace'] {
+.header[role="banner"] [role="navigation"] a[href="/marketplace"] {
 	display: none !important;
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -159,7 +159,7 @@ async function addTrendingMenuItem() {
 	const secondListItem = await elementReady('.header[role="banner"] ul[role="navigation"] li:nth-child(3)');
 	secondListItem.insertAdjacentElement('afterEnd',
 		<li>
-			<a href="/trending" class="js-selected-navigation-item header-navlink" data-ga-click="Header, click, Nav menu - item:trending context:user" data-selected-links=" /trending" data-hotkey="g t">Trending</a>
+			<a href="/trending" class="js-selected-navigation-item header-navlink" data-selected-links="/trending" data-hotkey="g t">Trending</a>
 		</li>
 	);
 }

--- a/src/content.js
+++ b/src/content.js
@@ -156,11 +156,10 @@ function addReleasesTab() {
 }
 
 async function addTrendingMenuItem() {
-	const secondListItem = await elementReady('.header-nav.float-left .header-nav-item:nth-child(2)');
-
+	const secondListItem = await elementReady('.header[role="banner"] ul[role="navigation"] li:nth-child(3)');
 	secondListItem.insertAdjacentElement('afterEnd',
-		<li class="header-nav-item">
-			<a href="/trending" class="header-nav-link" data-hotkey="g t">Trending</a>
+		<li>
+			<a href="/trending" class="js-selected-navigation-item header-navlink" data-ga-click="Header, click, Nav menu - item:trending context:user" data-selected-links=" /trending" data-hotkey="g t">Trending</a>
 		</li>
 	);
 }


### PR DESCRIPTION
And tested locally on Chrome.

Restoring the following features :
- A menu item "Trending now appears after "Marketplace" and before "Gist".
- Pressing g and t will now make the browser navigate to the trending page

Fix bug #638 for feature #153 .