### PR TITLE
Enable reaction avatars for teams' discussions

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -398,8 +398,8 @@ we will add it back on for the simple news alerts we decide to show
 
 /* Styles for avatars Refined GitHub adds to Reactions */
 .reaction-summary-item {
-	padding-left: 10px !important;
-	padding-right: 10px !important;
+	padding-left: 0.7em !important;
+	padding-right: 0.7em !important;
 }
 .reaction-summary-item.user-has-reacted {
 	--background: #f2f8fa;

--- a/source/content.css
+++ b/source/content.css
@@ -425,6 +425,9 @@ we will add it back on for the simple news alerts we decide to show
 .review-comment .reaction-summary-item a {
 	font-size: 9px;
 }
+.discussion-post .reaction-summary-item a {
+	margin-top: -1px;
+}
 
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item img {

--- a/source/content.js
+++ b/source/content.js
@@ -186,7 +186,7 @@ function ajaxedPagesHandler() {
 		safely(addPatchDiffLinks);
 	}
 
-	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit()) {
+	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit() || pageDetect.isDiscussion()) {
 		safely(addReactionParticipants);
 		safely(showRealNames);
 	}

--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -13,7 +13,7 @@ function getParticipants(container) {
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')
 		.split(', ')
-		.filter(username => username !== currentUser)
+		.filter(username => username === currentUser)
 		.map(username => ({
 			container,
 			username

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -89,4 +89,4 @@ export const isSingleFile = () => /^blob\//.test(getRepoPath());
 
 export const isTrending = () => location.pathname.startsWith('/trending');
 
-export const isDiscussion = () => /^([^/]+[/][^/]+\/)teams[/][^/]+[^/]+($|[/]$|[/]discussions)/.test(getCleanPathname());
+export const isDiscussion = () => /^([^/]+\/[^/]+\/)teams\/[^/]+[^/]+($|\/$|\/discussions)/.test(getCleanPathname());

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -89,4 +89,4 @@ export const isSingleFile = () => /^blob\//.test(getRepoPath());
 
 export const isTrending = () => location.pathname.startsWith('/trending');
 
-export const isDiscussion = () => /^([^/]+\/[^/]+\/)teams\/[^/]+[^/]+($|\/$|\/discussions)/.test(getCleanPathname());
+export const isDiscussion = () => /^([^/]+\/[^/]+\/)teams\/[^/]+[^/]+($|\/discussions)/.test(getCleanPathname());

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -88,3 +88,5 @@ export const isSingleCommit = () => /^commit\/[0-9a-f]{5,40}/.test(getRepoPath()
 export const isSingleFile = () => /^blob\//.test(getRepoPath());
 
 export const isTrending = () => location.pathname.startsWith('/trending');
+
+export const isDiscussion = () => /^([^/]+[/][^/]+\/)teams[/][^/]+[^/]+($|[/]$|[/]discussions)/.test(getCleanPathname());

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -89,4 +89,4 @@ export const isSingleFile = () => /^blob\//.test(getRepoPath());
 
 export const isTrending = () => location.pathname.startsWith('/trending');
 
-export const isDiscussion = () => /^([^/]+\/[^/]+\/)teams\/[^/]+[^/]+($|\/discussions)/.test(getCleanPathname());
+export const isDiscussion = () => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -37,6 +37,8 @@ export const isCompare = () => /^compare/.test(getRepoPath());
 
 export const isDashboard = () => /^$|^(orgs[/][^/]+[/])?dashboard([/]|$)/.test(getCleanPathname());
 
+export const isDiscussion = () => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());
+
 export const isEnterprise = () => location.hostname !== 'github.com' && location.hostname !== 'gist.github.com';
 
 export const isGist = () => location.hostname.startsWith('gist.') || location.pathname.startsWith('gist/');
@@ -88,5 +90,3 @@ export const isSingleCommit = () => /^commit\/[0-9a-f]{5,40}/.test(getRepoPath()
 export const isSingleFile = () => /^blob\//.test(getRepoPath());
 
 export const isTrending = () => location.pathname.startsWith('/trending');
-
-export const isDiscussion = () => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -344,3 +344,10 @@ test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
 	'https://github.com/jaredhanson/node-trending/tree/master/lib/trending'
 ]);
 
+test('isDiscussion', urlMatcherMacro, pageDetect.isDiscussion, [
+	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
+	'https://github.com/orgs/refined-github/teams/core-team/',
+	'https://github.com/orgs/refined-github/teams/core-team'
+], [
+	'https://github.com/orgs/refined-github/teams/core-team/members'
+]);

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -346,7 +346,6 @@ test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
 
 test('isDiscussion', urlMatcherMacro, pageDetect.isDiscussion, [
 	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
-	'https://github.com/orgs/refined-github/teams/core-team/',
 	'https://github.com/orgs/refined-github/teams/core-team'
 ], [
 	'https://github.com/orgs/refined-github/teams/core-team/members'

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -148,6 +148,16 @@ test('isDashboard', urlMatcherMacro, pageDetect.isDashboard, [
 	'https://github.com/sindresorhus'
 ]);
 
+test('isDiscussion', urlMatcherMacro, pageDetect.isDiscussion, [
+	'https://github.com/orgs/refined-github/teams/core-team/discussions?pinned=1',
+	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
+	'https://github.com/orgs/refined-github/teams/core-team'
+], [
+	'https://github.com/orgs/refined-github/teams/core-team/members',
+	'https://github.com/sindresorhus/teams/tree/discussions',
+	'https://github.com/sindresorhus/orgs/tree/teams/core-team'
+]);
+
 test('isEnterprise', urlMatcherMacro, pageDetect.isEnterprise, [
 	'https://github.big-corp.com/',
 	'https://not-github.com/',
@@ -342,11 +352,4 @@ test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
 	'https://github.com/settings/trending',
 	'https://github.com/watching',
 	'https://github.com/jaredhanson/node-trending/tree/master/lib/trending'
-]);
-
-test('isDiscussion', urlMatcherMacro, pageDetect.isDiscussion, [
-	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
-	'https://github.com/orgs/refined-github/teams/core-team'
-], [
-	'https://github.com/orgs/refined-github/teams/core-team/members'
 ]);


### PR DESCRIPTION
I found out today the reaction avatars were not working for the recently launched ”Discussions” feature on GitHub. Unfortunately I do not have a live public example to link directly to test it, however I attach some screenshots before and after the change.

**Before:**
![before](https://user-images.githubusercontent.com/11782/33940483-6f8ae47a-e00f-11e7-99c6-03085cb2ee5d.png)

**After:**
![after](https://user-images.githubusercontent.com/11782/33940485-70693cb6-e00f-11e7-839a-5e79785e4569.png)
