### PR TITLE
Improve avatar style during loading and for transparent avatars

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -436,7 +436,8 @@ we will add it back on for the simple news alerts we decide to show
 	height: 20px;
 
 	background: #efefef; /* Placeholder before they load */
-	box-shadow: 0 0 0 2px #fff;
+	color: #fff; /* Affects box-shadow, needed because of .user-has-reacted */
+	box-shadow: 0 0 0 2px;
 	border-radius: 3px;
 
 	margin-left: -2px;
@@ -449,7 +450,7 @@ we will add it back on for the simple news alerts we decide to show
 	border-radius: 3px;
 }
 
-.reaction-summary-item.user-has-reacted img {
+.reaction-summary-item.user-has-reacted a {
 	color: #f2f8fa;
 }
 

--- a/extension/content.css
+++ b/extension/content.css
@@ -430,20 +430,22 @@ we will add it back on for the simple news alerts we decide to show
 }
 
 .reaction-summary-item a {
+	display: inline-block;
+	vertical-align: middle;
+	width: 20px;
+	height: 20px;
+
+	background: #efefef; /* Placeholder before they load */
+	box-shadow: 0 0 0 2px #fff;
+	border-radius: 3px;
+
 	margin-left: -2px;
 	transition: margin-left 0.2s;
 }
 
-.reaction-summary-item img,
-.reaction-summary-item span {
-	width: 20px;
-	height: 20px;
-	vertical-align: middle;
-}
-
 .reaction-summary-item img {
-	color: #FFF; /* affects box-shadow */
-	box-shadow: 0 0 0 2px;
+	max-width: 100%;
+	background: #fff; /* Appears under round avatars */
 	border-radius: 3px;
 }
 

--- a/extension/content.css
+++ b/extension/content.css
@@ -424,9 +424,12 @@ we will add it back on for the simple news alerts we decide to show
 	padding-right: 0 !important;
 }
 
-.reaction-summary-item a,
-.reaction-summary-item img {
-	display: inline-block;
+.reaction-summary-item {
+	--background: #FFF;
+}
+
+.reaction-summary-item.user-has-reacted {
+	--background: #f2f8fa;
 }
 
 .reaction-summary-item a {
@@ -435,23 +438,19 @@ we will add it back on for the simple news alerts we decide to show
 	width: 20px;
 	height: 20px;
 
-	background: #efefef; /* Placeholder before they load */
-	color: #fff; /* Affects box-shadow, needed because of .user-has-reacted */
-	box-shadow: 0 0 0 2px;
+	background: #efefef; /* Placeholder before the images load */
+	box-shadow: 0 0 0 2px var(--background);
 	border-radius: 3px;
 
 	margin-left: -2px;
 	transition: margin-left 0.2s;
 }
 
+/* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item img {
 	max-width: 100%;
-	background: #fff; /* Appears under round avatars */
-	border-radius: 3px;
-}
-
-.reaction-summary-item.user-has-reacted a {
-	color: #f2f8fa;
+	background-color: var(--background);
+	border-radius: inherit;
 }
 
 /* Overlap reaction avatars when there are 5+ types of reactions */


### PR DESCRIPTION
# Bug

Transparent avatars:

> <img width="127" alt="hole-y avatars" src="https://user-images.githubusercontent.com/1402241/28609344-e3a0aae6-7216-11e7-8ee4-39eff44d3b43.png" valign=middle>  <-- before this PR

As seen on this comment: https://github.com/sindresorhus/refined-github/pull/571#issuecomment-313707428


# Enhancement 

Avatars' gray placeholders appear before they load:

> ![](https://user-images.githubusercontent.com/1402241/28609365-f6643698-7216-11e7-88bc-bee2e2e69672.gif)

Testable on https://github.com/babel/babel/pull/3646
