### PR TITLE
Show upload drag and drop area on new release page

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -148,7 +148,7 @@
 }
 
 /* Remove upload message on comment box */
-.is-default .drag-and-drop {
+.upload-enabled.is-default .drag-and-drop {
 	display: none;
 }
 .upload-enabled textarea {


### PR DESCRIPTION
The visible drag and drop area is the only method of attaching files to a release. It looks like the selector meant to hide the extra message on discussions accidentally applies to also releases.

Before:

<img width="782" alt="screen shot 2018-04-15 at 12 26 55" src="https://user-images.githubusercontent.com/19264/38776994-ed2bad20-40a8-11e8-8a6f-6b3b32cfbe66.png">

After:

<img width="782" alt="screen shot 2018-04-15 at 12 27 11" src="https://user-images.githubusercontent.com/19264/38776997-f489f234-40a8-11e8-9727-6354510d324a.png">
