### PR TITLE
Don't shorten URLs in markdown code blocks

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -1,6 +1,5 @@
 import 'webext-dynamic-content-scripts';
 import onAjaxedPages from 'github-injection';
-import {applyToLink as shortenLink} from 'shorten-repo-url';
 import select from 'select-dom';
 import domLoaded from 'dom-loaded';
 
@@ -55,6 +54,7 @@ import embedGistInline from './features/embed-gist-inline';
 import expandCollapseOutdatedComments from './features/expand-collapse-outdated-comments';
 import addJumpToBottomLink from './features/add-jump-to-bottom-link';
 import addQuickReviewButtons from './features/add-quick-review-buttons';
+import shortenLinks from './features/shorten-links';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, enableFeature} from './libs/utils';
@@ -135,14 +135,8 @@ function ajaxedPagesHandler() {
 	enableFeature(hideEmptyMeta);
 	enableFeature(removeUploadFilesButton);
 	enableFeature(addTitleToEmojis);
-
-	enableFeature(() => {
-		for (const a of select.all('a[href]')) {
-			shortenLink(a, location.href);
-		}
-	}, 'shorten-links');
-
-	enableFeature(linkifyCode); // Must be after link shortening #789
+	enableFeature(shortenLinks);
+	enableFeature(linkifyCode);
 
 	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
 		enableFeature(addYoursMenuItem);

--- a/source/features/linkify-urls-in-code.js
+++ b/source/features/linkify-urls-in-code.js
@@ -4,7 +4,7 @@ import linkifyIssues from 'linkify-issues';
 import {getOwnerAndRepo} from '../libs/page-detect';
 import getTextNodes from '../libs/get-text-nodes';
 
-const linkifiedURLClass = 'refined-github-linkified-code';
+export const linkifiedURLClass = 'rgh-linkified-code';
 const {
 	ownerName,
 	repoName
@@ -15,8 +15,8 @@ const options = {
 	repo: repoName,
 	type: 'dom',
 	baseUrl: '',
-	attrs: {
-		target: '_blank'
+	attributes: {
+		class: linkifiedURLClass // Necessary to avoid also shortening the links
 	}
 };
 

--- a/source/features/shorten-links.js
+++ b/source/features/shorten-links.js
@@ -1,0 +1,9 @@
+import select from 'select-dom';
+import {applyToLink} from 'shorten-repo-url';
+import {linkifiedURLClass} from './linkify-urls-in-code';
+
+export default function () {
+	for (const a of select.all(`a[href]:not(.${linkifiedURLClass})`)) {
+		applyToLink(a, location.href);
+	}
+}


### PR DESCRIPTION
Fixes #938 

Reproduce:

1. Visit https://github.com/drlogout/caddy-proxy
2. Click the "Issues" tab
3. Press the browser's back button
