### PR TITLE
Show latest tag in `latest release button`

### DIFF
--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -28,7 +28,8 @@ function addTagLink(branchSelector) {
 		link.setAttribute('aria-label', 'You’re on the latest release');
 	} else {
 		link.href = select(`[data-name="${latestRelease}"]`).href;
-		link.setAttribute('aria-label', `Visit the latest release (${latestRelease})`);
+		link.setAttribute('aria-label', 'Visit the latest release');
+		link.append(' ', <span class="css-truncate-target">{latestRelease}</span>);
 	}
 
 	branchSelector.after(link);


### PR DESCRIPTION
Too much noise?

<a href="https://github.com/babel/babel/"><img width="368" alt="always visible tag" src="https://user-images.githubusercontent.com/1402241/36968396-f9115420-2094-11e8-8bd6-ddc1748a891d.png"></a>

Test on: https://github.com/babel/babel/