### PR TITLE
Use utc-version to generate manifest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"release:cws": "cd distribution && webstore upload --auto-publish",
 		"release": "run-s build:minified update-version save-url release:*",
 		"save-url": "echo https://github.com/$TRAVIS_REPO_SLUG/tree/$TRAVIS_COMMIT > distribution/SOURCE_URL",
-		"update-version": "VERSION=$(date -u +%y.%-m.%-d.%-H%M); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
+		"update-version": "VERSION=$(utc-version); echo $VERSION; dot-json distribution/manifest.json version $VERSION",
 		"can-release": "if [ \"$TRAVIS_EVENT_TYPE\" = cron ] && [ $(git rev-list -n 1 --since=\"26 hours ago\" master) ]; then echo :ship-it:; else false; fi"
 	},
 	"dependencies": {
@@ -50,6 +50,7 @@
 		"stylelint": "^8.3.1",
 		"stylelint-config-xo": "^0.4.0",
 		"uglifyjs-webpack-plugin": "^1.1.2",
+		"utc-version": "^1.0.0",
 		"webext": "^1.9.1-with-submit.1",
 		"webpack": "^3.7.1",
 		"xo": "*"


### PR DESCRIPTION
Not sure if this is wanted, but I made a package to generate the versions using the same scheme that you are using and I'd thought I'd share.

There is a subtle difference which I _think_ is a bug/unintended in the current approach. The `date` command will generate versions were the last part will have leading zeros between 00.00 and 00.59, my package will not.

e.g.

```sh
$ date -u +%y.%-m.%-d.%-H%M
18.1.22.001

$ utc-version
18.1.22.1
```

This will also work on Windows, I'm not sure that `date` does...

Cheers 👋 