### PR TITLE
Display possibly related issues on the 'New Issue' page

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"babel-loader": "^7.1.2",
 		"babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
 		"babel-plugin-transform-react-jsx": "^6.24.1",
+		"babel-plugin-transform-unicode-property-regex": "^2.0.5",
 		"chrome-webstore-upload-cli": "^1.0.0",
 		"common-tags": "^1.7.2",
 		"copy-webpack-plugin": "^4.4.2",
@@ -90,6 +91,12 @@
 				{
 					"pragma": "h",
 					"useBuiltIns": true
+				}
+			],
+			[
+				"transform-unicode-property-regex",
+				{
+					"useUnicodeFlag": true
 				}
 			]
 		],

--- a/source/content.css
+++ b/source/content.css
@@ -659,6 +659,12 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	margin-right: 8px;
 }
 
+/* Make issue suggestions as wide as possible, within the current viewport */
+.rgh-issue-suggestions {
+	min-width: 100%;
+	width: calc(50vw - 510px + 100%);
+	max-width: max-content;
+}
 .rgh-issue-suggestions .Box {
 	transition: opacity 0.2s;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -659,6 +659,10 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	margin-right: 8px;
 }
 
+.rgh-issue-suggestions .Box {
+	transition: opacity 0.2s;
+}
+
 /* For `add-ci-link` */
 .rgh-ci-link {
 	position: relative;

--- a/source/content.js
+++ b/source/content.js
@@ -70,6 +70,7 @@ import closeOutOfViewModals from './features/close-out-of-view-modals';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
 import monospaceTextareas from './features/monospace-textareas';
 import improveShortcutHelp from './features/improve-shortcut-help';
+import displayIssueSuggestions from './features/display-issue-suggestions';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature} from './libs/utils';
@@ -220,6 +221,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isNewIssue()) {
 		enableFeature(addUploadBtn);
+		enableFeature(displayIssueSuggestions);
 	}
 
 	if (pageDetect.isIssue() || pageDetect.isPRConversation()) {

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -44,7 +44,7 @@ async function displayIssueSuggestions(title) {
 		const linkQuery = encodeURIComponent(`${words.join(' ')} is:issue`);
 
 		sidebarItem = (
-			<div class="discussion-sidebar-item pt-0">
+			<div class="rgh-issue-suggestions discussion-sidebar-item pt-0">
 				<div class="text-bold mb-2">Possibly related issues</div>
 				<div class="Box Box--condensed">
 					{
@@ -77,5 +77,11 @@ async function displayIssueSuggestions(title) {
 }
 
 export default function () {
-	select('#issue_title').addEventListener('blur', ({target}) => displayIssueSuggestions(target.value));
+	const title = select('#issue_title');
+	title.addEventListener('blur', ({target}) => displayIssueSuggestions(target.value));
+	title.addEventListener('focus', () => {
+		if (insertedSidebarItem) {
+			select('.Box', insertedSidebarItem).style.opacity = 0.7;
+		}
+	});
 }

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -77,6 +77,5 @@ async function displayIssueSuggestions(title) {
 }
 
 export default function () {
-	console.log(select('#issue_title'));
 	select('#issue_title').addEventListener('blur', ({target}) => displayIssueSuggestions(target.value));
 }

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -1,27 +1,26 @@
-import select from 'select-dom';
 import {h} from 'dom-chef';
+import select from 'select-dom';
+import {getRepoURL} from '../libs/page-detect';
+import fetchApi from '../libs/api';
 import {openIssue, closedIssue} from '../libs/icons';
 
-export default function () {
+let insertedSidebarItem;
+
+async function displayIssueSuggestions(title = 'issue comment') {
+	const repo = getRepoURL();
+	const query = encodeURIComponent(`${title.replace(/:/g, '\\:')} repo:${repo} type:issue`);
+	const url = `search/issues?q=${query}`;
+	const issues = (await fetchApi(url)).items;
 	const sidebar = select('.discussion-sidebar');
-	const issues = [
-		{
-			title: 'My cat has grown tentacles and turned purple, should I worry?',
-			open: false
-		},
-		{
-			title: 'Help, my cat\'s bugging me to install a browser extension!',
-			open: true
-		}
-	];
-	sidebar.prepend(
+
+	const sidebarItem = (
 		<div class="discussion-sidebar-item">
 			<div class="text-bold mb-2">Possibly related issues</div>
 			<div class="Box Box--condensed">
 				{
 					issues.map(issue => (
-						<a class="Box-row d-flex px-2" href="#1321">
-							<div class="flex-shrink">{issue.open ? openIssue() : closedIssue()}</div>
+						<a class="Box-row d-flex px-2" href={issue.html_url}>
+							<div class="flex-shrink">{issue.state === 'open' ? openIssue() : closedIssue()}</div>
 							<div class="flex-grow pl-2">{issue.title}</div>
 						</a>
 					))
@@ -29,4 +28,16 @@ export default function () {
 			</div>
 		</div>
 	);
+
+	if (insertedSidebarItem) {
+		insertedSidebarItem.replaceWith(sidebarItem);
+	} else {
+		sidebar.prepend(sidebarItem);
+	}
+	insertedSidebarItem = sidebarItem;
+}
+
+export default function () {
+	console.log(select('#issue_title'));
+	select('#issue_title').addEventListener('blur', ({target}) => displayIssueSuggestions(target.value));
 }

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -9,6 +9,10 @@ let insertedSidebarItem;
 const escapeQualifiers = str => str.replace(/[a-z-]+:[a-z-]+/g, '"$1"');
 
 async function displayIssueSuggestions(title) {
+	if (title === '') {
+		return;
+	}
+
 	const repo = getRepoURL();
 	const apiQuery = encodeURIComponent(`${escapeQualifiers(title)} repo:${repo} is:issue`);
 	const response = await fetchApi(`search/issues?q=${apiQuery}&per_page=5`).catch(() => null);
@@ -16,7 +20,6 @@ async function displayIssueSuggestions(title) {
 
 	if (response && response.items && response.items.length > 0) {
 		const {items: issues, total_count: totalCount} = response;
-
 		const linkQuery = encodeURIComponent(`${escapeQualifiers(title)} is:issue`);
 
 		sidebarItem = (

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -1,0 +1,32 @@
+import select from 'select-dom';
+import {h} from 'dom-chef';
+import {openIssue, closedIssue} from '../libs/icons';
+
+export default function () {
+	const sidebar = select('.discussion-sidebar');
+	const issues = [
+		{
+			title: 'My cat has grown tentacles and turned purple, should I worry?',
+			open: false
+		},
+		{
+			title: 'Help, my cat\'s bugging me to install a browser extension!',
+			open: true
+		}
+	];
+	sidebar.prepend(
+		<div class="discussion-sidebar-item">
+			<div class="text-bold mb-2">Possibly related issues</div>
+			<div class="Box Box--condensed">
+				{
+					issues.map(issue => (
+						<a class="Box-row d-flex px-2" href="#1321">
+							<div class="flex-shrink">{issue.open ? openIssue() : closedIssue()}</div>
+							<div class="flex-grow pl-2">{issue.title}</div>
+						</a>
+					))
+				}
+			</div>
+		</div>
+	);
+}

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -44,7 +44,7 @@ async function displayIssueSuggestions(title) {
 		const linkQuery = encodeURIComponent(`${words.join(' ')} is:issue`);
 
 		sidebarItem = (
-			<div class="discussion-sidebar-item">
+			<div class="discussion-sidebar-item pt-0">
 				<div class="text-bold mb-2">Possibly related issues</div>
 				<div class="Box Box--condensed">
 					{

--- a/source/libs/api.js
+++ b/source/libs/api.js
@@ -1,5 +1,12 @@
+const cache = new Map();
+
 export default async endpoint => {
+	if (cache.has(endpoint)) {
+		return cache.get(endpoint);
+	}
 	const api = location.hostname === 'github.com' ? 'https://api.github.com/' : `${location.origin}/api/`;
 	const response = await fetch(api + endpoint);
-	return response.json();
+	const json = await response.json();
+	cache.set(endpoint, json);
+	return json;
 };

--- a/test/searchable-words.js
+++ b/test/searchable-words.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import {getSearchableWords as fn} from '../source/features/display-issue-suggestions';
+
+test('Searchable words filter', t => {
+	t.deepEqual(fn(' n o t h i n g	n e s s'), []);
+	t.deepEqual(fn('Hello, world!'), ['Hello', 'world']);
+	t.deepEqual(fn(' 400  	[error] is\\ nonsense !'), ['400', 'error', 'nonsense']);
+	t.deepEqual(fn('1col is broken'), ['1col', 'broken']);
+	t.deepEqual(fn('ava is 🔥🔥🔥'), ['ava']);
+	t.deepEqual(fn('1身 分'), ['1身', '分']);
+	t.deepEqual(fn('làm 7/2 nộp'), ['làm', 'nộp']);
+	t.deepEqual(fn('测试'), ['测试']);
+	t.deepEqual(fn('حمید'), ['حمید']);
+	t.deepEqual(fn('테스트'), ['테스트']);
+});


### PR DESCRIPTION
*A basic implementation of the feature suggested by @fenollp in #1138.*

When the title input field on the `New Issue` page is blurred, an API request is made to fetch issues on the repository with the title as the query. The first five issues are then displayed in the sidebar.

![](https://user-images.githubusercontent.com/29176678/37566899-85953e6e-2abf-11e8-9f0e-52d18c87bbe3.gif)

<img src="https://user-images.githubusercontent.com/29176678/37566948-48f6b7c0-2ac0-11e8-98e0-6fe1d6840ed3.png" align="right">

If there are more than five, an *X more results* link that links to the regular issue search is added below.

Currently, the search is really basic. While StackOverflow's suggestions get more accurate as you enter more text, this search only looks for issues that contain the text in the title which is not the best way to determine whether an issue is relevant. Please let me know if you have any ideas on how the search could be improved.

###### Closes #1138