### PR TITLE
Stop repainting embedded gist while scrolling

### DIFF
--- a/source/features/embed-gist-inline.js
+++ b/source/features/embed-gist-inline.js
@@ -27,7 +27,11 @@ async function embedGist(link) {
 				<style>{`
 					.gist .gist-data {
 						max-height: 16em;
-						overflow-y: auto;
+						backface-visibility: hidden;
+					}
+
+					.gist .blob-wrapper {
+						backface-visibility: hidden;
 					}
 				`}</style>,
 				<link rel="stylesheet" href={gistData.stylesheet} />,


### PR DESCRIPTION
Embedded gists can sometime be very long, and any element with `overflow` property set to other than `none` repaints its content on every scroll event, which is very expensive and adds scroll jank.

This PR instructs the browser to not repaint the contents of the overflowing element.

Example: https://github.com/signalapp/Signal-Desktop/issues/1884