### PR TITLE
Fix selector for hiding pushes and forks

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -248,10 +248,10 @@ deleted a branch
 added someone as a collaborator
 forked a repo
 */
-.news .alert.push,
+.news .push,
 .news .alert.delete.simple,
 .news .member_add,
-.news .alert.fork.simple {
+.news .fork {
 	display: none !important;
 }
 


### PR DESCRIPTION
I don't know what the selectors for deleting branches and adding someone as a collab is though since I couldn't find any in my news feed.