### PR TITLE
Fix selector for hiding other users starring/forking your repos

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -591,7 +591,7 @@ async function onDomReady() {
 		if (options.hideStarsOwnRepos) {
 			observeEl('#dashboard .news', () => {
 				$('#dashboard .news .watch_started, #dashboard .news .fork')
-					.has(`.title a[href^="/${username}"]`)
+					.has(`a[href^="/${username}"]`)
 					.css('display', 'none');
 			});
 		}


### PR DESCRIPTION
Fixes #723 .

Remove the selector for `.title` in descendants of `.watch_starred` or `.fork`. We can assume the presence of `a[href^="/${username}"]` anywhere in the descendants is enough to assume it is a star/fork of the user's repo.