### PR TITLE
Use the pull request message as the commit message when merging with `Squash and merge`

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -47,6 +47,7 @@ import addMilestoneNavigation from './features/add-milestone-navigation';
 import addFilterCommentsByYou from './features/add-filter-comments-by-you';
 import removeProjectsTab from './features/remove-projects-tab';
 import fixSquashAndMergeTitle from './features/fix-squash-and-merge-title';
+import fixSquashAndMergeMessage from './features/fix-squash-and-merge-message';
 import addTitleToEmojis from './features/add-title-to-emojis';
 import sortMilestonesByClosestDueDate from './features/sort-milestones-by-closest-due-date';
 import moveAccountSwitcherToSidebar from './features/move-account-switcher-to-sidebar';
@@ -219,6 +220,7 @@ function ajaxedPagesHandler() {
 		enableFeature(scrollToTopOnCollapse);
 		enableFeature(addDeleteForkLink);
 		enableFeature(fixSquashAndMergeTitle);
+		enableFeature(fixSquashAndMergeMessage);
 		enableFeature(openCIDetailsInNewTab);
 		enableFeature(waitForBuild);
 		enableFeature(toggleAllThingsWithAlt);

--- a/source/features/fix-squash-and-merge-message.js
+++ b/source/features/fix-squash-and-merge-message.js
@@ -1,0 +1,12 @@
+import select from 'select-dom';
+
+export default function () {
+	const btn = select('.merge-message .btn-group-squash [type=submit]');
+	if (!btn) {
+		return;
+	}
+	btn.addEventListener('click', () => {
+		const desc = select_dom_default()(".comment-form-textarea[name='pull_request[body]']").textContent;
+    select_dom_default()("#merge_message_field").value = `${desc}`;
+	});
+}

--- a/source/features/fix-squash-and-merge-message.js
+++ b/source/features/fix-squash-and-merge-message.js
@@ -7,6 +7,6 @@ export default function () {
 	}
 	btn.addEventListener('click', () => {
 		const desc = select_dom_default()(".comment-form-textarea[name='pull_request[body]']").textContent;
-    select_dom_default()("#merge_message_field").value = `${desc}`;
+    		select_dom_default()("#merge_message_field").value = `${desc}`;
 	});
 }

--- a/source/features/fix-squash-and-merge-message.js
+++ b/source/features/fix-squash-and-merge-message.js
@@ -6,7 +6,7 @@ export default function () {
 		return;
 	}
 	btn.addEventListener('click', () => {
-		const desc = select_dom_default()(".comment-form-textarea[name='pull_request[body]']").textContent;
-    		select_dom_default()("#merge_message_field").value = `${desc}`;
+		const desc = select()('.comment-form-textarea[name=\'pull_request[body]\']').textContent;
+		select()('#merge_message_field').value = `${desc}`;
 	});
 }

--- a/source/features/fix-squash-and-merge-message.js
+++ b/source/features/fix-squash-and-merge-message.js
@@ -1,12 +1,13 @@
 import select from 'select-dom';
 
 export default function () {
-	const btn = select('.merge-message .btn-group-squash [type=submit]');
-	if (!btn) {
+	const button = select('.merge-message .btn-group-squash [type=submit]');
+	if (!button) {
 		return;
 	}
-	btn.addEventListener('click', () => {
-		const desc = select('.comment-form-textarea[name=\'pull_request[body]\']').textContent;
-		select('#merge_message_field').value = `${desc}`;
+
+	button.addEventListener('click', () => {
+		const description = select('.comment-form-textarea[name=\'pull_request[body]\']').textContent;
+		select('#merge_message_field').value = description;
 	});
 }

--- a/source/features/fix-squash-and-merge-message.js
+++ b/source/features/fix-squash-and-merge-message.js
@@ -6,7 +6,7 @@ export default function () {
 		return;
 	}
 	btn.addEventListener('click', () => {
-		const desc = select()('.comment-form-textarea[name=\'pull_request[body]\']').textContent;
-		select()('#merge_message_field').value = `${desc}`;
+		const desc = select('.comment-form-textarea[name=\'pull_request[body]\']').textContent;
+		select('#merge_message_field').value = `${desc}`;
 	});
 }


### PR DESCRIPTION
It's related to #423 , which uses the PR title as the squash commit title.

This PR introduces a new feature, which uses the PR description as the squash commit body message.

The change is in contrast to the default github behavior, that is, compiling a list of individual commit messages before the squash.

Fixes #1322