### PR TITLE
Unify reponav-dropdown creation

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -684,7 +684,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 }
 
 /* Optically align Dependencies dropdown link*/
-.rgh-dependency-graph {
+.rgh-dependency-graph .octicon-package {
 	margin-left: -2px;
 	margin-right: 2px;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -21,6 +21,7 @@ import addFileCopyButton from './libs/copy-file';
 import linkifyCode, {editTextNodes} from './libs/linkify-urls-in-code';
 import autoLoadMoreNews from './libs/auto-load-more-news';
 import addOPLabels from './libs/op-labels';
+import addMoreDropdown from './libs/more-dropdown';
 import addReleasesTab from './libs/add-releases-tab';
 import scrollToTopOnCollapse from './libs/scroll-to-top-on-collapse';
 
@@ -57,75 +58,6 @@ function linkifyBranchRefs() {
 
 		const branchUrl = '/' + el.title.replace(':', '/tree/');
 		$(el).closest('.commit-ref').wrap(<a href={branchUrl}></a>);
-	}
-}
-
-function addCompareLink() {
-	if (select.exists('.refined-github-compare-tab')) {
-		return;
-	}
-
-	select('.reponav-dropdown .dropdown-menu').prepend(
-		<a href={`/${repoUrl}/compare`} class="dropdown-item refined-github-compare-tab" data-skip-pjax>
-			{icons.darkCompare()}
-			<span itemprop="name"> Compare</span>
-		</a>
-	);
-}
-
-function addDependencyGraphLink() {
-	if (select.exists('.rgh-dependency-graph')) {
-		return;
-	}
-
-	// GHE does not currently have this feature
-	if (pageDetect.isEnterprise()) {
-		return;
-	}
-
-	select('.reponav-dropdown .dropdown-menu').prepend(
-		<a href={`/${repoUrl}/network/dependencies`} class="dropdown-item rgh-dependency-graph" data-skip-pjax>
-			{icons.dependency()}
-			<span itemprop="name"> Dependencies</span>
-		</a>
-	);
-}
-
-function createMoreDropdown() {
-	if (select.exists('.refined-github-more')) {
-		return;
-	}
-	const moreDropdown = <div class="reponav-dropdown js-menu-container refined-github-more">
-		<button type="button" class="btn-link reponav-item reponav-dropdown js-menu-target " data-no-toggle="" aria-expanded="false" aria-haspopup="true">More <svg aria-hidden="true" class="octicon octicon-triangle-down v-align-middle text-y" height="11" version="1.1" viewBox="0 0 12 16" width="8"><path fill-rule="evenodd" d="M0 5l6 6 6-6z"></path></svg></button>
-		<div class="dropdown-menu-content js-menu-content">
-			<div class="dropdown-menu dropdown-menu-sw"></div>
-		</div>
-	</div>;
-
-	const settingsTab = select('[data-selected-links~="repo_settings"]');
-	if (settingsTab) {
-		settingsTab.parentNode.insertBefore(moreDropdown, settingsTab);
-	} else {
-		const repoNav = select('.reponav');
-		if (repoNav) {
-			repoNav.appendChild(moreDropdown);
-		}
-	}
-}
-
-function moveInsightsLink() {
-	if (select.exists('.refined-github-insights')) {
-		return;
-	}
-	const insightsTab = select('[data-selected-links~="pulse"]');
-	if (insightsTab) {
-		insightsTab.remove();
-		select('.reponav-dropdown .dropdown-menu').prepend(
-			<a href={`/${repoUrl}/pulse`} class="dropdown-item refined-github-insights" data-skip-pjax>
-				{icons.graph()}
-				<span itemprop="name"> Insights</span>
-			</a>
-		);
 	}
 }
 
@@ -652,12 +584,9 @@ async function onDomReady() {
 	if (pageDetect.isRepo()) {
 		gitHubInjection(() => {
 			safely(hideEmptyMeta);
-			safely(createMoreDropdown);
-			safely(moveInsightsLink);
+			safely(addMoreDropdown);
 			safely(addReleasesTab);
 			safely(removeProjectsTab);
-			safely(addDependencyGraphLink);
-			safely(addCompareLink);
 			safely(addTitleToEmojis);
 			safely(addReadmeButtons);
 

--- a/src/libs/add-releases-tab.js
+++ b/src/libs/add-releases-tab.js
@@ -39,8 +39,7 @@ export default () => {
 		</a>
 	);
 
-	select('.reponav-dropdown, [data-selected-links~="repo_settings"]')
-		.insertAdjacentElement('beforeBegin', releasesTab);
+	select('.reponav-dropdown').before(releasesTab);
 
 	cacheReleasesCount();
 

--- a/src/libs/icons.js
+++ b/src/libs/icons.js
@@ -27,3 +27,5 @@ export const darkCompare = () => <svg xmlns="http://www.w3.org/2000/svg" class="
 export const graph = () => <svg aria-hidden="true" class="octicon octicon-graph" height="16" version="1.1" viewBox="0 0 16 16" width="16"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"></path></svg>;
 
 export const dependency = () => <svg class="octicon octicon-package" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1 4.27v7.47c0 .45.3.84.75.97l6.5 1.73c.16.05.34.05.5 0l6.5-1.73c.45-.13.75-.52.75-.97V4.27c0-.45-.3-.84-.75-.97l-6.5-1.74a1.4 1.4 0 0 0-.5 0L1.75 3.3c-.45.13-.75.52-.75.97zm7 9.09l-6-1.59V5l6 1.61v6.75zM2 4l2.5-.67L11 5.06l-2.5.67L2 4zm13 7.77l-6 1.59V6.61l2-.55V8.5l2-.53V5.53L15 5v6.77zm-2-7.24L6.5 2.8l2-.53L15 4l-2 .53z"></path></svg>;
+
+export const triangleDown = () => <svg aria-hidden="true" class="octicon octicon-triangle-down v-align-middle text-y" height="11" version="1.1" viewBox="0 0 12 16" width="8"><path fill-rule="evenodd" d="M0 5l6 6 6-6z"></path></svg>;

--- a/src/libs/more-dropdown.js
+++ b/src/libs/more-dropdown.js
@@ -10,7 +10,10 @@ export default function () {
 		return;
 	}
 
-	const moreDropdown = (
+	// Last tab, but before settings
+	const insertionPoint = select.all('.reponav-item:not([href$="settings"])').pop();
+
+	insertionPoint.after(
 		<div class="reponav-dropdown js-menu-container refined-github-more">
 			<button type="button" class="btn-link reponav-item reponav-dropdown js-menu-target " data-no-toggle aria-expanded="false" aria-haspopup="true">More {icons.triangleDown()}</button>
 			<div class="dropdown-menu-content js-menu-content">
@@ -35,18 +38,9 @@ export default function () {
 		</div>
 	);
 
+	// Remove native Insights tab
 	const insightsTab = select('[data-selected-links~="pulse"]');
 	if (insightsTab) {
 		insightsTab.remove();
-	}
-
-	const settingsTab = select('[data-selected-links~="repo_settings"]');
-	if (settingsTab) {
-		settingsTab.before(moreDropdown);
-		return;
-	}
-	const repoNav = select('.reponav');
-	if (repoNav) {
-		repoNav.append(moreDropdown);
 	}
 }

--- a/src/libs/more-dropdown.js
+++ b/src/libs/more-dropdown.js
@@ -1,0 +1,52 @@
+import select from 'select-dom';
+import {h} from 'dom-chef';
+import * as icons from './icons';
+import * as pageDetect from './page-detect';
+
+const repoUrl = pageDetect.getRepoURL();
+
+export default function () {
+	if (select.exists('.refined-github-more')) {
+		return;
+	}
+
+	const moreDropdown = (
+		<div class="reponav-dropdown js-menu-container refined-github-more">
+			<button type="button" class="btn-link reponav-item reponav-dropdown js-menu-target " data-no-toggle aria-expanded="false" aria-haspopup="true">More {icons.triangleDown()}</button>
+			<div class="dropdown-menu-content js-menu-content">
+				<div class="dropdown-menu dropdown-menu-sw">
+					<a href={`/${repoUrl}/compare`} class="dropdown-item" data-skip-pjax>
+						{icons.darkCompare()}
+						<span itemprop="name"> Compare</span>
+					</a>
+					{
+						pageDetect.isEnterprise() ? '' :
+						<a href={`/${repoUrl}/network/dependencies`} class="dropdown-item rgh-dependency-graph" data-skip-pjax>
+							{icons.dependency()}
+							<span itemprop="name"> Dependencies</span>
+						</a>
+					}
+					<a href={`/${repoUrl}/pulse`} class="dropdown-item" data-skip-pjax>
+						{icons.graph()}
+						<span itemprop="name"> Insights</span>
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+
+	const insightsTab = select('[data-selected-links~="pulse"]');
+	if (insightsTab) {
+		insightsTab.remove();
+	}
+
+	const settingsTab = select('[data-selected-links~="repo_settings"]');
+	if (settingsTab) {
+		settingsTab.before(moreDropdown);
+		return;
+	}
+	const repoNav = select('.reponav');
+	if (repoNav) {
+		repoNav.append(moreDropdown);
+	}
+}


### PR DESCRIPTION
After https://github.com/sindresorhus/refined-github/pull/739 the dropdown creation was getting lengthy. It made sense to merge all the related code.

Current output unchanged:

<img width="219" alt="screen shot 2017-10-25 at 16 19 46" src="https://user-images.githubusercontent.com/1402241/31988051-643a5a90-b933-11e7-9dbf-52a4e2bf9ba8.png"> (before settings tab)
<img width="214" alt="screen shot 2017-10-25 at 16 19 50" src="https://user-images.githubusercontent.com/1402241/31988053-6482b074-b933-11e7-852d-1927b2a28898.png"> (no settings tab)
