### PR TITLE
Hide download folder button on repo root

### DIFF
--- a/source/features/add-download-folder-button.js
+++ b/source/features/add-download-folder-button.js
@@ -3,7 +3,8 @@ import select from 'select-dom';
 import * as pageDetect from '../libs/page-detect';
 
 export default () => {
-	if (pageDetect.isRepoTree()) {
+	// Add to folder listings, excluding the repo root (that already has an official download ZIP button)
+	if (pageDetect.isRepoTree() && !pageDetect.isRepoRoot()) {
 		const buttonGroup = select(`.file-navigation .BtnGroup.float-right`);
 		if (buttonGroup && !select.exists('.rgh-download-folder')) {
 			buttonGroup.prepend(

--- a/source/features/remove-upload-files-button.js
+++ b/source/features/remove-upload-files-button.js
@@ -4,7 +4,7 @@ import * as pageDetect from '../libs/page-detect';
 const repoUrl = pageDetect.getRepoURL();
 
 export default () => {
-	if (pageDetect.isRepoRoot() || pageDetect.isRepoTree()) {
+	if (pageDetect.isRepoTree()) {
 		const uploadFilesButton = select(`.file-navigation a[href^="/${repoUrl}/upload"]`);
 		if (uploadFilesButton) {
 			uploadFilesButton.remove();

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -89,7 +89,7 @@ export const isRepoRoot = () => /^(tree[/][^/]+)?$/.test(getRepoPath());
 
 export const isRepoSettings = () => /^settings/.test(getRepoPath());
 
-export const isRepoTree = () => /^tree\//.test(getRepoPath());
+export const isRepoTree = () => isRepoRoot() || /^tree\//.test(getRepoPath());
 
 export const isSingleCommit = () => /^commit\/[0-9a-f]{5,40}/.test(getRepoPath());
 

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -354,13 +354,14 @@ test('isRepoSettings', urlMatcherMacro, pageDetect.isRepoSettings, [
 ]);
 
 test('isRepoTree', urlMatcherMacro, pageDetect.isRepoTree, [
+	'https://github.com/sindresorhus/refined-github',
 	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
 	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution',
 	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution',
 	'https://github.com/sindresorhus/refined-github/tree/57bf4'
 ], [
 	'https://github.com/sindresorhus/refined-github/issues',
-	'https://github.com/sindresorhus/refined-github'
+	'https://github.com/sindresorhus/refined-github/blob/tree/master/distribution'
 ]);
 
 test('isSingleCommit', urlMatcherMacro, pageDetect.isSingleCommit, [


### PR DESCRIPTION
The repo root already has an official Download ZIP button.

`isRepoTree` initially excluded the main repo page, but still included the root non-default branches, like: https://github.com/webpack/webpack/tree/TheLarkInn-patch-1

Also it changes the `isRepoTree` test.