### PR TITLE
Fix adding patch and diff links to commit pages

### DIFF
--- a/source/features/add-patch-diff-links.js
+++ b/source/features/add-patch-diff-links.js
@@ -13,7 +13,7 @@ export default function () {
 		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
 	}
 
-	select('.commit-meta > div:last-child').append(
+	select('.commit-meta > :last-child').append(
 		<span class="sha-block patch-diff-links">
 			<a href={`${commitUrl}.patch`} class="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }


### PR DESCRIPTION
Fixes and closes #1080 (again!).

Test links:
* https://github.com/sindresorhus/refined-github/commit/09041df0cba07b115bd0de437540bda271e6efb7
* https://github.com/sindresorhus/refined-github/pull/1119/commits/0f51dfe30eb36e60369a188786d88b6e421f1543