### PR TITLE
Create a release shortcut

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,7 @@ And [many more…](source/content.css)
 ### More shortcuts
 
 - [Access a repository's releases using the `Releases` tab or by pressing <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
+- Create a new release on the Releases tab by pressing <kbd>c</kbd>.
 - [Compare a repository's branches with the `Compare` link under `More`.](https://user-images.githubusercontent.com/170270/27501134-cf0a2a18-586b-11e7-8430-22f33030e923.png)
 - [Access the `Labels` `Milestones` navigation from individual milestone pages.](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
 - [Search for issues and PRs with the `Everything commented by you` filter.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)

--- a/source/content.js
+++ b/source/content.js
@@ -53,6 +53,7 @@ import moveAccountSwitcherToSidebar from './features/move-account-switcher-to-si
 import openCIDetailsInNewTab from './features/open-ci-details-in-new-tab';
 import focusConfirmationButtons from './features/focus-confirmation-buttons';
 import addKeyboardShortcutsToCommentFields from './features/add-keyboard-shortcuts-to-comment-fields';
+import addCreateReleaseShortcut from './features/add-create-release-shortcut';
 import addConfirmationToCommentCancellation from './features/add-confirmation-to-comment-cancellation';
 import addCILink from './features/add-ci-link';
 import embedGistInline from './features/embed-gist-inline';
@@ -253,6 +254,10 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isIssueList() || pageDetect.isPR() || pageDetect.isIssue()) {
 		enableFeature(showRecentlyPushedBranches);
+	}
+
+	if (pageDetect.isReleasesOrTags()) {
+		enableFeature(addCreateReleaseShortcut);
 	}
 
 	if (pageDetect.isCommit()) {

--- a/source/features/add-create-release-shortcut.js
+++ b/source/features/add-create-release-shortcut.js
@@ -1,0 +1,10 @@
+import select from 'select-dom';
+import {registerShortcut} from './improve-shortcut-help';
+
+export default function () {
+	registerShortcut('releases', 'c', 'Create a new release');
+	const createReleaseButton = select('a[href$="/releases/new"]:not([data-hotkey])');
+	if (createReleaseButton) {
+		createReleaseButton.setAttribute('data-hotkey', 'c');
+	}
+}

--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -40,7 +40,7 @@ export default async () => {
 	updateReleasesCount();
 	appendReleasesCount((await localCache)[repoKey]);
 
-	if (pageDetect.isReleases()) {
+	if (pageDetect.isReleasesOrTags()) {
 		const selected = select('.reponav-item.selected');
 		if (selected) {
 			selected.classList.remove('js-selected-navigation-item', 'selected');

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -86,7 +86,7 @@ export const isPRSearch = () => location.pathname.startsWith('/pulls');
 
 export const isQuickPR = () => isCompare() && /[?&]quick_pull=1(&|$)/.test(location.search);
 
-export const isReleases = () => /^(releases|tags)/.test(getRepoPath());
+export const isReleasesOrTags = () => /^(releases|tags)/.test(getRepoPath());
 
 export const isRepo = () => /^[^/]+\/[^/]+/.test(getCleanPathname()) &&
 	!isReserved(getOwnerAndRepo().ownerName) &&

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -315,8 +315,11 @@ test('isQuickPR', urlMatcherMacro, pageDetect.isQuickPR, [
 	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?expand=1'
 ]);
 
-test('isReleases', urlMatcherMacro, pageDetect.isReleases, [
-	'https://github.com/sindresorhus/refined-github/releases'
+test('isReleasesOrTags', urlMatcherMacro, pageDetect.isReleasesOrTags, [
+	'https://github.com/sindresorhus/refined-github/releases',
+	'https://github.com/sindresorhus/refined-github/tags',
+	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',
+	'https://github.com/sindresorhus/refined-github/releases/tag/0.2.1'
 ], [
 	'https://github.com/sindresorhus/refined-github',
 	'https://github.com/sindresorhus/refined-github/graphs'


### PR DESCRIPTION
Closes #1254.

- [x] Create release from releases list
- [x] Create release from releases empty page
- [x] Create release from tags empty page

Registering the shortcut in a non-existent section didn't work though. Perhaps we could separately think how to handle that in the `registerShortcut` function.