### PR TITLE
Change all .then to await

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -87,7 +87,8 @@ async function init() {
 	// See #522
 	// $(document).on('copy', '.markdown-body', copyMarkdown);
 
-	domLoaded.then(onDomReady);
+	await domLoaded;
+	onDomReady();
 }
 
 function onDomReady() {

--- a/src/features/add-ci-link.js
+++ b/src/features/add-ci-link.js
@@ -10,9 +10,10 @@ let request;
 
 async function fetchStatus() {
 	const url = `${location.origin}/${getRepoURL()}/commits/`;
-	const dom = await fetch(url, {
+	const response = await fetch(url, {
 		credentials: 'include'
-	}).then(r => r.text()).then(domify);
+	});
+	const dom = domify(await response.text());
 
 	const icon = select('.commit-build-statuses', dom);
 

--- a/src/features/linkify-branch-refs.js
+++ b/src/features/linkify-branch-refs.js
@@ -29,13 +29,11 @@ export function inPR() {
 	}
 }
 
-export function inQuickPR() {
-	safeElementReady('.branch-name').then(el => {
-		if (!el) {
-			return;
-		}
+export async function inQuickPR() {
+	const el = await safeElementReady('.branch-name');
+	if (el) {
 		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const branchUrl = `/${ownerName}/${repoName}/tree/${el.textContent}`;
 		$(el).closest('.branch-name').wrap(<a href={branchUrl}></a>);
-	});
+	}
 }

--- a/src/features/mark-unread.js
+++ b/src/features/mark-unread.js
@@ -328,10 +328,11 @@ function updateLocalParticipatingCount() {
 
 async function setup() {
 	storage = await new SynchronousStorage(
-		() => {
-			return browser.storage.local.get({
+		async () => {
+			const storage = await browser.storage.local.get({
 				unreadNotifications: []
-			}).then(storage => storage.unreadNotifications);
+			});
+			return storage.unreadNotifications;
 		},
 		unreadNotifications => {
 			return browser.storage.local.set({unreadNotifications});

--- a/src/features/move-account-switcher-to-sidebar.js
+++ b/src/features/move-account-switcher-to-sidebar.js
@@ -1,12 +1,10 @@
 import select from 'select-dom';
 import {safeElementReady} from '../libs/utils';
 
-export default function () {
-	safeElementReady('.dashboard-sidebar').then(sidebar => {
-		const switcher = select('.account-switcher');
-		if (sidebar && switcher) {
-			sidebar.prepend(switcher);
-		}
-	});
+export default async function () {
+	const sidebar = await safeElementReady('.dashboard-sidebar');
+	const switcher = select('.account-switcher');
+	if (sidebar && switcher) {
+		sidebar.prepend(switcher);
+	}
 }
-

--- a/src/features/show-names.js
+++ b/src/features/show-names.js
@@ -15,10 +15,10 @@ const getCachedUsers = async () => {
 const fetchName = async username => {
 	// /following/you_know is the lightest page we know
 	// location.origin is required for Firefox #490
-	const pageHTML = await fetch(`${location.origin}/${username}/following`)
-		.then(res => res.text());
+	const response = await fetch(`${location.origin}/${username}/following`);
+	const dom = domify(await response.text());
 
-	const el = domify(pageHTML).querySelector('h1 strong');
+	const el = dom.querySelector('h1 strong');
 
 	// The full name might not be set
 	const fullname = el && el.textContent.slice(1, -1);

--- a/src/features/show-recently-pushed-branches.js
+++ b/src/features/show-recently-pushed-branches.js
@@ -13,9 +13,10 @@ export default async function () {
 	const codeTabURL = select('[data-hotkey="g c"]').href;
 	const fragmentURL = `/${repoUrl}/show_partial?partial=tree%2Frecently_touched_branches_list`;
 
-	const html = await fetch(codeTabURL, {
+	const response = await fetch(codeTabURL, {
 		credentials: 'include'
-	}).then(res => res.text());
+	});
+	const html = await response.text();
 
 	// https://github.com/sindresorhus/refined-github/issues/216
 	if (html.includes(fragmentURL)) {

--- a/src/libs/api.js
+++ b/src/libs/api.js
@@ -1,4 +1,5 @@
-export default endpoint => {
+export default async endpoint => {
 	const api = location.hostname === 'github.com' ? 'https://api.github.com/' : `${location.origin}/api/`;
-	return fetch(api + endpoint).then(res => res.json());
+	const response = await fetch(api + endpoint);
+	return response.json();
 };


### PR DESCRIPTION
As requested in https://github.com/sindresorhus/refined-github/pull/800#discussion_r149753499

All were changed except:

```js
src/libs/synchronous-storage.js:
   28  		this._get = get;
   29  		this._set = set;
   30: 		return get().then(value => {
   31  			this._cache = value;
   32  			return this;
```

-> because It's inside a constructor.

```js
src/libs/utils.js:
   30  
   31  	// Don't check ad-infinitum
   32: 	domLoaded.then(() => requestAnimationFrame(() => waiting.cancel()));
   33  
   34  	// If cancelled, return null like a regular select() would
```

-> because it's not meant to be awaited.