### PR TITLE
Lighten deletions in markdown

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -820,3 +820,8 @@ body > .footer li a {
 .dashboard .d-flex.border-bottom.border-gray-light {
 	padding: 8px 0 !important;
 }
+
+/* Lighten deletions in markdown */
+.markdown-body del {
+	color: #6a737d;
+}

--- a/source/content.css
+++ b/source/content.css
@@ -821,7 +821,7 @@ body > .footer li a {
 	padding: 8px 0 !important;
 }
 
-/* Lighten deletions in markdown */
+/* Lighten deletions in Markdown */
 .markdown-body del {
 	color: #6a737d;
 }


### PR DESCRIPTION
I've had this in my Stylus stylesheet for a while now and think that it greatly improves readability of comments with deletions. Color is the same as quotes. Feel free to close if you don't like it.

Before | After
--- | ---
![Before](https://user-images.githubusercontent.com/4331946/34641719-bdc6b748-f308-11e7-9ac8-45f78d17ac9d.png) | ![After](https://user-images.githubusercontent.com/4331946/34641718-bbac42ca-f308-11e7-9843-112c4dd2acc4.png)
