### PR TITLE
Fix unread issues not highlighted in all notifications

### DIFF
--- a/src/features/mark-unread.js
+++ b/src/features/mark-unread.js
@@ -333,6 +333,17 @@ function updateLocalParticipatingCount() {
 	}
 }
 
+function markExistingNotificationUnread() {
+	storage.get()
+		.filter(notification => isNotificationExist(notification.url))
+		.forEach(notification => {
+			const li = select(`a.js-notification-target[href^="${stripHash(notification.url)}"]`).closest('li.js-notification');
+			li.classList.add('unread');
+			li.classList.remove('read');
+			li.closest('ul').prepend(li);
+		});
+}
+
 async function setup() {
 	storage = await new SynchronousStorage(
 		async () => {
@@ -355,6 +366,7 @@ async function setup() {
 
 		if (pageDetect.isNotifications()) {
 			renderNotifications();
+			markExistingNotificationUnread();
 			addCustomAllReadBtn();
 			updateLocalNotificationsCount();
 			updateLocalParticipatingCount();


### PR DESCRIPTION
### fixes #834 

- highlights the marked unread notifications in "All Notifications" and brings them up in that repository notifications box