### PR TITLE
Fix alignment of ci icon

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -743,6 +743,10 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	animation: fade-in 0.2s;
 }
 
+.rgh-ci-link .octicon {
+	margin-top: 0px !important;
+}
+
 :root .repohead h1 .commit-build-statuses .octicon {
 	position: static;
 	color: inherit;

--- a/source/content.css
+++ b/source/content.css
@@ -744,7 +744,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 }
 
 .rgh-ci-link .octicon {
-	margin-top: 0px !important;
+	margin-top: 0 !important;
 }
 
 :root .repohead h1 .commit-build-statuses .octicon {


### PR DESCRIPTION
Resets `top-margin` to `0px` for the CI icon.

Before:

![image](https://user-images.githubusercontent.com/4730164/38156473-19639a88-344c-11e8-9269-e7650fe00a2a.png)

After:

![image](https://user-images.githubusercontent.com/4730164/38156490-4017b434-344c-11e8-9d53-97787670f349.png)



---
Closes #1221 