### PR TITLE
Shorten version number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ node_js:
   - 'node'
 env:
   - EXTENSION_ID=hlepfoohegkhhmjieoechaddaejaokhf
+
+cache:
+  directories:
+  - $HOME/.npm-daily-version # This is necessary to preserve the version
+
 deploy:
   provider: script
   skip_cleanup: true

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
 		"release": "run-s build:minified update-version release:*",
-		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d)"
+		"update-version": "dot-json extension/manifest.json version $(daily-version)"
 	},
 	"dependencies": {
 		"copy-text-to-clipboard": "^1.0.2",
@@ -35,6 +35,7 @@
 		"chrome-webstore-upload-cli": "^1.0.0",
 		"common-tags": "^1.4.0",
 		"cross-env": "^5.0.1",
+		"daily-version": "^0.10.0",
 		"dot-json": "^1.0.3",
 		"npm-run-all": "^4.0.2",
 		"uglifyjs-webpack-plugin": "^1.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"release:amo": "cd extension && webext submit",
 		"release:cws": "cd extension && webstore upload --auto-publish",
 		"release": "run-s build:minified update-version release:*",
-		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d.%-H%M)"
+		"update-version": "dot-json extension/manifest.json version $(date -u +%y.%-m.%-d)"
 	},
 	"dependencies": {
 		"copy-text-to-clipboard": "^1.0.2",


### PR DESCRIPTION
Closes #595 
```
From 17.8.20.834
to   17.8.20
```
Travis has been behaving well and deployments happening in the middle of UTC day, so same-day deployments are far from possible — even if that does happen we only lose a day anyway.