### PR TITLE
Fix /pulls view after label reordering

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -649,25 +649,21 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 
 /* Move labels in the Issue/PR list below the title */
 .js-issue-row .lh-condensed {
-	display: grid;
-	grid-template-rows: auto auto auto;
-	grid-template-columns: auto 1fr;
+	display: flex;
+	flex-wrap: wrap;
 }
 .js-issue-row .labels {
-	grid-area: 3;
-	padding-top: 4px;
-	grid-column-start: span 2;
+	order: 1;
 }
 .js-issue-row .h4, /* Title */
 .js-issue-row .d-inline-block.mr-1 {  /* Build status */
-	grid-area: 1;
 	padding-right: 4px; /* Space before the build status */
 }
 .js-issue-row .mt-1.text-small.text-gray { /* Issue details line */
-	grid-area: 2;
-	grid-column-start: span 2;
+	flex-basis: 100%;
 }
 .js-issue-row .label {
+	margin-top: 4px;
 	font-size: 11px !important;
 	padding: 2px 3px 3px 3px !important;
 }


### PR DESCRIPTION
The bug was here: https://github.com/pulls

# Default GitHub

<img width="983" alt="normal" src="https://user-images.githubusercontent.com/1402241/29744007-1e47fb50-8ac6-11e7-954d-52d53d4abd3b.png">

# Master

<img width="983" alt="before" src="https://user-images.githubusercontent.com/1402241/29744006-1e469ddc-8ac6-11e7-8f89-e6371d51e1da.png">

# This PR

<img width="986" alt="after" src="https://user-images.githubusercontent.com/1402241/29744008-1e49a6da-8ac6-11e7-95ff-6d4944dc3a17.png">
