### PR TITLE
Move onDomReady after duplicate load check

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -619,6 +619,8 @@ function init() {
 	// TODO: Enable this when we've improved how copying Markdown works
 	// See #522
 	// $(document).on('copy', '.markdown-body', copyMarkdown);
+
+	onDomReady();
 }
 
 async function onDomReady() {
@@ -753,4 +755,3 @@ async function onDomReady() {
 }
 
 init();
-onDomReady();


### PR DESCRIPTION
Fixes #774

Auto merging this after Travis because it was a previously unnecessary change. 