### PR TITLE
Add related extensions to options

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -37,6 +37,11 @@
 			Enable logging (Show in the console what features are enabled on each page)
 		</label>
 	</p>
+
+	<h2>More features</h2>
+	<p>
+		Want more? Check out our <a href="https://github.com/sindresorhus/refined-github#related" target="_blank">related GitHub extensions</a>
+	</p>
 </form>
 <script src="browser-polyfill.min.js"></script>
 <script src="options.js"></script>


### PR DESCRIPTION
Context: https://github.com/sindresorhus/refined-github/pull/546#issuecomment-313748489

At the bottom:

<img width="458" alt="" src="https://user-images.githubusercontent.com/1402241/34431810-c5e5e9ae-eca4-11e7-941e-c99f978c039a.png">

It looks long but #924 helps shorten the page also