### PR TITLE
Move GHE domain dialog to Browser Action

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"shorten-repo-url": "^1.1.0",
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
-		"webext-dynamic-content-scripts": "^3.0.0",
+		"webext-dynamic-content-scripts": "^5.0.0-0",
 		"webext-options-sync": "^0.12.0",
 		"webextension-polyfill": "^0.2.1"
 	},

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"shorten-repo-url": "^1.1.0",
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
+		"webext-domain-permission-toggle": "0.0.1",
 		"webext-dynamic-content-scripts": "^5.0.0-0",
 		"webext-options-sync": "^0.12.0",
 		"webextension-polyfill": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
 		"shorten-repo-url": "^1.1.0",
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
-		"webext-domain-permission-toggle": "0.0.1",
-		"webext-dynamic-content-scripts": "^5.0.0-0",
+		"webext-domain-permission-toggle": "0.0.2",
+		"webext-dynamic-content-scripts": "^5.0.0-1",
 		"webext-options-sync": "^0.12.0",
 		"webextension-polyfill": "^0.2.1"
 	},

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"to-markdown": "^3.1.0",
 		"to-semver": "^1.1.0",
 		"webext-domain-permission-toggle": "0.0.2",
-		"webext-dynamic-content-scripts": "^5.0.0-1",
+		"webext-dynamic-content-scripts": "^5.0.0-2",
 		"webext-options-sync": "^0.12.0",
 		"webextension-polyfill": "^0.2.1"
 	},

--- a/src/background.js
+++ b/src/background.js
@@ -48,7 +48,7 @@ browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) =>
 			]
 		}, granted => {
 			if (chrome.runtime.lastError) {
-				alert(`Error: ${chrome.runtime.lastError}`);
+				alert(`Error: ${chrome.runtime.lastError.message}`);
 			} else if (granted && confirm('Do you want to reload this page to apply Refined GitHub?')) {
 				chrome.tabs.reload(tabId);
 			}

--- a/src/background.js
+++ b/src/background.js
@@ -49,7 +49,7 @@ browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) =>
 		}, granted => {
 			if (chrome.runtime.lastError) {
 				alert(`Error: ${chrome.runtime.lastError}`);
-			} else if (granted && confirm('Reload this page to apply Refined GitHub?')) {
+			} else if (granted && confirm('Do you want to reload this page to apply Refined GitHub?')) {
 				chrome.tabs.reload(tabId);
 			}
 		});

