### PR TITLE
Fix JS error on Trending sub pages

### DIFF
--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -6,6 +6,7 @@ export const isDashboard = () => location.pathname === '/' || /^(\/orgs\/[^/]+)?
 
 export const isTrending = () => location.pathname.startsWith('/trending');
 
+// @todo Replace with DOM-based test because this is too generic #708
 export const isRepo = () => !isGist() && !isTrending() && /^\/[^/]+\/[^/]+/.test(location.pathname);
 
 export const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, '');

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -4,7 +4,9 @@ export const isGist = () => location.hostname.startsWith('gist.') || location.pa
 
 export const isDashboard = () => location.pathname === '/' || /^(\/orgs\/[^/]+)?\/dashboard/.test(location.pathname);
 
-export const isRepo = () => !isGist() && /^\/[^/]+\/[^/]+/.test(location.pathname);
+export const isTrending = () => location.pathname.startsWith('/trending');
+
+export const isRepo = () => !isGist() && !isTrending() && /^\/[^/]+\/[^/]+/.test(location.pathname);
 
 export const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, '');
 

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -35,6 +35,16 @@ test('isDashboard', urlMatcherMacro, pageDetect.isDashboard, [
 	'https://github.com/sindresorhus'
 ]);
 
+test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
+	'https://github.com/trending',
+	'https://github.com/trending/developers',
+	'https://github.com/trending/unknown'
+], [
+	'https://github.com/settings/trending',
+	'https://github.com/watching',
+	'https://github.com/jaredhanson/node-trending/tree/master/lib/trending'
+]);
+
 test('isRepo', urlMatcherMacro, pageDetect.isRepo, [
 	'http://github.com/sindresorhus/refined-github',
 	'https://github.com/sindresorhus/refined-github/issues/146',
@@ -42,7 +52,8 @@ test('isRepo', urlMatcherMacro, pageDetect.isRepo, [
 ], [
 	'https://github.com/sindresorhus',
 	'https://github.com',
-	'https://github.com/stars'
+	'https://github.com/stars',
+	'https://github.com/trending/developers'
 ]);
 
 test('isRepoTree', urlMatcherMacro, pageDetect.isRepoTree, [


### PR DESCRIPTION
Currently we're trying to add releases on the trending page, update the `isRepo` check to account for
the `/trending/X` URLs.

This error is from https://github.com/trending/developers
```js
add-releases-tab.js:42 Uncaught (in promise) TypeError: Cannot read property 'insertAdjacentElement' of null
   at add_releases_tab (add-releases-tab.js:42)
   at github_injection_default (content.js:594)
   at gitHubInjection (index.js:23)
   at onDomReady (content.js:591)
   at <anonymous>
```