### PR TITLE
Fix account switcher on Discover page - fixes #857

### DIFF
--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -35,7 +35,7 @@ export const isCommitList = () => /^commits\//.test(getRepoPath());
 
 export const isCompare = () => /^compare/.test(getRepoPath());
 
-export const isDashboard = () => /^((orgs[/][^/]+[/])?dashboard([/]index[/]\d+)?)?$/.test(getCleanPathname());
+export const isDashboard = () => /^((orgs[/][^/]+[/])?dashboard([/]|$)?)?/.test(getCleanPathname());
 
 export const isEnterprise = () => location.hostname !== 'github.com' && location.hostname !== 'gist.github.com';
 

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -35,7 +35,7 @@ export const isCommitList = () => /^commits\//.test(getRepoPath());
 
 export const isCompare = () => /^compare/.test(getRepoPath());
 
-export const isDashboard = () => /^((orgs[/][^/]+[/])?dashboard([/]|$)?)?/.test(getCleanPathname());
+export const isDashboard = () => /^$|^(orgs[/][^/]+[/])?dashboard([/]|$)/.test(getCleanPathname());
 
 export const isEnterprise = () => location.hostname !== 'github.com' && location.hostname !== 'gist.github.com';
 


### PR DESCRIPTION
The switcher will now render correctly on the [Discover repositories](https://github.com/dashboard/discover) page.