### PR TITLE
Don't show names for GitHub apps

### DIFF
--- a/source/features/show-names.js
+++ b/source/features/show-names.js
@@ -35,7 +35,8 @@ export default async () => {
 
 	// {sindresorhus: [a.author, a.author], otheruser: [a.author]}
 	const selector = `.js-discussion .author:not(.refined-github-fullname)`;
-	const usersOnPage = groupBy(select.all(selector), el => el.textContent);
+	const usersOnPage = groupBy(select.all(selector)
+		.filter(el => !el.getAttribute('href').startsWith('/apps/')), el => el.textContent);
 
 	const fetchAndAdd = async username => {
 		if (typeof cache[username] === 'undefined' && username !== myUsername) {


### PR DESCRIPTION
Currently, Refined GitHub fetches the name of the user with the same username when it encounters a feed entry by a GitHub app bot.

#### Current behavior
![current behavior](https://user-images.githubusercontent.com/29176678/34644321-921c7840-f334-11e7-80b0-e46a427caef2.png)
*Refined GitHub displays the name of [the user `stale`](https://github.com/stale) although [`stale` is a GitHub app](https://github.com/apps/stale).*

#### Fixed behavior
![fixed behavior](https://user-images.githubusercontent.com/29176678/34644311-548274a8-f334-11e7-8952-f70d626ee81e.png)
*Refined GitHub no longer displays the name.*