### PR TITLE
Don't exclude the `process` object

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,9 +11,6 @@ module.exports = {
 		options: './source/options'
 	},
 	plugins: [
-		new webpack.DefinePlugin({
-			process: '0'
-		}),
 		new webpack.optimize.ModuleConcatenationPlugin(),
 		new CopyWebpackPlugin([{
 			from: '*',


### PR DESCRIPTION
Some npm package we depend on can at any time start expecting a property on `process` to exists and then break. The `process` polyfill is pretty small anyway.