### PR TITLE
don't create tab on update

### DIFF
--- a/source/background.js
+++ b/source/background.js
@@ -36,25 +36,6 @@ browser.runtime.onMessage.addListener(async message => {
 	}
 });
 
-browser.runtime.onInstalled.addListener(async ({reason}) => {
-	if (reason !== 'install') {
-		// TODO: uncomment this when all old users received this notification
-		// return;
-	}
-	const {userWasNotified} = await browser.storage.local.get('userWasNotified');
-	if (userWasNotified) {
-		return;
-	}
-	const {installType} = await browser.management.getSelf();
-	if (installType === 'development') {
-		return;
-	}
-	browser.tabs.create({
-		url: 'https://github.com/sindresorhus/refined-github/issues/1137'
-	});
-	browser.storage.local.set('userWasNotified', true);
-});
-
 // GitHub Enterprise support
 dynamicContentScripts.addToFutureTabs();
 domainPermissionToggle.addContextMenu();


### PR DESCRIPTION
Extension updates happen at random times, unannounced. Opening a new tab steals focus and disrupts tasks. This is an awesome set-it-and-forget-it extension and it shouldn't be jumping in my face.

Simple fix: don't do it. A more interesting possibility would be to replace the new tab with a small overlay on the current page.