### PR TITLE
Hide PR summary duplicate info

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -116,6 +116,9 @@
 .mergeability-details .branch-action-item-icon {
 	margin-top: -4px;
 }
+.mergeability-details .branch-action-item .float-right.btn {
+	margin-top: -6px;
+}
 .alt-merge-options {
 	display: none !important;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -99,7 +99,23 @@
 	display: none !important;
 }
 
-/* Remove useless message on the right side of the PR merge box */
+/* Hide extra copy on PR mergeability summary */
+.mergeability-details .js-details-container .h4,
+.mergeability-details .js-details-container .status-meta .btn-link,
+.mergeability-details > :not(.js-details-container) .status-meta {
+	display: none;
+}
+.mergeability-details .js-details-container .status-meta {
+	color: inherit;
+	font-size: 16px;
+	font-weight: 600;
+}
+.mergeability-details .js-details-container .text-red + .status-meta {
+	color: var(--github-red);
+}
+.mergeability-details .branch-action-item-icon {
+	margin-top: -4px;
+}
 .alt-merge-options {
 	display: none !important;
 }
@@ -804,22 +820,4 @@ body > .footer li a {
 /* Make activities narrower */
 .dashboard .d-flex.border-bottom.border-gray-light {
 	padding: 8px 0 !important;
-}
-
-/* Reduce PR mergeability summary */
-.mergeability-details .js-details-container .h4,
-.mergeability-details .js-details-container .status-meta .btn-link,
-.mergeability-details > :not(.js-details-container) .status-meta {
-	display: none;
-}
-.mergeability-details .js-details-container .status-meta {
-	color: inherit;
-	font-size: 16px;
-	font-weight: 600;
-}
-.mergeability-details .js-details-container .text-red + .status-meta {
-	color: var(--github-red);
-}
-.mergeability-details .branch-action-item-icon {
-	margin-top: -4px;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -805,3 +805,21 @@ body > .footer li a {
 .dashboard .d-flex.border-bottom.border-gray-light {
 	padding: 8px 0 !important;
 }
+
+/* Reduce PR mergeability summary */
+.mergeability-details .js-details-container .h4,
+.mergeability-details .js-details-container .status-meta .btn-link,
+.mergeability-details > :not(.js-details-container) .status-meta {
+	display: none;
+}
+.mergeability-details .js-details-container .status-meta {
+	color: inherit;
+	font-size: 16px;
+	font-weight: 600;
+}
+.mergeability-details .js-details-container .text-red + .status-meta {
+	color: var(--github-red);
+}
+.mergeability-details .branch-action-item-icon {
+	margin-top: -4px;
+}


### PR DESCRIPTION
Demo gifs containing before and after

![positive](https://user-images.githubusercontent.com/1402241/34437442-db6b0ba2-ecd0-11e7-82ea-a23ba343dcfe.gif)

![negative](https://user-images.githubusercontent.com/1402241/34437443-db9e4968-ecd0-11e7-87e6-1dbb24c81c90.gif)

![conflicts](https://user-images.githubusercontent.com/1402241/34437625-9212b4d0-ecd2-11e7-95a7-5cd185aa2ce4.gif)


We could arguably also hide "build finished/failed" messages, but perhaps [some bots include good info.](https://github.com/siddharthkp/bundlesize)