### PR TITLE
Drop Firefox 54 support

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
 	"applications": {
 		"gecko": {
 			"id": "{a4c4eda4-fb84-4a84-b4a1-f7c1cbf2a1ad}",
-			"strict_min_version": "52.0"
+			"strict_min_version": "55.0"
 		}
 	},
 	"permissions": [

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ We use GitHub a lot and notice many dumb annoyances we'd like to fix. So here be
 
 Our hope is that GitHub will notice and implement some of these much needed improvements. So if you like any of these improvements, please email [GitHub support](mailto:support@github.com) about doing it.
 
-GitHub Enterprise is also supported by [authorizing your own domain in the options](https://github.com/sindresorhus/refined-github/pull/450). This is supported in Chrome and Firefox 55+ (to be released in August 2017).
+GitHub Enterprise is also supported by [authorizing your own domain in the options](https://github.com/sindresorhus/refined-github/pull/450).
 
 - **[What's new lately](https://blog.sindresorhus.com/whats-new-in-refined-github-836d05582df7)**
 - [Original announcement](https://blog.sindresorhus.com/refined-github-21185789685d)

--- a/src/libs/auto-load-more-news.js
+++ b/src/libs/auto-load-more-news.js
@@ -16,25 +16,6 @@ const loadMore = debounce(() => {
 	}
 }, {wait: 200});
 
-// Delete after Firefox 55 goes stable
-// Also update applications.gecko.strict_min_version to 55.0 in manifest.json
-const IntersectionObserver = window.IntersectionObserver || class IntersectionObserverLocalfill {
-	maybeLoadMore() {
-		if (window.innerHeight > btn.getBoundingClientRect().top - 500) {
-			loadMore();
-		}
-	}
-	observe() {
-		window.addEventListener('scroll', this.maybeLoadMore);
-		window.addEventListener('resize', this.maybeLoadMore);
-		this.maybeLoadMore();
-	}
-	disconnect() {
-		window.removeEventListener('scroll', this.maybeLoadMore);
-		window.removeEventListener('resize', this.maybeLoadMore);
-	}
-};
-
 const inView = new IntersectionObserver(([{isIntersecting}]) => {
 	if (isIntersecting) {
 		loadMore();


### PR DESCRIPTION
- [Firefox 55 was released on Aug 8](https://www.mozilla.org/en-US/firefox/55.0/releasenotes/)
- Min version is specified, so old 54 users will just not get the new version until they upgrade
- We've been stuck in mozilla queue for 2 weeks anyway, we'll probably have to wait longer.