### PR TITLE
add badge to linked issues

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Adds labels to comments by the original poster](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
 - [Adds build status and link to CI by the repo's title](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Color-codes and counts reviews in PRs list](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
+- Shows Issue or Pull Request status next to linked Issues or Pull Requests
 
 ### Declutter
 

--- a/source/content.js
+++ b/source/content.js
@@ -64,6 +64,7 @@ import waitForBuild from './features/wait-for-build';
 import addDownloadFolderButton from './features/add-download-folder-button';
 import hideUselessNewsfeedEvents from './features/hide-useless-newsfeed-events';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
+import addBadgeToLinkedIssues from './features/add-badge-to-linked-issues';
 
 import * as pageDetect from './libs/page-detect';
 import {observeEl, safeElementReady, enableFeature} from './libs/utils';
@@ -153,6 +154,7 @@ function ajaxedPagesHandler() {
 	enableFeature(hideEmptyMeta);
 	enableFeature(removeUploadFilesButton);
 	enableFeature(addTitleToEmojis);
+	enableFeature(addBadgeToLinkedIssues);
 	enableFeature(sortIssuesByUpdateTime);
 	enableFeature(shortenLinks);
 	enableFeature(linkifyCode);
@@ -218,6 +220,10 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRList() || pageDetect.isIssueList() || pageDetect.isPR() || pageDetect.isIssue()) {
 		enableFeature(showRecentlyPushedBranches);
+	}
+
+	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isMilestone()) {
+		enableFeature(addBadgeToLinkedIssues);
 	}
 
 	if (pageDetect.isCommit()) {

--- a/source/features/add-badge-to-linked-issues.js
+++ b/source/features/add-badge-to-linked-issues.js
@@ -1,0 +1,37 @@
+import select from 'select-dom';
+import domify from '../libs/domify';
+
+async function fetchStatus(url) {
+	const response = await fetch(url, {
+		credentials: 'include'
+	});
+	const dom = domify(await response.text());
+	const badge = select('.TableObject-item > .State', dom);
+
+	// Style the badge so it is smaller (like in the timeline)
+	badge.classList.add('rgh-issue-badge');
+	badge.classList.add('State--small'); // Make the badge smaller
+	badge.classList.add('ml-1'); // Add margin left
+	badge.classList.add('mr-1'); // Add margin right
+	// Shrink the icon by 2px so it matches the little ones that show up in the timeline
+	const svg = select('svg', badge);
+	svg.setAttribute('width', svg.getAttribute('width') - 2);
+	svg.setAttribute('height', svg.getAttribute('height') - 2);
+	// // Move the text into an Aria label
+	// badge.setAttribute('aria-label', badge.lastChild.textContent);
+	// badge.removeChild(badge.lastChild);
+
+	return badge;
+}
+
+export default function () {
+	for (const issueLink of select.all('.markdown-body a.issue-link')) {
+		// Fetch as a Promise instead of async so multiple badges can load
+		if (!issueLink.classList.contains('rgh-has-badge')) {
+			issueLink.classList.add('rgh-has-badge');
+			fetchStatus(issueLink.getAttribute('href')).then(badge => {
+				issueLink.parentElement.insertBefore(badge, issueLink);
+			});
+		}
+	}
+}


### PR DESCRIPTION
Thanks for this great browser extension!

This adds a badge next to any linked Issue or Pull Request that shows the current status. 

The information shown is similar to the timeline view except it is the inverse. The timeline view shows the status of Issues/Pull Requests that refer to this Issue/Pull Request while this shows the status of Issues/Pull Requests that this refers to.

It helps answer questions like "Has the Pull Request that this depends on been merged yet?" or "Which of the Issues for this release still need to be resolved?"

# Screenshots

Here are some examples of the badges:

![image](https://user-images.githubusercontent.com/253202/35666423-054c1e5c-06f8-11e8-9270-adab6e0b76e2.png)

![image](https://user-images.githubusercontent.com/253202/35666436-1932f4ae-06f8-11e8-97f0-0012080d1f82.png)

![image](https://user-images.githubusercontent.com/253202/35666448-21a5c18e-06f8-11e8-9d42-bb6f6145a1c5.png)
