### PR TITLE
Mention hide-useless-newsfeed-events in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -138,10 +138,8 @@ GitHub Enterprise is also supported. More info in the options.
 
 ### Declutter
 
-- [The dashboard shows more in less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
-- News feed items of users starring or forking your repos are removed.
-- Various entries are hidden from the dashboard, that we believe they are not really useful on a regular basis to GitHub power users.  
-<sup>*(There has been discussed quite a few times in the issue tracker that too much content is hidden from the dashboard, especially the Commit entries (*"user x pushed to repo y z commits"*). This is intended: if you follow hundreds of people and watch hundreds of repos, pushes and branches quickly become irrelevant to you. You may disable this feature by adding `hide-useless-newsfeed-events` in the extension options).*</sup>
+- [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png) 
+- Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
 - Obvious tooltips are removed.

--- a/readme.md
+++ b/readme.md
@@ -140,9 +140,8 @@ GitHub Enterprise is also supported. More info in the options.
 
 - [The dashboard shows more in less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
 - News feed items of users starring or forking your repos are removed.
-- Various entries are hidden from the dashboard by default, as we believe they are not really useful on a regular basis to GitHub power users.  
-*(There has been discussed quite a few times in the issue tracker that too much content is hidden from the dashboard, especially the Commit entries (*"user x pushed to repo y z commits"*). This is intended.  
-You may disable this feature by adding `hide-useless-newsfeed-events` in the extension options).*
+- Various entries are hidden from the dashboard, that we believe they are not really useful on a regular basis to GitHub power users.  
+<sup>*(There has been discussed quite a few times in the issue tracker that too much content is hidden from the dashboard, especially the Commit entries (*"user x pushed to repo y z commits"*). This is intended: if you follow hundreds of people and watch hundreds of repos, pushes and branches quickly become irrelevant to you. You may disable this feature by adding `hide-useless-newsfeed-events` in the extension options).*</sup>
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
@@ -151,7 +150,7 @@ You may disable this feature by adding `hide-useless-newsfeed-events` in the ext
 
 ### UI improvements
 
-- [Tabs in code are shown as 4 spaced instead of 8 space.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
+- [Tabs in code are shown as 4 spaces instead of 8 spaces.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
 - [Labels are moved to the left of issue and pull request lists.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
 - [Approve or reject reviews faster with one-click review type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
 - Pressing `Cancel` on an inline comment opens a prompt to prevent accidental cancelling.

--- a/readme.md
+++ b/readme.md
@@ -138,7 +138,7 @@ GitHub Enterprise is also supported. More info in the options.
 
 ### Declutter
 
-- [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png) 
+- [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
 - Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).

--- a/readme.md
+++ b/readme.md
@@ -142,7 +142,7 @@ GitHub Enterprise is also supported. More info in the options.
 - News feed items of users starring or forking your repos are removed.
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
-- Obvious tooltops are removed.
+- Obvious tooltips are removed.
 - The `Projects` repository tab is hidden when there are no projects
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
 
@@ -171,7 +171,7 @@ And [many more…](source/content.css)
 - [Access the `Labels` `Milestones` navigation from individual milestone pages.](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
 - [Search for issues and PRs with the `Everything commented by you` filter.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
 - [See just the issues and PRs _on your repos_ or _commented on by you_ in the global `Issues`/`Pull Requests` pages.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
-- Access trending reporties using the `Trending` link in the global navbar or by pressing <kbd>g</kbd> <kbd>t</kbd>.
+- Access trending repositories using the `Trending` link in the global navbar or by pressing <kbd>g</kbd> <kbd>t</kbd>.
 - Leave a single comment in pull request diffs instead of starting a review by pressing <kbd>shift</kbd> <kbd>enter</kbd>.
 - [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
 - Visit your profile by pressing <kbd>g</kbd> <kbd>m</kbd>.
@@ -189,6 +189,12 @@ And [many more…](source/content.css)
 Most features [can be disabled](https://github.com/sindresorhus/refined-github/pull/877) if they are JavaScript-based *(Experimental)* and you can override the CSS with your own in [the extension options.](https://github.com/sindresorhus/refined-github/pull/1193)
 
 We're happy to receive suggestions and contributions, but be aware this is a highly opinionated project. There's a very high bar for adding options. Users will always disagree with something. That being said, we're open to discussing things. If something doesn't make the cut, you can [build your custimized Refined GitHub locally](https://github.com/sindresorhus/refined-github/blob/master/contributing.md#workflow), rather than installing it from the Chrome Store.
+
+
+## Note for new users
+
+There has been discussed quite a few times in the issue tracker (issues [#561](https://github.com/sindresorhus/refined-github/issues/561), [#747](https://github.com/sindresorhus/refined-github/issues/747), [#822](https://github.com/sindresorhus/refined-github/issues/822), [#1063](https://github.com/sindresorhus/refined-github/issues/1063), [#1336](https://github.com/sindresorhus/refined-github/issues/1336) ) that the extension removes (too much) content from the dashboard, especially the commit entries (*"user x pushed to repo y z commits"*).  
+This is intended: the extension removes by default things which we believe are not really useful on a regular basis to GitHub power users. You may disable most features to your liking - this one by adding `hide-useless-newsfeed-events` in the extension options.
 
 
 ## Contribute

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,9 @@ GitHub Enterprise is also supported. More info in the options.
 
 - [The dashboard shows more in less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
 - News feed items of users starring or forking your repos are removed.
+- Various entries are hidden from the dashboard by default, as we believe they are not really useful on a regular basis to GitHub power users.  
+*(There has been discussed quite a few times in the issue tracker that too much content is hidden from the dashboard, especially the Commit entries (*"user x pushed to repo y z commits"*). This is intended.  
+You may disable this feature by adding `hide-useless-newsfeed-events` in the extension options).*
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
@@ -189,12 +192,6 @@ And [many more…](source/content.css)
 Most features [can be disabled](https://github.com/sindresorhus/refined-github/pull/877) if they are JavaScript-based *(Experimental)* and you can override the CSS with your own in [the extension options.](https://github.com/sindresorhus/refined-github/pull/1193)
 
 We're happy to receive suggestions and contributions, but be aware this is a highly opinionated project. There's a very high bar for adding options. Users will always disagree with something. That being said, we're open to discussing things. If something doesn't make the cut, you can [build your custimized Refined GitHub locally](https://github.com/sindresorhus/refined-github/blob/master/contributing.md#workflow), rather than installing it from the Chrome Store.
-
-
-## Note for new users
-
-There has been discussed quite a few times in the issue tracker (issues [#561](https://github.com/sindresorhus/refined-github/issues/561), [#747](https://github.com/sindresorhus/refined-github/issues/747), [#822](https://github.com/sindresorhus/refined-github/issues/822), [#1063](https://github.com/sindresorhus/refined-github/issues/1063), [#1336](https://github.com/sindresorhus/refined-github/issues/1336) ) that the extension removes (too much) content from the dashboard, especially the commit entries (*"user x pushed to repo y z commits"*).  
-This is intended: the extension removes by default things which we believe are not really useful on a regular basis to GitHub power users. You may disable most features to your liking - this one by adding `hide-useless-newsfeed-events` in the extension options.
 
 
 ## Contribute


### PR DESCRIPTION
For issue #1336 :
- Added a note that any hidden events in dashboard by default is intended and configurable.
- Corrected a few typos.
