### PR TITLE
Hide some file-related tooltips

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -62,6 +62,12 @@
 }
 
 /* Remove tooltips where unnecessary */
+[aria-label="Change this file using the online editor"]::before,
+[aria-label="Change this file using the online editor"]::after,
+[aria-label="View the whole file"]::before,
+[aria-label="View the whole file"]::after,
+[aria-label="Edit comment"]::before,
+[aria-label="Edit comment"]::after,
 .notification-indicator::before,
 .notification-indicator::after {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -62,10 +62,16 @@
 }
 
 /* Remove tooltips where unnecessary */
-[aria-label="Change this file using the online editor"]::before,
-[aria-label="Change this file using the online editor"]::after,
-[aria-label="View the whole file"]::before,
-[aria-label="View the whole file"]::after,
+[aria-label^="View the whole file"]::before,
+[aria-label^="View the whole file"]::after,
+[aria-label^="Change this file"]::before,
+[aria-label^="Change this file"]::after,
+[aria-label="Delete this file"]::before,
+[aria-label="Delete this file"]::after,
+[aria-label="Edit this file"]::before,
+[aria-label*="reacted with"]::before,
+[aria-label*="reacted with"]::after,
+[aria-label="Edit this file"]::after,
 [aria-label="Edit comment"]::before,
 [aria-label="Edit comment"]::after,
 .notification-indicator::before,

--- a/source/content.css
+++ b/source/content.css
@@ -62,18 +62,18 @@
 }
 
 /* Remove tooltips where unnecessary */
-[aria-label^="View the whole file"]::before,
-[aria-label^="View the whole file"]::after,
-[aria-label^="Change this file"]::before,
-[aria-label^="Change this file"]::after,
-[aria-label="Delete this file"]::before,
-[aria-label="Delete this file"]::after,
-[aria-label="Edit this file"]::before,
-[aria-label*="reacted with"]::before,
-[aria-label*="reacted with"]::after,
-[aria-label="Edit this file"]::after,
-[aria-label="Edit comment"]::before,
-[aria-label="Edit comment"]::after,
+[aria-label^='View the whole file']::before,
+[aria-label^='View the whole file']::after,
+[aria-label^='Change this file']::before,
+[aria-label^='Change this file']::after,
+[aria-label='Delete this file']::before,
+[aria-label='Delete this file']::after,
+[aria-label='Edit this file']::before,
+[aria-label*='reacted with']::before,
+[aria-label*='reacted with']::after,
+[aria-label='Edit this file']::after,
+[aria-label='Edit comment']::before,
+[aria-label='Edit comment']::after,
 .notification-indicator::before,
 .notification-indicator::after {
 	display: none !important;


### PR DESCRIPTION
Also, a cool trick:

```js
document.body.insertAdjacentHTML('beforeend', `
<style>
.tooltipped::before,
.tooltipped::after {
	opacity: 1;
    display: inline-block;
    text-decoration: none;
}
</style>
`);
```

<img width="868" alt="shot" src="https://user-images.githubusercontent.com/1402241/36220958-0de85b8c-11ef-11e8-825b-0af8cdb7d72c.png">
