### PR TITLE
Show Firefox mis-support only in Firefox' options

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -15,12 +15,25 @@
 	textarea {
 		width: 100%;
 	}
+	.only-firefox {
+		display: none;
+	}
+	@-moz-document url-prefix() {
+		.no-firefox {
+			display: none;
+		}
+		.only-firefox {
+			display: block;
+		}
+	}
 </style>
 <form id="options-form">
 	<h2>GitHub Enterprise</h2>
-	<p>
-		While on your GitHub, right-click on Refined GitHub's icon in the toolbar and select <strong>Enable Refined GitHub on this domain</strong>.
-		<a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Example</a>. This is <a href="https://github.com/sindresorhus/refined-github/issues/840#issuecomment-349936195" target="_blank">not yet supported by Firefox</a>.
+	<p class="no-firefox">
+		Visit your GH Enterprise, right-click on <a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Refined GitHub's icon in the toolbar</a> and select <strong>Enable Refined GitHub on this domain</strong>.
+	</p>
+	<p class="only-firefox">
+		<a href="https://github.com/sindresorhus/refined-github/issues/840#issuecomment-349936195" target="_blank">Not yet supported by Firefox</a>.
 	</p>
 
 	<h2>Disable features</h2>


### PR DESCRIPTION
# Firefox

<img width="419" alt="" src="https://user-images.githubusercontent.com/1402241/34431792-9ae1e898-eca4-11e7-98fb-b38534be4f6c.png">

# Chrome

<img width="465" alt="" src="https://user-images.githubusercontent.com/1402241/34431791-9aaae3e8-eca4-11e7-83f5-931684e9a8a5.png">

Also shortens the copy