### PR TITLE
Avoid showing related issues when the issue title is empty

### DIFF
--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -29,11 +29,11 @@ export function getSearchableWords(text) {
 }
 
 async function displayIssueSuggestions(title) {
+	if (title.trim().length === 0) {
+		return;
+	}
 	const words = getSearchableWords(title);
-	if (title.length < 3 && (words[0] === '' || words.length === 0)) {
-		if (insertedSidebarItem) {
-			insertedSidebarItem.remove();
-		}
+	if (words.length === 0) {
 		return;
 	}
 

--- a/source/features/display-issue-suggestions.js
+++ b/source/features/display-issue-suggestions.js
@@ -30,7 +30,10 @@ export function getSearchableWords(text) {
 
 async function displayIssueSuggestions(title) {
 	const words = getSearchableWords(title);
-	if (words.length === 0) {
+	if (title.length < 3 && (words[0] === '' || words.length === 0)) {
+		if (insertedSidebarItem) {
+			insertedSidebarItem.remove();
+		}
 		return;
 	}
 


### PR DESCRIPTION
### Fixes #1267 

This pull request fixes the issue where suggestions would be displayed with an empty title.

Now, the user must enter a **minimum of 3 characters** in order to generate suggestions. Also if the user **clears** the title field leaves **less than 3 characters**, the suggestion box is removed.


![refined-github_capture](https://user-images.githubusercontent.com/15523758/39173671-65e1b40a-4773-11e8-8305-8ce2547a5454.gif)
