### PR TITLE
Privately remind users not to leave :+1: and :-1: as comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
 	"stylelint": {
 		"extends": "stylelint-config-xo",
 		"rules": {
+			"selector-type-no-unknown": null,
 			"declaration-no-important": null,
 			"property-no-vendor-prefix": null,
 			"no-descending-specificity": null,

--- a/source/content.css
+++ b/source/content.css
@@ -40,15 +40,15 @@
 	margin: 0;
 }
 
-/* Privately remind users to use Reactions for voting */
-.current-user .comment-body > p:only-child > g-emoji[alias$="1"]:only-child {
+/* Privately remind users to use Reactions for +1/-1 voting */
+.current-user .comment-body > p:only-child > g-emoji[alias$='1']:only-child {
 	display: flex;
 	flex-direction: column;
 	text-align: center;
 	padding: 3em;
 	font-size: 4em;
 }
-.current-user .comment-body > p:only-child > g-emoji[alias$="1"]:only-child:after {
+.current-user .comment-body > p:only-child > g-emoji[alias$='1']:only-child::after {
 	content: 'This should be posted as a reaction, not as a comment.';
 	font-family: sans-serif;
 	margin-top: 2em;

--- a/source/content.css
+++ b/source/content.css
@@ -40,6 +40,21 @@
 	margin: 0;
 }
 
+/* Privately remind users to use Reactions for voting */
+.current-user .comment-body > p:only-child > g-emoji[alias$="1"]:only-child {
+	display: flex;
+	flex-direction: column;
+	text-align: center;
+	padding: 3em;
+	font-size: 4em;
+}
+.current-user .comment-body > p:only-child > g-emoji[alias$="1"]:only-child:after {
+	content: 'This should be posted as a reaction, not as a comment.';
+	font-family: sans-serif;
+	margin-top: 2em;
+	font-size: 20px;
+}
+
 /* Remove the toolbar from the right repo box on the dashboard */
 .dashboard-sidebar .user-repos > h3,
 .dashboard-sidebar .user-repos > .boxed-group-action {

--- a/source/content.css
+++ b/source/content.css
@@ -41,14 +41,16 @@
 }
 
 /* Privately remind users to use Reactions for +1/-1 voting */
-.current-user .comment-body > p:only-child > g-emoji[alias$='1']:only-child {
+.current-user .comment-body > p:only-child > g-emoji[alias='+1']:only-child,
+.current-user .comment-body > p:only-child > g-emoji[alias='-1']:only-child {
 	display: flex;
 	flex-direction: column;
 	text-align: center;
 	padding: 3em;
 	font-size: 4em;
 }
-.current-user .comment-body > p:only-child > g-emoji[alias$='1']:only-child::after {
+.current-user .comment-body > p:only-child > g-emoji[alias='+1']:only-child::after,
+.current-user .comment-body > p:only-child > g-emoji[alias='-1']:only-child::after {
 	content: 'This should be posted as a reaction, not as a comment.';
 	font-family: sans-serif;
 	margin-top: 2em;


### PR DESCRIPTION
Less of a feature, more of a community service. This only appears to who left the comment.

<img width="777" alt="" src="https://user-images.githubusercontent.com/1402241/38125873-db0131b8-3416-11e8-91e0-ce79ae1028ac.png">

Feature annoyance rating: 🔥🔥🔥💦💦