### PR TITLE
Add unread indicator next to discussion in lists

### DIFF
--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -1,6 +1,7 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate';
+import domLoaded from 'dom-loaded';
 import gitHubInjection from 'github-injection';
 import SynchronousStorage from '../libs/synchronous-storage';
 import observeEl from '../libs/simplified-element-observer';
@@ -350,7 +351,7 @@ export default async function () {
 			return browser.storage.local.set({unreadNotifications});
 		}
 	);
-	gitHubInjection(() => {
+	gitHubInjection(async () => {
 		destroy();
 
 		if (pageDetect.isNotifications()) {
@@ -371,6 +372,15 @@ export default async function () {
 
 			// The sidebar changes when new comments are added or the issue status changes
 			observeEl('.discussion-sidebar', addMarkUnreadButton);
+		} else if (pageDetect.isIssueList()) {
+			await domLoaded;
+			for (const discussion of storage.get()) {
+				const url = new URL(discussion.url);
+				const listItem = select(`.read [href='${url.pathname}']`);
+				if (listItem) {
+					listItem.closest('.read').classList.replace('read', 'unread');
+				}
+			}
 		}
 
 		updateUnreadIndicator();


### PR DESCRIPTION
This blue line appears next to a discussion if you have notifications regarding that:

<img width="131" alt="" src="https://user-images.githubusercontent.com/1402241/40577605-a5101410-6108-11e8-82cf-b5df9605efd7.png">


Fixes https://github.com/sindresorhus/refined-github/issues/1032#issuecomment-362380041