### PR TITLE
Allow tooltips for team mentions

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -70,6 +70,8 @@
 [aria-label*='reacted with']::after,
 .tooltipped[disabled]::before, /* Disabled buttons' tooltips might have useful information */
 .tooltipped[disabled]::after,
+.tooltipped.team-mention::before, /* Team mentions show all team members in the tooltip */
+.tooltipped.team-mention::after,
 .AvatarStack-body::before, /* Notification participants avatars */
 .AvatarStack-body::after,
 .js-zeroclipboard::before, /* Copy button feedback */


### PR DESCRIPTION
I always ping team members for a certain project, but sometimes I don't know what members are in a specific team (and if I have/want to ping other persons too), so I'd like to activate tooltips for team mentions.

![image](https://user-images.githubusercontent.com/495017/35047117-4cd1a054-fb99-11e7-8553-5cb59d2857dc.png)
