### PR TITLE
Whitespace toggle: Only remove extra copy if it exists

### DIFF
--- a/source/features/add-diff-view-without-whitespace-option.js
+++ b/source/features/add-diff-view-without-whitespace-option.js
@@ -35,5 +35,8 @@ export default function () {
 	);
 
 	// Make space for the new button by removing "Changes from" #655
-	select('[data-hotkey="c"]').firstChild.remove();
+	const uselessCopy = select('[data-hotkey="c"]');
+	if (uselessCopy) {
+		uselessCopy.firstChild.remove();
+	}
 }


### PR DESCRIPTION
## Bug

<img width="536" alt="screen shot 2017-12-08 at 16 54 19" src="https://user-images.githubusercontent.com/1402241/33758242-775d03f2-dc38-11e7-9354-60246e28522b.png">

## Example

https://github.com/sindresorhus/refined-github/commit/d10510f660d4e1393ad01af097f97de36ced680c

## Context

This feature is meant to remove `Changes from` from PR files view, but it doesn't exist in regular commit diffs.

<img width="236" alt="screen shot 2017-12-08 at 16 56 28" src="https://user-images.githubusercontent.com/1402241/33758341-d5570f3e-dc38-11e7-9cb3-36ee6c481eaa.png">
