### PR TITLE
Meta: stop marking ajaxedPagesHandler as complex

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -159,6 +159,7 @@ function onDomReady() {
 	onAjaxedPages(ajaxedPagesHandler);
 }
 
+// eslint-disable-next-line complexity
 function ajaxedPagesHandler() {
 	enableFeature(hideEmptyMeta);
 	enableFeature(removeUploadFilesButton);


### PR DESCRIPTION
```
> xo && stylelint source/*.css


  source/content.js
  ...
  ⚠  162:1  Function ajaxedPagesHandler has a complexity of 30.  complexity
  
  ...

  3 warnings

  43 passed
```

This does nothing and nothing can be done about it except moving the filters inside each feature, which is something I've been doing [in some features.](https://github.com/sindresorhus/refined-github/blob/master/source/content.js#L162-L168) Being just a bunch of function calls and `if`s it's not really complex.