### PR TITLE
Add quick review buttons

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ GitHub Enterprise is also supported. More info in the options.
 
 - [Improves readability of tab indented code](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
 - [Aligns labels to the left in Issues and PRs lists](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
+- [Lets you approve or reject reviews faster](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
 - Prompts you when pressing `Cancel` on an inline comment in case it was a mistake
 - Easier copy-pasting from diffs by making +/- signs unselectable
 - Automagically expands the news feed when you scroll down

--- a/source/content.css
+++ b/source/content.css
@@ -711,3 +711,8 @@ body > .footer ul:first-of-type li:first-of-type { /* The `© 2017 GitHub, Inc.`
 .footer-octicon {
 	display: none;
 }
+
+/* Widen review popup to fit 4 buttons */
+:root .pull-request-review-menu {
+	width: 430px;
+}

--- a/source/content.js
+++ b/source/content.js
@@ -52,6 +52,7 @@ import addConfirmationToCommentCancellation from './features/add-confirmation-to
 import addCILink from './features/add-ci-link';
 import embedGistInline from './features/embed-gist-inline';
 import expandCollapseOutdatedComments from './features/expand-collapse-outdated-comments';
+import addQuickReviewButtons from './features/add-quick-review-buttons';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, enableFeature} from './libs/utils';
@@ -198,6 +199,10 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 		enableFeature(addCopyFilePathToPRs);
 		enableFeature(preserveWhitespaceOptionInNav);
+	}
+
+	if (pageDetect.isPRFiles()) {
+		enableFeature(addQuickReviewButtons);
 	}
 
 	if (pageDetect.isSingleFile()) {

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -34,7 +34,11 @@ export default function () {
 				value="comment"
 				class="btn btn-sm">
 				Comment
-			</button>
+			</button>,
+			<input
+				type="hidden"
+				name="pull_request_review[event]"
+				value="comment"/> // This defaults cmd+enter to Comment when there's more than one field
 		);
 	}
 

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -2,6 +2,12 @@ import {h} from 'dom-chef';
 import select from 'select-dom';
 
 export default function () {
+	const submitButton = select('#submit-review [type="submit"]');
+	if (!submitButton) {
+		// Already applied
+		return;
+	}
+
 	const container = select('#submit-review .form-actions');
 	const approveCheck = select('#submit-review [value="approve"]');
 	const commentCheck = select('#submit-review [value="comment"]');
@@ -48,6 +54,6 @@ export default function () {
 		approveCheck.closest('.form-checkbox').remove();
 		commentCheck.closest('.form-checkbox').remove();
 		rejectCheck.closest('.form-checkbox').remove();
-		select('#submit-review [type="submit"]').remove();
+		submitButton.remove();
 	}
 }

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -20,6 +20,18 @@ export default function () {
 		return;
 	}
 
+	// Set the default action for cmd+enter to Comment
+	if (radios.length > 1) {
+		container.append(
+			<input
+				type="hidden"
+				name="pull_request_review[event]"
+				value="comment"/>,
+
+		);
+	}
+
+	// Generate the new buttons
 	for (const radio of radios) {
 		if (!radio.disabled) {
 			container.append(
@@ -33,21 +45,14 @@ export default function () {
 		}
 	}
 
+	// Make sure that the comment button is last
 	if (radios.length > 1) {
 		container.append(
-			// Move the comment button at the end
-			select('#submit-review button[value="comment"]'),
-
-			// Make it the default action for cmd+enter
-			<input
-				type="hidden"
-				name="pull_request_review[event]"
-				value="comment"/>,
-
+			select('#submit-review button[value="comment"]')
 		);
 	}
 
-	// Remove original form at last to avoid leaving a broken form
+	// Remove original fields at last to avoid leaving a broken form
 	for (const radio of radios) {
 		radio.closest('.form-checkbox').remove();
 	}

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -31,7 +31,7 @@ export default function () {
 		container.append(
 			<button
 				name="pull_request_review[event]"
-				value="approve"
+				value="comment"
 				class="btn btn-sm">
 				Comment
 			</button>

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -45,11 +45,19 @@ export default function () {
 		}
 	}
 
-	// Make sure that the comment button is last
+	// Make sure that the comment and cancel buttons are last
 	if (radios.length > 1) {
+		const cancelReview = select('#submit-review .review-cancel-button');
 		container.append(
 			select('#submit-review button[value="comment"]')
 		);
+		if (cancelReview) {
+			cancelReview.classList.remove('mr-1');
+			container.append(
+				' ',
+				cancelReview
+			);
+		}
 	}
 
 	// Remove original fields at last to avoid leaving a broken form

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -1,6 +1,11 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 
+const btnClassMap = {
+	approve: 'btn-primary',
+	reject: 'btn-danger'
+};
+
 export default function () {
 	const submitButton = select('#submit-review [type="submit"]');
 	if (!submitButton) {
@@ -9,51 +14,42 @@ export default function () {
 	}
 
 	const container = select('#submit-review .form-actions');
-	const approveCheck = select('#submit-review [value="approve"]');
-	const commentCheck = select('#submit-review [value="comment"]');
-	const rejectCheck = select('#submit-review [value="reject"]');
+	const radios = select.all('#submit-review [name="pull_request_review[event]"]');
 
-	if (!approveCheck.disabled) {
-		container.append(
-			<button
-				name="pull_request_review[event]"
-				value="approve"
-				class="btn btn-sm btn-primary">
-				Approve
-			</button>
-		);
+	if (radios.length === 0) {
+		return;
 	}
-	if (!rejectCheck.disabled) {
-		container.append(
-			<button
-				name="pull_request_review[event]"
-				value="reject"
-				class="btn btn-sm btn-danger">
-				Request changes
-			</button>
-		);
+
+	for (const radio of radios) {
+		if (!radio.disabled) {
+			container.append(
+				<button
+					name="pull_request_review[event]"
+					value={radio.value}
+					class={`btn btn-sm ${btnClassMap[radio.value] || ''}`}>
+					{radio.nextSibling.textContent.trim()}
+				</button>
+			);
+		}
 	}
-	if (!commentCheck.disabled) {
+
+	if (radios.length > 1) {
 		container.append(
-			<button
-				name="pull_request_review[event]"
-				value="comment"
-				class="btn btn-sm">
-				Comment
-			</button>,
+			// Move the comment button at the end
+			select('#submit-review button[value="comment"]'),
+
+			// Make it the default action for cmd+enter
 			<input
 				type="hidden"
 				name="pull_request_review[event]"
-				value="comment"/> // This defaults cmd+enter to Comment when there's more than one field
+				value="comment"/>,
+
 		);
 	}
 
-	// Remove original form at last to avoid leaving a broken form,
-	// if at least one option is available.
-	if (!approveCheck.disabled || !rejectCheck.disabled || !commentCheck.disabled) {
-		approveCheck.closest('.form-checkbox').remove();
-		commentCheck.closest('.form-checkbox').remove();
-		rejectCheck.closest('.form-checkbox').remove();
-		submitButton.remove();
+	// Remove original form at last to avoid leaving a broken form
+	for (const radio of radios) {
+		radio.closest('.form-checkbox').remove();
 	}
+	submitButton.remove();
 }

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -1,0 +1,49 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+
+export default function () {
+	const container = select('#submit-review .form-actions');
+	const approveCheck = select('#submit-review [value="approve"]');
+	const commentCheck = select('#submit-review [value="comment"]');
+	const rejectCheck = select('#submit-review [value="reject"]');
+
+	if (!approveCheck.disabled) {
+		container.append(
+			<button
+				name="pull_request_review[event]"
+				value="approve"
+				class="btn btn-sm btn-primary">
+				Approve
+			</button>
+		);
+	}
+	if (!rejectCheck.disabled) {
+		container.append(
+			<button
+				name="pull_request_review[event]"
+				value="reject"
+				class="btn btn-sm btn-danger">
+				Request changes
+			</button>
+		);
+	}
+	if (!commentCheck.disabled) {
+		container.append(
+			<button
+				name="pull_request_review[event]"
+				value="approve"
+				class="btn btn-sm">
+				Comment
+			</button>
+		);
+	}
+
+	// Remove original form at last to avoid leaving a broken form,
+	// if at least one option is available.
+	if (!approveCheck.disabled || !rejectCheck.disabled || !commentCheck.disabled) {
+		approveCheck.closest('.form-checkbox').remove();
+		commentCheck.closest('.form-checkbox').remove();
+		rejectCheck.closest('.form-checkbox').remove();
+		select('#submit-review [type="submit"]').remove();
+	}
+}

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -47,16 +47,11 @@ export default function () {
 
 	// Make sure that the comment and cancel buttons are last
 	if (radios.length > 1) {
+		container.append(select('#submit-review button[value="comment"]'));
 		const cancelReview = select('#submit-review .review-cancel-button');
-		container.append(
-			select('#submit-review button[value="comment"]')
-		);
 		if (cancelReview) {
-			cancelReview.classList.remove('mr-1');
-			container.append(
-				' ',
-				cancelReview
-			);
+			cancelReview.classList.add('float-left');
+			container.append(cancelReview);
 		}
 	}
 


### PR DESCRIPTION
Related to #883 

Test it on #886 

**One issue:** <kbd>cmd</kbd>+<kbd>enter</kbd> will submit the form correctly when there's only one button (**Comment**), but currently fails when there is more than one button. What should we do in that case? 
- 👉 Default to **Comment** (if a different action was meant, just submit a new comment-less review)
  _**Edit:** I picked this one because GitHub also defaults to "comment", as you can see in the first screenshot_
- ~~Disable <kbd>cmd</kbd>+<kbd>enter</kbd>~~


# Before

<img width="425" alt="" src="https://user-images.githubusercontent.com/1402241/34173823-ba9d67e0-e531-11e7-9b0d-834e839cf189.png">

# All buttons available

<img width="431" alt="" src="https://user-images.githubusercontent.com/1402241/34147531-fb56f822-e4d8-11e7-816e-e774fa5b6dbe.png">

# Only comment available

<img width="426" alt="f" src="https://user-images.githubusercontent.com/1402241/34147552-1220ac56-e4d9-11e7-8e4f-f9c72e547211.png">
