### PR TITLE
Remove "labeled an issue" from news feed

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -247,11 +247,13 @@ pushed to a branch
 deleted a branch
 added someone as a collaborator
 forked a repo
+labeled an issue
 */
 .news .push,
 .news .alert.delete.simple,
 .news .member_add,
-.news .fork {
+.news .fork,
+.news .issues_labeled {
 	display: none !important;
 }
 


### PR DESCRIPTION
While this will make the news feed pretty non-existent, seeing when issues gets labeled is pretty useless. I really hope that GitHub will bring back some now removed stuff from the news feed.