### PR TITLE
Fix dropdowns backdrop z-index issues

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -721,8 +721,11 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	background: rgba(0, 0, 0, 0.1);
 	animation: fade-in 0.2s;
 }
+summary.HeaderNavlink::before {
+	z-index: 30 !important; /* Bring the header backdrop above the PR bar */
+}
 :root .pagehead ul.pagehead-actions {
-	position: static; /* Demote watch/star/fork */
+	position: static; /* Watch, star, and fork buttons don‘t need a stacking context */
 }
 
 /* Reduce duplicate backdrop in PR diff view */
@@ -885,15 +888,4 @@ body > .footer li a {
 .markdown-body summary, /* Summary elements are always clickable when present */
 .markdown-body details:not([open]) { /* Summary-less details have unselectable clickable elements */
 	cursor: pointer;
-}
-
-/* Backdrop from header dropdown should be above all main body content */
-.Header,
-.application-main {
-	position: relative;
-	z-index: 1;
-}
-
-:root .Header {
-	z-index: 2;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -894,6 +894,6 @@ body > .footer li a {
 	z-index: 1;
 }
 
-.Header {
+:root .Header {
 	z-index: 2;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -886,3 +886,14 @@ body > .footer li a {
 .markdown-body details:not([open]) { /* Summary-less details have unselectable clickable elements */
 	cursor: pointer;
 }
+
+/* Backdrop from header dropdown should be above all main body content*/	
+.Header,
+.application-main {
+	z-index: 1;
+	position: relative;
+}
+
+.Header {
+	z-index: 2; 
+}

--- a/source/content.css
+++ b/source/content.css
@@ -887,13 +887,13 @@ body > .footer li a {
 	cursor: pointer;
 }
 
-/* Backdrop from header dropdown should be above all main body content*/	
+/* Backdrop from header dropdown should be above all main body content */
 .Header,
 .application-main {
-	z-index: 1;
 	position: relative;
+	z-index: 1;
 }
 
 .Header {
-	z-index: 2; 
+	z-index: 2;
 }


### PR DESCRIPTION
Set the header z-index above the main body content so that the drop-down backdrop on the header will be displayed above the body content.

fixes #994
fixes #1038