### PR TITLE
Fix subpixel rendering Chrome bug in tooltips' triangles

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -721,3 +721,14 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 		opacity: 0;
 	}
 }
+
+/* Fix subpixel rendering Chrome bug in tooltips' triangles */
+.tooltipped:hover::before,
+.tooltipped:hover::after,
+.tooltipped:active::before,
+.tooltipped:active::after,
+.tooltipped:focus::before,
+.tooltipped:focus::after {
+	animation-fill-mode: backwards !important;
+	opacity: 1;
+}


### PR DESCRIPTION
Visible on retina displays. I hoped GH would fix it, but here we are. Before and after:

<img width="111" alt="before" src="https://user-images.githubusercontent.com/1402241/32434153-e3709c48-c2a2-11e7-8644-a82519edd748.png">
<img width="108" alt="after" src="https://user-images.githubusercontent.com/1402241/32434151-e3123022-c2a2-11e7-8cbe-8b5ce2bae765.png">

