### PR TITLE
Change "Mark as unread" indicator to green

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -520,6 +520,11 @@ Hidden content area created to increase hover target
 	margin-top: 8px;
 }
 
+/* Change color of marker if there are only discussion marked as unread */
+.notification-indicator[data-ga-click$=":read"] .unread {
+	background: linear-gradient(#34d058, #28a745)
+}
+
 /* +/- Pseudo elements on diffs */
 .refined-github-diff-signs .blob-code-addition:before,
 .refined-github-diff-signs .blob-code-deletion:before {


### PR DESCRIPTION
Isn't this cute?

<img width="90" alt="unread-only" src="https://user-images.githubusercontent.com/1402241/29749624-a188c6e0-8b5a-11e7-9452-39cec9847436.png">

We can distinguish between new notifications and threads marked as unread. 

- Green: only threads marked as unread
- Blue: real notifications (and maybe the above)

The gradient comes straight from GH's buttons.