### PR TITLE
Only show 'Jump to bottom' link on PR Conversation tab

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -176,12 +176,15 @@ function ajaxedPagesHandler() {
 		enableFeature(linkifyIssuesInTitles);
 		enableFeature(addUploadBtn);
 		enableFeature(embedGistInline);
-		enableFeature(addJumpToBottomLink);
 
 		observeEl('.new-discussion-timeline', () => {
 			enableFeature(addOPLabels);
 			enableFeature(addTimeMachineLinksToComments);
 		});
+	}
+
+	if (pageDetect.isIssue() || pageDetect.isPRConversation()) {
+		enableFeature(addJumpToBottomLink);
 	}
 
 	if (pageDetect.isPRList() || pageDetect.isIssueList()) {

--- a/source/features/add-jump-to-bottom-link.js
+++ b/source/features/add-jump-to-bottom-link.js
@@ -3,13 +3,12 @@ import select from 'select-dom';
 
 export default function () {
 	const meta = select('.gh-header-meta > .TableObject-item--primary');
-	const jumpToBottomLink = select('#refined-github-jump-to-bottom-link');
-	if (!meta || jumpToBottomLink) {
+	if (!meta) {
 		return;
 	}
 
 	meta.append(
 		' · ',
-		<a href="#partial-timeline-marker" id="refined-github-jump-to-bottom-link">Jump to bottom</a>
+		<a href="#partial-timeline-marker">Jump to bottom</a>
 	);
 }

--- a/source/features/add-jump-to-bottom-link.js
+++ b/source/features/add-jump-to-bottom-link.js
@@ -3,12 +3,13 @@ import select from 'select-dom';
 
 export default function () {
 	const meta = select('.gh-header-meta > .TableObject-item--primary');
-	if (!meta) {
+	const jumpToBottomLink = select('#refined-github-jump-to-bottom-link');
+	if (!meta || jumpToBottomLink) {
 		return;
 	}
 
 	meta.append(
 		' · ',
-		<a href="#partial-timeline-marker">Jump to bottom</a>
+		<a href="#partial-timeline-marker" id="refined-github-jump-to-bottom-link">Jump to bottom</a>
 	);
 }

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -63,6 +63,8 @@ export const isNotifications = () => /^([^/]+[/][^/]+\/)?notifications/.test(get
 
 export const isPR = () => /^pull\/\d+/.test(getRepoPath());
 
+export const isPRConversation = () => /^pull\/\d+$/.test(getRepoPath());
+
 export const isPRCommit = () => /^pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(getRepoPath());
 
 export const isPRFiles = () => /^pull\/\d+\/files/.test(getRepoPath());

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -245,6 +245,16 @@ test('isPR', urlMatcherMacro, pageDetect.isPR, [
 	'https://github.com/sindresorhus/refined-github/pulls'
 ]);
 
+test('isPRConversation', urlMatcherMacro, pageDetect.isPRConversation, [
+	'https://github.com/sindresorhus/refined-github/pull/148'
+], [
+	'https://github.com/sindresorhus/refined-github/pull/148/commits',
+	'https://github.com/sindresorhus/refined-github/pull/148/files',
+	'http://github.com/sindresorhus/ava',
+	'https://github.com',
+	'https://github.com/sindresorhus/refined-github/pulls'
+]);
+
 test('isPRCommit', urlMatcherMacro, pageDetect.isPRCommit, [
 	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85',
 	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196'


### PR DESCRIPTION
Today I stumbled upon a bug related to the ”Jump to bottom” feature introduced in #904. Whenever a user keep changing between tabs in the PR view, the link had been added multiple times even if it had already existed in the DOM.

Preview of the behaviour: [a GIF file](https://user-images.githubusercontent.com/11782/34378469-3de83d9a-eaf6-11e7-8417-5ecf486f04d9.gif)
