### PR TITLE
Fix opacity for merge commits

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -297,7 +297,9 @@ followed someone
 }
 
 /* Fade out merge commits from commit list */
-.refined-github-merge-commit .table-list-cell:first-child {
+.refined-github-merge-commit .commit-title,
+.refined-github-merge-commit .commit-meta > div:not(.commit-indicator),
+.refined-github-merge-commit .commit-build-statuses > summary {
 	opacity: 0.7;
 }
 


### PR DESCRIPTION
Setting `opacity` on `table-list-cell` for merge commits had a negative effect on the build statuses overlay (see the attached screens).

**Before:**

<img width="841" alt="broken-status-overlay-merge-commit" src="https://user-images.githubusercontent.com/11782/37458789-67c24a92-2846-11e8-9f5f-45e0c5115815.png">

**After:**

![fixed-status-overlay-merge-commit](https://user-images.githubusercontent.com/11782/37458794-6a93af0e-2846-11e8-9ed7-42b4a2669419.png)

In addition I fixed some tiny issues in the CSS file which I spotted when running `npm test` locally.

Live test case: https://github.com/Microsoft/TypeScript/commits/master