### PR TITLE
Fixed PR filters popup being obscured

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -789,7 +789,8 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 .issues-listing .table-list-header {
 	position: sticky;
 	top: 0;
-	z-index: 30; /* Must be above .modal-backdrop (z-index 20) #1317 */
+	/* Must be above .modal-backdrop (z-index 20) #1317 and below .select-menu.active (z-index 30) */
+	z-index: 25;
 }
 :root .select-menu-list {
 	/* Since the header is sticky, filters must now fit the viewport */


### PR DESCRIPTION
The sticky table-header-bar is obscuring the PR filter list:

<img width="404" alt="screen shot 2018-05-13 at 3 35 33 am" src="https://user-images.githubusercontent.com/278624/39960111-0caa62e6-5660-11e8-8516-b5c52c85761c.png">

