### PR TITLE
Meta: Improve Options style in Firefox (and Chrome)

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -1,0 +1,31 @@
+textarea {
+	width: 100%;
+}
+
+/* Increase spacing between sections */
+h2 ~ h2 {
+	margin-top: 2em;
+}
+
+/* Firefox only */
+.only-firefox {
+	display: none;
+}
+@-moz-document url-prefix('') {
+	:root h2 {
+		font-weight: normal;
+	}
+	:root body {
+		max-width: 600px;
+		font: message-box, sans-serif;
+	}
+	input[type='checkbox'] {
+		vertical-align: -41%;
+	}
+	.no-firefox {
+		display: none;
+	}
+	.only-firefox {
+		display: block;
+	}
+}

--- a/source/options.html
+++ b/source/options.html
@@ -1,33 +1,10 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>Refined GitHub options</title>
-<style>
-	body {
-		width: 350px;
-		margin: 14px 17px; /* Chrome default, match for Firefox */
-		font-family: sans-serif;
-	}
-	/* Increase spacing between sections */
-	h2 ~ h2,
-	form ~ form {
-		margin-top: 2em;
-	}
-	textarea {
-		width: 100%;
-	}
-	.only-firefox {
-		display: none;
-	}
-	@-moz-document url-prefix() {
-		.no-firefox {
-			display: none;
-		}
-		.only-firefox {
-			display: block;
-		}
-	}
-</style>
-<form id="options-form">
+<link rel="stylesheet" href="options.css">
+<link rel="stylesheet" href="chrome://global/skin/in-content/common.css">
+<link rel="stylesheet" href="chrome://mozapps/skin/extensions/extensions.css">
+<form id="options-form" class="detail-view-container">
 	<h2>GitHub Enterprise</h2>
 	<p class="no-firefox">
 		Visit your GH Enterprise, right-click on <a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Refined GitHub's icon in the toolbar</a> and select <strong>Enable Refined GitHub on this domain</strong>.


### PR DESCRIPTION
Firefox styles are now only applied there. Chrome has a better style without them.

A minor annoyance is the two extra `<link>`s and their loading errors in Chrome. But I prefer that to having/updating an extensive Firefox style _in-house_

# Firefox Before

<img width="659" alt="before" src="https://user-images.githubusercontent.com/1402241/34436891-68f362a8-eccc-11e7-9ce1-98be7f67b00a.png"> 

# Firefox After

<img width="637" alt="after" src="https://user-images.githubusercontent.com/1402241/34436895-72bb36c6-eccc-11e7-9cf0-cf1f43b0d1ff.png">

# Chrome before

<img width="452" alt="ch before" src="https://user-images.githubusercontent.com/1402241/34436905-8efad9e0-eccc-11e7-9278-a301630a3476.png">

# Chrome after

<img width="454" alt="ch after" src="https://user-images.githubusercontent.com/1402241/34436898-80ba872c-eccc-11e7-8858-aaefdc759617.png">