### PR TITLE
Limit deployments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ deploy:
   script: npm run release
   on:
     branch: master
-    # Only deploy on cronjobs + if the last commit was within the last day ± 1 hour.
-    # Temporarily comment out this condition to let any commits be deployed.
-    condition: $TRAVIS_EVENT_TYPE = cron &&  $(git log -1 --pretty=format:%ct) -gt $(gdate --date='26 hours ago' +%s)
+    condition: $TRAVIS_EVENT_TYPE = cron || -n "$TRAVIS_TAG"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
 		"release": "run-s build:minified update-version release:*",
-		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
+		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d)"
 	},
 	"dependencies": {
 		"copy-text-to-clipboard": "^1.0.2",


### PR DESCRIPTION
- Limit to 1 weekly CRON deployment (must be done on Travis)
- Also allow deployment via tags just to give a simple reversible manual deployment mechanism.