### PR TITLE
Enable PR Quick Review buttons on PR commit pages as well

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -278,10 +278,10 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 		enableFeature(addCopyFilePathToPRs);
 		enableFeature(preserveWhitespaceOptionInNav);
+		enableFeature(addQuickReviewButtons);
 	}
 
 	if (pageDetect.isPRFiles()) {
-		enableFeature(addQuickReviewButtons);
 		enableFeature(extendDiffExpander);
 	}
 


### PR DESCRIPTION
I thought someone had an opened an issue for this, but I can no longer find it, but I run into this almost daily when pushes a new commit to fix feedback and the one click option doesn't exist.