### PR TITLE
Preserve Mark Unread button on ajax updates

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -462,7 +462,8 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* Mark as unread */
-.btn-mark-unread {
+.rgh-btn-mark-unread {
+	width: 100%;
 	margin-top: 8px;
 }
 

--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -29,11 +29,11 @@ function stripHash(url) {
 function addMarkUnreadButton() {
 	const container = select('.js-thread-subscription-status');
 	if (container) {
-		const button = <button class="btn btn-sm btn-mark-unread js-mark-unread">Mark as unread</button>;
+		const button = <button class="btn btn-sm rgh-btn-mark-unread">Mark as unread</button>;
 		button.addEventListener('click', markUnread, {
 			once: true
 		});
-		container.append(button);
+		container.after(button);
 	}
 }
 
@@ -385,7 +385,7 @@ function destroy() {
 		listener.destroy();
 	}
 	listeners.length = 0;
-	for (const button of select.all('.js-mark-unread')) {
+	for (const button of select.all('.rgh-btn-mark-unread')) {
 		button.remove();
 	}
 }


### PR DESCRIPTION
In PRs and Issues,  the button was placed in a ajaxed area, meaning that it would get removed by GitHub when new comments were loaded via ajax.

This moves it out but it doesn't change its visual position.

<img width="235" alt="screen shot 2018-01-14 at 21 23 19" src="https://user-images.githubusercontent.com/1402241/34916861-2ee6d50c-f971-11e7-9af6-b4abe5cfcc63.png">
