### PR TITLE
Extend diff expander (see more lines) button

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - [Uses the pull request title as commit title when merging with 'Squash and merge'](https://github.com/sindresorhus/refined-github/issues/276)
 - [Automatically embeds linked gists in comments](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- [Extends diff view show unchanged lines button to full width](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 
 ### More actions
 

--- a/readme.md
+++ b/readme.md
@@ -110,7 +110,6 @@ GitHub Enterprise is also supported. More info in the options.
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - [Uses the pull request title as commit title when merging with 'Squash and merge'](https://github.com/sindresorhus/refined-github/issues/276)
 - [Automatically embeds linked gists in comments](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
-- [Extends diff view show unchanged lines button to full width](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 
 ### More actions
 
@@ -157,6 +156,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Shows the reactions popover on hover instead of click
 - Changes the default sort order of milestones to "Closest due date"
 - Changes the default sort order of issues/PRs to "Recently updated"
+- [Extends diff view show unchanged lines button to full width](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 
 And [lots](source/content.css) [more...](source/content.js)
 

--- a/readme.md
+++ b/readme.md
@@ -156,7 +156,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Shows the reactions popover on hover instead of click
 - Changes the default sort order of milestones to "Closest due date"
 - Changes the default sort order of issues/PRs to "Recently updated"
-- [Extends diff view show unchanged lines button to full width](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
+- [Makes the "Expand diff" button wider](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.png)
 
 And [lots](source/content.css) [more...](source/content.js)
 

--- a/source/content.css
+++ b/source/content.css
@@ -822,8 +822,8 @@ body > .footer li a {
 }
 
 /* For 'diff-expand' feature */
-.refined-github-diff-expand:hover .diff-expander,
-.refined-github-diff-expand:hover .blob-code {
+.refined-github-diff-expand .js-expandable-line:hover .diff-expander,
+.refined-github-diff-expand .js-expandable-line:hover .blob-code {
 	border-color: #0366d6;
 	color: #fff;
 	background: #0366d6;

--- a/source/content.css
+++ b/source/content.css
@@ -822,15 +822,10 @@ body > .footer li a {
 }
 
 /* For 'extend-diff-expander' feature */
-.refined-github-diff-expand .js-expandable-line:hover .diff-expander,
-.refined-github-diff-expand .js-expandable-line:hover .blob-code {
+.js-expandable-line:hover .diff-expander,
+.js-expandable-line:hover .blob-code {
 	border-color: #0366d6;
 	color: #fff;
 	background: #0366d6;
 	cursor: pointer;
-}
-
-/* Fix alignment of expand icon */
-.refined-github-diff-expand .blob-num-expandable .octicon {
-	vertical-align: middle;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -821,7 +821,7 @@ body > .footer li a {
 	padding: 8px 0 !important;
 }
 
-/* For 'diff-expand' feature */
+/* For 'extend-diff-expander' feature */
 .refined-github-diff-expand .js-expandable-line:hover .diff-expander,
 .refined-github-diff-expand .js-expandable-line:hover .blob-code {
 	border-color: #0366d6;

--- a/source/content.css
+++ b/source/content.css
@@ -820,3 +820,17 @@ body > .footer li a {
 .dashboard .d-flex.border-bottom.border-gray-light {
 	padding: 8px 0 !important;
 }
+
+/* For 'diff-expand' feature */
+.refined-github-diff-expand:hover .diff-expander,
+.refined-github-diff-expand:hover .blob-code {
+	border-color: #0366d6;
+	color: #fff;
+	background: #0366d6;
+	cursor: pointer;
+}
+
+/* Fix alignment of expand icon */
+.refined-github-diff-expand .blob-num-expandable .octicon {
+	vertical-align: middle;
+}

--- a/source/content.js
+++ b/source/content.js
@@ -55,6 +55,7 @@ import embedGistInline from './features/embed-gist-inline';
 import expandCollapseOutdatedComments from './features/expand-collapse-outdated-comments';
 import addJumpToBottomLink from './features/add-jump-to-bottom-link';
 import addQuickReviewButtons from './features/add-quick-review-buttons';
+import diffExpand from './features/diff-expand';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, enableFeature} from './libs/utils';
@@ -216,6 +217,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRFiles()) {
 		enableFeature(addQuickReviewButtons);
+		enableFeature(diffExpand);
 	}
 
 	if (pageDetect.isSingleFile()) {

--- a/source/content.js
+++ b/source/content.js
@@ -55,7 +55,7 @@ import embedGistInline from './features/embed-gist-inline';
 import expandCollapseOutdatedComments from './features/expand-collapse-outdated-comments';
 import addJumpToBottomLink from './features/add-jump-to-bottom-link';
 import addQuickReviewButtons from './features/add-quick-review-buttons';
-import diffExpand from './features/diff-expand';
+import extendDiffExpander from './features/extend-diff-expander';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, enableFeature} from './libs/utils';
@@ -217,7 +217,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRFiles()) {
 		enableFeature(addQuickReviewButtons);
-		enableFeature(diffExpand);
+		enableFeature(extendDiffExpander);
 	}
 
 	if (pageDetect.isSingleFile()) {

--- a/source/features/diff-expand.js
+++ b/source/features/diff-expand.js
@@ -2,17 +2,17 @@ import select from 'select-dom';
 
 const activeClassName = 'refined-github-diff-expand';
 
-function attachClickHandler(expander) {
-	const button = select('.js-expand', expander);
-	expander.classList.add(activeClassName);
-	expander.addEventListener('click', e => {
-		e.preventDefault();
-		button.click();
-	}, { once: true });
+function attachClickHandler(diff) {
+	diff.classList.add('refined-github-diff-expand');
+	diff.addEventListener('click', e => {
+		if (e.target.parentElement.classList.contains('js-expandable-line')) {
+			e.preventDefault();
+			select('.js-expand', e.target.parentElement).click();
+		}
+	});
 }
 
 export default () => {
-	console.log('diff-expand');
-	select.all(`.js-expandable-line:not(.${activeClassName})`)
+	select.all('.diff-table')
 	.forEach(attachClickHandler);
 };

--- a/source/features/diff-expand.js
+++ b/source/features/diff-expand.js
@@ -1,0 +1,18 @@
+import select from 'select-dom';
+
+const activeClassName = 'refined-github-diff-expand';
+
+function attachClickHandler(expander) {
+	const button = select('.js-expand', expander);
+	expander.classList.add(activeClassName);
+	expander.addEventListener('click', e => {
+		e.preventDefault();
+		button.click();
+	}, { once: true });
+}
+
+export default () => {
+	console.log('diff-expand');
+	select.all(`.js-expandable-line:not(.${activeClassName})`)
+	.forEach(attachClickHandler);
+};

--- a/source/features/extend-diff-expander.js
+++ b/source/features/extend-diff-expander.js
@@ -4,7 +4,7 @@ import delegate from 'delegate';
 function expandDiff(event) {
 	// Skip if the user clicked directly on the icon
 	if (!event.target.closest('.js-expand')) {
-		select('.js-expand', event.currentTarget).click();
+		select('.js-expand', event.delegateTarget).click();
 	}
 }
 

--- a/source/features/extend-diff-expander.js
+++ b/source/features/extend-diff-expander.js
@@ -4,7 +4,7 @@ import delegate from 'delegate';
 function expandDiff(event) {
 	// Skip if the user clicked directly on the icon
 	if (!event.target.closest('.js-expand')) {
-		select('.js-expand', event.target.parentElement).click();
+		select('.js-expand', event.currentTarget).click();
 	}
 }
 

--- a/source/features/extend-diff-expander.js
+++ b/source/features/extend-diff-expander.js
@@ -1,19 +1,13 @@
 import select from 'select-dom';
+import delegate from 'delegate';
 
-function attachClickHandler(diff) {
-	diff.classList.add('refined-github-diff-expand');
-	diff.addEventListener('click', e => {
-		if (e.target.parentElement.classList.contains('js-expandable-line')) {
-			e.preventDefault();
-			select('.js-expand', e.target.parentElement).click();
-		}
-	});
+function expandDiff(event) {
+	// Skip if the user clicked directly on the icon
+	if (!event.target.closest('.js-expand')) {
+		select('.js-expand', event.target.parentElement).click();
+	}
 }
 
-export default () => {
-	const diffView = select('.diff-view');
-
-	if (diffView) {
-		attachClickHandler(diffView);
-	}
-};
+export default function () {
+	delegate('.diff-view', '.js-expandable-line', 'click', expandDiff);
+}

--- a/source/features/extend-diff-expander.js
+++ b/source/features/extend-diff-expander.js
@@ -11,6 +11,9 @@ function attachClickHandler(diff) {
 }
 
 export default () => {
-	select.all('.diff-table')
-	.forEach(attachClickHandler);
+	const diffView = select('.diff-view');
+
+	if (diffView) {
+		attachClickHandler(diffView);
+	}
 };

--- a/source/features/extend-diff-expander.js
+++ b/source/features/extend-diff-expander.js
@@ -1,7 +1,5 @@
 import select from 'select-dom';
 
-const activeClassName = 'refined-github-diff-expand';
-
 function attachClickHandler(diff) {
 	diff.classList.add('refined-github-diff-expand');
 	diff.addEventListener('click', e => {


### PR DESCRIPTION
Allow the entire expandable line to be clicked to see more lines, rather than just the expander button in the left margin. Includes hover style to match the button.

Closes #547 