### PR TITLE
Preserve span tags inside links

### DIFF
--- a/src/libs/linkify-urls-in-code.js
+++ b/src/libs/linkify-urls-in-code.js
@@ -26,9 +26,15 @@ export const editTextNodes = (fn, el) => {
 		if (fn === linkifyUrls && textNode.textContent.length < 11) { // Shortest url: http://j.mp
 			continue;
 		}
-		const linkified = fn(textNode.textContent, options);
-		if (linkified.children.length > 0) { // Children are <a>
-			textNode.replaceWith(linkified);
+		if ($(el).find('span.x').length > 0) {
+			const replaceNode = $(el).find('span.pl-s')[0];
+			const linkified = fn(replaceNode.textContent, options);
+			replaceNode.replaceWith(linkified);
+		} else {
+			const linkified = fn(textNode.textContent, options);
+			if (linkified.children.length > 0) { // Children are <a>
+				textNode.replaceWith(linkified);
+			}
 		}
 	}
 };


### PR DESCRIPTION
When part of a url is changed, github adds another class to that part of the url to highlight the
change. This added extra nodes in between the url. Hence, the url is being linkified upto the change
resulting in invalid links
closes #695