### PR TITLE
Upgrade webpack-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"utc-version": "^1.1.0",
 		"webext": "^1.9.1-with-submit.1",
 		"webpack": "^4.8.3",
-		"webpack-cli": "^2.1.4",
+		"webpack-cli": "^3.0.1",
 		"xo": "^0.21.1"
 	},
 	"xo": {


### PR DESCRIPTION
This removes the following warnings when installing:
```
warning webpack-cli > jscodeshift > babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
warning webpack-cli > webpack-addons > jscodeshift > babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!
warning webpack-cli > jscodeshift > nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.
warning webpack-cli > webpack-addons > jscodeshift > nomnom@1.8.1: Package no longer supported. Contact support@npmjs.com for more info.
```