### PR TITLE
Show more than three Avatars for Reactions

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -452,15 +452,8 @@ we will add it back on for the simple news alerts we decide to show
 }
 
 /* Overlap reaction avatars when there are 5+ types of reactions */
-.reaction-summary-item:first-child:nth-last-child(n+5):not(:hover) a:nth-child(n+2),
-.reaction-summary-item:first-child:nth-last-child(n+5) ~ *:not(:hover) a:nth-child(n+2) {
+.rgh-reactions-near-limit .reaction-summary-item:not(:hover) a:not(:first-of-type) {
 	margin-left: -12px;
-}
-
-/* Limit reaction avatars when there are 6 types of reactions */
-.reaction-summary-item:first-child:nth-last-child(6) a:nth-child(n+3),
-.reaction-summary-item:first-child:nth-last-child(6) ~ * a:nth-child(n+3) {
-	display: none;
 }
 
 /* Hide reaction popover text */

--- a/src/libs/reactions-avatars.js
+++ b/src/libs/reactions-avatars.js
@@ -1,7 +1,10 @@
 import debounce from 'debounce-fn';
 import select from 'select-dom';
 import {h} from 'dom-chef';
-import {getUsername} from './utils';
+import {getUsername, flatZip} from './utils';
+
+const arbitraryAvatarLimit = 39;
+const approximateHeaderLength = 3; // Each button header takes about as much as 3 avatars
 
 function getParticipants(container) {
 	const currentUser = getUsername();
@@ -34,13 +37,10 @@ function flatZip(table) {
 
 function add() {
 	for (const list of select.all(`.has-reactions .comment-reactions-options:not(.rgh-reactions)`)) {
-		const avatarLimit = 39 - (list.children.length * 3); // Each button header takes about as much as 3 avatars
+		const avatarLimit = arbitraryAvatarLimit - (list.children.length * approximateHeaderLength);
+
 		const participantByReaction = [].map.call(list.children, getParticipants);
-		const flatParticipants = flatZip(participantByReaction);
-		const droppedParticipants = flatParticipants.splice(avatarLimit);
-		if (droppedParticipants.length > 0) {
-			console.log('Dropping avatars of', droppedParticipants.map(r => r.username), 'from', list);
-		}
+		const flatParticipants = flatZip(participantByReaction).slice(avatarLimit);
 
 		for (const participant of flatParticipants) {
 			participant.container.append(

--- a/src/libs/reactions-avatars.js
+++ b/src/libs/reactions-avatars.js
@@ -25,7 +25,7 @@ function add() {
 		const avatarLimit = arbitraryAvatarLimit - (list.children.length * approximateHeaderLength);
 
 		const participantByReaction = [].map.call(list.children, getParticipants);
-		const flatParticipants = flatZip(participantByReaction).slice(avatarLimit);
+		const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
 		for (const participant of flatParticipants) {
 			participant.container.append(

--- a/src/libs/reactions-avatars.js
+++ b/src/libs/reactions-avatars.js
@@ -30,7 +30,7 @@ function add() {
 		for (const participant of flatParticipants) {
 			participant.container.append(
 				<a href={`/${participant.username}`}>
-					<img src={`/${participant.username}.png`}/>
+					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`}/>
 				</a>
 			);
 		}

--- a/src/libs/reactions-avatars.js
+++ b/src/libs/reactions-avatars.js
@@ -20,21 +20,6 @@ function getParticipants(container) {
 		}));
 }
 
-// Concats arrays but does so like a zipper instead of appending them
-// [[0, 1, 2], [0, 1]] => [0, 0, 1, 1, 2]
-function flatZip(table) {
-	const maxColumns = Math.max(...table.map(row => row.length));
-	const zipped = [];
-	for (let col = 0; col < maxColumns; col++) {
-		for (const row of table) {
-			if (row[col]) {
-				zipped.push(row[col]);
-			}
-		}
-	}
-	return zipped;
-}
-
 function add() {
 	for (const list of select.all(`.has-reactions .comment-reactions-options:not(.rgh-reactions)`)) {
 		const avatarLimit = arbitraryAvatarLimit - (list.children.length * approximateHeaderLength);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -42,13 +42,16 @@ export const observeEl = (el, listener, options = {childList: true}) => {
 // Concats arrays but does so like a zipper instead of appending them
 // [[0, 1, 2], [0, 1]] => [0, 0, 1, 1, 2]
 // Like lodash.zip
-export const flatZip = (table) => {
+export const flatZip = (table, limit = Infinity) => {
 	const maxColumns = Math.max(...table.map(row => row.length));
 	const zipped = [];
 	for (let col = 0; col < maxColumns; col++) {
 		for (const row of table) {
 			if (row[col]) {
 				zipped.push(row[col]);
+				if (limit !== Infinity && zipped.length === limit) {
+					return zipped;
+				}
 			}
 		}
 	}

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -38,3 +38,19 @@ export const observeEl = (el, listener, options = {childList: true}) => {
 	// Run on updates
 	return new MutationObserver(listener).observe(el, options);
 };
+
+// Concats arrays but does so like a zipper instead of appending them
+// [[0, 1, 2], [0, 1]] => [0, 0, 1, 1, 2]
+// Like lodash.zip
+export const flatZip = (table) => {
+	const maxColumns = Math.max(...table.map(row => row.length));
+	const zipped = [];
+	for (let col = 0; col < maxColumns; col++) {
+		for (const row of table) {
+			if (row[col]) {
+				zipped.push(row[col]);
+			}
+		}
+	}
+	return zipped;
+};


### PR DESCRIPTION
Fixes #240

Testable on https://github.com/babel/babel/pull/3646

> <img width="708" alt="more than 3 avatars" src="https://user-images.githubusercontent.com/1402241/28608582-667e7726-7213-11e7-9729-e0b33779ff0b.png">

Still limited and compressed when they don't fit:

> <img width="715" alt="lots of avatars" src="https://user-images.githubusercontent.com/1402241/28608590-75819c30-7213-11e7-9af9-f9b00a91d2ee.png">

Since this is now in JS, _limited_ avatars won't be loaded at all (contrary to what happened before)