### PR TITLE
📌Sticky Issues Header

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ GitHub Enterprise is also supported. More info in the options.
 
 - [Full names of comment authors are shown next to their username.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
 - [File headers are always visible.](https://user-images.githubusercontent.com/81981/28682784-78bac340-72fe-11e7-9386-bdbab7703693.gif)
+- [Issue listing header is always visible.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
 - [Merge commits are dimmed in commits list.](https://user-images.githubusercontent.com/1402241/36772362-8ddf8138-1c87-11e8-9f34-1f6b76e5499f.png)
 - [The comments of who opened an issue/PR are marked with `Original Poster` label.](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
 - [Repo URLs are shortened to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)

--- a/source/content.css
+++ b/source/content.css
@@ -785,6 +785,13 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	z-index: 10;
 }
 
+/* Sticky table header on issues list */
+.issues-listing .table-list-header {
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
 /* Momentarily offset the line so its #deeplink won’t be covered by the header #974 */
 .js-file-line.highlighted {
 	/* stylelint-disable time-min-milliseconds */


### PR DESCRIPTION
### Why is this good?

This PR makes the bar the contains `labels / milestones / assign` at the top of the issues listing sticky on scroll.

This is super useful when you want to manipulate multiple issues at once, you can check issues and scroll down the list with available options and total selected remaining in view.

### Screenshot

One selected issue is off screen, but sticky bar makes it clear that this is the case.

![image](https://user-images.githubusercontent.com/380914/39851642-e29e5fc4-53cc-11e8-8912-8ca4c5129318.png)
