### PR TITLE
Add preview issue/PR title tooltip in comment

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -21,6 +21,7 @@ import linkifyCode, {editTextNodes} from './libs/linkify-urls-in-code';
 import autoLoadMoreNews from './libs/auto-load-more-news';
 import addOPLabels from './libs/op-labels';
 import addReleasesTab from './libs/add-releases-tab';
+import previewIssues from './libs/preview-issues';
 
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
@@ -626,6 +627,7 @@ async function onDomReady() {
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
 				addReactionParticipants();
 				showRealNames();
+				previewIssues();
 			}
 
 			if (pageDetect.isCommitList()) {

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -1,8 +1,6 @@
 import select from 'select-dom';
 import {observeEl} from './utils';
 
-const LOADING_TEXT = 'Loading…';
-
 const addTooltip = (issueLink, title) => {
 	issueLink.setAttribute('aria-label', title);
 	issueLink.removeAttribute('title');
@@ -43,7 +41,7 @@ const preview = () => {
 	for (const issueLink of issueLinks) {
 		// Add the original tooltip classes
 		issueLink.classList.add('tooltipped', 'tooltipped-se');
-		issueLink.setAttribute('aria-label', LOADING_TEXT);
+		issueLink.setAttribute('aria-label', 'Loading…');
 
 		observeEl(issueLink, observeTitle, {
 			attributeFilter: ['title']

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -22,8 +22,11 @@ const addToolTip = issueLink => {
 		return;
 	}
 
-	// Add github original tooltip classes
-	issueLink.classList.add('tooltipped', 'tooltipped-se');
+	// Don't add class again to prevent infinite loop
+	if (!issueLink.classList.contains('tooltipped')) {
+		// Add github original tooltip classes
+		issueLink.classList.add('tooltipped', 'tooltipped-se');
+	}
 
 	// `title` attribute is loaded asynchronously
 	const title = issueLink.getAttribute('aria-label') === loadingText ?

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import {observeEl} from './utils';
 
-const LOADING_TEXT = 'loading...';
+const LOADING_TEXT = 'Loading…';
 
 const addTooltip = (issueLink, title) => {
 	issueLink.setAttribute('aria-label', title);
@@ -41,7 +41,7 @@ const preview = () => {
 	const issueLinks = select.all('.comment .issue-link');
 
 	for (const issueLink of issueLinks) {
-		// Add github original tooltip classes
+		// Add the original tooltip classes
 		issueLink.classList.add('tooltipped', 'tooltipped-se');
 		issueLink.setAttribute('aria-label', LOADING_TEXT);
 

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -1,3 +1,4 @@
+import select from 'select-dom';
 import {observeEl} from './utils';
 
 const loadingText = 'loading...';
@@ -18,13 +19,13 @@ const addToolTip = issueLink => {
 };
 
 const preview = () => {
-	const issueLinks = Array.from(document.querySelectorAll('.comment .issue-link'));
+	const issueLinks = select.all('.comment .issue-link');
 
-	issueLinks.forEach(issueLink => {
+	for (const issueLink of issueLinks) {
 		observeEl(issueLink, () => addToolTip(issueLink), {
 			attributeFilter: ['title']
 		});
-	});
+	}
 };
 
 export default preview;

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -1,13 +1,13 @@
-import { observeEl } from './utils';
+import {observeEl} from './utils';
 
 const loadingText = 'loading...';
 
-const addToolTip = (issueLink) => {
+const addToolTip = issueLink => {
 	issueLink.classList.add('tooltipped', 'tooltipped-se');
 
-	const title = issueLink.getAttribute('aria-label') !== loadingText
-		? issueLink.getAttribute('aria-label')
-		: issueLink.getAttribute('title');
+	const title = issueLink.getAttribute('aria-label') === loadingText ?
+		issueLink.getAttribute('title') :
+		issueLink.getAttribute('aria-label');
 
 	if (title) {
 		issueLink.setAttribute('aria-label', title);
@@ -20,9 +20,9 @@ const addToolTip = (issueLink) => {
 const preview = () => {
 	const issueLinks = Array.from(document.querySelectorAll('.comment .issue-link'));
 
-	issueLinks.forEach((issueLink) => {
+	issueLinks.forEach(issueLink => {
 		observeEl(issueLink, () => addToolTip(issueLink), {
-			attributeFilter: ['title'],
+			attributeFilter: ['title']
 		});
 	});
 };

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -1,0 +1,30 @@
+import { observeEl } from './utils';
+
+const loadingText = 'loading...';
+
+const addToolTip = (issueLink) => {
+	issueLink.classList.add('tooltipped', 'tooltipped-se');
+
+	const title = issueLink.getAttribute('aria-label') !== loadingText
+		? issueLink.getAttribute('aria-label')
+		: issueLink.getAttribute('title');
+
+	if (title) {
+		issueLink.setAttribute('aria-label', title);
+		issueLink.removeAttribute('title');
+	} else {
+		issueLink.setAttribute('aria-label', loadingText);
+	}
+};
+
+const preview = () => {
+	const issueLinks = Array.from(document.querySelectorAll('.comment .issue-link'));
+
+	issueLinks.forEach((issueLink) => {
+		observeEl(issueLink, () => addToolTip(issueLink), {
+			attributeFilter: ['title'],
+		});
+	});
+};
+
+export default preview;

--- a/src/libs/preview-issues.js
+++ b/src/libs/preview-issues.js
@@ -4,8 +4,28 @@ import {observeEl} from './utils';
 const loadingText = 'loading...';
 
 const addToolTip = issueLink => {
+	// Has already injected tooltipster
+	if (issueLink.classList.contains('tooltipstered')) {
+		// Has both tooltip and tooltipster, remove the tooltip to prevent duplicated tooltip
+		if (issueLink.classList.contains('tooltipped')) {
+			const label = issueLink.getAttribute('aria-label');
+			const title = issueLink.getAttribute('title');
+
+			issueLink.classList.remove('tooltipped');
+			issueLink.removeAttribute('aria-label');
+			if (!title) {
+				issueLink.setAttribute('title', label);
+			}
+		}
+
+		// Skip adding tooltip
+		return;
+	}
+
+	// Add github original tooltip classes
 	issueLink.classList.add('tooltipped', 'tooltipped-se');
 
+	// `title` attribute is loaded asynchronously
 	const title = issueLink.getAttribute('aria-label') === loadingText ?
 		issueLink.getAttribute('title') :
 		issueLink.getAttribute('aria-label');
@@ -14,6 +34,7 @@ const addToolTip = issueLink => {
 		issueLink.setAttribute('aria-label', title);
 		issueLink.removeAttribute('title');
 	} else {
+		// Is loading
 		issueLink.setAttribute('aria-label', loadingText);
 	}
 };
@@ -23,7 +44,7 @@ const preview = () => {
 
 	for (const issueLink of issueLinks) {
 		observeEl(issueLink, () => addToolTip(issueLink), {
-			attributeFilter: ['title']
+			attributeFilter: ['title', 'class']
 		});
 	}
 };


### PR DESCRIPTION
**Feature Request**

I often find myself hovering on the issues number for so long just to preview the title of the issues. I think it will be nice if the titles are going to be shown on tooltips as soon as I hover on them. Like demonstrated below.

<img width="140" alt="2017-08-11 9 04 16" src="https://user-images.githubusercontent.com/7753001/29214323-7aecd464-7ed9-11e7-9d80-e7e87eee5c19.png">

It uses the default style of the tooltip of Github. I also remove the `title` attribute as soon as the tooltip is loaded to avoid duplicated informations, not sure whether it is a good idea though.

Hope this could be landed, Many thanks 😉 .