### PR TITLE
Bump z-index of sticky file headers

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -692,5 +692,5 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 .pull-request-tab-content .diff-view .file-header {
     position: sticky;
     top: 60px;
-    z-index: 1;
+    z-index: 10;
 }


### PR DESCRIPTION
The low z-index made some text appear on top of the header bar...

Before:

![image](https://user-images.githubusercontent.com/582487/31569239-a75c1b78-b079-11e7-8749-5019eb2aace1.png)

After:

![image](https://user-images.githubusercontent.com/582487/31569244-ad4d33a0-b079-11e7-9aa6-aa0ffc000471.png)
