### PR TITLE
Re-add missing RGH buttons when issue page updates

### DIFF
--- a/source/features/add-jump-to-bottom-link.js
+++ b/source/features/add-jump-to-bottom-link.js
@@ -1,7 +1,8 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
+import observeEl from '../libs/simplified-element-observer';
 
-export default function () {
+function add() {
 	const meta = select('.gh-header-meta > .TableObject-item--primary');
 	const jumpToBottomLink = select('#refined-github-jump-to-bottom-link');
 	if (!meta || jumpToBottomLink) {
@@ -12,4 +13,9 @@ export default function () {
 		' · ',
 		<a href="#partial-timeline-marker" id="refined-github-jump-to-bottom-link">Jump to bottom</a>
 	);
+}
+
+export default function () {
+	// The issue header changes when new comments are added or the issue status changes
+	observeEl('.js-issues-results', add);
 }

--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import delegate from 'delegate';
 import gitHubInjection from 'github-injection';
 import SynchronousStorage from '../libs/synchronous-storage';
+import observeEl from '../libs/simplified-element-observer';
 import * as icons from '../libs/icons';
 import * as pageDetect from '../libs/page-detect';
 import {getUsername, enableFeature} from '../libs/utils';
@@ -371,7 +372,9 @@ export default async function () {
 			enableFeature(addOpenAllNotificationsButton);
 		} else if (pageDetect.isPR() || pageDetect.isIssue()) {
 			markRead(location.href);
-			addMarkUnreadButton();
+
+			// The sidebar changes when new comments are added or the issue status changes
+			observeEl('.discussion-sidebar', addMarkUnreadButton);
 		}
 
 		updateUnreadIndicator();


### PR DESCRIPTION
Fixes #987

Fixes https://github.com/sindresorhus/refined-github/issues/987#issuecomment-359037251

Test:

1. Visit an issue or PR
2. Leave a comment, close the issue/PR, or wait for others' comments to flow in
3. "Jump to bottom" link and "mark as unread" button disappear from header and sidebar