### PR TITLE
Hide Github's Footer

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -77,7 +77,7 @@
 	display: none !important;
 }
 
-.site-footer {
+.site-footer, .footer {
 	visibility: hidden;
 }
 


### PR DESCRIPTION
Github's footer should be hidden. This updates the style to ensure that
it is.

Fixes #753 