### PR TITLE
Fix 'Your Repository' link on GHE

### DIFF
--- a/source/features/add-your-repositories-link-to-profile-dropdown.js
+++ b/source/features/add-your-repositories-link-to-profile-dropdown.js
@@ -11,5 +11,5 @@ export default function () {
 	);
 
 	// GHE doesn't wrap links in <li> yet
-	position.after(position.tagName === 'LI' ? <li>{link}</li> : link)
+	position.after(position.tagName === 'LI' ? <li>{link}</li> : link);
 }

--- a/source/features/add-your-repositories-link-to-profile-dropdown.js
+++ b/source/features/add-your-repositories-link-to-profile-dropdown.js
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import {getUsername} from '../libs/utils';
 
 export default function () {
-	const position = select('.user-nav [aria-label~="profile"] + .dropdown-menu > :nth-child(3)');
+	const position = select('.user-nav .dropdown:last-child .dropdown-menu > :nth-child(3)');
 	const link = (
 		<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
 			Your repositories

--- a/source/features/add-your-repositories-link-to-profile-dropdown.js
+++ b/source/features/add-your-repositories-link-to-profile-dropdown.js
@@ -3,21 +3,13 @@ import select from 'select-dom';
 import {getUsername} from '../libs/utils';
 
 export default function () {
-	const ghMenuItem = select('.user-nav .dropdown-menu li:nth-child(3)');
-	if (ghMenuItem) {
-		ghMenuItem.after(
-			<li>
-				<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
-					Your repositories
-				</a>
-			</li>
-		);
-	} else {
-		// GHE does not have the li wrapper currently
-		select('.user-nav .dropdown-menu a:nth-child(3)').after(
-			<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
-				Your repositories
-			</a>
-		);
-	}
+	const position = select('.user-nav [aria-label~="profile"] + .dropdown-menu > :nth-child(3)');
+	const link = (
+		<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
+			Your repositories
+		</a>
+	);
+
+	// GHE doesn't wrap links in <li> yet
+	position.after(position.tagName === 'LI' ? <li>{link}</li> : link)
 }

--- a/source/features/add-your-repositories-link-to-profile-dropdown.js
+++ b/source/features/add-your-repositories-link-to-profile-dropdown.js
@@ -3,11 +3,21 @@ import select from 'select-dom';
 import {getUsername} from '../libs/utils';
 
 export default function () {
-	select('.user-nav .dropdown-menu li:nth-child(3)').after(
-		<li>
+	const ghMenuItem = select('.user-nav .dropdown-menu li:nth-child(3)');
+	if (ghMenuItem) {
+		ghMenuItem.after(
+			<li>
+				<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
+					Your repositories
+				</a>
+			</li>
+		);
+	} else {
+		// GHE does not have the li wrapper currently
+		select('.user-nav .dropdown-menu a:nth-child(3)').after(
 			<a class="dropdown-item" href={`/${getUsername()}?tab=repositories`}>
 				Your repositories
 			</a>
-		</li>
-	);
+		);
+	}
 }


### PR DESCRIPTION
Currently GHE does not have the wrapping `<li>` on the `<a>` resulting in a null returned from the current selector.
This solution is not super elegant, but will allow GHE to just work once it's updated to the same markup as GH is using.