### PR TITLE
Fix issue where URLs in commented diffs aren't linkified

### DIFF
--- a/source/features/linkify-urls-in-code.js
+++ b/source/features/linkify-urls-in-code.js
@@ -34,7 +34,9 @@ export const editTextNodes = (fn, el) => {
 };
 
 export default () => {
-	const wrappers = select.all(`.highlight:not(.${linkifiedURLClass})`);
+	const wrappers = select.all(
+		`.highlight:not(.${linkifiedURLClass}), table[id^="discussion-diff"]:not(.${linkifiedURLClass})`
+	);
 
 	// Don't linkify any already linkified code
 	if (wrappers.length === 0) {

--- a/source/features/linkify-urls-in-code.js
+++ b/source/features/linkify-urls-in-code.js
@@ -34,9 +34,7 @@ export const editTextNodes = (fn, el) => {
 };
 
 export default () => {
-	const wrappers = select.all(
-		`.highlight:not(.${linkifiedURLClass}), table[id^="discussion-diff"]:not(.${linkifiedURLClass})`
-	);
+	const wrappers = select.all(`.blob-wrapper:not(.${linkifiedURLClass})`);
 
 	// Don't linkify any already linkified code
 	if (wrappers.length === 0) {


### PR DESCRIPTION
Fixes #999.

Just updated a CSS selector to match diff tables inside discussions.

Test on [saglacio/saglac.io#143 (commit-diff)](https://github.com/saglacio/saglac.io/pull/143/files/e92bf806d0a0757da2b16623172fa3041e65db36#diff-aeb42283af8ef8e9da40ededd3ae2ab2), and https://github.com/saglacio/saglac.io/pull/143#pullrequestreview-76120305