### PR TITLE
Limit gists embeds to 11.5 lines

### DIFF
--- a/source/features/embed-gist-inline.js
+++ b/source/features/embed-gist-inline.js
@@ -19,7 +19,9 @@ async function embedGist(link) {
 	const response = await fetch(`${link.href}.json`);
 	const gistData = await response.json();
 	const gistEl = createGistElement(gistData);
-	link.parentNode.attachShadow({mode: 'open'}).append(gistEl);
+	const shadowDom = link.parentNode.attachShadow({mode: 'open'});
+	shadowDom.append(gistEl);
+	shadowDom.append(<style>{'.gist .gist-data {max-height: 16em}'}</style>);
 }
 export default () => {
 	select.all('.js-comment-body p a:only-child')


### PR DESCRIPTION
Partial solution to #870 

Limit is **11.5** lines to avoid giving the impression that it's _only_ 12 lines.

Example from https://github.com/WhisperSystems/Signal-Desktop/issues/1884

<img width="730" alt="Infinite lines limited to 11.5" src="https://user-images.githubusercontent.com/1402241/34031904-9b33580a-e1ae-11e7-97d2-c61a16b08d4c.png">