### PR TITLE
Correct issue label CSS class

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -668,7 +668,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 .js-issue-row .mt-1.text-small.text-gray { /* Issue details line */
 	flex-basis: 100%;
 }
-.js-issue-row .label {
+.js-issue-row .IssueLabel {
 	padding: 2px 3px 3px !important;
 	margin-top: 4px;
 	font-size: 11px !important;


### PR DESCRIPTION
I noticed that the issue labels were quite big. After looking into the code, I discovered that the current CSS selector doesn't seem to be valid any longer. GitHub has renamed the `label` class to `IssueLabel` both on pull requests and issues.

I could also change it to `.js-issue-row .label, .js-issue-row .IssueLabel {` to be backwards-compatible (think maybe older GitHub enterprise versions?).