### PR TITLE
Support non-semver versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
 		"select-dom": "^4.1.0",
 		"shorten-repo-url": "^1.1.0",
 		"storm-textarea": "1.0.4",
-		"to-semver": "^1.1.0",
 		"turndown": "^4.0.1",
 		"webext-domain-permission-toggle": "0.0.2",
 		"webext-dynamic-content-scripts": "^5.0.0-2",

--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -14,16 +14,20 @@ import {getRepoURL, isRepoRoot, getOwnerAndRepo} from '../libs/page-detect';
 const branchInfoRegex = /([^ ]+)\.$/;
 
 function getTagLink() {
-	const latestRelease = select
+	const tags = select
 		.all('.branch-select-menu [data-tab-filter="tags"] .select-menu-item')
-		.map(element => element.dataset.name)
+		.map(element => element.dataset.name);
+
+	if (tags.length === 0) {
+		return;
+	}
+
+	const latestParsedRelease = tags
 		.filter(tag => /\d/.test(tag))
 		.sort(compareVersions)
 		.pop();
 
-	if (!latestRelease) {
-		return;
-	}
+	const latestRelease = latestParsedRelease || tags[0];
 
 	const link = <a class="btn btn-sm btn-outline tooltipped tooltipped-ne">{icons.tag()}</a>;
 

--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -1,9 +1,9 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
-import toSemver from 'to-semver';
 import * as icons from '../libs/icons';
 import {appendBefore} from '../libs/utils';
 import {groupSiblings} from '../libs/group-buttons';
+import compareVersions from '../libs/compare-versions';
 import {getRepoURL, isRepoRoot, getOwnerAndRepo} from '../libs/page-detect';
 
 // This regex should match all of these combinations:
@@ -14,9 +14,13 @@ import {getRepoURL, isRepoRoot, getOwnerAndRepo} from '../libs/page-detect';
 const branchInfoRegex = /([^ ]+)\.$/;
 
 function getTagLink() {
-	const tags = select.all('.branch-select-menu [data-tab-filter="tags"] .select-menu-item')
-		.map(element => element.dataset.name);
-	const [latestRelease] = toSemver(tags, {clean: false});
+	const latestRelease = select
+		.all('.branch-select-menu [data-tab-filter="tags"] .select-menu-item')
+		.map(element => element.dataset.name)
+		.filter(tag => /\d/.test(tag))
+		.sort(compareVersions)
+		.pop();
+
 	if (!latestRelease) {
 		return;
 	}

--- a/source/libs/compare-versions.js
+++ b/source/libs/compare-versions.js
@@ -1,0 +1,20 @@
+// No point version is the same as zero; betas and such are -1
+const clean = n => n === undefined ? '0' : String(n).replace(/^\D+/, '') || '-1';
+
+// Sort numbers naturally, excluding letters
+const compareSubVersion = (a, b) => clean(a).localeCompare(clean(b), 'en', {
+	numeric: true
+});
+
+// Sort versions, discarding any letters
+export default (a, b) => {
+	a = a.split(/[.-]/);
+	b = b.split(/[.-]/);
+	for (let i = 0; i < a.length || i < b.length; i++) {
+		const sort = compareSubVersion(a[i], b[i]);
+		if (sort !== 0) {
+			return sort;
+		}
+	}
+	return 0;
+};

--- a/test/compare-versions.js
+++ b/test/compare-versions.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+import fn from '../source/libs/compare-versions';
+
+test('Compare versions', t => {
+	t.is(-1, fn('1', '2'));
+	t.is(-1, fn('v1', '2'));
+	t.is(-1, fn('1.1', '1.2'));
+	t.is(-1, fn('1', '1.1'));
+	t.is(-1, fn('1', '1.0.1'));
+	t.is(-1, fn('2.0', '10.0'));
+	t.is(-1, fn('1.2.3', '1.22.3'));
+	t.is(-1, fn('1.1.1.1.1', '1.1.1.1.2'));
+	t.is(-1, fn('r1', 'r2'));
+	t.is(-1, fn('1.0-beta', '1.0'));
+	t.is(-1, fn('v0.11-M4', 'v0.20'));
+});


### PR DESCRIPTION
Fixes #1291

Tested on problematic repos:

- https://github.com/trello/navi (version has only 2 parts)
- https://github.com/live-clones/recalbox (a part has a leading zero)
- https://github.com/fsprojects/FSharp.Interop.Dynamic (version has 4 parts)
- https://github.com/mrdoob/three.js (version has one part and starts with `r`)
- https://github.com/sindresorhus/refined-github (not a real version, just the latest tag)

Possible trouble: betas might not be detected/sorted properly

Bonus: RGH loses 40KB 🙂 (`semver` package was heavy)