### PR TITLE
Resize Compare icon to be consistent

### DIFF
--- a/src/libs/icons.js
+++ b/src/libs/icons.js
@@ -22,6 +22,6 @@ export const fork = () => <svg aria-hidden="true" class="octicon octicon-repo-fo
 
 export const cloudUpload = () => <svg aria-hidden="true" class="octicon octicon-cloud-upload" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"></path></svg>;
 
-export const darkCompare = () => <svg xmlns="http://www.w3.org/2000/svg" class="octicon octicon-diff" height="16" viewBox="0 0 13 16" width="13"><path d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z" fill-rule="evenodd"/></svg>;
+export const darkCompare = () => <svg xmlns="http://www.w3.org/2000/svg" class="octicon octicon-diff" height="16" viewBox="0 0 16 16" width="16"><path d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z" fill-rule="evenodd"/></svg>;
 
 export const graph = () => <svg aria-hidden="true" class="octicon octicon-graph" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"></path></svg>;

--- a/src/libs/icons.js
+++ b/src/libs/icons.js
@@ -22,6 +22,6 @@ export const fork = () => <svg aria-hidden="true" class="octicon octicon-repo-fo
 
 export const cloudUpload = () => <svg aria-hidden="true" class="octicon octicon-cloud-upload" height="16" role="img" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M7 9H5l3-3 3 3H9v5H7V9zm5-4c0-.44-.91-3-4.5-3C5.08 2 3 3.92 3 6 1.02 6 0 7.52 0 9c0 1.53 1 3 3 3h3v-1.3H3c-1.62 0-1.7-1.42-1.7-1.7 0-.17.05-1.7 1.7-1.7h1.3V6c0-1.39 1.56-2.7 3.2-2.7 2.55 0 3.13 1.55 3.2 1.8v1.2H12c.81 0 2.7.22 2.7 2.2 0 2.09-2.25 2.2-2.7 2.2h-2V12h2c2.08 0 4-1.16 4-3.5C16 6.06 14.08 5 12 5z"></path></svg>;
 
-export const darkCompare = () => <svg xmlns="http://www.w3.org/2000/svg" class="octicon octicon-diff" height="16" viewBox="0 0 16 16" width="16"><path d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z" fill-rule="evenodd"/></svg>;
+export const darkCompare = () => <svg xmlns="http://www.w3.org/2000/svg" class="octicon octicon-diff" height="16" viewBox="0 0 13 16" width="15"><path d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z" fill-rule="evenodd"/></svg>;
 
 export const graph = () => <svg aria-hidden="true" class="octicon octicon-graph" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"></path></svg>;


### PR DESCRIPTION
The compare icon only has a width of 13 in the dropdown, where as the other icons have 16. This makes it 16 to align with the others.

![image](https://user-images.githubusercontent.com/857700/31733610-c893f5be-b401-11e7-979f-01dfcf83ecbd.png)


Found here: https://github.com/sindresorhus/refined-github/pull/739#issuecomment-337668957