### PR TITLE
Change cursor to pointer when hovering <details>

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -846,7 +846,7 @@ body > .footer li a {
 	color: #6a737d;
 }
 
-/* Make <detail> visibly clickable */
+/* Make <details> visibly clickable */
 .markdown-body summary, /* Summary elements are always clickable when present */
 .markdown-body details:not([open]) { /* Summary-less details have unselectable clickable elements */
 	cursor: pointer;

--- a/source/content.css
+++ b/source/content.css
@@ -845,3 +845,9 @@ body > .footer li a {
 .markdown-body del {
 	color: #6a737d;
 }
+
+/* Make <detail> visibly clickable */
+.markdown-body summary, /* Summary elements are always clickable when present */
+.markdown-body details:not([open]) { /* Summary-less details have unselectable clickable elements */
+	cursor: pointer;
+}


### PR DESCRIPTION
It's a no-brainer. Browsers decided that `<details>` don't trigger `cursor: pointer` for whatever reason.

![df](https://user-images.githubusercontent.com/1402241/35091114-48d6c5b2-fc6e-11e7-82e8-6c4ed5dde1d0.gif)
