### PR TITLE
Make package private

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,5 +109,6 @@
 			"at-rule-empty-line-before": null,
 			"selector-max-compound-selectors": null
 		}
-	}
+	},
+	"private": true
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"private": true,
 	"scripts": {
 		"lint": "xo && stylelint source/*.css",
 		"lint-fix": "xo --fix; stylelint --fix source/*.css",
@@ -109,6 +110,5 @@
 			"at-rule-empty-line-before": null,
 			"selector-max-compound-selectors": null
 		}
-	},
-	"private": true
+	}
 }


### PR DESCRIPTION
A little WhyNot™ fix that ...
- removes warnings when `npm install`-ing
  ![](https://user-images.githubusercontent.com/29176678/34644405-442e40d0-f336-11e7-8bb3-0ff063035b0d.png)
- uses `"private": true` for what it was made:
  packages that are not meant to be published to npm