### PR TITLE
Restore file-list highlight when using keyboard navigation

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -86,8 +86,10 @@
 	opacity: 0.6;
 }
 
-/* Remove annoying hover in the repo file list */
-.file-wrap .files .navigation-focus td {
+/* For `rgh-no-navigation-highlight` */
+.rgh-no-navigation-highlight .list-group-item.navigation-focus, /* Notifications list */
+.rgh-no-navigation-highlight .Box-row.navigation-focus, /* Issue list */
+.rgh-no-navigation-highlight .navigation-focus td { /* File list  */
 	background: none !important;
 }
 

--- a/source/content.css
+++ b/source/content.css
@@ -86,11 +86,6 @@
 	opacity: 0.6;
 }
 
-/* Remove annoying hover in the repo file list */
-.file-wrap .files .navigation-focus td {
-	background: none !important;
-}
-
 #readme > h3 {
 	display: none !important;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -86,6 +86,11 @@
 	opacity: 0.6;
 }
 
+/* Remove annoying hover in the repo file list */
+.file-wrap .files .navigation-focus td {
+	background: none !important;
+}
+
 #readme > h3 {
 	display: none !important;
 }

--- a/source/content.js
+++ b/source/content.js
@@ -72,6 +72,7 @@ import closeOutOfViewModals from './features/close-out-of-view-modals';
 import addScopedSearchOnUserProfile from './features/add-scoped-search-on-user-profile';
 import monospaceTextareas from './features/monospace-textareas';
 import improveShortcutHelp from './features/improve-shortcut-help';
+import hideNavigationHoverHighlight from './features/hide-navigation-hover-highlight';
 import displayIssueSuggestions from './features/display-issue-suggestions';
 
 import * as pageDetect from './libs/page-detect';
@@ -128,6 +129,7 @@ async function init() {
 	enableFeature(focusConfirmationButtons);
 	enableFeature(addKeyboardShortcutsToCommentFields);
 	enableFeature(addConfirmationToCommentCancellation);
+	enableFeature(hideNavigationHoverHighlight);
 	enableFeature(monospaceTextareas);
 
 	// TODO: Enable this when we've improved how copying Markdown works

--- a/source/features/hide-navigation-hover-highlight.js
+++ b/source/features/hide-navigation-hover-highlight.js
@@ -1,0 +1,9 @@
+const className = 'rgh-no-navigation-highlight';
+
+export default function () {
+	document.body.classList.add(className);
+	document.body.addEventListener('navigation:keydown', () => {
+		document.body.classList.remove(className);
+	}, {once: true});
+}
+

--- a/source/features/hide-navigation-hover-highlight.js
+++ b/source/features/hide-navigation-hover-highlight.js
@@ -1,3 +1,12 @@
+/*
+Some lists like notifications, file lists, and issue lists,
+are highlighted as you move the mouse over them. This highlight
+is useful when navigating via the keyboard (j/k), but annoying
+when just moving the mouse around.
+
+This feature will hide the highlight until the first keyboard
+navigation, then it will be displayed until the next full reload.
+*/
 const className = 'rgh-no-navigation-highlight';
 
 export default function () {

--- a/source/features/hide-navigation-hover-highlight.js
+++ b/source/features/hide-navigation-hover-highlight.js
@@ -15,4 +15,3 @@ export default function () {
 		document.body.classList.remove(className);
 	}, {once: true});
 }
-


### PR DESCRIPTION
This highlight is actually an accessibility/keyboard feature (`j`/`k`) and it's present in other parts of the site (notifications, issues, PRs) so either it's disabled everywhere on hover or left alone