### PR TITLE
Make modal backdrop visible

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -717,6 +717,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 :root .dropdown-details[open] > summary::before {
 	background: rgba(0, 0, 0, 0.1);
 	z-index: 20;
+	animation: fade-in 0.2s;
 }
 :root .pagehead ul.pagehead-actions {
 	position: static; /* Demote watch/start/fork */
@@ -725,4 +726,10 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 	/* Extend it to the window borders to hide a bug #735 */
 	padding: 0 calc(50vw - 50%);
 	margin: -20px calc(-50vw + 50%) 0;
+}
+
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -727,6 +727,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 :root .pr-toolbar .modal-backdrop {
 	position: absolute;
 	height: 100%;
+	width: 100%;
 }
 
 @keyframes fade-in {

--- a/extension/content.css
+++ b/extension/content.css
@@ -711,3 +711,10 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 .labels-list .TutorialPopover {
 	display: none !important;
 }
+
+/* Make the modal backdrop visible */
+body.menu-active .modal-backdrop,
+:root .dropdown-details[open]>summary::before {
+	background: rgba(0, 0, 0, 0.1);
+	z-index: 99; /* GitHub's z-index:1 is not enough, but they can't see the bug */
+}

--- a/extension/content.css
+++ b/extension/content.css
@@ -722,10 +722,11 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 :root .pagehead ul.pagehead-actions {
 	position: static; /* Demote watch/start/fork */
 }
+
+/* Reduce duplicate backdrop in PR diff view */
 :root .pr-toolbar {
-	/* Extend it to the window borders to hide a bug #735 */
-	padding: 0 calc(50vw - 50%);
-	margin: -20px calc(-50vw + 50%) 0;
+	position: absolute;
+	height: 100%;
 }
 
 @keyframes fade-in {

--- a/extension/content.css
+++ b/extension/content.css
@@ -716,14 +716,12 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 :root body.menu-active .modal-backdrop,
 :root .dropdown-details[open] > summary::before {
 	background: rgba(0, 0, 0, 0.1);
-	z-index: 99;
+	z-index: 20;
 }
-:root .select-menu-modal-holder {
-	z-index: 100;
+:root .pagehead ul.pagehead-actions {
+	position: static; /* Demote watch/start/fork */
 }
 :root .pr-toolbar {
-	z-index: 100;
-
 	/* Extend it to the window borders to hide a bug #735 */
 	padding: 0 calc(50vw - 50%);
 	margin: -20px calc(-50vw + 50%) 0;

--- a/extension/content.css
+++ b/extension/content.css
@@ -714,7 +714,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 
 /* Make the modal backdrop visible */
 body.menu-active .modal-backdrop,
-:root .dropdown-details[open]>summary::before {
+:root .dropdown-details[open] > summary::before {
 	background: rgba(0, 0, 0, 0.1);
 	z-index: 99; /* GitHub's z-index:1 is not enough, but they can't see the bug */
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -722,5 +722,9 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 	z-index: 100;
 }
 :root .pr-toolbar {
-	z-index: 31;
+	z-index: 100;
+
+	/* Extend it to the window borders to hide a bug #735 */
+	padding: 0 calc(50vw - 50%);
+	margin: -20px calc(-50vw + 50%) 0;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -720,7 +720,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 	animation: fade-in 0.2s;
 }
 :root .pagehead ul.pagehead-actions {
-	position: static; /* Demote watch/start/fork */
+	position: static; /* Demote watch/star/fork */
 }
 
 /* Reduce duplicate backdrop in PR diff view */

--- a/extension/content.css
+++ b/extension/content.css
@@ -713,8 +713,14 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 }
 
 /* Make the modal backdrop visible */
-body.menu-active .modal-backdrop,
+:root body.menu-active .modal-backdrop,
 :root .dropdown-details[open] > summary::before {
 	background: rgba(0, 0, 0, 0.1);
-	z-index: 99; /* GitHub's z-index:1 is not enough, but they can't see the bug */
+	z-index: 99;
+}
+:root .select-menu-modal-holder {
+	z-index: 100;
+}
+:root .pr-toolbar {
+	z-index: 31;
 }

--- a/extension/content.css
+++ b/extension/content.css
@@ -724,7 +724,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 }
 
 /* Reduce duplicate backdrop in PR diff view */
-:root .pr-toolbar {
+:root .pr-toolbar .modal-backdrop {
 	position: absolute;
 	height: 100%;
 }


### PR DESCRIPTION
GitHub's modals have an invisible layer which lets you _click anywhere to close._ This is invisible, which means that if you open a dropdown and then scroll it out of the view you will lose your first click and won't even know why.

# Before

![invisible](https://user-images.githubusercontent.com/1402241/31719906-965600dc-b3da-11e7-924a-42cb767f6dc1.gif)

# After

![visible](https://user-images.githubusercontent.com/1402241/31720038-068b6ac2-b3db-11e7-8b8a-8745e2d2a16a.gif)

# PR test areas

- Global: Top right, **profile** dropdown
- Repo: **Watch/Unwatch** dropdown
- Repo: **More** dropdown
- PRs: Files changed: **Review** button dropdown
- PRs: **change PR base** dropdown
- Issues: sidebar **reviewers/labels** dropdowns
- Issues: new comment: **Insert a reply** dropdown
- Issues list: **author/labels/milestones** filters
- Issues list: **filter** button near search box
- Homepage: **organization** dropdown
- Own profile: **contribution settings** + **jump to** dropdown
- Commits list: **verified** commits dropdown