### PR TITLE
Remove projects from sidebar & filters

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Removes annoying hover effect in the repo file browser
 - Hides unnecessary buttons from the comment box toolbar (each has a keyboard shortcut)
 - Removes obvious tooltips
-- Removes the "Projects" repo tab when there are no projects (New projects can be created on the "Settings" tab)
+- Removes the "Projects" when there are no projects from: repo tabs, filters on issues and Pull Request lists pages, sidebar items when viewing/creating a new issue/PR (New projects can be created on the "Settings" tab)
 
 ### UI improvements
 

--- a/source/content.js
+++ b/source/content.js
@@ -40,7 +40,7 @@ import preserveWhitespaceOptionInNav from './features/preserve-whitespace-option
 import addMilestoneNavigation from './features/add-milestone-navigation';
 import addFilterCommentsByYou from './features/add-filter-comments-by-you';
 import addProjectNewLink from './features/add-project-new-link';
-import removeProjectsTab from './features/remove-projects-tab';
+import removeProjects from './features/remove-projects';
 import fixSquashAndMergeTitle from './features/fix-squash-and-merge-title';
 import addTitleToEmojis from './features/add-title-to-emojis';
 import sortMilestonesByClosestDueDate from './features/sort-milestones-by-closest-due-date';
@@ -96,7 +96,7 @@ async function init() {
 			await safeElementReady('.pagehead + *');
 			enableFeature(addMoreDropdown);
 			enableFeature(addReleasesTab);
-			enableFeature(removeProjectsTab);
+			enableFeature(removeProjects);
 		});
 	}
 

--- a/source/features/remove-projects-tab.js
+++ b/source/features/remove-projects-tab.js
@@ -1,8 +1,0 @@
-import select from 'select-dom';
-
-export default function () {
-	const projectsTab = select('.js-repo-nav .reponav-item[data-selected-links^="repo_projects"]');
-	if (projectsTab && projectsTab.querySelector('.Counter, .counter').textContent === '0') {
-		projectsTab.remove();
-	}
-}

--- a/source/features/remove-projects.js
+++ b/source/features/remove-projects.js
@@ -12,20 +12,31 @@ function removeProjectsTab() {
 }
 
 function removeProjectsFilter() {
-	if (select.exists(projectsTabSelector)) {
-		return;
-	}
-
 	const filters = select.all('.issues-listing .table-list-filters .select-menu-button');
-	const [projectsFilter] = filters.filter(f => f.textContent.includes('Projects'));
+	const [projectsFilter] = filters.filter(filter => filter.textContent.includes('Projects'));
 
 	projectsFilter.remove();
+}
+
+function removeProjectsSidebarItem() {
+	const sidebarItems = select.all('.js-discussion-sidebar-item');
+	const [projectsSidebarItem] = sidebarItems.filter(item => select('.discussion-sidebar-heading', item).textContent.includes('Projects'));
+
+	projectsSidebarItem.remove();
 }
 
 export default function () {
 	removeProjectsTab();
 
+	if (select.exists(projectsTabSelector)) {
+		return;
+	}
+
 	if (pageDetect.isIssueList() || pageDetect.isPRList()) {
 		removeProjectsFilter();
+	}
+
+	if (pageDetect.isIssue() || pageDetect.isNewIssue() || pageDetect.isPRConversation() || pageDetect.isNewPR()) {
+		removeProjectsSidebarItem();
 	}
 }

--- a/source/features/remove-projects.js
+++ b/source/features/remove-projects.js
@@ -1,0 +1,31 @@
+import select from 'select-dom';
+import * as pageDetect from '../libs/page-detect';
+
+const projectsTabSelector = '.js-repo-nav .reponav-item[data-selected-links^="repo_projects"]';
+
+function removeProjectsTab() {
+	const projectsTab = select(projectsTabSelector);
+
+	if (projectsTab && projectsTab.querySelector('.Counter, .counter').textContent === '0') {
+		projectsTab.remove();
+	}
+}
+
+function removeProjectsFilter() {
+	if (select.exists(projectsTabSelector)) {
+		return;
+	}
+
+	const filters = select.all('.issues-listing .table-list-filters .select-menu-button');
+	const [projectsFilter] = filters.filter(f => f.textContent.includes('Projects'));
+
+	projectsFilter.remove();
+}
+
+export default function () {
+	removeProjectsTab();
+
+	if (pageDetect.isIssueList() || pageDetect.isPRList()) {
+		removeProjectsFilter();
+	}
+}

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -61,6 +61,8 @@ export const isMilestoneList = () => /^milestones\/?$/.test(getRepoPath());
 
 export const isNewIssue = () => /^issues\/new/.test(getRepoPath());
 
+export const isNewPR = () => /^compare\/.+$/.test(getRepoPath());
+
 export const isNotifications = () => /^([^/]+[/][^/]+\/)?notifications/.test(getCleanPathname());
 
 export const isPR = () => /^pull\/\d+/.test(getRepoPath());

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -232,6 +232,14 @@ test('isNewIssue', urlMatcherMacro, pageDetect.isNewIssue, [
 	'https://github.com/sindresorhus/refined-github/issues'
 ]);
 
+test('isNewPR', urlMatcherMacro, pageDetect.isNewPR, [
+	'https://github.com/sindresorhus/refined-github/compare/master...branch-name'
+], [
+	'http://github.com/sindresorhus/ava',
+	'https://github.com',
+	'https://github.com/sindresorhus/refined-github/issues'
+]);
+
 test('isNotifications', urlMatcherMacro, pageDetect.isNotifications, [
 	'https://github.com/notifications',
 	'https://github.com/notifications/participating',


### PR DESCRIPTION
Fixes #977.

**EDIT:**
- I found out we can also remove the ”Projects” filter from the issues/PRs list pages (it’s shown as a filter).
- I also found out you can select a project whenever opening a PR (in addition to ”Create a new issue” page)