### PR TITLE
Use native reponav dropdown if available

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -695,9 +695,11 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	padding-left: 15px;
 }
 
-/* Fix for GHE More Dropdown positioning */
-.reponav-dropdown.active .dropdown-menu {
-	left: auto !important;
+/* Fix for GHE More Dropdown items positioning */
+.reponav-dropdown a.dropdown-item:not(.rgh-reponav-more)::before {
+	content: '';
+	display: inline-block;
+	width: 16px;
 }
 
 /* Optically align Dependencies dropdown link */

--- a/source/features/more-dropdown.js
+++ b/source/features/more-dropdown.js
@@ -31,18 +31,18 @@ function getDropdown() {
 
 export default function () {
 	getDropdown().append(
-		<a href={`/${repoUrl}/compare`} class="dropdown-item" data-skip-pjax>
+		<a href={`/${repoUrl}/compare`} class="rgh-reponav-more dropdown-item" data-skip-pjax>
 			{icons.darkCompare()}
 			{' Compare'}
 		</a>,
 
 		pageDetect.isEnterprise() ? '' :
-			<a href={`/${repoUrl}/network/dependencies`} class="dropdown-item rgh-dependency-graph" data-skip-pjax>
+			<a href={`/${repoUrl}/network/dependencies`} class="rgh-reponav-more dropdown-item rgh-dependency-graph" data-skip-pjax>
 				{icons.dependency()}
 				{' Dependencies'}
 			</a>,
 
-		<a href={`/${repoUrl}/pulse`} class="dropdown-item" data-skip-pjax>
+		<a href={`/${repoUrl}/pulse`} class="rgh-reponav-more dropdown-item" data-skip-pjax>
 			{icons.graph()}
 			{' Insights'}
 		</a>

--- a/source/features/more-dropdown.js
+++ b/source/features/more-dropdown.js
@@ -6,14 +6,9 @@ import {appendBefore} from '../libs/utils';
 
 const repoUrl = pageDetect.getRepoURL();
 
-function getDropdown() {
-	const nativeDropdown = select('.reponav-dropdown .dropdown-menu');
-	if (nativeDropdown) {
-		return nativeDropdown;
-	}
-
+function createDropdown() {
 	// Markup copied from native GHE dropdown
-	const dropdown = (
+	appendBefore('.reponav', '[href$="settings"]', 
 		<div class="reponav-dropdown js-menu-container">
 			<button type="button" class="btn-link reponav-item js-menu-target" aria-expanded="false" aria-haspopup="true">
 				{'More '}
@@ -25,12 +20,13 @@ function getDropdown() {
 			</div>
 		</div>
 	);
-	appendBefore('.reponav', '[href$="settings"]', dropdown);
-	return select('.dropdown-menu', dropdown);
 }
 
 export default function () {
-	getDropdown().append(
+	if (!select.exists('.reponav-dropdown')) {
+		createDropdown();
+	}
+	select('.reponav-dropdown .dropdown-menu').append(
 		<a href={`/${repoUrl}/compare`} class="rgh-reponav-more dropdown-item" data-skip-pjax>
 			{icons.darkCompare()}
 			{' Compare'}

--- a/source/features/more-dropdown.js
+++ b/source/features/more-dropdown.js
@@ -8,7 +8,7 @@ const repoUrl = pageDetect.getRepoURL();
 
 function createDropdown() {
 	// Markup copied from native GHE dropdown
-	appendBefore('.reponav', '[href$="settings"]', 
+	appendBefore('.reponav', '[href$="settings"]',
 		<div class="reponav-dropdown js-menu-container">
 			<button type="button" class="btn-link reponav-item js-menu-target" aria-expanded="false" aria-haspopup="true">
 				{'More '}

--- a/source/features/more-dropdown.js
+++ b/source/features/more-dropdown.js
@@ -6,30 +6,46 @@ import {appendBefore} from '../libs/utils';
 
 const repoUrl = pageDetect.getRepoURL();
 
-export default function () {
-	appendBefore('.reponav', '[href$="settings"]',
-		<div class="reponav-dropdown js-menu-container refined-github-more">
-			<button type="button" class="btn-link reponav-item reponav-dropdown js-menu-target " data-no-toggle aria-expanded="false" aria-haspopup="true">More {icons.triangleDown()}</button>
-			<div class="dropdown-menu-content">
-				<div class="dropdown-menu dropdown-menu-sw js-menu-content">
-					<a href={`/${repoUrl}/compare`} class="dropdown-item" data-skip-pjax>
-						{icons.darkCompare()}
-						<span itemprop="name"> Compare</span>
-					</a>
-					{
-						pageDetect.isEnterprise() ? '' :
-							<a href={`/${repoUrl}/network/dependencies`} class="dropdown-item rgh-dependency-graph" data-skip-pjax>
-								{icons.dependency()}
-								<span itemprop="name"> Dependencies</span>
-							</a>
-					}
-					<a href={`/${repoUrl}/pulse`} class="dropdown-item" data-skip-pjax>
-						{icons.graph()}
-						<span itemprop="name"> Insights</span>
-					</a>
+function getDropdown() {
+	const nativeDropdown = select('.reponav-dropdown .dropdown-menu');
+	if (nativeDropdown) {
+		return nativeDropdown;
+	}
+
+	// Markup copied from native GHE dropdown
+	const dropdown = (
+		<div class="reponav-dropdown js-menu-container">
+			<button type="button" class="btn-link reponav-item js-menu-target" aria-expanded="false" aria-haspopup="true">
+				{'More '}
+				<span class="dropdown-caret"></span>
+			</button>
+			<div class="dropdown-menu-content js-menu-content">
+				<div class="dropdown-menu dropdown-menu-se">
 				</div>
 			</div>
 		</div>
+	);
+	appendBefore('.reponav', '[href$="settings"]', dropdown);
+	return select('.dropdown-menu', dropdown);
+}
+
+export default function () {
+	getDropdown().append(
+		<a href={`/${repoUrl}/compare`} class="dropdown-item" data-skip-pjax>
+			{icons.darkCompare()}
+			{' Compare'}
+		</a>,
+
+		pageDetect.isEnterprise() ? '' :
+			<a href={`/${repoUrl}/network/dependencies`} class="dropdown-item rgh-dependency-graph" data-skip-pjax>
+				{icons.dependency()}
+				{' Dependencies'}
+			</a>,
+
+		<a href={`/${repoUrl}/pulse`} class="dropdown-item" data-skip-pjax>
+			{icons.graph()}
+			{' Insights'}
+		</a>
 	);
 
 	// Remove native Insights tab

--- a/source/libs/icons.js
+++ b/source/libs/icons.js
@@ -28,8 +28,6 @@ export const code = () => <svg aria-hidden="true" class="octicon octicon-code" w
 
 export const dependency = () => <svg aria-hidden="true" class="octicon octicon-package" width="16" height="16"><path fill-rule="evenodd" d="M1 4.27v7.47c0 .45.3.84.75.97l6.5 1.73c.16.05.34.05.5 0l6.5-1.73c.45-.13.75-.52.75-.97V4.27c0-.45-.3-.84-.75-.97l-6.5-1.74a1.4 1.4 0 0 0-.5 0L1.75 3.3c-.45.13-.75.52-.75.97zm7 9.09l-6-1.59V5l6 1.61v6.75zM2 4l2.5-.67L11 5.06l-2.5.67L2 4zm13 7.77l-6 1.59V6.61l2-.55V8.5l2-.53V5.53L15 5v6.77zm-2-7.24L6.5 2.8l2-.53L15 4l-2 .53z"/></svg>;
 
-export const triangleDown = () => <svg aria-hidden="true" class="octicon octicon-triangle-down v-align-middle text-y" width="8" height="11" viewBox="0 0 12 16"><path fill-rule="evenodd" d="M0 5l6 6 6-6z"/></svg>;
-
 export const chevronDown = () => <svg aria-hidden="true" class="octicon octicon-chevron-down" width="10" height="16"><path fill-rule="evenodd" d="M10 10l-1.5 1.5L5 7.75 1.5 11.5 0 10l5-5z"/></svg>;
 
 export const chevronLeft = () => <svg aria-hidden="true" class="octicon octicon-chevron-left" height="16" width="8"><path fill-rule="evenodd" d="M5.5 3L7 4.5 3.25 8 7 11.5 5.5 13l-5-5z"/></svg>;


### PR DESCRIPTION
Fixes #1269 

Not tested on GHE. @Naramsim can you try this branch?

Style matches the native one as well:

<img width="185" alt="" src="https://user-images.githubusercontent.com/1402241/39036584-247d74c2-44a8-11e8-87d6-67459374e81f.png">

And it should look like this on GHE (mockup): 

<img width="182" alt="ghe mockup" src="https://user-images.githubusercontent.com/1402241/39037339-5fb5c5a6-44aa-11e8-9490-df8c2671ff92.png">
