### PR TITLE
Add link to your fork under a repo's title

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -66,9 +66,10 @@ import addDownloadFolderButton from './features/add-download-folder-button';
 import hideUselessNewsfeedEvents from './features/hide-useless-newsfeed-events';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
 import monospaceTextareas from './features/monospace-textareas';
+import addLinkToOwnFork from './features/add-link-to-own-fork';
 
 import * as pageDetect from './libs/page-detect';
-import {safeElementReady, enableFeature} from './libs/utils';
+import {safeElementReady, enableFeature, isRepoOwnedByLoggedInUser} from './libs/utils';
 import observeEl from './libs/simplified-element-observer';
 
 // Add globals for easier debugging
@@ -254,6 +255,10 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isUserProfile()) {
 		enableFeature(addGistsLink);
+	}
+
+	if (pageDetect.isRepo() && !isRepoOwnedByLoggedInUser()) {
+		enableFeature(addLinkToOwnFork);
 	}
 }
 

--- a/source/features/add-link-to-own-fork.js
+++ b/source/features/add-link-to-own-fork.js
@@ -1,0 +1,32 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import { getCurrentRepoDetails, getUsername } from '../libs/utils';
+import api from '../libs/api';
+
+export default async () => {
+	const user = getUsername();
+	const currentRepo = getCurrentRepoDetails().join('/');
+	const apiPath = `repos/${currentRepo}/forks`;
+	const header = select('h1.public');
+	const loaderNode = header.appendChild(
+		<span class="fork-flag forked-to-flag">Checking for forks...</span>
+	);
+
+	const forksList = await api(apiPath);
+
+	const forkDetails = getForkedRepoDetails(user, forksList);
+	if (!forkDetails) return;
+
+	loaderNode.parentElement
+		.replaceChild(
+			<span class="fork-flag forked-to-flag">
+				<span class="text">Forked to </span>
+				<a href={forkDetails.html_url}>{ forkDetails.full_name }</a>
+			</span>,
+			loaderNode
+		);
+}
+
+function getForkedRepoDetails(ownerName, forksList) {
+	return forksList.find(f => f.owner.login === ownerName) || null;
+}

--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -150,3 +150,11 @@ export const anySelector = selector => {
 	const prefix = document.head.style.MozOrient === '' ? 'moz' : 'webkit';
 	return selector.replace(/:any\(/g, `:-${prefix}-any(`);
 };
+
+export const getCurrentRepoDetails = () => {
+	return select('meta[property="og:title"]').getAttribute('content').split('/');
+};
+
+export const isRepoOwnedByLoggedInUser = () => {
+	return getUsername() === getCurrentRepoDetails()[0];
+};


### PR DESCRIPTION
_Note by @bfred-it: I updated this comment to add screenshots and paragraphs._

Fixes: #1129

<img width="377" alt="screen shot 2018-02-26 at 15 28 48" src="https://user-images.githubusercontent.com/1402241/36660210-ed0a50fe-1b09-11e8-8397-849fc926564c.png">

GitHub links upstream repo right below the title of our fork's title when we visit the fork's page. But it doesn't do the same thing on an upstream repo's page, i.e, link to the fork that we created. 

IMHO, it is odd that you have to go to the top-right corner and click on the big "Fork" button to switch to your fork. The intention of that button is to create a fork. If I own multiple organizations, clicking on the fork button asks me whether I want to fork under an organization or switch to the fork under my account. 

![](https://user-images.githubusercontent.com/2767425/36931919-3df715d0-1ee6-11e8-9242-9db501e36baa.png)

This is an added step to get to where we want and slows things down. I find it natural to expect the link to be below the title given that's how GitHub does it for a fork. This patch will add a link to our fork on upstream's page as soon as the dynamic pages are loaded.

I believe this can be extended in various ways (like a dropdown that shows forks under your orgs) but I want to know if the current implementation is fine and whether you guys think this is a good feature. The implementation currently has one main issue:

- Default pagination only returns 30 entries and I don't know if GitHub returns the details for logged-in user's fork in the first 30 entries itself.