### PR TITLE
Hide overlapping tooltips

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -76,8 +76,6 @@
 [aria-label='Open this file in GitHub Desktop']::after,
 [aria-label$='branch to make changes.']::before,
 [aria-label$='branch to make changes.']::after,
-[aria-label='Copy file path to clipboard']::before,
-[aria-label='Copy file path to clipboard']::after,
 .notification-indicator::before,
 .notification-indicator::after {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -72,6 +72,13 @@
 [aria-label='Edit this file']::after,
 [aria-label='Edit comment']::before,
 [aria-label='Edit comment']::after,
+[aria-label='Edit comment']::after,
+[aria-label='Open this file in GitHub Desktop']::before,
+[aria-label='Open this file in GitHub Desktop']::after,
+[aria-label$='branch to make changes.']::before,
+[aria-label$='branch to make changes.']::after,
+[aria-label='Copy file path to clipboard']::before,
+[aria-label='Copy file path to clipboard']::after,
 .notification-indicator::before,
 .notification-indicator::after {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -72,7 +72,6 @@
 [aria-label='Edit this file']::after,
 [aria-label='Edit comment']::before,
 [aria-label='Edit comment']::after,
-[aria-label='Edit comment']::after,
 [aria-label='Open this file in GitHub Desktop']::before,
 [aria-label='Open this file in GitHub Desktop']::after,
 [aria-label$='branch to make changes.']::before,


### PR DESCRIPTION
Hides the tooltip on the following buttons:

![image](https://user-images.githubusercontent.com/4730164/38155967-c1e74a0a-3448-11e8-8d6b-03a0558ca2d0.png)

Keeps the tooltip on the expand / collapse glyph since it contains a helpful tip:

![image](https://user-images.githubusercontent.com/4730164/38155937-9b97ded2-3448-11e8-9c96-b8d34ec96b83.png)

---
Closes #1212 