### PR TITLE
Filter out gist links that are inline

### DIFF
--- a/source/features/embed-gist-inline.js
+++ b/source/features/embed-gist-inline.js
@@ -9,6 +9,8 @@ const isGist = link =>
 		link.pathname.startsWith('gist/')
 	);
 
+const isOnlyChild = link => link.textContent.trim() === link.parentNode.textContent.trim();
+
 async function embedGist(link) {
 	const info = <em> (loading)</em>;
 	link.after(info);
@@ -40,6 +42,6 @@ async function embedGist(link) {
 }
 export default () => {
 	select.all('.js-comment-body p a:only-child')
-		.filter(isGist)
+		.filter(item => isGist(item) && isOnlyChild(item))
 		.forEach(embedGist);
 };


### PR DESCRIPTION
Filter out any gist links that are not on their own line by checking that the text content of the parent node and link match

fixes: #1263 