### PR TITLE
Fix duplicate content script injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"shorten-repo-url": "^1.1.0",
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
-		"webext-dynamic-content-scripts": "github:bfred-it/webext-dynamic-content-scripts#debug",
+		"webext-dynamic-content-scripts": "^3.0.0",
 		"webext-options-sync": "^0.12.0",
 		"webextension-polyfill": "^0.2.1"
 	},

--- a/src/content.js
+++ b/src/content.js
@@ -64,20 +64,7 @@ async function init() {
 	}
 
 	if (select.exists('html.refined-github')) {
-		console.error(`
-❤️💛💚💙💜❤️💛💚💙💜❤️💛💚💙💜❤️💛💚💙💜
-Minor bug in Refined GitHub, but we need your help to fix it:
-https://github.com/sindresorhus/refined-github/issues/565
-
-We'll need to know:
-
-1. Are you running two extensions at once? Chrome Web Store + development. If so, just disable one of them.
-2. Are you on GitHub Enteprise?
-3. The content of the console of this page.
-4. The content of the console of the background page after enabling the Developer mode in the Extensions page: https://i.imgur.com/zjIngb4.png
-
-Thank you! 🎉
-❤️💛💚💙💜❤️💛💚💙💜❤️💛💚💙💜❤️💛💚💙💜`);
+		console.warn('Refined GitHub has been loaded twice. If you didn’t install the developer version, this may be a bug. Please report it to: https://github.com/sindresorhus/refined-github/issues/565');
 		return;
 	}
 


### PR DESCRIPTION
Fixes #565

* RGH already includes the latest prerelease of the dependency.
* This PR merely points to the next major version of the dependency
* RGH v17.11.9.1725 was published as a last verification that this works

Next steps for me:

1. Wait for possible bug reports in #565 for the next few days
2. Publish `webext-dynamic-content-scripts@3.0.0`
3. Merge this PR