### PR TITLE
Add reply button to comments

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -51,6 +51,7 @@ import addKeyboardShortcutsToCommentFields from './features/add-keyboard-shortcu
 import addConfirmationToCommentCancellation from './features/add-confirmation-to-comment-cancellation';
 import addCILink from './features/add-ci-link';
 import expandCollapseOutdatedComments from './features/expand-collapse-outdated-comments';
+import replyButton from './features/reply-button';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, safely} from './libs/utils';
@@ -161,6 +162,7 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPR() || pageDetect.isIssue()) {
 		safely(linkifyIssuesInTitles);
 		safely(addUploadBtn);
+		safely(replyButton);
 
 		observeEl('.new-discussion-timeline', () => {
 			safely(addOPLabels);

--- a/source/features/reply-button.js
+++ b/source/features/reply-button.js
@@ -1,0 +1,30 @@
+import select from 'select-dom';
+import {h} from 'dom-chef';
+
+function getEventHandler(comment) {
+	return () => {
+		const body = select('.js-comment-body', comment).innerText.trim();
+		const blockquote = body.split('\n').map(line => '> ' + line).join('\n') + '\n\n';
+		const newCommentField = select('#new_comment_field');
+		newCommentField.value = blockquote;
+		newCommentField.focus();
+	};
+}
+
+export default () => {
+	select.all('.comment').forEach(comment => {
+		const replyAction = (
+			<button type="button" class="timeline-comment-action btn-link tooltipped tooltipped-nw" aria-label="Reply" onClick={getEventHandler(comment)}>
+				<svg width="16" height="16" class="octicon octicon-reply" viewBox="0 0 16 16" version="1.1" aria-hidden="true">
+					<path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path>
+				</svg>
+			</button>
+		);
+
+		const commentActions = select('.timeline-comment-actions', comment);
+
+		if (commentActions) {
+			commentActions.insertBefore(replyAction, commentActions.firstChild);
+		}
+	});
+};

--- a/source/features/reply-button.js
+++ b/source/features/reply-button.js
@@ -3,8 +3,8 @@ import {h} from 'dom-chef';
 
 function getEventHandler(comment) {
 	return () => {
-		const body = select('.js-comment-body', comment).innerText.trim();
-		const blockquote = body.split('\n').map(line => '> ' + line).join('\n') + '\n\n';
+		const body = select('.js-comment-body', comment).textContent.trim();
+		const blockquote = body.split('\n').map(line => `> ${line}`).join('\n') + '\n\n';
 		const newCommentField = select('#new_comment_field');
 		newCommentField.value = blockquote;
 		newCommentField.focus();
@@ -12,9 +12,9 @@ function getEventHandler(comment) {
 }
 
 export default () => {
-	select.all('.comment').forEach(comment => {
+	for (const comment of select.all('.comment')) {
 		const replyAction = (
-			<button type="button" class="timeline-comment-action btn-link tooltipped tooltipped-nw" aria-label="Reply" onClick={getEventHandler(comment)}>
+			<button class="timeline-comment-action btn-link tooltipped tooltipped-nw" aria-label="Reply" onClick={getEventHandler(comment)}>
 				<svg width="16" height="16" class="octicon octicon-reply" viewBox="0 0 16 16" version="1.1" aria-hidden="true">
 					<path fill-rule="evenodd" d="M6 3.5c3.92.44 8 3.125 8 10-2.312-5.062-4.75-6-8-6V11L.5 5.5 6 0v3.5z"></path>
 				</svg>
@@ -26,5 +26,5 @@ export default () => {
 		if (commentActions) {
 			commentActions.insertBefore(replyAction, commentActions.firstChild);
 		}
-	});
+	}
 };


### PR DESCRIPTION
Yo,

I'm using `refined-github` for a while, and it's really awesome. 
Yesterday I came across the follow issue at `dear-github`: https://github.com/dear-github/dear-github/issues/169, and I thought it's a good idea, so I decided to implement it.

What this PR adds is simply a feature called `reply-button`, that adds a button to every comment, and when that button is clicked it triggers an event that sends the focus to the new comment textarea, and fills it with the content of the previously clicked comment. (after adding `>` to the beginning of each line, to create a blockquote)

The quoted comment is being copied without HTML values. 

Feel free to ask for changes or comment with improvement ideas :) I'll try to be responsive. 

Thanks! 

Edit: 
Also, please enjoy few screenshots:

![image](https://user-images.githubusercontent.com/13808883/33781296-b0a97356-dc5c-11e7-9bcd-bcba551f0635.png)

![image](https://user-images.githubusercontent.com/13808883/33781307-bc885a7a-dc5c-11e7-9cd7-98af310ea309.png)

![image](https://user-images.githubusercontent.com/13808883/33781319-ca8754b4-dc5c-11e7-84e9-d7b0e3ed7912.png)
