### PR TITLE
Cleanup: Remove unused domify uncertainty

### DIFF
--- a/src/libs/domify.js
+++ b/src/libs/domify.js
@@ -1,14 +1,5 @@
 export default html => {
 	const template = document.createElement('template');
 	template.innerHTML = html;
-
-	const fragment = template.content;
-
-	// If it's a single element, return just the element
-	if (fragment.firstChild === fragment.lastChild) {
-		return fragment.firstChild;
-	}
-
-	// Return fragment for querying
-	return fragment;
+	return template.content;
 };


### PR DESCRIPTION
This behavior is unused and undesired.
What does ` <i>a</i>` return?
1 el

What does ` <i>a</i><i>a</i>` return?
frag with 3 nodes

Now it always returns a frag.