### PR TITLE
Maintain whitespace option on previous/next navigation.

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -374,7 +374,6 @@ function addDiffViewWithoutWhitespaceOption() {
 
 // When navigating with next/previous in review mode, maintain whitespace option.
 function addWhitespaceOptionToNextPrevious() {
-
 	// Only proceed if in review.
 	if (!select.exists('.pr-review-tools > .diffbar-item')) {
 		return;

--- a/src/content.js
+++ b/src/content.js
@@ -372,22 +372,22 @@ function addDiffViewWithoutWhitespaceOption() {
 	);
 }
 
-// When navigating with next/previous in review mode, maintain whitespace option.
-function addWhitespaceOptionToNextPrevious() {
-	// Only proceed if in review.
-	if (!select.exists('.pr-review-tools > .diffbar-item')) {
+// When navigating with next/previous in review mode, preserve whitespace option.
+function preserveWhitespaceOptionInNav() {
+	const navLinks = select.all('.commit > .BtnGroup.float-right > a.BtnGroup-item');
+	if (navLinks.length === 0) {
 		return;
 	}
 
 	const url = new URL(location.href);
 	const hidingWhitespace = url.searchParams.get('w') === '1';
-
-	for (const a of select.all('.commit > .BtnGroup.float-right > a.BtnGroup-item')) {
-		const linkUrl = new URL(a.href);
-		if (hidingWhitespace) {
+	
+	if (hidingWhitespace) {
+		for (const a of navLinks) {
+			const linkUrl = new URL(a.href);
 			linkUrl.searchParams.set('w', '1');
+			a.href = linkUrl;
 		}
-		a.href = linkUrl;
 	}
 }
 
@@ -613,7 +613,7 @@ async function onDomReady() {
 					observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
 				}
 				addDiffViewWithoutWhitespaceOption();
-				addWhitespaceOptionToNextPrevious();
+				preserveWhitespaceOptionInNav();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/src/content.js
+++ b/src/content.js
@@ -372,6 +372,26 @@ function addDiffViewWithoutWhitespaceOption() {
 	);
 }
 
+// When navigating with next/previous in review mode, maintain whitespace option.
+function addWhitespaceOptionToNextPrevious() {
+
+	// Only proceed if in review.
+	if (!select.exists('.pr-review-tools > .diffbar-item')) {
+		return;
+	}
+
+	const url = new URL(location.href);
+	const hidingWhitespace = url.searchParams.get('w') === '1';
+
+	for (const a of select.all('.commit > .BtnGroup.float-right > a.BtnGroup-item')) {
+		const linkUrl = new URL(a.href);
+		if (hidingWhitespace) {
+			linkUrl.searchParams.set('w', '1');
+		}
+		a.href = linkUrl;
+	}
+}
+
 function addMilestoneNavigation() {
 	select('.repository-content').insertAdjacentElement('beforeBegin',
 		<div class="subnav">
@@ -594,6 +614,7 @@ async function onDomReady() {
 					observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
 				}
 				addDiffViewWithoutWhitespaceOption();
+				addWhitespaceOptionToNextPrevious();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {

--- a/src/content.js
+++ b/src/content.js
@@ -381,7 +381,7 @@ function preserveWhitespaceOptionInNav() {
 
 	const url = new URL(location.href);
 	const hidingWhitespace = url.searchParams.get('w') === '1';
-	
+
 	if (hidingWhitespace) {
 		for (const a of navLinks) {
 			const linkUrl = new URL(a.href);


### PR DESCRIPTION
During a pull-request review, when going through individual commits, maintain the whitespace option when using the "Previous" and "Next" buttons ("p" and "n" shortcuts, respectively) to navigate between commits.

Closes #660.