### PR TITLE
Recently-pushed branches: Don't cover repo tabs

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1,6 +1,7 @@
 :root {
 	--github-green: #28a745;
 	--github-red: #cb2431;
+	--github-gray-background: #fafbfc;
 }
 
 .subscribe-feed {
@@ -723,10 +724,13 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	position: relative;
 }
 [data-url$='recently_touched_branches_list'] {
+	min-width: 400px; /* Always cover the repo watch/star/forks actions */
+	max-height: 35px; /* Only cover the actions */
 	position: absolute;
-	top: -54px;
+	top: -107px;
 	right: 0;
 	z-index: 10;
+	background: var(--github-gray-background);
 	white-space: nowrap;
 	animation: rgh-slide-in-right 0.3s ease-out;
 }
@@ -739,6 +743,8 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 }
 .RecentBranches {
 	display: flex;
+	width: max-content;
+	margin-left: auto;
 	flex-direction: column-reverse;
 }
 .RecentBranches .btn {

--- a/source/content.css
+++ b/source/content.css
@@ -772,7 +772,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	border-bottom-width: 3px;
 }
 .RecentBranches-item-link {
-	max-width: 150px !important;
+	max-width: 250px !important;
 	font-size: 14px;
 }
 .RecentBranches-item.p-2 {


### PR DESCRIPTION
Fixes #906

![demo gif](https://user-images.githubusercontent.com/1402241/34596715-a02b8168-f214-11e7-9d7d-57b0766aca65.gif)
