### PR TITLE
Improve shortcut help

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Adds build status and link to CI by the repo's title](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Color-codes and counts reviews in PRs list](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
 - [Show issue resolution in header (was it closed by a PR?)](https://user-images.githubusercontent.com/1402241/35973522-5c00acb6-0d08-11e8-89ca-03071de15c6f.png)
+- [Shows all keyboard shortcuts in the help modal](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>shift</kbd> <kbd>?</kbd> hotkey)*
 
 ### Declutter
 

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Adds build status and link to CI by the repo's title](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Color-codes and counts reviews in PRs list](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
 - [Show issue resolution in header (was it closed by a PR?)](https://user-images.githubusercontent.com/1402241/35973522-5c00acb6-0d08-11e8-89ca-03071de15c6f.png)
-- [Shows all keyboard shortcuts in the help modal](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>shift</kbd> <kbd>?</kbd> hotkey)*
+- [Shows all keyboard shortcuts in the help modal](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
 
 ### Declutter
 

--- a/source/content.css
+++ b/source/content.css
@@ -955,5 +955,5 @@ body > .footer li a {
 }
 
 .rgh-inactive-shortcut-group:not(:hover) {
-	opacity: .6;
+	opacity: 0.6;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -955,6 +955,10 @@ body > .footer li a {
 	cursor: default;
 }
 
+.rgh-inactive-shortcut-group {
+	transition: opacity 0.15s ease;
+}
+
 .rgh-inactive-shortcut-group:not(:hover) {
 	opacity: 0.6;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -949,3 +949,11 @@ body > .footer li a {
 	font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
 	font-size: 13px;
 }
+
+.shortcuts * {
+	cursor: default;
+}
+
+.rgh-inactive-shortcut-group:not(:hover) {
+	opacity: .6;
+}

--- a/source/content.css
+++ b/source/content.css
@@ -951,7 +951,8 @@ body > .footer li a {
 }
 
 /* For 'improve-shortcut-help' feature */
-.shortcuts * {
+:root .facebox .shortcuts {
+	width: 908px;
 	cursor: default;
 }
 

--- a/source/content.css
+++ b/source/content.css
@@ -958,3 +958,13 @@ body > .footer li a {
 .rgh-inactive-shortcut-group:not(:hover) {
 	opacity: 0.6;
 }
+
+.rgh-shortcut-circle {
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	margin-left: 5px;
+	background: #9c95b3;
+	cursor: pointer;
+}

--- a/source/content.css
+++ b/source/content.css
@@ -950,6 +950,7 @@ body > .footer li a {
 	font-size: 13px;
 }
 
+/* For 'improve-shortcut-help' feature */
 .shortcuts * {
 	cursor: default;
 }

--- a/source/content.js
+++ b/source/content.js
@@ -66,7 +66,7 @@ import addDownloadFolderButton from './features/add-download-folder-button';
 import hideUselessNewsfeedEvents from './features/hide-useless-newsfeed-events';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
 import monospaceTextareas from './features/monospace-textareas';
-import addShortcutHelp from './features/add-shortcut-help';
+import improveShortcutHelp from './features/improve-shortcut-help';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature} from './libs/utils';
@@ -136,7 +136,7 @@ function onDomReady() {
 	enableFeature(enableCopyOnY);
 	enableFeature(addProfileHotkey);
 	enableFeature(makeDiscussionSidebarSticky);
-	enableFeature(addShortcutHelp);
+	enableFeature(improveShortcutHelp);
 
 	if (!pageDetect.isGist()) {
 		enableFeature(moveMarketplaceLinkToProfileDropdown);

--- a/source/content.js
+++ b/source/content.js
@@ -66,6 +66,7 @@ import addDownloadFolderButton from './features/add-download-folder-button';
 import hideUselessNewsfeedEvents from './features/hide-useless-newsfeed-events';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
 import monospaceTextareas from './features/monospace-textareas';
+import addShortcutHelp from './features/add-shortcut-help';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature} from './libs/utils';
@@ -135,6 +136,7 @@ function onDomReady() {
 	enableFeature(enableCopyOnY);
 	enableFeature(addProfileHotkey);
 	enableFeature(makeDiscussionSidebarSticky);
+	enableFeature(addShortcutHelp);
 
 	if (!pageDetect.isGist()) {
 		enableFeature(moveMarketplaceLinkToProfileDropdown);

--- a/source/features/add-diff-view-without-whitespace-option.js
+++ b/source/features/add-diff-view-without-whitespace-option.js
@@ -1,6 +1,7 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import * as icons from '../libs/icons';
+import {registerShortcut} from './add-shortcut-help';
 
 export default function () {
 	const container = select([
@@ -33,6 +34,7 @@ export default function () {
 			</a>
 		</div>
 	);
+	registerShortcut('source', 'd w', 'Show/hide whitespaces in diffs');
 
 	// Make space for the new button by removing "Changes from" #655
 	const uselessCopy = select('[data-hotkey="c"]');

--- a/source/features/add-diff-view-without-whitespace-option.js
+++ b/source/features/add-diff-view-without-whitespace-option.js
@@ -1,7 +1,7 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import * as icons from '../libs/icons';
-import {registerShortcut} from './add-shortcut-help';
+import {registerShortcut} from './improve-shortcut-help';
 
 export default function () {
 	const container = select([

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import delegate from 'delegate';
-import {registerShortcut} from './add-shortcut-help';
+import {registerShortcut} from './improve-shortcut-help';
 
 function indentInput(el) {
 	const selection = window.getSelection().toString();

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -1,5 +1,6 @@
 import select from 'select-dom';
 import delegate from 'delegate';
+import {registerShortcut} from './add-shortcut-help';
 
 function indentInput(el) {
 	const selection = window.getSelection().toString();
@@ -46,6 +47,9 @@ function blurAccessibly(field) {
 }
 
 export default function () {
+	registerShortcut('issues', '↑', 'Edit your last comment');
+	registerShortcut('prFiles', 'shift enter', 'Leave a single comment');
+
 	delegate('.js-comment-field', 'keydown', event => {
 		const field = event.target;
 		if (event.key === 'Tab' && !event.shiftKey) {

--- a/source/features/add-profile-hotkey.js
+++ b/source/features/add-profile-hotkey.js
@@ -1,10 +1,12 @@
 import select from 'select-dom';
 import {getUsername} from '../libs/utils';
+import {registerShortcut} from './add-shortcut-help';
 
 export default function () {
 	const menuItem = select(`#user-links a.dropdown-item[href="/${getUsername()}"]`);
 
 	if (menuItem) {
 		menuItem.setAttribute('data-hotkey', 'g m');
+		registerShortcut('site', 'g m', 'Go to Profile');
 	}
 }

--- a/source/features/add-profile-hotkey.js
+++ b/source/features/add-profile-hotkey.js
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import {getUsername} from '../libs/utils';
-import {registerShortcut} from './add-shortcut-help';
+import {registerShortcut} from './improve-shortcut-help';
 
 export default function () {
 	const menuItem = select(`#user-links a.dropdown-item[href="/${getUsername()}"]`);

--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -37,7 +37,7 @@ export default async () => {
 			<span> Releases </span>
 		</a>
 	);
-	registerShortcut('repo', 'g r', 'Go to Releases');
+	registerShortcut('repos', 'g r', 'Go to Releases');
 
 	select('.reponav-dropdown').before(releasesTab);
 

--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as icons from '../libs/icons';
 import * as pageDetect from '../libs/page-detect';
-import {registerShortcut} from './add-shortcut-help';
+import {registerShortcut} from './improve-shortcut-help';
 
 const repoUrl = pageDetect.getRepoURL();
 const repoKey = `${repoUrl}-releases-count`;

--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -2,6 +2,7 @@ import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as icons from '../libs/icons';
 import * as pageDetect from '../libs/page-detect';
+import {registerShortcut} from './add-shortcut-help';
 
 const repoUrl = pageDetect.getRepoURL();
 const repoKey = `${repoUrl}-releases-count`;
@@ -36,6 +37,7 @@ export default async () => {
 			<span> Releases </span>
 		</a>
 	);
+	registerShortcut('repo', 'g r', 'Go to Releases');
 
 	select('.reponav-dropdown').before(releasesTab);
 

--- a/source/features/add-shortcut-help.js
+++ b/source/features/add-shortcut-help.js
@@ -1,0 +1,29 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import observeEl from '../libs/simplified-element-observer';
+
+function addShortcuts() {
+	const modal = select('.shortcuts');
+	const groups = select.all('.keyboard-mappings tbody', modal);
+	groups[1].append(
+		<tr>
+			<td class="keys">
+				<kbd>g</kbd>
+				<kbd>r</kbd>
+			</td>
+			<td>Go to Releases</td>
+		</tr>
+	);
+}
+
+export default () => {
+	observeEl('#facebox', records => {
+		if (Array.from(records).some(record => record.target.matches('.shortcuts') &&
+			Array.from(record.removedNodes).some(element => element.matches('.facebox-loading')))) {
+			addShortcuts();
+		}
+	}, {
+		childList: true,
+		subtree: true
+	});
+};

--- a/source/features/add-shortcut-help.js
+++ b/source/features/add-shortcut-help.js
@@ -43,10 +43,14 @@ function addShortcuts() {
 					// The "Projects"-related groups are quite big and not interesting to most users
 					groupElement.remove();
 				} else {
+					// Reduced opacity of previously hidden groups
 					groupElement.setAttribute('style', '');
 					groupElement.classList.remove('js-panel-hidden');
 					groupElement.classList.add('rgh-inactive-shortcut-group');
 				}
+			} else {
+				// Push relevant (not hidden) groups to the top
+				groupElement.parentElement.prepend(groupElement);
 			}
 
 			const groupShortcuts = shortcuts.filter(shortcut => shortcut.group === groupId);

--- a/source/features/add-shortcut-help.js
+++ b/source/features/add-shortcut-help.js
@@ -8,8 +8,7 @@ function addShortcuts() {
 	groups[1].append(
 		<tr>
 			<td class="keys">
-				<kbd>g</kbd>
-				<kbd>r</kbd>
+				<kbd>g</kbd> <kbd>r</kbd>
 			</td>
 			<td>Go to Releases</td>
 		</tr>

--- a/source/features/add-shortcut-help.js
+++ b/source/features/add-shortcut-help.js
@@ -2,16 +2,36 @@ import {h} from 'dom-chef';
 import select from 'select-dom';
 import observeEl from '../libs/simplified-element-observer';
 
+const shortcuts = [];
+
+export function registerShortcut(hotkey, description) {
+	if (shortcuts.some(shortcut => shortcut.hotkey === hotkey)) {
+		return;
+	}
+	shortcuts.push({hotkey, description});
+}
+
 function addShortcuts() {
 	const modal = select('.shortcuts');
-	const groups = select.all('.keyboard-mappings tbody', modal);
-	groups[1].append(
-		<tr>
-			<td class="keys">
-				<kbd>g</kbd> <kbd>r</kbd>
-			</td>
-			<td>Go to Releases</td>
-		</tr>
+	const thirdColumn = select.all('.column .keyboard-mappings', modal)[2];
+	thirdColumn.append(
+		<tbody>
+			<tr>
+				<th/>
+				<th>Refined GitHub</th>
+			</tr>
+			{
+				shortcuts.map(({hotkey, description}) => (
+					<tr>
+						<td class="keys">
+							{/* This is a monstrosity. Plese help me get rid of it. */}
+							{hotkey.split(' ').join(', ,').split(',').map(key => key === ' ' ? ' ' : <kbd>{key}</kbd>)}
+						</td>
+						<td>{description}</td>
+					</tr>
+				))
+			}
+		</tbody>
 	);
 }
 

--- a/source/features/add-shortcut-help.js
+++ b/source/features/add-shortcut-help.js
@@ -1,38 +1,70 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import observeEl from '../libs/simplified-element-observer';
+import {getRepoPath} from '../libs/page-detect';
 
+const groups = {
+	'Site wide shortcuts': 'site',
+	Repositories: 'repos',
+	'Source code browsing': 'source',
+	'Pull request list': 'pr',
+	'Pull request - Files changed tab': 'prFiles',
+	Issues: 'issues',
+	'Browsing commits': 'commits',
+	'Commit list': 'commitList',
+	Dashboards: 'dashboards',
+	Notifications: 'notifications',
+	'Network Graph': 'networkGraph',
+	'Moving a column': 'projectColumns',
+	'Moving a card': 'projectCards'
+};
 const shortcuts = [];
 
-export function registerShortcut(hotkey, description) {
+export function registerShortcut(group, hotkey, description) {
 	if (shortcuts.some(shortcut => shortcut.hotkey === hotkey)) {
 		return;
 	}
-	shortcuts.push({hotkey, description});
+	shortcuts.push({group, hotkey, description});
 }
 
 function addShortcuts() {
+	// Remove redundant "Show All" button
+	select('.js-see-all-keyboard-shortcuts').remove();
+
 	const modal = select('.shortcuts');
-	const thirdColumn = select.all('.column .keyboard-mappings', modal)[2];
-	thirdColumn.append(
-		<tbody>
-			<tr>
-				<th/>
-				<th>Refined GitHub</th>
-			</tr>
-			{
-				shortcuts.map(({hotkey, description}) => (
-					<tr>
-						<td class="keys">
-							{/* This is a monstrosity. Plese help me get rid of it. */}
-							{hotkey.split(' ').join(', ,').split(',').map(key => key === ' ' ? ' ' : <kbd>{key}</kbd>)}
-						</td>
-						<td>{description}</td>
-					</tr>
-				))
+	const groupElements = select.all('tbody', modal);
+	for (const groupElement of groupElements) {
+		const groupTitle = select('tr th:nth-child(2)', groupElement).textContent;
+		if (groupTitle in groups) {
+			const groupId = groups[groupTitle];
+
+			if (groupElement.style.display === 'none') {
+				if (groupId.startsWith('project') && !getRepoPath().startsWith('projects')) {
+					// The "Projects"-related groups are quite big and not interesting to most users
+					groupElement.remove();
+				} else {
+					groupElement.setAttribute('style', '');
+					groupElement.classList.remove('js-panel-hidden');
+					groupElement.classList.add('rgh-inactive-shortcut-group');
+				}
 			}
-		</tbody>
-	);
+
+			const groupShortcuts = shortcuts.filter(shortcut => shortcut.group === groupId);
+			if (groupShortcuts.length > 0) {
+				for (const {hotkey, description} of groupShortcuts) {
+					groupElement.append(
+						<tr>
+							<td class="keys">
+								{/* V This is a monstrosity. Please help me get rid of it. V */}
+								{hotkey.split(' ').join(', ,').split(',').map(key => key === ' ' ? ' ' : <kbd>{key}</kbd>)}
+							</td>
+							<td>{description}</td>
+						</tr>
+					);
+				}
+			}
+		}
+	}
 }
 
 export default () => {

--- a/source/features/add-trending-menu-item.js
+++ b/source/features/add-trending-menu-item.js
@@ -1,6 +1,7 @@
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 import {safeElementReady} from '../libs/utils';
+import {registerShortcut} from './add-shortcut-help';
 
 export default async function () {
 	const selectedClass = pageDetect.isTrending() ? 'selected' : '';
@@ -14,6 +15,7 @@ export default async function () {
 			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink header-nav-link px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
 		</li>
 	);
+	registerShortcut('site', 'g t', 'Go to Trending');
 
 	// Explore link highlights /trending urls by default, remove that behavior
 	if (pageDetect.isTrending()) {

--- a/source/features/add-trending-menu-item.js
+++ b/source/features/add-trending-menu-item.js
@@ -1,7 +1,7 @@
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 import {safeElementReady} from '../libs/utils';
-import {registerShortcut} from './add-shortcut-help';
+import {registerShortcut} from './improve-shortcut-help';
 
 export default async function () {
 	const selectedClass = pageDetect.isTrending() ? 'selected' : '';

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -56,7 +56,7 @@ function improveShortcutHelp() {
 					groupElement.remove();
 				} else {
 					// Reduced opacity of previously hidden groups
-					groupElement.setAttribute('style', '');
+					groupElement.removeAttribute('style');
 					groupElement.classList.remove('js-hidden-pane');
 					groupElement.classList.add('rgh-inactive-shortcut-group');
 				}

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -90,11 +90,9 @@ function improveShortcutHelp() {
 }
 
 function fixKeys() {
-	for (const keyGroup of select.all('.keys')) {
-		for (const key of select.all('kbd', keyGroup)) {
-			if (key.textContent.includes(' ')) {
-				key.replaceWith(domify(splitKeys(key.textContent)));
-			}
+	for (const key of select.all('.keys kbd')) {
+		if (key.textContent.includes(' ')) {
+			key.replaceWith(domify(splitKeys(key.textContent)));
 		}
 	}
 }

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -23,7 +23,7 @@ const groups = {
 	'Moving a column': 'projectColumns',
 	'Moving a card': 'projectCards'
 };
-const shortcuts = [];
+const shortcuts = new Map();
 
 /**
  * Registers a new shortcut to be displayed in the shortcut help modal.
@@ -32,10 +32,7 @@ const shortcuts = [];
  * @param {String} description What the shortcut does.
  */
 export function registerShortcut(groupId, hotkey, description) {
-	if (shortcuts.some(shortcut => shortcut.hotkey === hotkey)) {
-		return;
-	}
-	shortcuts.push({groupId, hotkey, description});
+	shortcuts.set(hotkey, {groupId, hotkey, description});
 }
 
 function splitKeys(keys) {
@@ -68,7 +65,7 @@ function improveShortcutHelp() {
 				groupElement.parentElement.prepend(groupElement);
 			}
 
-			for (const {hotkey, description, groupId: thisGroupId} of shortcuts) {
+			for (const {hotkey, description, groupId: thisGroupId} of shortcuts.values()) {
 				if (thisGroupId === groupId) {
 					groupElement.append(
 						<tr>

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -1,5 +1,6 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
+import domify from '../libs/domify';
 import observeEl from '../libs/simplified-element-observer';
 import {isProject} from '../libs/page-detect';
 
@@ -38,8 +39,7 @@ export function registerShortcut(groupId, hotkey, description) {
 }
 
 function splitKeys(keys) {
-	// V This is a monstrosity. Please help me get rid of it. V
-	return keys.split(' ').join(', ,').split(',').map(key => key === ' ' ? ' ' : <kbd>{key}</kbd>);
+	return keys.replace(/\S+/g, '<kbd>$&</kbd>');
 }
 
 function improveShortcutHelp() {
@@ -73,9 +73,7 @@ function improveShortcutHelp() {
 				for (const {hotkey, description} of groupShortcuts) {
 					groupElement.append(
 						<tr>
-							<td class="keys">
-								{splitKeys(hotkey)}
-							</td>
+							<td class="keys" dangerouslySetInnerHTML={{__html: splitKeys(hotkey)}}/>
 							<td>
 								{description}
 								<div
@@ -95,7 +93,7 @@ function fixKeys() {
 	for (const keyGroup of select.all('.keys')) {
 		for (const key of select.all('kbd', keyGroup)) {
 			if (key.textContent.includes(' ')) {
-				key.replaceWith(...splitKeys(key.textContent));
+				key.replaceWith(domify(splitKeys(key.textContent)));
 			}
 		}
 	}

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -79,7 +79,7 @@ function improveShortcutHelp() {
 							<td>
 								{description}
 								<div
-									class="rgh-shortcut-circle tooltipped tooltipped-e"
+									class="rgh-shortcut-circle tooltipped tooltipped-nw"
 									aria-label="Shortcut added by Refined GitHub"
 								/>
 							</td>

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -68,9 +68,8 @@ function improveShortcutHelp() {
 				groupElement.parentElement.prepend(groupElement);
 			}
 
-			const groupShortcuts = shortcuts.filter(shortcut => shortcut.groupId === groupId);
-			if (groupShortcuts.length > 0) {
-				for (const {hotkey, description} of groupShortcuts) {
+			for (const {hotkey, description, groupId: thisGroupId} of shortcuts) {
+				if (thisGroupId === groupId) {
 					groupElement.append(
 						<tr>
 							<td class="keys" dangerouslySetInnerHTML={{__html: splitKeys(hotkey)}}/>

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -27,7 +27,7 @@ export function registerShortcut(group, hotkey, description) {
 	shortcuts.push({group, hotkey, description});
 }
 
-function addShortcuts() {
+function improveShortcutHelp() {
 	// Remove redundant "Show All" button
 	select('.js-see-all-keyboard-shortcuts').remove();
 
@@ -75,7 +75,7 @@ export default () => {
 	observeEl('#facebox', records => {
 		if (Array.from(records).some(record => record.target.matches('.shortcuts') &&
 			Array.from(record.removedNodes).some(element => element.matches('.facebox-loading')))) {
-			addShortcuts();
+			improveShortcutHelp();
 		}
 	}, {
 		childList: true,

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -62,7 +62,13 @@ function improveShortcutHelp() {
 								{/* V This is a monstrosity. Please help me get rid of it. V */}
 								{hotkey.split(' ').join(', ,').split(',').map(key => key === ' ' ? ' ' : <kbd>{key}</kbd>)}
 							</td>
-							<td>{description}</td>
+							<td>
+								{description}
+								<div
+									class="rgh-shortcut-circle tooltipped tooltipped-e"
+									aria-label="Shortcut added by Refined GitHub"
+								/>
+							</td>
 						</tr>
 					);
 				}

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -45,7 +45,7 @@ function improveShortcutHelp() {
 				} else {
 					// Reduced opacity of previously hidden groups
 					groupElement.setAttribute('style', '');
-					groupElement.classList.remove('js-panel-hidden');
+					groupElement.classList.remove('js-hidden-pane');
 					groupElement.classList.add('rgh-inactive-shortcut-group');
 				}
 			} else {

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -3,6 +3,10 @@ import select from 'select-dom';
 import observeEl from '../libs/simplified-element-observer';
 import {getRepoPath} from '../libs/page-detect';
 
+/**
+ * A map of the shortcut group titles and their respective group IDs.
+ * The IDs can be used to register new shortcuts using `registerShortcut`.
+ */
 const groups = {
 	'Site wide shortcuts': 'site',
 	Repositories: 'repos',
@@ -20,11 +24,17 @@ const groups = {
 };
 const shortcuts = [];
 
-export function registerShortcut(group, hotkey, description) {
+/**
+ * Registers a new shortcut to be displayed in the shortcut help modal.
+ * @param {String} groupId The ID of the group as defined in the `groups` map.
+ * @param {String} hotkey The hotkey with keys separated by spaces.
+ * @param {String} description What the shortcut does.
+ */
+export function registerShortcut(groupId, hotkey, description) {
 	if (shortcuts.some(shortcut => shortcut.hotkey === hotkey)) {
 		return;
 	}
-	shortcuts.push({group, hotkey, description});
+	shortcuts.push({groupId, hotkey, description});
 }
 
 function improveShortcutHelp() {
@@ -53,7 +63,7 @@ function improveShortcutHelp() {
 				groupElement.parentElement.prepend(groupElement);
 			}
 
-			const groupShortcuts = shortcuts.filter(shortcut => shortcut.group === groupId);
+			const groupShortcuts = shortcuts.filter(shortcut => shortcut.groupId === groupId);
 			if (groupShortcuts.length > 0) {
 				for (const {hotkey, description} of groupShortcuts) {
 					groupElement.append(

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -55,7 +55,7 @@ function improveShortcutHelp() {
 					// The "Projects"-related groups are quite big and not interesting to most users
 					groupElement.remove();
 				} else {
-					// Reduced opacity of previously hidden groups
+					// Reduce opacity of previously hidden groups
 					groupElement.removeAttribute('style');
 					groupElement.classList.remove('js-hidden-pane');
 					groupElement.classList.add('rgh-inactive-shortcut-group');

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -63,7 +63,7 @@ export const isNewIssue = () => /^issues\/new/.test(getRepoPath());
 
 export const isNotifications = () => /^([^/]+[/][^/]+\/)?notifications/.test(getCleanPathname());
 
-export const isProject = () => /^projects\//.test(getRepoPath());
+export const isProject = () => /^projects\/\d+/.test(getRepoPath());
 
 export const isPR = () => /^pull\/\d+/.test(getRepoPath());
 

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -63,6 +63,8 @@ export const isNewIssue = () => /^issues\/new/.test(getRepoPath());
 
 export const isNotifications = () => /^([^/]+[/][^/]+\/)?notifications/.test(getCleanPathname());
 
+export const isProject = () => /^projects\//.test(getRepoPath());
+
 export const isPR = () => /^pull\/\d+/.test(getRepoPath());
 
 export const isPRConversation = () => /^pull\/\d+$/.test(getRepoPath());

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -245,6 +245,15 @@ test('isNotifications', urlMatcherMacro, pageDetect.isNotifications, [
 	'https://github.com/jaredhanson/node-notifications/tree/master/lib/notifications'
 ]);
 
+test('isProject', urlMatcherMacro, pageDetect.isProject, [
+	'https://github.com/sindresorhus/refined-github/projects/3'
+], [
+	'https://github.com/sindresorhus/refined-github/projects/project',
+	'https://github.com/sindresorhus/refined-github/project/3',
+	'http://github.com/sindresorhus/projects/3',
+	'https://github.com/projects/3'
+]);
+
 test('isPR', urlMatcherMacro, pageDetect.isPR, [
 	'https://github.com/sindresorhus/refined-github/pull/148'
 ], [


### PR DESCRIPTION
An attempt to improve the shortcut help that can be opened by pressing <kbd>?</kbd>.

* All shortcut groups are now shown.
* Relevant shortcut groups have a higher opacity.
* "Projects"-related groups are removed entirely unless the user is on a projects page.
* Refined GitHub shortcuts are included (which closes #579) and marked with a small purple circle.
* `<kbd>` tags containing multiple keys are split up for consistency.

![](https://user-images.githubusercontent.com/29176678/36502718-0f0f2f5c-174b-11e8-91ca-309274349325.png)

---

## API

There's a little API for other features to register their shortcuts:

```js
import {registerShortcut} from './improve-shortcut-help';

const group = 'site';
const hotkey = 'g t';
const description = 'Go to Trending';

registerShortcut(group, hotkey, description);
```

* `group`: the [ID of the group](https://github.com/shroudedcode/refined-github/blob/ee2cc184a59548a63964b73db095a7bc2ef07904/source/features/improve-shortcut-help.js#L6-L20) that the shortcut should be added to
* `hotkey`: a string with spaces separating the keys
* `description`: what the shortcut does, should use the same kind of wording that is used by GitHub
