### PR TITLE
Fix Reactions issues

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -515,8 +515,8 @@ Show reaction list when hovering over:
 	display: none !important;
 }
 
-/* Add colored button when hovering over reaction popover or hidden hover element */
-.reaction-popover-container:hover .timeline-comment-action {
+/* Keep colored button when reaction popup is open */
+.dropdown-details[open] .timeline-comment-action {
 	color: #4078c0;
 	opacity: 1;
 }

--- a/src/content.css
+++ b/src/content.css
@@ -751,7 +751,7 @@ a.tabnav-extra[href$="mastering-markdown/"] {
 :root body.menu-active .modal-backdrop,
 :root .dropdown-details[open] > summary::before {
 	background: rgba(0, 0, 0, 0.1);
-	z-index: 20;
+	z-index: 29;
 	animation: fade-in 0.2s;
 }
 :root .pagehead ul.pagehead-actions {

--- a/src/content.css
+++ b/src/content.css
@@ -469,6 +469,19 @@ we will add it back on for the simple news alerts we decide to show
 	left: 50% !important;
 	right: auto !important;
 }
+.add-reaction-popover {
+	animation-name: rgh-scale-in-centered !important;
+}
+
+@keyframes rgh-scale-in-centered {
+	0% {
+		transform: translate(-50%) scale(0.5);
+		opacity: 0;
+	}
+	100% {
+		transform: translate(-50%);
+	}
+}
 
 /*
 Undo reactions popup centering in split file view on the right.

--- a/src/content.css
+++ b/src/content.css
@@ -500,16 +500,6 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 	left: 140px !important;
 }
 
-/*
-Show reaction list when hovering over:
-- Popover
-- Add Reactions button
-*/
-.reaction-popover-container.dropdown:hover .dropdown-menu-content {
-	display: block;
-	pointer-events: all;
-}
-
 /* Never show loading spinner for reactions */
 .js-reaction-popover-container .reaction-popover-form .loading-spinner {
 	display: none !important;

--- a/src/content.css
+++ b/src/content.css
@@ -511,7 +511,7 @@ Show reaction list when hovering over:
 }
 
 /* Never show loading spinner for reactions */
-.reaction-popover-container .reaction-popover-form .loading-spinner {
+.js-reaction-popover-container .reaction-popover-form .loading-spinner {
 	display: none !important;
 }
 


### PR DESCRIPTION
GitHub replaced their old JS-based dropdown with `summary+details`. So here are some necessary changes.

![bugs](https://user-images.githubusercontent.com/1402241/33658616-530916f2-dab8-11e7-959c-1c0348d4efcf.gif)


I wasn't able to restore the show-popup-on-hover for whatever reason. `opacity !important` is ignored and it stays 0.

It might need to be implemented via JS (`mouseenter -> trigger click`). Let's merge these visual fixes for now and then open an issue to restore the feature.