### PR TITLE
Show issue resolution in header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Adds labels to comments by the original poster](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
 - [Adds build status and link to CI by the repo's title](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Color-codes and counts reviews in PRs list](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
+- [Show issue resolution in header (was it closed by a PR?)](https://user-images.githubusercontent.com/1402241/35973522-5c00acb6-0d08-11e8-89ca-03071de15c6f.png)
 
 ### Declutter
 

--- a/source/content.css
+++ b/source/content.css
@@ -656,6 +656,14 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	display: none;
 }
 
+/* Colorize `extend-issue-status-label` */
+.gh-header-meta .State {
+	text-decoration: none;
+}
+.gh-header-meta .State a {
+	color: #fff;
+}
+
 /* For `add-ci-link` */
 .rgh-ci-link {
 	position: relative;

--- a/source/content.js
+++ b/source/content.js
@@ -53,6 +53,7 @@ import addKeyboardShortcutsToCommentFields from './features/add-keyboard-shortcu
 import addConfirmationToCommentCancellation from './features/add-confirmation-to-comment-cancellation';
 import addCILink from './features/add-ci-link';
 import embedGistInline from './features/embed-gist-inline';
+import extendIssueStatusLabel from './features/extend-issue-status-label';
 import toggleAllThingsWithAlt from './features/toggle-all-things-with-alt';
 import addJumpToBottomLink from './features/add-jump-to-bottom-link';
 import addQuickReviewButtons from './features/add-quick-review-buttons';
@@ -198,6 +199,7 @@ function ajaxedPagesHandler() {
 		enableFeature(linkifyIssuesInTitles);
 		enableFeature(addUploadBtn);
 		enableFeature(embedGistInline);
+		enableFeature(extendIssueStatusLabel);
 
 		observeEl('.new-discussion-timeline', () => {
 			enableFeature(addOPLabels);

--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -1,0 +1,35 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import {wrap} from '../libs/utils';
+
+export default function () {
+	const lastAction = select.all(`
+		.discussion-item-closed,
+		.discussion-item-reopened
+	`).pop();
+
+	if (!lastAction) {
+		return;
+	}
+
+	let refEl = select(`
+		[href*="/pull/"],
+		[href*="/issues/"],
+		[href*="/commit/"]
+	`, lastAction);
+
+	if (!refEl) {
+		return;
+	}
+
+	// Commits are wrapped in `<code>`
+	refEl = refEl.closest('code') || refEl;
+
+	// Add extra info
+	const label = select('.gh-header-meta .State');
+	label.append(' in ', refEl.cloneNode(true));
+
+	// Link label to event in timeline
+	const fragment = select('.discussion-item-header[id]', lastAction).id;
+	wrap(label, <a href={'#' + fragment}></a>);
+}

--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -9,8 +9,8 @@ export default function () {
 		.discussion-item-reopended
 	`).pop();
 
-	// Leave if it was never closed or if it was reopened
-	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopended')) {
+	// Leave if it was never closed or if it was reopened or if it’s already linked
+	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopended') || select.exists('.gh-header-meta .State a')) {
 		return;
 	}
 

--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -14,7 +14,6 @@ export default function () {
 
 	let refEl = select(`
 		[href*="/pull/"],
-		[href*="/issues/"],
 		[href*="/commit/"]
 	`, lastAction);
 

--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -12,17 +12,15 @@ export default function () {
 		return;
 	}
 
-	let refEl = select(`
+	// Get PR or commits reference
+	const refEl = select(`
 		[href*="/pull/"],
-		[href*="/commit/"]
+		code
 	`, lastAction);
 
 	if (!refEl) {
 		return;
 	}
-
-	// Commits are wrapped in `<code>`
-	refEl = refEl.closest('code') || refEl;
 
 	// Add extra info
 	const label = select('.gh-header-meta .State');

--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -3,30 +3,21 @@ import select from 'select-dom';
 import {wrap} from '../libs/utils';
 
 export default function () {
-	const lastAction = select.all(`
-		.discussion-item-closed,
-		.discussion-item-reopened
+	const lastActionRef = select.all(`
+		.discussion-item-closed [href*="/pull/"],
+		.discussion-item-closed code,
+		.discussion-item-reopended
 	`).pop();
 
-	if (!lastAction) {
-		return;
-	}
-
-	// Get PR or commits reference
-	const refEl = select(`
-		[href*="/pull/"],
-		code
-	`, lastAction);
-
-	if (!refEl) {
+	// Leave if it was never closed or if it was reopened
+	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopended')) {
 		return;
 	}
 
 	// Add extra info
 	const label = select('.gh-header-meta .State');
-	label.append(' in ', refEl.cloneNode(true));
+	label.append(' in ', lastActionRef.cloneNode(true));
 
 	// Link label to event in timeline
-	const fragment = select('.discussion-item-header[id]', lastAction).id;
-	wrap(label, <a href={'#' + fragment}></a>);
+	wrap(label, <a href={'#' + lastActionRef.closest('[id]').id}></a>);
 }


### PR DESCRIPTION
## Features

- adds reference to PR/commit that closed the current issue/PR
- clicking the label will scroll to the event
- clicking the reference will visit it

## Notes

- I ended up leaving it red (@hkdobrev will love this) because this can also appear on RED PRs that are closed by _other_ merged PRs
- Sadly this has to wait for the whole discussion to load, which might be a few seconds later on long discussions.

## Screenshots

<img width="158" alt="pr by commit" src="https://user-images.githubusercontent.com/1402241/35973265-5b27b68c-0d07-11e8-99fd-98ce03752ecb.png">

<img width="150" alt="by pr" src="https://user-images.githubusercontent.com/1402241/35973268-5b99f512-0d07-11e8-87ee-98841fa321c6.png">

<img width="164" alt="by commit" src="https://user-images.githubusercontent.com/1402241/35973270-5bfaef34-0d07-11e8-9c9c-0e89903f0cc6.png">

## Example issues

https://github.com/bfred-it/github-issue-link-status/issues/2 (closed by commit)
https://github.com/sindresorhus/refined-github/issues/479 (closed by pr, then closed manually)
https://github.com/sindresorhus/refined-github/issues/565 (closed by a commit, then by a pr)
https://github.com/sindresorhus/refined-github/issues/233 (closed by pr, reopened)

Example PR:

https://github.com/sindresorhus/refined-twitter/pull/52 (closed by commit) 

## Readme screenshot

<img width="761" alt="" src="https://user-images.githubusercontent.com/1402241/35973522-5c00acb6-0d08-11e8-89ca-03071de15c6f.png">


Closes #948