### PR TITLE
Remove storage migration from mark-unread

### DIFF
--- a/src/libs/mark-unread.js
+++ b/src/libs/mark-unread.js
@@ -341,6 +341,11 @@ async function setup() {
 	gitHubInjection(() => {
 		destroy();
 
+		// Remove old data from previous storage
+		// Drop code in 2018
+		localStorage.removeItem('_unreadNotifications_migrated');
+		localStorage.removeItem('unreadNotifications');
+
 		if (pageDetect.isNotifications()) {
 			renderNotifications();
 			addCustomAllReadBtn();

--- a/src/libs/mark-unread.js
+++ b/src/libs/mark-unread.js
@@ -327,20 +327,6 @@ function updateLocalParticipatingCount() {
 	}
 }
 
-// Migrate old localStorage.unreadNotifications to new storage.
-// For extra safety, keep the old notifications under a different name.
-// Drop function in mid August and drop the new key as well.
-function migrateOldStorage() {
-	const oldStorage = localStorage.getItem('unreadNotifications');
-	if (oldStorage) {
-		const list = JSON.parse(oldStorage);
-		console.log('Migrating old unreadNotifications storage', list);
-		storage.set(list);
-		localStorage.setItem('_unreadNotifications_migrated', JSON.stringify(list));
-		localStorage.removeItem('unreadNotifications');
-	}
-}
-
 async function setup() {
 	storage = await new SynchronousStorage(
 		() => {
@@ -352,7 +338,6 @@ async function setup() {
 			return browser.storage.local.set({unreadNotifications});
 		}
 	);
-	migrateOldStorage();
 	gitHubInjection(() => {
 		destroy();
 


### PR DESCRIPTION
This code was supposed to only be temporary to allow migration of old data. But now it's been a few months already, it's safe to remove it.