### PR TITLE
Fix GitHub's own CSS bug in releases page

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -3,6 +3,11 @@
 	--github-red: #cb2431;
 }
 
+/* GitHub bug: releases page has unwanted bullet points */
+.release-timeline-tags {
+	list-style: none;
+}
+
 .subscribe-feed {
 	display: none !important;
 }


### PR DESCRIPTION
For example: https://github.com/sindresorhus/refined-github/releases

<img width="1101" alt="preview" src="https://user-images.githubusercontent.com/1402241/34658611-feb5cee6-f462-11e7-9f1c-92878c24303e.png">
