### PR TITLE
Add hotkeys for squash merging

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -28,6 +28,7 @@ import hideOwnStars from './features/hide-own-stars';
 import moveMarketplaceLinkToProfileDropdown from './features/move-marketplace-link-to-profile-dropdown';
 import addYourRepoLinkToProfileDropdown from './features/add-your-repositories-link-to-profile-dropdown';
 import addTrendingMenuItem from './features/add-trending-menu-item';
+import addSquashBranchHotkey from './features/add-squash-branch-hotkey';
 import addProfileHotkey from './features/add-profile-hotkey';
 import addYoursMenuItem from './features/add-yours-menu-item';
 import addCommentedMenuItem from './features/add-commented-menu-item';
@@ -192,6 +193,7 @@ function ajaxedPagesHandler() {
 	}
 
 	if (pageDetect.isPR()) {
+		enableFeature(addSquashBranchHotkey);
 		enableFeature(scrollToTopOnCollapse);
 		enableFeature(linkifyBranchRefs.inPR, 'linkify-branch-refs');
 		enableFeature(addDeleteForkLink);

--- a/source/features/add-squash-branch-hotkey.js
+++ b/source/features/add-squash-branch-hotkey.js
@@ -1,0 +1,15 @@
+import select from 'select-dom';
+
+export default function () {
+	const squashButton = select(`.btn-group-squash > button`);
+
+	if (squashButton) {
+		squashButton.setAttribute('data-hotkey', 'a s');
+	}
+
+  const confirmButton = select(`.btn-group-squash > button[name="do"]`);
+
+  if (confirmButton) {
+    confirmButton.setAttribute('data-hotkey', 'a s');
+  }
+}

--- a/source/features/add-squash-branch-hotkey.js
+++ b/source/features/add-squash-branch-hotkey.js
@@ -7,9 +7,9 @@ export default function () {
 		squashButton.dataset.hotkey = 'a s';
 	}
 
-  const confirmButton = select(`.btn-group-squash > button[name="do"]`);
+	const confirmButton = select(`.btn-group-squash > button[name="do"]`);
 
-  if (confirmButton) {
-    confirmButton.dataset.hotkey = 'a s';
-  }
+	if (confirmButton) {
+		confirmButton.dataset.hotkey = 'a s';
+	}
 }

--- a/source/features/add-squash-branch-hotkey.js
+++ b/source/features/add-squash-branch-hotkey.js
@@ -4,12 +4,12 @@ export default function () {
 	const squashButton = select(`.btn-group-squash > button`);
 
 	if (squashButton) {
-		squashButton.setAttribute('data-hotkey', 'a s');
+		squashButton.dataset.hotkey = 'a s';
 	}
 
   const confirmButton = select(`.btn-group-squash > button[name="do"]`);
 
   if (confirmButton) {
-    confirmButton.setAttribute('data-hotkey', 'a s');
+    confirmButton.dataset.hotkey = 'a s';
   }
 }


### PR DESCRIPTION
This is a proposal for adding a shortcut on the following buttons:

<img width="782" alt="screen shot 2018-03-10 at 22 11 22" src="https://user-images.githubusercontent.com/5759366/37246770-09c1b75a-24b0-11e8-81c6-ac1748312bf6.png">

<img width="784" alt="screen shot 2018-03-10 at 22 12 02" src="https://user-images.githubusercontent.com/5759366/37246773-1667f9ba-24b0-11e8-9307-7fe90a2e5115.png">

When pressing `a s` both buttons will be pressed and the branch will be squash merged. `a` for action since `m` and other shortcuts are already taken from Github.

This is a prototype just to get some information whether you folks want to include this or not. We can extend this for the other 2 types.