### PR TITLE
Keep comment tab undoes to 1 keypress

### DIFF
--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -1,35 +1,34 @@
 import select from 'select-dom';
 import delegate from 'delegate';
 
-function indentInput(el, size = 4) {
+function indentInput(el) {
 	const selection = window.getSelection().toString();
 	const {selectionStart, selectionEnd, value} = el;
 	const linesCount = selection.match(/^|\n/g).length;
-	const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;
 
 	el.focus();
 
 	if (linesCount > 1) {
 		// Select full first line to replace everything at once
+		const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;
 		el.setSelectionRange(firstLineStart, selectionEnd);
 
 		const newSelection = window.getSelection().toString();
 		const indentedText = newSelection.replace(
 			/^|\n/g, // Match all line starts
-			'$&' + ' '.repeat(size)
+			'$&\t'
 		);
 
 		// Replace newSelection with indentedText
 		document.execCommand('insertText', false, indentedText);
 
-		// Restore selection position
+		// Restore selection position, including the indentation
 		el.setSelectionRange(
-			selectionStart + size,
-			selectionEnd + (size * linesCount)
+			selectionStart + 1,
+			selectionEnd + linesCount
 		);
 	} else {
-		const indentSize = (size - ((selectionEnd - firstLineStart) % size)) || size;
-		document.execCommand('insertText', false, ' '.repeat(indentSize));
+		document.execCommand('insertText', false, '\t');
 	}
 }
 

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -6,8 +6,6 @@ function indentInput(el) {
 	const {selectionStart, selectionEnd, value} = el;
 	const linesCount = selection.match(/^|\n/g).length;
 
-	el.focus();
-
 	if (linesCount > 1) {
 		// Select full first line to replace everything at once
 		const firstLineStart = value.lastIndexOf('\n', selectionStart) + 1;


### PR DESCRIPTION
**Affected feature:** <kbd>tab</kbd> to indent

**Problem:** when indenting multiple lines, it needed just as many <kbd>cmd</kbd>+<kbd>u</kbd> to undo them.

![old](https://user-images.githubusercontent.com/1402241/33802976-b21e439c-ddbf-11e7-993e-32831530025e.gif)

**Solution:** use `insertText` once

![new](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)

**Why:** less wear of <kbd>cmd</kbd> and <kbd>u</kbd> keys and left-hand ligaments.