### PR TITLE
Fix empty options while destructuring

### DIFF
--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -13,7 +13,7 @@ const options = new OptionsSync().getAll();
  * https://github.com/sindresorhus/refined-github/issues/678
  */
 export const enableFeature = async (fn, filename) => {
-	const {disabledFeatures, logging} = await options;
+	const {disabledFeatures = [], logging = false} = await options;
 	const log = logging ? console.log : () => {};
 
 	filename = filename || fn.name.replace(/_/g, '-');

--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -13,7 +13,7 @@ const options = new OptionsSync().getAll();
  * https://github.com/sindresorhus/refined-github/issues/678
  */
 export const enableFeature = async (fn, filename) => {
-	const {disabledFeatures = [], logging = false} = await options;
+	const {disabledFeatures = '', logging = false} = await options;
 	const log = logging ? console.log : () => {};
 
 	filename = filename || fn.name.replace(/_/g, '-');


### PR DESCRIPTION
Quick fix for #1010 using default values while destructuring.

Can someone think of a better way of retreving options from browser storage `¯\_(ツ)_/¯`?

/cc @sindresorhus @bfred-it @hkdobrev @busches