### PR TITLE
Meta: enableFeature improvements

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -22,7 +22,7 @@ import addTimeMachineLinksToComments from './features/add-time-machine-links-to-
 import removeUploadFilesButton from './features/remove-upload-files-button';
 import scrollToTopOnCollapse from './features/scroll-to-top-on-collapse';
 import removeDiffSigns from './features/remove-diff-signs';
-import * as linkifyBranchRefs from './features/linkify-branch-refs';
+import linkifyBranchRefs from './features/linkify-branch-refs';
 import hideEmptyMeta from './features/hide-empty-meta';
 import hideOwnStars from './features/hide-own-stars';
 import moveMarketplaceLinkToProfileDropdown from './features/move-marketplace-link-to-profile-dropdown';
@@ -166,6 +166,7 @@ function ajaxedPagesHandler() {
 	enableFeature(shortenLinks);
 	enableFeature(linkifyCode);
 	enableFeature(addDownloadFolderButton);
+	enableFeature(linkifyBranchRefs);
 
 	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
 		enableFeature(addYoursMenuItem);
@@ -193,16 +194,11 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPR()) {
 		enableFeature(scrollToTopOnCollapse);
-		enableFeature(linkifyBranchRefs.inPR, 'linkify-branch-refs');
 		enableFeature(addDeleteForkLink);
 		enableFeature(fixSquashAndMergeTitle);
 		enableFeature(openCIDetailsInNewTab);
 		enableFeature(waitForBuild);
 		enableFeature(toggleAllThingsWithAlt);
-	}
-
-	if (pageDetect.isQuickPR()) {
-		enableFeature(linkifyBranchRefs.inQuickPR, 'linkify-branch-refs');
 	}
 
 	if (pageDetect.isPR() || pageDetect.isIssue()) {

--- a/source/features/linkify-branch-refs.js
+++ b/source/features/linkify-branch-refs.js
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import {safeElementReady, wrap} from '../libs/utils';
 import * as pageDetect from '../libs/page-detect';
 
-export function inPR() {
+function inPR() {
 	let deletedBranch = false;
 	const lastBranchAction = select.all(`
 		.discussion-item-head_ref_deleted .commit-ref,
@@ -35,11 +35,19 @@ export function inPR() {
 	}
 }
 
-export async function inQuickPR() {
+async function inQuickPR() {
 	const el = await safeElementReady('.branch-name');
 	if (el) {
 		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const branchUrl = `/${ownerName}/${repoName}/tree/${el.textContent}`;
 		wrap(el.closest('.branch-name'), <a href={branchUrl}></a>);
+	}
+}
+
+export default function () {
+	if (pageDetect.isPR()) {
+		inPR();
+	} else if (pageDetect.isQuickPR()) {
+		inQuickPR();
 	}
 }

--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -18,14 +18,17 @@ export const enableFeature = async fn => {
 	const filename = fn.name.replace(/_/g, '-');
 	if (/^$|^anonymous$/.test(filename)) {
 		console.warn('This feature is nameless', fn);
-	} else {
-		log('✅', filename); // Testing only
-		if (disabledFeatures.includes(filename)) {
-			log('↩️', 'Skipping', filename); // Testing only
-			return;
-		}
+	} else if (disabledFeatures.includes(filename)) {
+		log('↩️', 'Skipping', filename);
+		return;
 	}
-	fn();
+	try {
+		fn();
+		log('✅', filename);
+	} catch (err) {
+		console.log('❌', filename);
+		console.error(err);
+	}
 };
 
 export const isFeatureEnabled = async featureName => {

--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -11,11 +11,11 @@ const options = new OptionsSync().getAll();
  * Prevent fn's errors from blocking the remaining tasks.
  * https://github.com/sindresorhus/refined-github/issues/678
  */
-export const enableFeature = async (fn, filename) => {
+export const enableFeature = async fn => {
 	const {disabledFeatures = '', logging = false} = await options;
 	const log = logging ? console.log : () => {};
 
-	filename = filename || fn.name.replace(/_/g, '-');
+	const filename = fn.name.replace(/_/g, '-');
 	if (/^$|^anonymous$/.test(filename)) {
 		console.warn('This feature is nameless', fn);
 	} else {


### PR DESCRIPTION
- The `name` parameter was only used in one case. I'm dropping it
- Dropped a couple of unnecessary comments
- Show feature name when outputting errors (whether logging is enabled or not) 

<img width="384" alt="errors" src="https://user-images.githubusercontent.com/1402241/37510752-cd9c6774-292e-11e8-9a5e-c72b4dbf2bb8.png">
