### PR TITLE
Add participant username as title to reactions avatars

### DIFF
--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -29,7 +29,7 @@ function add() {
 
 		for (const participant of flatParticipants) {
 			participant.container.append(
-				<a href={`/${participant.username}`} aria-label={participant.username} class="tooltipped rgh-tooltipped">
+				<a href={`/${participant.username}`} aria-label={participant.username} class="tooltipped tooltipped-n rgh-tooltipped">
 					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`}/>
 				</a>
 			);

--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -29,7 +29,7 @@ function add() {
 
 		for (const participant of flatParticipants) {
 			participant.container.append(
-				<a href={`/${participant.username}`} title={participant.username}>
+				<a href={`/${participant.username}`} aria-label={participant.username} class="tooltipped rgh-tooltipped">
 					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`}/>
 				</a>
 			);

--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -29,7 +29,7 @@ function add() {
 
 		for (const participant of flatParticipants) {
 			participant.container.append(
-				<a href={`/${participant.username}`}>
+				<a href={`/${participant.username}`} title={participant.username}>
 					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`}/>
 				</a>
 			);


### PR DESCRIPTION
Currently in order to see who has reacted on GitHub, you have to either know which avatar belongs to who, or check the link’s preview in Chrome in the bottom left corner. Why not exposing it as the link’s title, so it would be visible when hovering over the avatar? ;)