### PR TITLE
Markdown rich diff tooltip appears underneath diff settings bar

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -778,6 +778,11 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	z-index: 10;
 }
 
+/* Tooltip visible over sticky header on hover */
+.pull-request-tab-content .diff-view .file-header:hover {
+	z-index: 30;
+}
+
 /* Sticky file headers in regular file view */
 .file .file-header {
 	position: sticky;


### PR DESCRIPTION
Tooltips now appear above buttons on hover. 

<img width="420" alt="screen shot 2018-05-08 at 14 24 58" src="https://user-images.githubusercontent.com/19957343/39781269-ef61a466-52cb-11e8-9ca3-c5acee0ef0ee.png">

<img width="408" alt="screen shot 2018-05-08 at 14 29 03" src="https://user-images.githubusercontent.com/19957343/39781357-337c8486-52cc-11e8-94f7-623e9021c531.png">

I ran ```npm test``` and got the following output https://user-images.githubusercontent.com/19957343/39781814-7cb09b82-52cd-11e8-93c6-c4fc504443c3.png

Fixes #1295