### PR TITLE
Fix account-switcher broken by GitHub

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -150,9 +150,10 @@
 		top: -1000px;
 	}
 }
-.account-switcher button {
+.account-switcher .select-menu-button {
 	width: 100%;
 	margin-bottom: 15px;
+	text-align: center;
 }
 .account-switcher .select-menu-button-gravatar {
 	float: none !important;


### PR DESCRIPTION
GitHub apparantly has changed the dashboard switcher `button` element to a `summary` element.

**Before:**
![image](https://user-images.githubusercontent.com/12368291/32730653-cba1282e-c8ad-11e7-9d26-d110eaf45950.png)

**After:**
![image](https://user-images.githubusercontent.com/12368291/32730684-e31857ca-c8ad-11e7-9d72-101711d01252.png)

This is just a quick PR as this a change from the GitHub's side, it is still unknown that may also have broken RG somewhere else.