### PR TITLE
Match context switcher's width to the width of the containers below it

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -17,7 +17,12 @@
 	display: none !important;
 }
 
-/* Match the width of the account switcher modal to that of the user repo list */
+/* Match context switcher's width to the width of the containers below it */
+.dashboard-sidebar .select-menu {
+	width: 100%;
+}
+
+/* Match context switcher modal's width to that of the user repo list */
 .dashboard-sidebar .select-menu-modal {
 	margin: 0;
 	width: 313px;


### PR DESCRIPTION
GitHub recently pushed changes that altered the previous layout. This PR fixes the issue.

Before:
![capture](https://user-images.githubusercontent.com/10110245/33236759-55c6affc-d212-11e7-8e30-f1756df58a78.PNG)

After:
![capture2](https://user-images.githubusercontent.com/10110245/33236760-57dbc96c-d212-11e7-9d35-07e170bc77ef.PNG)
