### PR TITLE
Make discussion sidebar sticky

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -55,6 +55,7 @@ import expandCollapseOutdatedComments from './features/expand-collapse-outdated-
 import addJumpToBottomLink from './features/add-jump-to-bottom-link';
 import addQuickReviewButtons from './features/add-quick-review-buttons';
 import sortIssuesByUpdateTime from './features/sort-issues-by-update-time';
+import makeDiscussionSidebarSticky from './features/make-discussion-sidebar-sticky';
 import shortenLinks from './features/shorten-links';
 
 import * as pageDetect from './libs/page-detect';
@@ -114,6 +115,7 @@ function onDomReady() {
 	enableFeature(markUnread);
 	enableFeature(enableCopyOnY);
 	enableFeature(addProfileHotkey);
+	enableFeature(makeDiscussionSidebarSticky);
 
 	if (!pageDetect.isGist()) {
 		enableFeature(moveMarketplaceLinkToProfileDropdown);

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -1,0 +1,23 @@
+import select from 'select-dom';
+import debounce from 'debounce-fn';
+import onAjaxedPages from 'github-injection';
+import {isSingleFile} from '../libs/page-detect';
+
+function updateStickiness() {
+	const sidebar = select('.discussion-sidebar');
+	const sidebarHeight = sidebar.offsetHeight + 25;
+	sidebar.style.position = sidebarHeight < window.innerHeight ? 'sticky' : null;
+}
+
+const handler = debounce(updateStickiness, {wait: 100});
+
+export default function () {
+	onAjaxedPages(() => {
+		if (isSingleFile()) {
+			updateStickiness();
+			window.addEventListener('resize', handler);
+		} else {
+			window.removeEventListener('resize', handler);
+		}
+	});
+}

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -1,7 +1,7 @@
 import select from 'select-dom';
 import debounce from 'debounce-fn';
 import onAjaxedPages from 'github-injection';
-import {isSingleFile} from '../libs/page-detect';
+import * as pageDetect from '../libs/page-detect';
 
 function updateStickiness() {
 	const sidebar = select('.discussion-sidebar');
@@ -13,7 +13,7 @@ const handler = debounce(updateStickiness, {wait: 100});
 
 export default function () {
 	onAjaxedPages(() => {
-		if (isSingleFile()) {
+		if (pageDetect.isIssue() || pageDetect.isPRConversation()) {
 			updateStickiness();
 			window.addEventListener('resize', handler);
 		} else {


### PR DESCRIPTION
Implements the functionality suggested by @bfred-it in #842.

> Perhaps it can just be done the old way: `if it fits, make it sticky` (repeat on resize)

*Closes #842*