### PR TITLE
Prevent console error in `close-out-of-view-modals`

### DIFF
--- a/source/features/close-out-of-view-modals.js
+++ b/source/features/close-out-of-view-modals.js
@@ -4,10 +4,10 @@ import delegate from 'delegate';
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
 		observer.unobserve(target);
-		select(`
-			.dropdown-details[open] summary,
-			body.menu-active .modal-backdrop
-		`).click();
+		const dropdown = select(`.dropdown-details[open] summary,body.menu-active .modal-backdrop`);
+		if (dropdown) {
+		dropdown.click();
+		}
 	}
 });
 

--- a/source/features/close-out-of-view-modals.js
+++ b/source/features/close-out-of-view-modals.js
@@ -4,18 +4,18 @@ import delegate from 'delegate';
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
 		observer.unobserve(target);
-		const dropdown = select(`.dropdown-details[open] summary,body.menu-active .modal-backdrop`);
+		const dropdown = select(`
+			.dropdown-details[open] summary,
+			body.menu-active .modal-backdrop
+		`);
 		if (dropdown) {
-		dropdown.click();
+			dropdown.click();
 		}
 	}
 });
 
 export default function () {
-	delegate(`
-		.dropdown-details,
-		.js-menu-target
-	`, 'click', event => {
+	delegate('.dropdown-details, .js-menu-target', 'click', event => {
 		const button = event.delegateTarget;
 		const modal = button
 			.closest('.select-menu, .dropdown')


### PR DESCRIPTION
### Fixes #1273 

Added an if check to avoid calling `.click()` with a `null` value.