### PR TITLE
Lock review buttons after clicking

### DIFF
--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -56,14 +56,14 @@ export default function () {
 	}
 	submitButton.remove();
 
-	// To avoid double submit
-	const reviewButtons = document.querySelectorAll('#submit-review .form-actions button');
-	for (const button of reviewButtons) {
-		button.addEventListener('click', () => {
-			reviewButtons.forEach(button => {
-				button.style.opacity = 0.5;
-				button.style.pointerEvents = 'none';
-			});
+	// Freeze form to avoid duplicate submissions
+	select('#submit-review').addEventListener('submit', async () => {
+		// Disabled are not submitted, so this is needed
+		// to avoid disabling the fields before the submission
+		setTimeout(() => {
+			for (const control of select.all('#submit-review button, #submit-review textarea')) {
+				control.disabled = true;
+			}
 		});
-	}
+	});
 }

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -58,8 +58,7 @@ export default function () {
 
 	// Freeze form to avoid duplicate submissions
 	select('#submit-review').addEventListener('submit', async () => {
-		// Disabled are not submitted, so this is needed
-		// to avoid disabling the fields before the submission
+		// Delay disabling the fields to let them be submitted first
 		setTimeout(() => {
 			for (const control of select.all('#submit-review button, #submit-review textarea')) {
 				control.disabled = true;

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -58,12 +58,12 @@ export default function () {
 
 	// To avoid double submit
 	const reviewButtons = document.querySelectorAll('#submit-review .form-actions button');
-	reviewButtons.forEach(button => {
+	for (const button of reviewButtons) {
 		button.addEventListener('click', () => {
 			reviewButtons.forEach(button => {
 				button.style.opacity = 0.5;
 				button.style.pointerEvents = 'none';
 			});
 		});
-	});
+	}
 }

--- a/source/features/add-quick-review-buttons.js
+++ b/source/features/add-quick-review-buttons.js
@@ -55,4 +55,15 @@ export default function () {
 		radio.closest('.form-checkbox').remove();
 	}
 	submitButton.remove();
+
+	// To avoid double submit
+	const reviewButtons = document.querySelectorAll('#submit-review .form-actions button');
+	reviewButtons.forEach(button => {
+		button.addEventListener('click', () => {
+			reviewButtons.forEach(button => {
+				button.style.opacity = 0.5;
+				button.style.pointerEvents = 'none';
+			});
+		});
+	});
 }


### PR DESCRIPTION
I've been using refined-github for some time and I'm loving it so far!
I found an issue with review buttons. Due to how it currently works, it's possible to accidentally double click a button which will lead to double submission (or however many times you manage to click it until the page reloads):

<img width="524" alt="screen shot 2018-05-08 at 12 11 23 pm" src="https://user-images.githubusercontent.com/8418866/39737648-f8a7464c-52b8-11e8-83ca-ff129d2902ac.png">

This PR adds locking to the review buttons after one of them was clicked:

![gif](http://files.rdev.im/Screen-Recording-2018-05-08-12-14-57.gif)