### PR TITLE
Disable referrer for linkified URLs

### DIFF
--- a/source/features/linkify-urls-in-code.js
+++ b/source/features/linkify-urls-in-code.js
@@ -17,6 +17,7 @@ const options = {
 	type: 'dom',
 	baseUrl: '',
 	attributes: {
+		rel: 'noreferrer noopener',
 		class: linkifiedURLClass // Necessary to avoid also shortening the links
 	}
 };


### PR DESCRIPTION
Fixes #1376 

Tested in Firefox 60, 62, Chromium 66