### PR TITLE
.insertAdjacentElement -> .after/.before

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -407,7 +407,7 @@ function addDiffViewWithoutWhitespaceOption() {
 		url.searchParams.set('w', 1);
 	}
 
-	container.insertAdjacentElement('afterend',
+	container.after(
 		<div class="diffbar-item refined-github-toggle-whitespace">
 			<a href={url}
 				data-hotkey="d w"
@@ -444,7 +444,7 @@ function preserveWhitespaceOptionInNav() {
 }
 
 function addMilestoneNavigation() {
-	select('.repository-content').insertAdjacentElement('beforeBegin',
+	select('.repository-content').before(
 		<div class="subnav">
 			<div class="subnav-links float-left" role="navigation">
 				<a href={`/${repoUrl}/labels`} class="subnav-item">Labels</a>
@@ -459,7 +459,7 @@ function addFilterCommentsByYou() {
 		return;
 	}
 	select('.subnav-search-context .js-navigation-item:last-child')
-		.insertAdjacentElement('beforeBegin',
+		.before(
 			<a
 				href={`/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`}
 				class="select-menu-item js-navigation-item refined-github-filter">
@@ -472,7 +472,7 @@ function addFilterCommentsByYou() {
 
 function addProjectNewLink() {
 	if (select.exists('#projects-feature:checked') && !select.exists('#refined-github-project-new-link')) {
-		select(`#projects-feature ~ p.note`).insertAdjacentElement('afterEnd',
+		select(`#projects-feature ~ p.note`).after(
 			<a href={`/${repoUrl}/projects/new`} class="btn btn-sm" id="refined-github-project-new-link">Add a project</a>
 		);
 	}

--- a/src/content.js
+++ b/src/content.js
@@ -472,7 +472,7 @@ function addFilterCommentsByYou() {
 
 function addProjectNewLink() {
 	if (select.exists('#projects-feature:checked') && !select.exists('#refined-github-project-new-link')) {
-		select(`#projects-feature ~ p.note`).after(
+		select('#projects-feature ~ p.note').after(
 			<a href={`/${repoUrl}/projects/new`} class="btn btn-sm" id="refined-github-project-new-link">Add a project</a>
 		);
 	}

--- a/src/libs/copy-file.js
+++ b/src/libs/copy-file.js
@@ -10,7 +10,7 @@ export default () => {
 
 	const targetSibling = select('#raw-url');
 	const fileUri = targetSibling.getAttribute('href');
-	targetSibling.insertAdjacentElement('beforeBegin',
+	targetSibling.before(
 		<a href={fileUri} class="btn btn-sm BtnGroup-item copy-btn">Copy</a>
 	);
 

--- a/src/libs/op-labels.js
+++ b/src/libs/op-labels.js
@@ -31,7 +31,7 @@ export default () => {
 	`, newComments);
 
 	for (const placeholder of placeholders) {
-		placeholder.insertAdjacentElement('beforeBegin',
+		placeholder.before(
 			<span class="timeline-comment-label tooltipped tooltipped-multiline tooltipped-s" aria-label={tooltip}>
 				Original&nbsp;Poster
 			</span>


### PR DESCRIPTION
Just replacing the wordy API with shorter equivalent ones that have been available for about 6 browser releases.