### PR TITLE
Make CI links in a pull request open in a new tab

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -479,6 +479,13 @@ function moveAccountSwitcherToSidebar() {
 	});
 }
 
+function openCIDetailsInNewTab () {
+	const CIDetailsLinks = select.all('a.status-actions');
+	for(let link of CIDetailsLinks) {
+		link.setAttribute("target", "_blank");
+	}
+}
+
 function init() {
 	//
 	// const username = getUsername();
@@ -598,6 +605,7 @@ async function onDomReady() {
 				linkifyBranchRefs();
 				addDeleteForkLink();
 				fixSquashAndMergeTitle();
+				openCIDetailsInNewTab();
 			}
 
 			if (pageDetect.isPR() || pageDetect.isIssue()) {

--- a/src/content.js
+++ b/src/content.js
@@ -479,10 +479,11 @@ function moveAccountSwitcherToSidebar() {
 	});
 }
 
-function openCIDetailsInNewTab () {
+function openCIDetailsInNewTab() {
 	const CIDetailsLinks = select.all('a.status-actions');
-	for(let link of CIDetailsLinks) {
-		link.setAttribute("target", "_blank");
+	for (const link of CIDetailsLinks) {
+		link.setAttribute('target', '_blank');
+		link.setAttribute('rel', 'noopener');
 	}
 }
 


### PR DESCRIPTION
When a user clicks on the "details" link to view a CI build instead of taking you away from GitHub, it just opens the CI build information in a new browser tab.