### PR TITLE
Avoid file header overlap when loading linked lines

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -667,7 +667,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	z-index: 10;
 }
 
-/* Momentarily offset the line so its #deeplink won’t be covered by the header */
+/* Momentarily offset the line so its #deeplink won’t be covered by the header #974 */
 :target + .highlighted {
 	/* stylelint-disable time-min-milliseconds */
 	animation: sticky-file-header-target-fixer 0s 0.1ms backwards;

--- a/source/content.css
+++ b/source/content.css
@@ -667,6 +667,19 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	z-index: 10;
 }
 
+/* Momentarily offset the line so its #deeplink won’t be covered by the header */
+:target + .highlighted {
+	/* stylelint-disable time-min-milliseconds */
+	animation: sticky-file-header-target-fixer 0s 0.1ms backwards;
+}
+@keyframes sticky-file-header-target-fixer {
+	from {
+		transform: translateY(-78px); /* Matches GH’s regular line clicking position */
+		opacity: 0;
+	}
+}
+
+
 /* Remove annoying "helpful" banner on the issue tracker listing */
 .issues-listing .mb-4.js-notice {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -683,7 +683,6 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	transform: translateY(-45px);
 }
 
-
 /* Remove annoying "helpful" banner on the issue tracker listing */
 .issues-listing .mb-4.js-notice {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -678,6 +678,10 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 		opacity: 0;
 	}
 }
+.file .markdown-body .anchor {
+	padding-top: 45px;
+	transform: translateY(-45px);
+}
 
 
 /* Remove annoying "helpful" banner on the issue tracker listing */


### PR DESCRIPTION
Magic fixes #919 

This has a couple side effects:
- code: occasionally causing a flicker when clicking the line numbers
- md: causing the "link" icon to be invisibly 45px taller (i.e. 45px above it are invisibly clickable)
  