### PR TITLE
Enable toggleAllThingsWithAlt on all commits

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ GitHub Enterprise is also supported. More info in the options.
 ### Added features
 
 - [Lets you wait for a build before automatically merging a PR](https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif)
-- Toggle all [outdated PR comments](https://user-images.githubusercontent.com/25818354/33240033-3e271588-d2af-11e7-93af-13b6e325f65d.gif) or [PR files](https://user-images.githubusercontent.com/1402241/35192652-6f79dc42-fec9-11e7-89ad-2b4a9c5f4f52.gif) with <kbd>Alt</kbd>+click
+- Toggle all [outdated PR comments](https://user-images.githubusercontent.com/25818354/33240033-3e271588-d2af-11e7-93af-13b6e325f65d.gif) or [PR/Commit files](https://user-images.githubusercontent.com/1402241/35192652-6f79dc42-fec9-11e7-89ad-2b4a9c5f4f52.gif) with <kbd>Alt</kbd>+click
 - Copy canonical link to file when [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) is used
 - Supports indenting with the tab key in textareas like the comment box (<kbd>Shift</kbd> <kbd>Tab</kbd> for original behavior)
 - [Uses the pull request title as commit title when merging with 'Squash and merge'](https://github.com/sindresorhus/refined-github/issues/276)

--- a/source/content.js
+++ b/source/content.js
@@ -215,6 +215,11 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isCommit()) {
 		enableFeature(addPatchDiffLinks);
+		enableFeature(toggleAllThingsWithAlt);
+	}
+
+	if (pageDetect.isCompare()) {
+		enableFeature(toggleAllThingsWithAlt);
 	}
 
 	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit() || pageDetect.isDiscussion()) {

--- a/source/features/toggle-all-things-with-alt.js
+++ b/source/features/toggle-all-things-with-alt.js
@@ -56,6 +56,6 @@ function handleClick(event) {
 }
 
 export default function () {
-	delegate('.issues-listing', '.js-details-target', 'click', handleClick);
+	delegate('.repository-content', '.js-details-target', 'click', handleClick);
 	addTooltips();
 }


### PR DESCRIPTION
This feature was only working on PR pages (files changed tab or pr commit), but not when opening a specific commit outside a PR.