### PR TITLE
Fix status label for reopend issues

### DIFF
--- a/source/features/extend-issue-status-label.js
+++ b/source/features/extend-issue-status-label.js
@@ -6,11 +6,11 @@ export default function () {
 	const lastActionRef = select.all(`
 		.discussion-item-closed [href*="/pull/"],
 		.discussion-item-closed code,
-		.discussion-item-reopended
+		.discussion-item-reopened
 	`).pop();
 
 	// Leave if it was never closed or if it was reopened or if it’s already linked
-	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopended') || select.exists('.gh-header-meta .State a')) {
+	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopened') || select.exists('.gh-header-meta .State a')) {
 		return;
 	}
 


### PR DESCRIPTION
Closes #1194.

```
https://github.com/postcss/autoprefixer/issues/954
```