### PR TITLE
Add more comment field shortcuts

### DIFF
--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -1,6 +1,5 @@
 import select from 'select-dom';
 import delegate from 'delegate';
-import {getUsername} from '../libs/utils';
 
 function indentInput(el) {
 	const selection = window.getSelection().toString();
@@ -63,7 +62,7 @@ export default function () {
 
 			if (lastOwnComment) {
 				select('.js-comment-edit-button', lastOwnComment).click();
-				
+
 				// Move caret to end of field
 				select('.js-comment-field', lastOwnComment).selectionStart = 1000000;
 			}

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -1,5 +1,6 @@
 import select from 'select-dom';
 import delegate from 'delegate';
+import {getUsername} from '../libs/utils';
 
 function indentInput(el) {
 	const selection = window.getSelection().toString();
@@ -49,10 +50,31 @@ export default function () {
 				event.preventDefault();
 			}
 		} else if (event.key === 'Escape') {
-			const cancelButton = select('.js-hide-inline-comment-form', field.form);
+			const inlineCancelButton = select('.js-hide-inline-comment-form', field.form);
 
-			if (field.value !== '' && cancelButton) {
-				cancelButton.click();
+			if (inlineCancelButton) {
+				if (field.value !== '') {
+					inlineCancelButton.click();
+				}
+			} else if (field.value === '') {
+				field.blur();
+			}
+		} else if (event.key === 'ArrowUp') {
+			if (field.id === 'new_comment_field' && field.value === '') {
+				const comments = select.all('.js-comment')
+					.filter(el => select('.author', el).textContent === getUsername());
+
+				if (comments.length > 0) {
+					const comment = comments[comments.length - 1];
+					const editButton = select('.js-comment-edit-button', comment);
+					editButton.click();
+
+					requestAnimationFrame(() => {
+						const commentField = select('.js-comment-field', comment);
+						const position = commentField.textContent.length;
+						commentField.setSelectionRange(position, position);
+					});
+				}
 			}
 		}
 	});

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -52,26 +52,23 @@ export default function () {
 		} else if (event.key === 'Escape') {
 			const inlineCancelButton = select('.js-hide-inline-comment-form', field.form);
 
-			if (inlineCancelButton) {
-				if (field.value !== '') {
-					inlineCancelButton.click();
-				}
-			} else if (field.value === '') {
+			// Cancel comment if inline, blur the field if it's a regular comment
+			if (field.value === '') {
 				field.blur();
+			} else if (inlineCancelButton) {
+				inlineCancelButton.click();
 			}
-		} else if (event.key === 'ArrowUp') {
-			if (field.id === 'new_comment_field' && field.value === '') {
-				const lastOwnComment = select.all(`.js-comment.current-user`).pop();
+		} else if (event.key === 'ArrowUp' && field.id === 'new_comment_field' && field.value === '') {
+			const lastOwnComment = select.all(`.js-comment.current-user`).pop();
 
-				if (lastOwnComment) {
-					select('.js-comment-edit-button', lastOwnComment).click();
+			if (lastOwnComment) {
+				select('.js-comment-edit-button', lastOwnComment).click();
 
-					requestAnimationFrame(() => {
-						const commentField = select('.js-comment-field', lastOwnComment);
-						const position = commentField.textContent.length;
-						commentField.setSelectionRange(position, position);
-					});
-				}
+				requestAnimationFrame(() => {
+					const commentField = select('.js-comment-field', lastOwnComment);
+					const position = commentField.textContent.length;
+					commentField.setSelectionRange(position, position);
+				});
 			}
 		}
 	});

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -61,16 +61,13 @@ export default function () {
 			}
 		} else if (event.key === 'ArrowUp') {
 			if (field.id === 'new_comment_field' && field.value === '') {
-				const comments = select.all('.js-comment')
-					.filter(el => select('.author', el).textContent === getUsername());
+				const lastOwnComment = select.all(`.js-comment.current-user`).pop();
 
-				if (comments.length > 0) {
-					const comment = comments[comments.length - 1];
-					const editButton = select('.js-comment-edit-button', comment);
-					editButton.click();
+				if (lastOwnComment) {
+					select('.js-comment-edit-button', lastOwnComment).click();
 
 					requestAnimationFrame(() => {
-						const commentField = select('.js-comment-field', comment);
+						const commentField = select('.js-comment-field', lastOwnComment);
 						const position = commentField.textContent.length;
 						commentField.setSelectionRange(position, position);
 					});

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -63,12 +63,9 @@ export default function () {
 
 			if (lastOwnComment) {
 				select('.js-comment-edit-button', lastOwnComment).click();
-
-				requestAnimationFrame(() => {
-					const commentField = select('.js-comment-field', lastOwnComment);
-					const position = commentField.textContent.length;
-					commentField.setSelectionRange(position, position);
-				});
+				
+				// Move caret to end of field
+				select('.js-comment-field', lastOwnComment).selectionStart = 1000000;
 			}
 		}
 	});

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -30,6 +30,21 @@ function indentInput(el) {
 	}
 }
 
+// Element.blur() will reset the tab focus to the start of the document.
+// This places it back next to the blurred field
+function blurAccessibly(field) {
+	field.blur();
+
+	const range = new Range();
+	const selection = getSelection();
+	const focusHolder = new Text();
+	field.after(focusHolder);
+	range.selectNodeContents(focusHolder);
+	selection.removeAllRanges();
+	selection.addRange(range);
+	focusHolder.remove();
+}
+
 export default function () {
 	delegate('.js-comment-field', 'keydown', event => {
 		const field = event.target;
@@ -53,7 +68,7 @@ export default function () {
 
 			// Cancel comment if inline, blur the field if it's a regular comment
 			if (field.value === '') {
-				field.blur();
+				blurAccessibly(field);
 			} else if (inlineCancelButton) {
 				inlineCancelButton.click();
 			}

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -79,7 +79,9 @@ export default function () {
 				select('.js-comment-edit-button', lastOwnComment).click();
 
 				// Move caret to end of field
-				select('.js-comment-field', lastOwnComment).selectionStart = 1000000;
+				requestAnimationFrame(() => {
+					select('.js-comment-field', lastOwnComment).selectionStart = Number.MAX_SAFE_INTEGER;
+				});
 			}
 		}
 	});


### PR DESCRIPTION
This pull request addresses two issues by adding new shortcuts to comment fields.

## <kbd>Esc</kbd> to blur comment field

When the user is inside an **empty** comment field and presses <kbd>Esc</kbd> the comment field will be unfocussed/"blurred".

*Closes #848*

## <kbd>Up</kbd> to edit last comment

When the user is inside the "Leave a comment" field at the bottom of issues and presses <kbd>Up</kbd> while the field is **empty**, Refined GitHub will `.click()` the edit button of the last comment by the user and put the caret at the end of the input field.

*Closes #858*