### PR TITLE
Avoid file header overlap when loading linked *multiple* lines

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -681,7 +681,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 }
 
 /* Momentarily offset the line so its #deeplink won’t be covered by the header #974 */
-:target + .highlighted {
+.js-file-line.highlighted {
 	/* stylelint-disable time-min-milliseconds */
 	animation: sticky-file-header-target-fixer 0s 0.1ms backwards;
 }


### PR DESCRIPTION
Fixes #1027 