### PR TITLE
Always use source maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 		"test": "xo && cross-env BABEL_ENV=testing ava && run-s build minify",
 		"build": "webpack",
 		"watch": "webpack --watch",
-		"watch:sourcemap": "webpack --watch --devtool eval-cheap-module-source-map",
 		"minify": "cross-env BABEL_ENV=production babel --out-dir . extension/content.js",
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
+	devtool: 'source-map',
 	entry: {
 		content: './src/content',
 		background: './src/background',


### PR DESCRIPTION
Source maps increase the first build time by 300ms, but a rebuild only takes 300ms in `watch` mode (which I hope you're using when checking out PRs and working on the extension)

Seeing the real source code makes sense when debugging stuff. No one wants to read webpack's output.

The only issue is that it doubles the extension's zip since currently the `.js.map` files are included — but perhaps seeing the source _in production_ is good and it doesn't affect the JS files' loading time.