### PR TITLE
Show upload messages

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -115,8 +115,8 @@
 }
 
 /* Remove upload message on comment box */
-.write-content .drag-and-drop {
-	display: none !important;
+.is-default .drag-and-drop {
+	display: none;
 }
 .upload-enabled textarea {
 	border-bottom: 1px solid #ccc !important;


### PR DESCRIPTION
This hides the upload bar only when it's in its default state and shows it during the upload and on various errors.

# Before

![no messages](https://user-images.githubusercontent.com/1402241/32051928-1dc1f25a-ba1c-11e7-9358-5d43a20c968e.gif)


# After

![show error](https://user-images.githubusercontent.com/1402241/32051927-1d81c50e-ba1c-11e7-9dec-ae0381191d0a.gif)