### PR TITLE
Fix keyboard shortcuts on comment fields

### DIFF
--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -24,12 +24,13 @@ export default function () {
 
 	delegate('.js-comment-field', 'keydown', event => {
 		const field = event.target;
-		if (event.key === 'Tab' && !event.shiftKey) {
-			// Don't indent if the suggester box is active
-			if (select.exists('.suggester.active')) {
-				return;
-			}
 
+		// Don't do anything if the suggester box is active
+		if (select.exists('.suggester.active', field.form)) {
+			return;
+		}
+
+		if (event.key === 'Tab' && !event.shiftKey) {
 			indentTextarea(field);
 			event.preventDefault();
 		} else if (event.key === 'Enter' && event.shiftKey) {
@@ -40,16 +41,20 @@ export default function () {
 				event.preventDefault();
 			}
 		} else if (event.key === 'Escape') {
-			const inlineCancelButton = select('.js-hide-inline-comment-form', field.form);
+			// Cancel buttons have different classes for inline comments and editable comments
+			const cancelButton = select(`
+				.js-hide-inline-comment-form,
+				.js-comment-cancel-button
+			`, field.form);
 
-			// Cancel comment if inline, blur the field if it's a regular comment
-			if (field.value === '') {
+			// Blur the field if it's a regular comment, cancel if there is a button
+			if (field.id === 'new_comment_field') {
 				blurAccessibly(field);
-			} else if (inlineCancelButton) {
-				inlineCancelButton.click();
+			} else if (cancelButton) {
+				cancelButton.click();
 			}
 		} else if (event.key === 'ArrowUp' && field.id === 'new_comment_field' && field.value === '') {
-			const lastOwnComment = select.all(`.js-comment.current-user`).pop();
+			const lastOwnComment = select.all('.js-comment.current-user').pop();
 
 			if (lastOwnComment) {
 				select('.js-comment-edit-button', lastOwnComment).click();

--- a/source/features/add-keyboard-shortcuts-to-comment-fields.js
+++ b/source/features/add-keyboard-shortcuts-to-comment-fields.js
@@ -47,11 +47,11 @@ export default function () {
 				.js-comment-cancel-button
 			`, field.form);
 
-			// Blur the field if it's a regular comment, cancel if there is a button
-			if (field.id === 'new_comment_field') {
-				blurAccessibly(field);
-			} else if (cancelButton) {
+			// Cancel if there is a button, else blur the field
+			if (cancelButton) {
 				cancelButton.click();
+			} else {
+				blurAccessibly(field);
 			}
 		} else if (event.key === 'ArrowUp' && field.id === 'new_comment_field' && field.value === '') {
 			const lastOwnComment = select.all('.js-comment.current-user').pop();


### PR DESCRIPTION
Fixes #1252.

* Don't do **anything** if the selector box is open (separated this so that it may possibly useful for #1003)
* Add support for hiding "edit comment" box
* On 'Escape', if there is a cancel button then close the view, else blur the field