### PR TITLE
Check if `newsfeedObserver` is set before referencing it

### DIFF
--- a/source/features/auto-load-more-news.js
+++ b/source/features/auto-load-more-news.js
@@ -37,7 +37,7 @@ const findButton = () => {
 	btn = select('.ajax-pagination-btn');
 	if (btn) {
 		inView.observe(btn);
-	} else {
+	} else if (newsfeedObserver) {
 		newsfeedObserver.disconnect();
 	}
 };


### PR DESCRIPTION
This fixes #941