### PR TITLE
Hide "used" buttons in notifications

### DIFF
--- a/source/features/open-all-notifications.js
+++ b/source/features/open-all-notifications.js
@@ -28,9 +28,19 @@ async function openNotifications({delegateTarget}) {
 		action: 'openAllInTabs'
 	});
 
-	// Mark all as read, this also enables the native "marked as read notification"
-	for (const button of select.all('.mark-all-as-read', container)) {
-		button.click();
+	// Mark all as read
+	for (const notification of select.all('.unread', container)) {
+		notification.classList.replace('unread', 'read');
+	}
+
+	// Remove all now-useless buttons
+	for (const button of select.all(`
+		.rgh-open-notifications-button,
+		.open-repo-notifications,
+		.mark-all-as-read,
+		[href='#mark_as_read_confirm_box']
+	`, container)) {
+		button.remove();
 	}
 }
 


### PR DESCRIPTION
Addresses https://github.com/sindresorhus/refined-github/pull/1306#issuecomment-389518788

And avoids the ajax calls caused by clicking the "Mark all as read" buttons instead of just replacing the class.