--- a/src/background.js
+++ b/src/background.js
@@ -42,6 +42,7 @@ browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) =>
 	/* eslint-disable no-alert */
 	/* global chrome */
 	if (menuItemId === 'enable-extension-on-new-domain') {
+		/* API not yet supported by webext-polyfill mozilla/webextension-polyfill#38 */
 		chrome.permissions.request({
 			origins: [
 				`${new URL(url).origin}/*`

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,6 @@
 import OptionsSync from 'webext-options-sync';
-import DPT from 'webext-domain-permission-toggle';
-import DCS from 'webext-dynamic-content-scripts';
+import domainPermissionToggle from 'webext-domain-permission-toggle';
+import dynamicContentScripts from 'webext-dynamic-content-scripts';
 
 // Define defaults
 new OptionsSync().define({
@@ -27,5 +27,5 @@ browser.runtime.onMessage.addListener(async message => {
 });
 
 // GitHub Enterprise support
-DCS.addToFutureTabs();
-DPT.addContextMenu();
+dynamicContentScripts.addToFutureTabs();
+domainPermissionToggle.addContextMenu();

--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,5 @@
 import OptionsSync from 'webext-options-sync';
 import injectContentScripts from 'webext-dynamic-content-scripts';
-import {promisifyChromeAPI as p} from './libs/utils';
 
 // Define defaults
 new OptionsSync().define({
@@ -43,20 +42,16 @@ browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) =>
 	/* eslint-disable no-alert */
 	/* global chrome */
 	if (menuItemId === 'enable-extension-on-new-domain') {
-		try {
-			const granted = await p(chrome.permissions.request, {
-				origins: [
-					`${new URL(url).origin}/*`
-				]
-			});
-			if (granted) {
-				if (confirm('Reload this page to apply Refined GitHub?')) {
-					chrome.tabs.reload(tabId);
-				}
+		chrome.permissions.request({
+			origins: [
+				`${new URL(url).origin}/*`
+			]
+		}, granted => {
+			if (chrome.runtime.lastError) {
+				alert(`Error: ${chrome.runtime.lastError}`);
+			} else if (granted && confirm('Reload this page to apply Refined GitHub?')) {
+				chrome.tabs.reload(tabId);
 			}
-		} catch (err) {
-			console.error(err);
-			alert(`Error: ${err.message}`);
-		}
+		});
 	}
 });

--- a/src/background.js
+++ b/src/background.js
@@ -1,4 +1,5 @@
 import OptionsSync from 'webext-options-sync';
+import DPT from 'webext-domain-permission-toggle';
 import DCS from 'webext-dynamic-content-scripts';
 
 // Define defaults
@@ -26,33 +27,5 @@ browser.runtime.onMessage.addListener(async message => {
 });
 
 // GitHub Enterprise support
-
-browser.contextMenus.create({
-	id: 'enable-extension-on-new-domain',
-	title: 'Enable Refined GitHub on this domain',
-	contexts: ['page_action'],
-	documentUrlPatterns: [
-		'http://*/*',
-		'https://*/*'
-	]
-});
-
-browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) => {
-	/* eslint-disable no-alert */
-	/* global chrome */
-	if (menuItemId === 'enable-extension-on-new-domain') {
-		/* API not yet supported by webext-polyfill mozilla/webextension-polyfill#38 */
-		chrome.permissions.request({
-			origins: [
-				`${new URL(url).origin}/*`
-			]
-		}, granted => {
-			if (chrome.runtime.lastError) {
-				alert(`Error: ${chrome.runtime.lastError.message}`);
-			} else if (granted && confirm('Do you want to reload this page to apply Refined GitHub?')) {
-				chrome.tabs.reload(tabId);
-			}
-		});
-	}
-});
 DCS.addToFutureTabs();
+DPT.addContextMenu();

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 import OptionsSync from 'webext-options-sync';
-import injectContentScripts from 'webext-dynamic-content-scripts';
+import DCS from 'webext-dynamic-content-scripts';
 
 // Define defaults
 new OptionsSync().define({
@@ -26,7 +26,6 @@ browser.runtime.onMessage.addListener(async message => {
 });
 
 // GitHub Enterprise support
-injectContentScripts();
 
 browser.contextMenus.create({
 	id: 'enable-extension-on-new-domain',
@@ -56,3 +55,4 @@ browser.contextMenus.onClicked.addListener(async ({menuItemId}, {tabId, url}) =>
 		});
 	}
 });
+DCS.addToFutureTabs();

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -23,21 +23,6 @@ export const groupBy = (iterable, grouper) => {
 };
 
 /**
- * Naively promisify chrome.* APIs when they're not supported by webext-polyfill.
- * Note: always prefer pre-Promisified browser.* APIs
- */
-export const promisifyChromeAPI = async (fn, ...args) => {
-	/* global chrome */
-	return new Promise((resolve, reject) => fn(...args, r => {
-		if (chrome.runtime.lastError) {
-			reject(chrome.runtime.lastError);
-		} else {
-			resolve(r);
-		}
-	}));
-};
-
-/**
  * Automatically stops checking for an element to appear once the DOM is ready.
  */
 export const safeElementReady = selector => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -23,6 +23,21 @@ export const groupBy = (iterable, grouper) => {
 };
 
 /**
+ * Naively promisify chrome.* APIs when they're not supported by webext-polyfill.
+ * Note: always prefer pre-Promisified browser.* APIs
+ */
+export const promisifyChromeAPI = async (fn, ...args) => {
+	/* global chrome */
+	return new Promise((resolve, reject) => fn(...args, r => {
+		if (chrome.runtime.lastError) {
+			reject(chrome.runtime.lastError);
+		} else {
+			resolve(r);
+		}
+	}));
+};
+
+/**
  * Automatically stops checking for an element to appear once the DOM is ready.
  */
 export const safeElementReady = selector => {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,8 @@
 	},
 	"permissions": [
 		"storage",
-		"clipboardWrite"
+		"clipboardWrite",
+		"contextMenus"
 	],
 	"optional_permissions": [
 		"http://*/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,7 +18,9 @@
 		"activeTab"
 	],
 	"browser_action": {
-		"default_icon": "icon.png"
+		"default_icon": "icon.png",
+		"default_popup": "options.html",
+		"browser_style": true
 	},
 	"optional_permissions": [
 		"http://*/*",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,8 +14,12 @@
 	"permissions": [
 		"storage",
 		"clipboardWrite",
-		"contextMenus"
+		"contextMenus",
+		"activeTab"
 	],
+	"browser_action": {
+		"default_icon": "icon.png"
+	},
 	"optional_permissions": [
 		"http://*/*",
 		"https://*/*"

--- a/src/options.html
+++ b/src/options.html
@@ -16,7 +16,7 @@
 <form id="options-form">
 	<h2>Information</h2>
 	<p>
-		GitHub Enterprise user? While on your site, click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
+		GitHub Enterprise user? While on your site, right click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
 		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Example</a>
 	</p>
 	<h2>News feed</h2>

--- a/src/options.html
+++ b/src/options.html
@@ -19,6 +19,11 @@
 			Hide other users starring/forking your repos
 		</label>
 	</p>
+	<h2>Information</h2>
+	<p>
+		GitHub Enterprise user? While on your site, click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
+		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png">Example</a>
+	</p>
 </form>
 <script src="browser-polyfill.min.js"></script>
 <script src="options.js"></script>

--- a/src/options.html
+++ b/src/options.html
@@ -2,7 +2,9 @@
 <meta charset="utf-8">
 <title>Refined GitHub options</title>
 <style>
-	html {
+	body {
+		width: 350px;
+		margin: 14px 17px; /* Chrome default, match for Firefox */
 		font-family: sans-serif;
 	}
 	/* Increase spacing between sections */
@@ -12,17 +14,17 @@
 	}
 </style>
 <form id="options-form">
+	<h2>Information</h2>
+	<p>
+		GitHub Enterprise user? While on your site, click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
+		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Example</a>
+	</p>
 	<h2>News feed</h2>
 	<p>
 		<label>
 			<input type="checkbox" name="hideStarsOwnRepos">
 			Hide other users starring/forking your repos
 		</label>
-	</p>
-	<h2>Information</h2>
-	<p>
-		GitHub Enterprise user? While on your site, click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
-		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png">Example</a>
 	</p>
 </form>
 <script src="browser-polyfill.min.js"></script>

--- a/src/options.html
+++ b/src/options.html
@@ -20,12 +20,5 @@
 		</label>
 	</p>
 </form>
-<form id="custom-domain">
-	<h2>GitHub Enterprise support</h2>
-	<p class="js-permission-api">
-		<input type="url" placeholder="https://github.yourdomain.com" size="30" required id="custom-domain-origin">
-		<button type="submit">Authorize</button>
-	</p>
-</form>
 <script src="browser-polyfill.min.js"></script>
 <script src="options.js"></script>

--- a/src/options.html
+++ b/src/options.html
@@ -16,7 +16,7 @@
 <form id="options-form">
 	<h2>Information</h2>
 	<p>
-		GitHub Enterprise user? While on your site, right click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
+		GitHub Enterprise user? While on your site, right-click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
 		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Example</a>
 	</p>
 	<h2>News feed</h2>

--- a/src/options.js
+++ b/src/options.js
@@ -1,26 +1,3 @@
 import OptionsSync from 'webext-options-sync';
 
 new OptionsSync().syncForm('#options-form');
-
-/**
- * GitHub Enterprise support
- */
-const cdForm = document.querySelector('#custom-domain');
-const cdInput = document.querySelector('#custom-domain-origin');
-
-cdForm.addEventListener('submit', async event => {
-	event.preventDefault();
-
-	const origin = new URL(cdInput.value).origin;
-
-	if (origin) {
-		const granted = await browser.permissions.request({
-			origins: [
-				`${origin}/*`
-			]
-		});
-		if (granted) {
-			cdForm.reset();
-		}
-	}
-});


### PR DESCRIPTION
This lets the user enable Enterprise support in 2/3 clicks, without having to copy paste URLs. The _After_ screenshot could be used in the readme as instructions.

I plan to extract this feature into its own npm module so it can be easily shared across extensions that require the same functionality (i.e. enable content scripts on multiple hosts) so they have a common interface.

# Before

<img width="466" alt="Options" src="https://user-images.githubusercontent.com/1402241/32874404-fcd7f154-cacc-11e7-9d27-258942a59c05.png">

# After

<img width="331" alt="Context menu" src="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png">
