### PR TITLE
Meta: move badges away from title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,5 @@
-# <img src="source/icon.png" width="45" align="left"> Refined GitHub [![Chrome version][badge-cws]][link-cws] [![Firefox version][badge-amo]][link-amo] [![Deployment][badge-travis]][link-travis]
+# <img src="source/icon.png" width="45" align="left"> Refined GitHub
 
-[badge-cws]: https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?label=chrome
-[badge-amo]: https://img.shields.io/amo/v/refined-github-.svg?label=firefox
-[badge-travis]: https://img.shields.io/travis/sindresorhus/refined-github/master.svg?label=deployment
 [link-cws]: https://chrome.google.com/webstore/detail/refined-github/hlepfoohegkhhmjieoechaddaejaokhf "Version published on Chrome Web Store"
 [link-amo]: https://addons.mozilla.org/en-US/firefox/addon/refined-github-/ "Version published on Mozilla Add-ons"
 [link-travis]: https://travis-ci.org/sindresorhus/refined-github
@@ -23,8 +20,8 @@ GitHub Enterprise is also supported. More info in the options.
 
 ## Install
 
-- [**Chrome** extension][link-cws]
-- [**Firefox** add-on][link-amo]
+- [**Chrome** extension][link-cws] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?label=%20">][link-cws]
+- [**Firefox** add-on][link-amo] [<img valign="middle" src="https://img.shields.io/amo/v/refined-github-.svg?label=%20">][link-amo]
 - **Opera** extension: Use [this Opera extension](https://addons.opera.com/en/extensions/details/download-chrome-extension-9/) to install the Chrome version.
 
 


### PR DESCRIPTION
\+ drop deployment badge

Now that we have <img width="42" alt="" src="https://user-images.githubusercontent.com/1402241/36077002-1e334e16-0f97-11e8-97a2-b43d63c99604.png"> I don't see the need for badges anymore

One-click demo: https://github.com/sindresorhus/refined-github/tree/readme-badges#-refined-github