### PR TITLE
Avoid running removeDiffSigns on every table

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -314,7 +314,7 @@ function removeDiffSigns() {
 
 			// If a line is empty, the next line will collapse
 			if (code.textContent.length === 0) {
-				code.prepend(new Text(' '));
+				code.prepend(' ');
 			}
 		}
 	}

--- a/src/content.js
+++ b/src/content.js
@@ -306,7 +306,7 @@ function removeSelectableWhiteSpaceFromDiffs() {
 
 /* Lasciate ogne speranza, voi ch'intrate. */
 function removeDiffSigns() {
-	for (const line of select.all('tr:not(.refined-github-diff-signs)')) {
+	for (const line of select.all('.diff-table tr:not(.refined-github-diff-signs)')) {
 		line.classList.add('refined-github-diff-signs');
 		for (const code of select.all('.blob-code-inner', line)) {
 			// Drop -, + or space

--- a/src/content.js
+++ b/src/content.js
@@ -669,14 +669,21 @@ async function onDomReady() {
 			safely(addCompareLink);
 			safely(addTitleToEmojis);
 			safely(addReadmeButtons);
+			safely(addDiffViewWithoutWhitespaceOption);
+			safely(enableCopyOnY.destroy);
+
+			safely(() => {
+				const diffElements = select('.js-discussion, #files');
+				if (diffElements) {
+					observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
+				}
+			});
 
 			safely(() => {
 				for (const a of select.all('a[href]')) {
 					shortenLink(a, location.href);
 				}
 			});
-
-			safely(enableCopyOnY.destroy);
 
 			if (pageDetect.isPR()) {
 				safely(scrollToTopOnCollapse);
@@ -708,15 +715,6 @@ async function onDomReady() {
 				safely(addPatchDiffLinks);
 			}
 
-			if (pageDetect.hasDiff()) {
-				const diffElements = select('.js-discussion, #files');
-				if (diffElements) {
-					observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
-				}
-				safely(addDiffViewWithoutWhitespaceOption);
-				safely(preserveWhitespaceOptionInNav);
-			}
-
 			if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
 				safely(addReactionParticipants);
 				safely(showRealNames);
@@ -728,6 +726,7 @@ async function onDomReady() {
 
 			if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 				safely(addCopyFilePathToPRs);
+				safely(preserveWhitespaceOptionInNav);
 			}
 
 			if (pageDetect.isSingleFile()) {

--- a/src/content.js
+++ b/src/content.js
@@ -23,6 +23,7 @@ import autoLoadMoreNews from './libs/auto-load-more-news';
 import addOPLabels from './libs/op-labels';
 import addReleasesTab from './libs/add-releases-tab';
 import scrollToTopOnCollapse from './libs/scroll-to-top-on-collapse';
+import removeDiffSigns from './libs/remove-diff-signs';
 
 import * as icons from './libs/icons';
 import * as pageDetect from './libs/page-detect';
@@ -292,41 +293,6 @@ function addPatchDiffLinks() {
 			<a href={`${commitUrl}.diff`} class="sha">diff</a>
 		</span>
 	);
-}
-
-function removeSelectableWhiteSpaceFromDiffs() {
-	for (const commentBtn of select.all('.add-line-comment')) {
-		for (const node of commentBtn.childNodes) {
-			if (node.nodeType === Node.TEXT_NODE) {
-				node.remove();
-			}
-		}
-	}
-}
-
-/* Lasciate ogne speranza, voi ch'intrate. */
-function removeDiffSigns() {
-	for (const line of select.all('.diff-table tr:not(.refined-github-diff-signs)')) {
-		line.classList.add('refined-github-diff-signs');
-		for (const code of select.all('.blob-code-inner', line)) {
-			// Drop -, + or space
-			code.firstChild.textContent = code.firstChild.textContent.slice(1);
-
-			// If a line is empty, the next line will collapse
-			if (code.textContent.length === 0) {
-				code.prepend(' ');
-			}
-		}
-	}
-}
-
-function removeDiffSignsAndWatchExpansions() {
-	removeSelectableWhiteSpaceFromDiffs();
-	removeDiffSigns();
-	for (const file of $('.diff-table:not(.rgh-watching-lines)').has('.diff-expander')) {
-		file.classList.add('rgh-watching-lines');
-		observeEl(file.tBodies[0], removeDiffSigns);
-	}
 }
 
 function markMergeCommitsInList() {
@@ -671,13 +637,7 @@ async function onDomReady() {
 			safely(addReadmeButtons);
 			safely(addDiffViewWithoutWhitespaceOption);
 			safely(enableCopyOnY.destroy);
-
-			safely(() => {
-				const diffElements = select('.js-discussion, #files');
-				if (diffElements) {
-					observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
-				}
-			});
+			safely(removeDiffSigns);
 
 			safely(() => {
 				for (const a of select.all('a[href]')) {

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -58,8 +58,6 @@ export const isQuickPR = () => isCompare() && /[?&]quick_pull=1(&|$)/.test(locat
 
 export const hasCode = () => isRepo() && select.exists('.highlight');
 
-export const hasDiff = () => isRepo() && (isSingleCommit() || isPRCommit() || isPRFiles() || isCompare() || (isPR() && select.exists('.diff-table')));
-
 export const isReleases = () => isRepo() && /^\/(releases|tags)/.test(getRepoPath());
 
 export const isBlame = () => isRepo() && /^\/blame\//.test(getRepoPath());

--- a/src/libs/remove-diff-signs.js
+++ b/src/libs/remove-diff-signs.js
@@ -1,0 +1,44 @@
+/* Lasciate ogne speranza, voi ch'intrate. */
+import select from 'select-dom';
+import {observeEl} from './utils';
+
+function removeDiffSigns() {
+	for (const line of select.all('.diff-table tr:not(.refined-github-diff-signs)')) {
+		line.classList.add('refined-github-diff-signs');
+		for (const code of select.all('.blob-code-inner', line)) {
+			// Drop -, + or space
+			code.firstChild.textContent = code.firstChild.textContent.slice(1);
+
+			// If a line is empty, the next line will collapse
+			if (code.textContent.length === 0) {
+				code.prepend(' ');
+			}
+		}
+	}
+}
+
+function removeSelectableWhiteSpaceFromDiffs() {
+	for (const commentBtn of select.all('.add-line-comment')) {
+		for (const node of commentBtn.childNodes) {
+			if (node.nodeType === Node.TEXT_NODE) {
+				node.remove();
+			}
+		}
+	}
+}
+
+function removeDiffSignsAndWatchExpansions() {
+	removeSelectableWhiteSpaceFromDiffs();
+	removeDiffSigns();
+	for (const file of $('.diff-table:not(.rgh-watching-lines)').has('.diff-expander')) {
+		file.classList.add('rgh-watching-lines');
+		observeEl(file.tBodies[0], removeDiffSigns);
+	}
+}
+
+export default function () {
+	const diffElements = select('.js-discussion, #files');
+	if (diffElements) {
+		observeEl(diffElements, removeDiffSignsAndWatchExpansions, {childList: true, subtree: true});
+	}
+}

--- a/src/libs/remove-diff-signs.js
+++ b/src/libs/remove-diff-signs.js
@@ -1,4 +1,4 @@
-/* Lasciate ogne speranza, voi ch'intrate. */
+/* Lasciate ogne speranza, voi ch'entrate. */
 import select from 'select-dom';
 import {observeEl} from './utils';
 


### PR DESCRIPTION
Fixes #765 

I manually ran the tests described in https://github.com/sindresorhus/refined-github/pull/613

Bug example:

https://github.com/sindresorhus/refined-github/blob/bacb4bcc7aaa7a0052b0b623d1b2fa794b03e339/.gitignore#L1

> Screenshot
> <img width="205" alt="bug" src="https://user-images.githubusercontent.com/1402241/32050771-a5c5ebca-ba17-11e7-9ca2-495ae334ff3c.png">


Edit: life would be easier if we had [`ode_modules`](https://www.vocabulary.com/dictionary/ode) instead of `node_modules`