### PR TITLE
Treat all notifications pages as notifications

### DIFF
--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -6,8 +6,13 @@ export const isDashboard = () => location.pathname === '/' || /^(\/orgs\/[^/]+)?
 
 export const isTrending = () => location.pathname.startsWith('/trending');
 
+export const isNotifications = () => /^\/(?:[^/]+\/[^/]+\/)?notifications/.test(location.pathname);
+
 // @todo Replace with DOM-based test because this is too generic #708
-export const isRepo = () => !isGist() && !isTrending() && /^\/[^/]+\/[^/]+/.test(location.pathname);
+export const isRepo = () => /^\/[^/]+\/[^/]+/.test(location.pathname) &&
+	!isGist() &&
+	!isTrending() &&
+	!isNotifications();
 
 export const getRepoPath = () => location.pathname.replace(/^\/[^/]+\/[^/]+/, '');
 
@@ -58,8 +63,6 @@ export const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || is
 export const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
 
 export const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());
-
-export const isNotifications = () => location.pathname.startsWith('/notifications');
 
 export const isRepoSettings = () => isRepo() && /^\/settings/.test(getRepoPath());
 

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -48,11 +48,14 @@ test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
 test('isRepo', urlMatcherMacro, pageDetect.isRepo, [
 	'http://github.com/sindresorhus/refined-github',
 	'https://github.com/sindresorhus/refined-github/issues/146',
+	'https://github.com/sindresorhus/notifications/',
 	'https://github.com/sindresorhus/refined-github/pull/145'
 ], [
 	'https://github.com/sindresorhus',
 	'https://github.com',
 	'https://github.com/stars',
+	'http://github.com/sindresorhus/refined-github/notifications',
+	'https://github.com/sindresorhus/notifications/notifications',
 	'https://github.com/trending/developers'
 ]);
 
@@ -173,10 +176,13 @@ test('isBlame', urlMatcherMacro, pageDetect.isBlame, [
 test('isNotifications', urlMatcherMacro, pageDetect.isNotifications, [
 	'https://github.com/notifications',
 	'https://github.com/notifications/participating',
+	'http://github.com/sindresorhus/refined-github/notifications',
+	'https://github.com/sindresorhus/notifications/notifications',
 	'https://github.com/notifications?all=1'
 ], [
 	'https://github.com/settings/notifications',
 	'https://github.com/watching',
+	'https://github.com/sindresorhus/notifications/',
 	'https://github.com/jaredhanson/node-notifications/tree/master/lib/notifications'
 ]);
 


### PR DESCRIPTION
Currently only `/notifications*` is treated as a notifications page, but we also want the same "Mark all as read" and "Open all in tabs" options for other notifications pages, for example `/sindresorhus/refined-github/notifications*`. So we need to match `*/notifications*`.

Continuation of https://github.com/sindresorhus/refined-github/issues/701

See https://github.com/sindresorhus/refined-github/issues/701#issuecomment-331732397

>If you only want to open notifications from a specific repo, you can just select it from the list on the left and then click `Open all in tabs` there:
>
><img width="1010" alt="image" src="https://user-images.githubusercontent.com/15943089/30785822-bf33e34e-a164-11e7-8496-9a1e0e7fe65e.png">