### PR TITLE
Uglify all the things

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
 	"scripts": {
-		"test": "xo && cross-env BABEL_ENV=testing ava && run-s build minify",
+		"test": "xo && cross-env BABEL_ENV=testing ava && run-s build:minified",
 		"build": "webpack",
+		"build:minified": "cross-env NODE_ENV=production webpack",
 		"watch": "webpack --watch",
-		"minify": "cross-env BABEL_ENV=production babel --out-dir . extension/content.js",
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
-		"release": "run-s build minify update-version release:*",
+		"release": "run-s build:minified update-version release:*",
 		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
 	},
 	"dependencies": {
@@ -28,17 +28,16 @@
 	},
 	"devDependencies": {
 		"ava": "*",
-		"babel-cli": "^6.24.1",
 		"babel-core": "^6.25.0",
 		"babel-loader": "^7.1.1",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
 		"babel-plugin-transform-react-jsx": "^6.24.1",
-		"babel-preset-babili": "^0.1.4",
 		"chrome-webstore-upload-cli": "^1.0.0",
 		"common-tags": "^1.4.0",
 		"cross-env": "^5.0.1",
 		"dot-json": "^1.0.3",
 		"npm-run-all": "^4.0.2",
+		"uglifyjs-webpack-plugin": "^1.0.0-beta.1",
 		"webext": "^1.9.1-with-submit.1",
 		"webpack": "^3.0.0",
 		"xo": "*"
@@ -87,22 +86,6 @@
 			"testing": {
 				"plugins": [
 					"transform-es2015-modules-commonjs"
-				]
-			},
-			"production": {
-				"minified": false,
-				"presets": [
-					[
-						"babili",
-						{
-							"deadcode": {
-								"optimizeRawSize": true
-							},
-							"mangle": false,
-							"removeConsole": false,
-							"simplify": false
-						}
-					]
 				]
 			}
 		}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
 const webpack = require('webpack');
+const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
 	devtool: 'source-map',
@@ -31,3 +32,11 @@ module.exports = {
 		]
 	}
 };
+
+if (process.env.NODE_ENV === 'production') {
+	module.exports.plugins.push(
+		new UglifyJSPlugin({
+			sourceMap: true
+		})
+	);
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,13 @@ module.exports = {
 if (process.env.NODE_ENV === 'production') {
 	module.exports.plugins.push(
 		new UglifyJSPlugin({
-			sourceMap: true
+			sourceMap: true,
+			uglifyOptions: {
+				mangle: false,
+				output: {
+					beautify: true
+				}
+			}
 		})
 	);
 }


### PR DESCRIPTION
- Lets us skip the extra babel-cli step.
- Enables **full** source map output (otherwise not available because of
babel/babel#3940)
- Which means we can have full source maps after the minification.
- Which means that we get the real code even when debugging a published
version.
- Which means that we can minify the JS fully and just submit the source
maps to Mozilla Addons (if they accept them, let's try with a beautified version first)

[In a few weeks](https://github.com/webpack-contrib/uglifyjs-webpack-plugin/pull/63#issuecomment-313283672), when they have tested out uglify-es, this will become part of webpack core and we can drop the dependency.