### PR TITLE
Avoid file header overlap when loading linked lines

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -667,6 +667,19 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	z-index: 10;
 }
 
+/* Momentarily offset the line so its #deeplink won’t be covered by the header */
+:target + .highlighted {
+	/* stylelint-disable time-min-milliseconds */
+	animation: sticky-file-header-target-fixer 0s 0.1ms backwards;
+}
+@keyframes sticky-file-header-target-fixer {
+	from {
+		transform: translateY(-78px); /* Matches GH’s regular line clicking position */
+		opacity: 0;
+	}
+}
+
+
 /* Remove annoying "helpful" banner on the issue tracker listing */
 .issues-listing .mb-4.js-notice {
 	display: none !important;


### PR DESCRIPTION
Magic fixes #919 