### PR TITLE
Improve gist embed FOUC style while loading

### DIFF
--- a/source/features/embed-gist-inline.js
+++ b/source/features/embed-gist-inline.js
@@ -20,8 +20,13 @@ async function embedGist(link) {
 	const gistData = await response.json();
 	const gistEl = createGistElement(gistData);
 	const shadowDom = link.parentNode.attachShadow({mode: 'open'});
+	shadowDom.append(<style>{`
+		.gist .gist-data {
+			max-height: 16em;
+			overflow-y: auto;
+		}
+	`}</style>);
 	shadowDom.append(gistEl);
-	shadowDom.append(<style>{'.gist .gist-data {max-height: 16em}'}</style>);
 }
 export default () => {
 	select.all('.js-comment-body p a:only-child')

--- a/source/features/embed-gist-inline.js
+++ b/source/features/embed-gist-inline.js
@@ -8,25 +8,20 @@ const isGist = link =>
 		link.pathname.startsWith('gist/')
 	);
 
-const createGistElement = gistData => (
-	<div>
-		<link rel="stylesheet" href={gistData.stylesheet} />
-		<div dangerouslySetInnerHTML={{__html: gistData.div}} />
-	</div>
-);
-
 async function embedGist(link) {
 	const response = await fetch(`${link.href}.json`);
 	const gistData = await response.json();
-	const gistEl = createGistElement(gistData);
-	const shadowDom = link.parentNode.attachShadow({mode: 'open'});
-	shadowDom.append(<style>{`
-		.gist .gist-data {
-			max-height: 16em;
-			overflow-y: auto;
-		}
-	`}</style>);
-	shadowDom.append(gistEl);
+
+	link.parentNode.attachShadow({mode: 'open'}).append(
+		<style>{`
+			.gist .gist-data {
+				max-height: 16em;
+				overflow-y: auto;
+			}
+		`}</style>,
+		<link rel="stylesheet" href={gistData.stylesheet} />,
+		<div dangerouslySetInnerHTML={{__html: gistData.div}} />
+	);
 }
 export default () => {
 	select.all('.js-comment-body p a:only-child')


### PR DESCRIPTION
Related to #870 

The stylesheet for the embed loads after the first content paint, so the Flash Of Unstyled Content overflows and overlaps until that completes. This PR avoid the overflow and makes it look decent during the FUOC.

# Before

![before](https://user-images.githubusercontent.com/1402241/34032381-c53a2e2e-e1b0-11e7-98f3-c2f7553a6001.gif)

# After

![after](https://user-images.githubusercontent.com/1402241/34032383-cadef7ce-e1b0-11e7-87f0-fd4c36b2c217.gif)
