### PR TITLE
Add keyboard shortcut for adding a single comment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ And [lots](extension/content.css) [more...](src/content.js)
 - [Adds `Yours` button to Issues/Pull Requests page](https://user-images.githubusercontent.com/170270/27501189-1b914bbe-586c-11e7-8e1e-b3ffd8b767fa.png)
 - [Condenses long URLs into references like _user/repo/.file@`d71718d`_](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
 - Adds a `Trending` link to the global navbar. *(<kbd>g</kbd> <kbd>t</kbd> hotkey)*
+- Adds a keyboard shortcut to leave a single comment in PR diffs instead of starting a review. *(<kbd>shift</kbd>+<kbd>enter</kbd>)*
 
 ### Previously part of Refined GitHub
 

--- a/src/content.js
+++ b/src/content.js
@@ -32,6 +32,7 @@ window.$ = $;
 window.select = select;
 
 const repoUrl = pageDetect.getRepoURL();
+const isMac = /Mac/i.test(navigator.platform);
 
 function linkifyBranchRefs() {
 	let deletedBranch = false;
@@ -550,7 +551,8 @@ function init() {
 
 			indentInput(event.target);
 			return false;
-		} else if (event.key === 'Enter' && event.shiftKey && (event.ctrlKey || event.metaKey)) {
+		} else if (event.key === 'Enter' && event.shiftKey &&
+				((isMac && event.metaKey) || (!isMac && event.ctrlKey))) {
 			const singleCommentButton = event.target.form.querySelector('.review-simple-reply-button');
 
 			if (singleCommentButton) {

--- a/src/content.js
+++ b/src/content.js
@@ -561,9 +561,9 @@ function init() {
 				return false;
 			}
 		} else if (event.which === 27) {
-			const form = event.target.closest('.js-inline-comment-form'),
-				textarea = form.querySelector('.review-simple-reply-button'),
-				cancelButton = form.querySelector('.js-hide-inline-comment-form');
+			const form = event.target.closest('.js-inline-comment-form');
+			const textarea = form.querySelector('.review-simple-reply-button');
+			const cancelButton = form.querySelector('.js-hide-inline-comment-form');
 
 			if (textarea && textarea.value !== '' && cancelButton) {
 				event.preventDefault();

--- a/src/content.js
+++ b/src/content.js
@@ -548,14 +548,12 @@ function init() {
 				return;
 			}
 
-			event.preventDefault();
 			indentInput(event.target);
 			return false;
 		} else if (event.key === 'Enter' && event.shiftKey && (event.ctrlKey || event.metaKey)) {
 			const singleCommentButton = event.target.form.querySelector('.review-simple-reply-button');
 
 			if (singleCommentButton) {
-				event.preventDefault();
 				singleCommentButton.click();
 				return false;
 			}
@@ -563,8 +561,7 @@ function init() {
 			const cancelButton = event.target.form.querySelector('.js-hide-inline-comment-form');
 
 			if (event.target.value !== '' && cancelButton) {
-				event.preventDefault();
-				$(cancelButton).click();
+				cancelButton.click();
 				return false;
 			}
 		}

--- a/src/content.js
+++ b/src/content.js
@@ -540,7 +540,7 @@ function init() {
 		select('.facebox-content button').focus();
 	});
 
-	// Support indent with tab key in comments
+	// Support keyboard shortcuts in comments
 	$(document).on('keydown', '.js-comment-field', event => {
 		if (event.which === 9 && !event.shiftKey) {
 			// Don't indent if the suggester box is active
@@ -551,6 +551,25 @@ function init() {
 			event.preventDefault();
 			indentInput(event.target);
 			return false;
+		} else if (event.which === 13 && event.shiftKey && (event.ctrlKey || event.metaKey)) {
+			const singleCommentButton = event.target.closest('.js-inline-comment-form')
+					.querySelector('.review-simple-reply-button');
+
+			if (singleCommentButton) {
+				event.preventDefault();
+				singleCommentButton.click();
+				return false;
+			}
+		} else if (event.which === 27) {
+			const form = event.target.closest('.js-inline-comment-form'),
+				textarea = form.querySelector('.review-simple-reply-button'),
+				cancelButton = form.querySelector('.js-hide-inline-comment-form');
+
+			if (textarea && textarea.value !== '' && cancelButton) {
+				event.preventDefault();
+				$(cancelButton).click();
+				return false;
+			}
 		}
 	});
 

--- a/src/content.js
+++ b/src/content.js
@@ -32,7 +32,6 @@ window.$ = $;
 window.select = select;
 
 const repoUrl = pageDetect.getRepoURL();
-const isMac = /Mac/i.test(navigator.platform);
 
 function linkifyBranchRefs() {
 	let deletedBranch = false;
@@ -551,8 +550,7 @@ function init() {
 
 			indentInput(event.target);
 			return false;
-		} else if (event.key === 'Enter' && event.shiftKey &&
-				((isMac && event.metaKey) || (!isMac && event.ctrlKey))) {
+		} else if (event.key === 'Enter' && event.shiftKey) {
 			const singleCommentButton = event.target.form.querySelector('.review-simple-reply-button');
 
 			if (singleCommentButton) {

--- a/src/content.js
+++ b/src/content.js
@@ -542,7 +542,7 @@ function init() {
 
 	// Support keyboard shortcuts in comments
 	$(document).on('keydown', '.js-comment-field', event => {
-		if (event.which === 9 && !event.shiftKey) {
+		if (event.key === 'Tab' && !event.shiftKey) {
 			// Don't indent if the suggester box is active
 			if ($('.suggester').hasClass('active')) {
 				return;
@@ -551,21 +551,18 @@ function init() {
 			event.preventDefault();
 			indentInput(event.target);
 			return false;
-		} else if (event.which === 13 && event.shiftKey && (event.ctrlKey || event.metaKey)) {
-			const singleCommentButton = event.target.closest('.js-inline-comment-form')
-					.querySelector('.review-simple-reply-button');
+		} else if (event.key === 'Enter' && event.shiftKey && (event.ctrlKey || event.metaKey)) {
+			const singleCommentButton = event.target.form.querySelector('.review-simple-reply-button');
 
 			if (singleCommentButton) {
 				event.preventDefault();
 				singleCommentButton.click();
 				return false;
 			}
-		} else if (event.which === 27) {
-			const form = event.target.closest('.js-inline-comment-form');
-			const textarea = form.querySelector('.review-simple-reply-button');
-			const cancelButton = form.querySelector('.js-hide-inline-comment-form');
+		} else if (event.key === 'Escape') {
+			const cancelButton = event.target.form.querySelector('.js-hide-inline-comment-form');
 
-			if (textarea && textarea.value !== '' && cancelButton) {
+			if (event.target.value !== '' && cancelButton) {
 				event.preventDefault();
 				$(cancelButton).click();
 				return false;


### PR DESCRIPTION
Closes #312.

Use `ctrl/cmd-shift-enter` as a shortcut to enter a single comment instead of starting a review.

Also close a comment when `esc` is pressed in a non-empty comment since the extension shows a confirmation dialog in that case.

Questions:

  * Would the `if/else` be better as a `switch`?
  * Does it matter that `ctrl or cmd-shift-enter` triggers this on Mac, and `ctrl or Windows-shift-enter` works on Windows?  I could look at `navigator.platform` to limit it to `ctrl` on Windows and `cmd` on Mac.