### PR TITLE
Mark :visited issues

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -5,6 +5,12 @@
 	--github-gray-text: #6a737d;
 }
 
+/* Mark :visited issues/PRs */
+.unread.issue-notification .list-group-item-link:visited, /* "unread" only because "read" ones are better off gray */
+.issues-listing .link-gray-dark:visited {
+	color: #609 !important;
+}
+
 /* GitHub bug: releases page has unwanted bullet points */
 .release-timeline-tags {
 	list-style: none;

--- a/source/content.css
+++ b/source/content.css
@@ -8,7 +8,7 @@
 /* Mark :visited issues/PRs */
 .unread.issue-notification .list-group-item-link:visited, /* "unread" only because "read" ones are better off gray */
 .issues-listing .link-gray-dark:visited {
-	color: #609 !important;
+	color: #666 !important;
 }
 
 /* GitHub bug: releases page has unwanted bullet points */

--- a/source/content.css
+++ b/source/content.css
@@ -8,7 +8,7 @@
 /* Mark :visited issues/PRs */
 .unread.issue-notification .list-group-item-link:visited, /* "unread" only because "read" ones are better off gray */
 .issues-listing .link-gray-dark:visited {
-	color: #666 !important;
+	color: #586069 !important;
 }
 
 /* GitHub bug: releases page has unwanted bullet points */


### PR DESCRIPTION
Closes #1153 

Give it a try for a few days. ~~If you have stylish~~ _[In our options](https://github.com/sindresorhus/refined-github/pull/1193)_ you can just try this without checking out the PR:

```css
/* Mark :visited issues/PRs */
.unread.issue-notification .list-group-item-link:visited, /* "unread" only because "read" ones are better off gray */
.issues-listing .link-gray-dark:visited {
	color: #586069 !important;
}
```

~~The only concern is that _black looks better than purple_ but I think its usefulness will help you forget that.~~