### PR TITLE
Improve repo page detection across the board

### DIFF
--- a/src/features/add-trending-menu-item.js
+++ b/src/features/add-trending-menu-item.js
@@ -5,6 +5,10 @@ import {safeElementReady} from '../libs/utils';
 export default async function () {
 	const selectedClass = pageDetect.isTrending() ? 'selected' : '';
 	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"], .header-nav-link[href="/issues"]');
+	if (!issuesLink) {
+		return;
+	}
+
 	issuesLink.parentNode.after(
 		<li class="header-nav-item">
 			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink header-nav-link px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
@@ -13,7 +17,7 @@ export default async function () {
 
 	// Explore link highlights /trending urls by default, remove that behavior
 	if (pageDetect.isTrending()) {
-		const exploreLink = await safeElementReady('a[href="/explore"]').catch(() => null);
+		const exploreLink = await safeElementReady('a[href="/explore"]');
 		if (exploreLink) {
 			exploreLink.classList.remove('selected');
 		}

--- a/src/features/linkify-branch-refs.js
+++ b/src/features/linkify-branch-refs.js
@@ -31,6 +31,9 @@ export function inPR() {
 
 export function inQuickPR() {
 	safeElementReady('.branch-name').then(el => {
+		if (!el) {
+			return;
+		}
 		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const branchUrl = `/${ownerName}/${repoName}/tree/${el.textContent}`;
 		$(el).closest('.branch-name').wrap(<a href={branchUrl}></a>);

--- a/src/features/move-account-switcher-to-sidebar.js
+++ b/src/features/move-account-switcher-to-sidebar.js
@@ -4,7 +4,7 @@ import {safeElementReady} from '../libs/utils';
 export default function () {
 	safeElementReady('.dashboard-sidebar').then(sidebar => {
 		const switcher = select('.account-switcher');
-		if (switcher) {
+		if (sidebar && switcher) {
 			sidebar.prepend(switcher);
 		}
 	});

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -9,8 +9,14 @@ export const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, ''
 // Parses a repo's subpage, e.g.
 // '/user/repo/issues/' -> 'issues'
 // '/user/repo/' -> ''
-// returns undefined or false if the path is not a repo
-export const getRepoPath = () => isRepo() && (/^[^/]+[/][^/]+[/]?(.*)$/.exec(getCleanPathname()) || [])[1];
+// returns false if the path is not a repo
+export const getRepoPath = () => {
+	if (!isRepo()) {
+		return false;
+	}
+	const match = /^[^/]+[/][^/]+[/]?(.*)$/.exec(getCleanPathname());
+	return match && match[1];
+};
 
 export const getRepoURL = () => location.pathname.slice(1).split('/', 2).join('/');
 

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -9,8 +9,8 @@ export const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, ''
 // Parses a repo's subpage, e.g.
 // '/user/repo/issues/' -> 'issues'
 // '/user/repo/' -> ''
-// and returns undefined if the path is not 2+ levels deep
-export const getRepoPath = () => (/^[^/]+[/][^/]+[/]?(.*)$/.exec(getCleanPathname()) || [])[1];
+// returns undefined or false if the path is not a repo
+export const getRepoPath = () => isRepo() && (/^[^/]+[/][^/]+[/]?(.*)$/.exec(getCleanPathname()) || [])[1];
 
 export const getRepoURL = () => location.pathname.slice(1).split('/', 2).join('/');
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -31,8 +31,12 @@ export const emptyElement = element => {
  */
 export const safeElementReady = selector => {
 	const waiting = elementReady(selector);
+
+	// Don't check ad-infinitum
 	domLoaded.then(() => requestAnimationFrame(() => waiting.cancel()));
-	return waiting;
+
+	// If cancelled, return null like a regular select() would
+	return waiting.catch(() => null);
 };
 
 export const observeEl = (el, listener, options = {childList: true}) => {

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -22,11 +22,19 @@ test('getRepoPath', t => {
 	const pairs = new Map([
 		[
 			'https://github.com',
-			undefined
+			false
 		],
 		[
-			'https://github.com/',
-			undefined
+			'https://gist.github.com/',
+			false
+		],
+		[
+			'https://github.com/settings/developers',
+			false
+		],
+		[
+			'https://github.com/sindresorhus/notifications/notifications',
+			false
 		],
 		[
 			'https://github.com/sindresorhus/refined-github',


### PR DESCRIPTION
Fixes #783 again

I decided to put the check in `getRepoPath` because this function kinda implies that it only gets a repo's path, not blindly get whatever happens to be 2 dirs deep.