### PR TITLE
Show more info on dashboard without hover

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -856,18 +856,11 @@ body > .footer li a {
 .dashboard .flex-items-baseline .f3 {
 	display: none;
 }
-/* Show details on hover */
+
 .dashboard .flex-items-baseline .f6.mt-2 {
-	overflow: hidden;
-	height: 0;
-	opacity: 0;
-	transition: height 0.1s, opacity 0.2s;
+	opacity: 0.5;
 }
-.dashboard .flex-items-baseline:hover .f6.mt-2 {
-	height: 1.4em;
-	opacity: 1;
-}
-.dashboard .flex-items-baseline:not(:hover) .border {
+.dashboard .flex-items-baseline .border {
 	color: var(--github-gray-text) !important;
 }
 .dashboard .flex-items-baseline .border {

--- a/source/content.css
+++ b/source/content.css
@@ -842,22 +842,23 @@ body > .footer li a {
 	width: 430px;
 }
 
-/* Hide dashboard activity cards, unless hovered */
-.dashboard .flex-items-baseline .border.rounded-1 {
-	max-width: 480px;
-	margin-top: 30px !important;
-	position: absolute;
-	background: #fff;
-	box-shadow: 0 3px 12px rgba(27, 31, 35, 0.15); /* Style by GitHub */
-	transition: opacity 0.2s 0.2s;
-	pointer-events: none;
+/* Reduce dashboard activity cards */
+.dashboard .py-3 .avatar {
+	margin-top: 7px; /* Align between event and repo description */
 }
-.dashboard .flex-items-baseline:not(:hover) .border.rounded-1 {
-	opacity: 0;
-	transition-delay: 0s;
-}
-.dashboard .flex-items-baseline .f3 {
+.dashboard .py-3:not(:hover) .f6.mt-2, /* Show details on hover */
+.dashboard .py-3 .f3 { /* Hide duplicate repo name */
 	display: none;
+}
+:root .dashboard .flex-items-baseline {
+	align-items: flex-start !important;
+}
+:root .dashboard .flex-items-baseline .border.rounded-1 {
+	padding: 0 !important;
+	border: 0 !important;
+	margin: 0 !important;
+	position: static;
+	opacity: 1;
 }
 
 /* Make activities narrower */

--- a/source/content.css
+++ b/source/content.css
@@ -2,6 +2,7 @@
 	--github-green: #28a745;
 	--github-red: #cb2431;
 	--github-gray-background: #fafbfc;
+	--github-gray-text: #6a737d;
 }
 
 /* GitHub bug: releases page has unwanted bullet points */
@@ -843,22 +844,23 @@ body > .footer li a {
 }
 
 /* Reduce dashboard activity cards */
+.dashboard .py-3 {
+	align-items: flex-start !important;
+}
 .dashboard .py-3 .avatar {
 	margin-top: 7px; /* Align between event and repo description */
 }
-.dashboard .py-3:not(:hover) .f6.mt-2, /* Show details on hover */
-.dashboard .py-3 .f3 { /* Hide duplicate repo name */
+.dashboard .py-3 .f3, /* Hide duplicate repo name */
+.dashboard .py-3:not(:hover) .f6.mt-2 { /* Show details on hover */
 	display: none;
 }
-:root .dashboard .flex-items-baseline {
-	align-items: flex-start !important;
+.dashboard .py-3:not(:hover) .border {
+	color: var(--github-gray-text) !important;
 }
-:root .dashboard .flex-items-baseline .border.rounded-1 {
+.dashboard .py-3 .border {
 	padding: 0 !important;
 	border: 0 !important;
 	margin: 0 !important;
-	position: static;
-	opacity: 1;
 }
 
 /* Make activities narrower */

--- a/source/content.css
+++ b/source/content.css
@@ -848,12 +848,24 @@ body > .footer li a {
 .dashboard .flex-items-baseline {
 	align-items: flex-start !important;
 }
+/* Align between event and repo description */
 .dashboard .flex-items-baseline .avatar {
-	margin-top: 7px; /* Align between event and repo description */
+	margin-top: 7px;
 }
-.dashboard .flex-items-baseline .f3, /* Hide duplicate repo name */
-.dashboard .flex-items-baseline:not(:hover) .f6.mt-2 { /* Show details on hover */
+/* Hide duplicate repo name */
+.dashboard .flex-items-baseline .f3 {
 	display: none;
+}
+/* Show details on hover */
+.dashboard .flex-items-baseline .f6.mt-2 {
+	overflow: hidden;
+	height: 0;
+	opacity: 0;
+	transition: height 0.1s, opacity 0.2s;
+}
+.dashboard .flex-items-baseline:hover .f6.mt-2 {
+	height: 1.4em;
+	opacity: 1;
 }
 .dashboard .flex-items-baseline:not(:hover) .border {
 	color: var(--github-gray-text) !important;

--- a/source/content.css
+++ b/source/content.css
@@ -844,20 +844,21 @@ body > .footer li a {
 }
 
 /* Reduce dashboard activity cards */
-.dashboard .py-3 {
+/* `.flex-items-baseline` excludes label events */
+.dashboard .flex-items-baseline {
 	align-items: flex-start !important;
 }
-.dashboard .py-3 .avatar {
+.dashboard .flex-items-baseline .avatar {
 	margin-top: 7px; /* Align between event and repo description */
 }
-.dashboard .py-3 .f3, /* Hide duplicate repo name */
-.dashboard .py-3:not(:hover) .f6.mt-2 { /* Show details on hover */
+.dashboard .flex-items-baseline .f3, /* Hide duplicate repo name */
+.dashboard .flex-items-baseline:not(:hover) .f6.mt-2 { /* Show details on hover */
 	display: none;
 }
-.dashboard .py-3:not(:hover) .border {
+.dashboard .flex-items-baseline:not(:hover) .border {
 	color: var(--github-gray-text) !important;
 }
-.dashboard .py-3 .border {
+.dashboard .flex-items-baseline .border {
 	padding: 0 !important;
 	border: 0 !important;
 	margin: 0 !important;

--- a/source/content.css
+++ b/source/content.css
@@ -849,7 +849,7 @@ body > .footer li a {
 	align-items: flex-start !important;
 }
 /* Align between event and repo description */
-.dashboard .flex-items-baseline .avatar {
+.dashboard .py-3 .avatar {
 	margin-top: 7px;
 }
 /* Hide duplicate repo name */

--- a/source/content.css
+++ b/source/content.css
@@ -861,12 +861,10 @@ body > .footer li a {
 	opacity: 0.5;
 }
 .dashboard .flex-items-baseline .border {
-	color: var(--github-gray-text) !important;
-}
-.dashboard .flex-items-baseline .border {
 	padding: 0 !important;
 	border: 0 !important;
 	margin: 0 !important;
+	color: var(--github-gray-text) !important;
 }
 
 /* Make activities narrower */


### PR DESCRIPTION
Something like #922, but without deduplication (that'd require JS)

I personally found the hover card to be more annoying than useful so this might be a compromise between showing large cards for all and showing some info unobtrusively.

![demo](https://user-images.githubusercontent.com/1402241/35480568-65d5cdde-0443-11e8-91e8-909155201823.gif)

