### PR TITLE
Highlight Trending link correctly

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -127,12 +127,21 @@ function moveMarketplaceLinkToProfileDropdown() {
 }
 
 async function addTrendingMenuItem() {
+	const selectedClass = pageDetect.isTrending() ? 'selected' : '';
 	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"], .header-nav-link[href="/issues"]');
 	issuesLink.parentNode.after(
 		<li class="header-nav-item">
-			<a href="/trending" class="js-selected-navigation-item HeaderNavlink header-nav-link px-2" data-hotkey="g t">Trending</a>
+			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink header-nav-link px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
 		</li>
 	);
+
+	// Explore link highlights /trending urls by default, remove that behavior
+	if (pageDetect.isTrending()) {
+		const exploreLink = await safeElementReady('a[href="/explore"]').catch(() => null);
+		if (exploreLink) {
+			exploreLink.classList.remove('selected');
+		}
+	}
 }
 
 function addYoursMenuItem() {


### PR DESCRIPTION
Highlight Trending link when on the Trending page and subpages and
remove highlighting from Explore when on Trending pages.

Fixes issue #705