### PR TITLE
Fix reactions popups position issues

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -454,6 +454,32 @@ we will add it back on for the simple news alerts we decide to show
 	z-index: -1;
 }
 
+/* Center reactions popup and its triangle */
+.add-reaction-popover,
+.add-reaction-popover::before,
+.add-reaction-popover::after  {
+	transform: translate(-50%) !important;
+	left: 50% !important;
+	right: auto !important;
+}
+
+/*
+Undo reactions popup centering in split file view on the right.
+The popup is clipped on the right otherwise.
+The selector considers
+- Unified view (skipped)
+- Split view with comment on the left only (skipped)
+- Split view with comment on the right only
+- Split view with comments on the left and right
+*/
+td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover {
+	left: -15px !important;
+}
+td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::before,
+td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::after {
+	left: 140px !important;
+}
+
 /*
 Show reaction list when hovering over:
 - Popover
@@ -470,15 +496,6 @@ Hidden content area created to increase hover target
 /* Never show loading spinner for reactions */
 .reaction-popover-container .reaction-popover-form .loading-spinner {
 	display: none !important;
-}
-
-/* Move popup arrow point to center of popup */
-.reaction-popover-container.dropdown .dropdown-menu-sw.dropdown-menu::before,
-.reaction-popover-container.dropdown .dropdown-menu-sw.dropdown-menu::after,
-.reaction-popover-container.dropdown .dropdown-menu-ne.dropdown-menu::before,
-.reaction-popover-container.dropdown .dropdown-menu-ne.dropdown-menu::after {
-	left: 102px; /* 220px / 2 - 8px for popover arrow */
-	right: auto;
 }
 
 /* Add colored button when hovering over reaction popover or hidden hover element */

--- a/src/content.css
+++ b/src/content.css
@@ -443,25 +443,15 @@ we will add it back on for the simple news alerts we decide to show
 	display: none;
 }
 
-/*
-Create invisible content area below/above reactions popover to increase hover target
-Center popup on add reactions button
-*/
-.reaction-popover-container.dropdown .dropdown-menu-content {
-	margin-top: -15px;
+/* Increase reaction popover hitbox area to avoid involuntary closes */
+.reaction-popover-form:before {
+	content: '';
 	position: absolute;
-	left: -94px;
-	width: 220px;
-	height: 15px;
-}
-
-/*
-Remove margin-top from invisible hover target for popover below comment content
-Add some space below popup so it doesn't cover button
-*/
-.comment-reactions .reaction-popover-container.dropdown .dropdown-menu-content {
-	margin-top: 0;
-	bottom: 20px;
+	top: -20px;
+	right: -10px;
+	bottom: -20px;
+	left: -10px;
+	z-index: -1;
 }
 
 /*
@@ -475,12 +465,6 @@ Hidden content area created to increase hover target
 .dropdown-menu-content:hover {
 	display: block;
 	pointer-events: all;
-}
-
-/* Remove top/bottom margin from popovers so there's no gap with invisible hover element */
-.reaction-popover-container.dropdown .dropdown-menu.add-reaction-popover {
-	margin-top: 0;
-	margin-bottom: 0;
 }
 
 /* Never show loading spinner for reactions */

--- a/src/content.css
+++ b/src/content.css
@@ -498,7 +498,6 @@ Show reaction list when hovering over:
 /* Add colored button when hovering over reaction popover or hidden hover element */
 .reaction-popover-container:hover .timeline-comment-action {
 	color: #4078c0;
-	text-decoration: none;
 	opacity: 1;
 }
 

--- a/src/content.css
+++ b/src/content.css
@@ -57,8 +57,8 @@
 
 .notification-actions .tooltipped:before,
 .notification-actions .tooltipped:after,
-.reaction-summary-item:before,
-.reaction-summary-item:after,
+[aria-label~="reacted with"]:before,
+[aria-label~="reacted with"]:after,
 .avatar-group-item:before,
 .avatar-group-item:after,
 .js-zeroclipboard:before,
@@ -441,12 +441,6 @@ we will add it back on for the simple news alerts we decide to show
 .reaction-popover-form.js-pick-reaction span.js-reaction-description,
 .reaction-popover-form.js-pick-reaction .dropdown-divider {
 	display: none;
-}
-
-/* Remove "Add your Reaction" tooltips */
-.reaction-popover-container .tooltipped::before,
-.reaction-popover-container .tooltipped::after {
-	display: none !important;
 }
 
 /*

--- a/src/content.css
+++ b/src/content.css
@@ -484,11 +484,8 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 Show reaction list when hovering over:
 - Popover
 - Add Reactions button
-Hidden content area created to increase hover target
 */
-.dropdown-menu.add-reaction-popover:hover,
-.reaction-popover-container.dropdown:hover .dropdown-menu-content,
-.dropdown-menu-content:hover {
+.reaction-popover-container.dropdown:hover .dropdown-menu-content {
 	display: block;
 	pointer-events: all;
 }


### PR DESCRIPTION
# Bugs

## Wrong Y position in review comments 
<img width="264" alt="" src="https://user-images.githubusercontent.com/1402241/32830012-d4660e2a-ca2e-11e7-998b-e8c65b191853.png">

## ▲'s  shadow is off to the right

<img width="256" alt="" src="https://user-images.githubusercontent.com/1402241/32830013-d4a680ea-ca2e-11e7-842f-2afe9814d74c.png">

## Split PR files view: clipped to the right in small windows

<img width="290" alt="" src="https://user-images.githubusercontent.com/1402241/32830014-d4e0e820-ca2e-11e7-8070-bd0103c09e66.png">

# Also updated

## Larger Hitbox (not actually visible)

<img width="306" alt="screen shot 2017-11-15 at 16 00 53" src="https://user-images.githubusercontent.com/1402241/32830011-d4319000-ca2e-11e7-8844-0e6faa7c54ea.png">

# Notes

The actual centering of the ▲ (relative to the button) varies in GitHub's own interface, so I avoided manually fixing each instance of the popup. 