### PR TITLE
Fix diff signs' positioning

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -483,9 +483,9 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 /* +/- Pseudo elements on diffs */
 .refined-github-diff-signs .blob-code-addition::before,
 .refined-github-diff-signs .blob-code-deletion::before {
-	display: inline-block;
-	position: absolute;
 	margin-top: 1px;
+	margin-left: 4px;
+	position: absolute;
 	color: rgba(0, 0, 0, 0.3);
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
 	font-size: 11px;

--- a/source/content.css
+++ b/source/content.css
@@ -481,16 +481,11 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* +/- Pseudo elements on diffs */
-.refined-github-diff-signs .blob-code-addition,
-.refined-github-diff-signs .blob-code-deletion {
-	position: relative;
-}
-
 .refined-github-diff-signs .blob-code-addition::before,
 .refined-github-diff-signs .blob-code-deletion::before {
 	display: inline-block;
 	position: absolute;
-	top: 1px;
+	margin-top: 1px;
 	color: rgba(0, 0, 0, 0.3);
 	font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
 	font-size: 11px;

--- a/source/content.css
+++ b/source/content.css
@@ -481,6 +481,11 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* +/- Pseudo elements on diffs */
+.refined-github-diff-signs .blob-code-addition,
+.refined-github-diff-signs .blob-code-deletion {
+	position: relative;
+}
+
 .refined-github-diff-signs .blob-code-addition::before,
 .refined-github-diff-signs .blob-code-deletion::before {
 	display: inline-block;


### PR DESCRIPTION
I saw today the diff signs were a little off in the PR files view. This PR fixes this behaviour (see the attached screenshot).

![broken-additions-signs](https://user-images.githubusercontent.com/11782/36541242-9877b984-17dd-11e8-88f1-a009a16749aa.png)

Live example: https://github.com/sindresorhus/refined-github/pull/1108/files