### PR TITLE
Fix default branch buttons in some cases

### DIFF
--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import toSemver from 'to-semver';
 import * as icons from '../libs/icons';
 import {groupSiblings} from '../libs/group-buttons';
-import {getRepoURL, isRepoRoot} from '../libs/page-detect';
+import {getRepoURL, isRepoRoot, getOwnerAndRepo} from '../libs/page-detect';
 
 // This regex should match all of these combinations:
 // "This branch is even with master."

--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -37,8 +37,11 @@ function addTagLink(branchSelector) {
 }
 
 function getDefaultBranchNameIfDifferent() {
+	const {ownerName, repoName} = getOwnerAndRepo();
+	const cacheKey = `rgh-default-branch-${ownerName}-${repoName}`;
+
 	// Return the cached name if it differs from the current one
-	const cachedName = sessionStorage.getItem('rgh-default-branch');
+	const cachedName = sessionStorage.getItem(cacheKey);
 	if (cachedName) {
 		const currentBranch = select('[data-hotkey="w"] span').textContent;
 		return cachedName === currentBranch ? false : cachedName;
@@ -54,7 +57,7 @@ function getDefaultBranchNameIfDifferent() {
 	const [, branchName] = branchInfo.textContent.trim().match(branchInfoRegex) || [];
 	if (branchName) {
 		// Temporarily cache it between loads to enable it on files
-		sessionStorage.setItem('rgh-default-branch', branchName);
+		sessionStorage.setItem(cacheKey, branchName);
 		return branchName;
 	}
 }

--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -63,6 +63,10 @@ function getDefaultBranchNameIfDifferent() {
 }
 
 function addDefaultBranchLink(branchSelector) {
+	if (select.exists('.repohead .octicon-repo-forked')) {
+		return; // It's a fork, no "default branch" info available #1132
+	}
+
 	const branchName = getDefaultBranchNameIfDifferent();
 	if (!branchName) {
 		return;

--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -68,9 +68,16 @@ function addDefaultBranchLink(branchSelector) {
 		return;
 	}
 
-	const url = isRepoRoot() ?
-		`/${getRepoURL()}` :
-		select(`.select-menu-item[data-name='${branchName}']`).href;
+	let url;
+	if (isRepoRoot()) {
+		url = `/${getRepoURL()}`;
+	} else {
+		const branchLink = select(`.select-menu-item[data-name='${branchName}']`);
+		if (!branchLink) {
+			return;
+		}
+		url = branchLink.href;
+	}
 
 	branchSelector.before(
 		<a


### PR DESCRIPTION
Changes:

- The caching of the default branch was site-wide instead of repo-wide. Oops.
- We can't know the default branch on forks, so the button won't appear there anymore. https://github.com/sindresorhus/refined-github/pull/1115#issuecomment-371908428 https://github.com/sindresorhus/refined-github/pull/1132#issuecomment-372924429
- Sometimes we know the branch, but we don't have a link to it. https://github.com/sindresorhus/refined-github/issues/1160

Follows #1115 
Replaces #1132 (more context there)