### PR TITLE
Restore tab behavior in comment areas

### DIFF
--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -48,20 +48,19 @@ export default function () {
 			}
 
 			indentInput(field);
-			return false;
+			event.preventDefault();
 		} else if (event.key === 'Enter' && event.shiftKey) {
 			const singleCommentButton = select('.review-simple-reply-button', field.form);
 
 			if (singleCommentButton) {
 				singleCommentButton.click();
-				return false;
+				event.preventDefault();
 			}
 		} else if (event.key === 'Escape') {
 			const cancelButton = select('.js-hide-inline-comment-form', field.form);
 
 			if (field.value !== '' && cancelButton) {
 				cancelButton.click();
-				return false;
 			}
 		}
 	});


### PR DESCRIPTION
`return false` in jQuery event handlers means `preventDefault` + `stopImmediatePropagation`

In this case, only `preventDefault` or nothing at all was needed.

<kbd>tab</kbd> bug example:

![demo](https://user-images.githubusercontent.com/1402241/33780546-150daf72-dc8c-11e7-8653-8d308253f778.gif)

Bug caused by #832 