### PR TITLE
Correctly group buttons in Mark as Unread feature

### DIFF
--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -293,18 +293,16 @@ function addCustomAllReadBtn() {
 		return;
 	}
 
-	select('#notification-center .tabnav-tabs').append(
-		<div class="float-right">
-			<a href="#mark_as_read_confirm_box" class="btn btn-sm" rel="facebox">Mark all as read</a>
+	select('.tabnav .float-right').append(
+		<a href="#mark_as_read_confirm_box" class="btn btn-sm" rel="facebox">Mark all as read</a>,
 
-			<div id="mark_as_read_confirm_box" style={{display: 'none'}}>
-				<h2 class="facebox-header" data-facebox-id="facebox-header">Are you sure?</h2>
+		<div id="mark_as_read_confirm_box" style={{display: 'none'}}>
+			<h2 class="facebox-header" data-facebox-id="facebox-header">Are you sure?</h2>
 
-				<p data-facebox-id="facebox-description">Are you sure you want to mark all unread notifications as read?</p>
+			<p data-facebox-id="facebox-description">Are you sure you want to mark all unread notifications as read?</p>
 
-				<div class="full-button">
-					<button id="clear-local-notification" class="btn btn-block">Mark all notifications as read</button>
-				</div>
+			<div class="full-button">
+				<button id="clear-local-notification" class="btn btn-block">Mark all notifications as read</button>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Fixes #1033

# Before

<img width="312" alt="before" src="https://user-images.githubusercontent.com/1402241/35384889-4c184594-01f9-11e8-8f3d-dae0e179ed22.png">

# After

<img width="329" alt="" src="https://user-images.githubusercontent.com/1402241/35384817-19c1eb5e-01f9-11e8-9ca3-c124e19297a5.png">
