### PR TITLE
Add option to provide multiple personal tokens for different hosts

### DIFF
--- a/source/libs/api.js
+++ b/source/libs/api.js
@@ -7,11 +7,11 @@ export default async endpoint => {
 		return cache.get(endpoint);
 	}
 	const headers = {};
-	const {personalToken} = await new OptionsSync().getAll();
-	if (personalToken) {
-		headers.Authorization = `token ${personalToken}`;
+	const {personalTokens} = await new OptionsSync().getAll();
+	if (personalTokens && personalTokens[location.hostname]) {
+		headers.Authorization = `token ${personalTokens[location.hostname]}`;
 	}
-	const api = location.hostname === 'github.com' ? 'https://api.github.com/' : `${location.origin}/api/`;
+	const api = location.hostname === 'github.com' ? 'https://api.github.com/' : `${location.origin}/api/v3/`;
 	const response = await fetch(api + endpoint, {headers});
 	const json = await response.json();
 	cache.set(endpoint, json);

--- a/source/options.html
+++ b/source/options.html
@@ -27,9 +27,13 @@
 
 	<p>
 		<label>
-			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub" target="_blank">found here</a> (for high rate API calls and private repos)<br>
+			<strong>Personal tokens</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub" target="_blank">found here</a> (for high rate API calls and private repos)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
-			<input name="personalToken" spellcheck="false" autocomplete="off" size="40" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
+			<input name="personalToken" hidden style="display: none;"/>
+			<input name="personalTokens" hidden style="display: none;"/>
+			<div id="token-wrapper">
+				<div id="tokens"></div>
+			</div>
 		</label>
 	</p>
 

--- a/source/options.js
+++ b/source/options.js
@@ -1,3 +1,4 @@
+import {h} from 'dom-chef';
 import textarea from 'storm-textarea';
 import OptionsSync from 'webext-options-sync';
 import indentTextarea from './libs/indent-textarea';
@@ -13,4 +14,137 @@ document.querySelector('[name="customCSS"]').addEventListener('keydown', event =
 	}
 });
 
-new OptionsSync().syncForm('#options-form');
+const optionsSync = new OptionsSync();
+optionsSync.define({
+	defaults: {
+		personalTokens: {},
+	},
+	migrations: [
+		// migrate personal token to object
+		(savedOptions, currentDefaults) => {
+			if(savedOptions.personalToken) {
+				savedOptions.personalTokens = {
+					'github.com': savedOptions.personalToken
+				};
+				delete savedOptions.personalToken;
+			}
+		},
+		OptionsSync.migrations.removeUnused
+	]
+});
+
+const tokenInputList = document.querySelector('#tokens');
+
+function updateTokenForm() {
+	// clear children
+	while (tokenInputList.firstChild) {
+		tokenInputList.removeChild(tokenInputList.firstChild);
+	}
+
+	optionsSync.getAll().then(options => {
+		const tokens = options.personalTokens;
+		const tokenKeys = Object.keys(tokens);
+		if(tokenKeys.length !== 0) {
+			const tokenInputs = tokenKeys.map(hostName => generateTokenInputRow(hostName, tokens[hostName]))
+			tokenInputs.forEach(input => tokenInputList.appendChild(input))
+		}
+	});
+}
+
+function updateHostName(oldHostName, event) {
+	const newHostName = event.target.value;
+	optionsSync.getAll().then(options => {
+		var value = options.personalTokens[oldHostName];
+		options.personalTokens[newHostName] = value;
+		delete options.personalTokens[oldHostName];
+		optionsSync.setAll(options);
+	});
+}
+
+function updateTokenValue(hostName, event) {
+	const newValue = event.target.value;
+	optionsSync.getAll().then(options => {
+		options.personalTokens[hostName] = newValue;
+		optionsSync.setAll(options);
+	});
+}
+
+function removeHost(hostname) {
+	optionsSync.getAll().then(options => {
+		delete options.personalTokens[hostname];
+		optionsSync.setAll(options);
+		updateTokenForm();
+	});
+}
+
+function generateTokenInputRow(hostName, value) {
+	const hostnameInput = (
+		<input
+			style={{width: '100px'}}
+			spellcheck="false"
+			autocomplete="off"
+			pattern="^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])"
+			placeholder="hostname"
+			value={hostName}
+		/>
+	);
+	hostnameInput.onchange = (event) => updateHostName(hostName, event);
+
+	const tokenInput = (
+		<input
+			spellcheck="false"
+			autocomplete="off"
+			size="40"
+			maxlength="40"
+			pattern="[\da-f]{40}"
+			placeholder="personal token"
+			value={value}
+		/>
+	);
+	tokenInput.onchange = (event) => updateTokenValue(hostName || hostnameInput.value, event);
+
+	const removeButton = <button type="button">X</button>;
+	removeButton.onclick = () => removeHost(hostName);
+
+	return (
+		<div style={{display: 'flex', marginBottom: '8px'}}>
+			{hostnameInput} : {tokenInput} {removeButton}
+		</div>
+	);
+}
+
+function addPersonalKeyRow() {
+	// get the hostname of the active tab
+	chrome.tabs.query({
+		active: true,
+		currentWindow: true
+	}, function(tabs) {
+		var tab = tabs[0];
+		var url = tab.url;
+		var l = document.createElement("a");
+		l.href = url;
+
+		const currHost = l.hostname;
+
+		optionsSync.getAll().then(options => {
+			if(options.personalTokens[currHost]) {
+				// if they already have a value for the host, make an empty input
+				tokenInputList.appendChild(generateTokenInputRow('', ''));
+			} else {
+				// append input with hostname already filled
+				tokenInputList.appendChild(generateTokenInputRow(currHost, ''));
+			}
+		});
+		
+	});
+}
+
+const addButton = <button type="button">Add token</button>;
+addButton.onclick = addPersonalKeyRow;
+
+document.querySelector('#token-wrapper').appendChild(addButton)
+
+// init token input
+updateTokenForm();
+
+optionsSync.syncForm('#options-form');

--- a/source/options.js
+++ b/source/options.js
@@ -1,3 +1,5 @@
+/* global chrome */
+
 import {h} from 'dom-chef';
 import textarea from 'storm-textarea';
 import OptionsSync from 'webext-options-sync';
@@ -17,12 +19,12 @@ document.querySelector('[name="customCSS"]').addEventListener('keydown', event =
 const optionsSync = new OptionsSync();
 optionsSync.define({
 	defaults: {
-		personalTokens: {},
+		personalTokens: {}
 	},
 	migrations: [
-		// migrate personal token to object
-		(savedOptions, currentDefaults) => {
-			if(savedOptions.personalToken) {
+		// Migrate personal token to object
+		savedOptions => {
+			if (savedOptions.personalToken) {
 				savedOptions.personalTokens = {
 					'github.com': savedOptions.personalToken
 				};
@@ -36,7 +38,7 @@ optionsSync.define({
 const tokenInputList = document.querySelector('#tokens');
 
 function updateTokenForm() {
-	// clear children
+	// Clear children
 	while (tokenInputList.firstChild) {
 		tokenInputList.removeChild(tokenInputList.firstChild);
 	}
@@ -44,9 +46,9 @@ function updateTokenForm() {
 	optionsSync.getAll().then(options => {
 		const tokens = options.personalTokens;
 		const tokenKeys = Object.keys(tokens);
-		if(tokenKeys.length !== 0) {
-			const tokenInputs = tokenKeys.map(hostName => generateTokenInputRow(hostName, tokens[hostName]))
-			tokenInputs.forEach(input => tokenInputList.appendChild(input))
+		if (tokenKeys.length !== 0) {
+			const tokenInputs = tokenKeys.map(hostName => generateTokenInputRow(hostName, tokens[hostName]));
+			tokenInputs.forEach(input => tokenInputList.appendChild(input));
 		}
 	});
 }
@@ -54,7 +56,7 @@ function updateTokenForm() {
 function updateHostName(oldHostName, event) {
 	const newHostName = event.target.value;
 	optionsSync.getAll().then(options => {
-		var value = options.personalTokens[oldHostName];
+		const value = options.personalTokens[oldHostName];
 		options.personalTokens[newHostName] = value;
 		delete options.personalTokens[oldHostName];
 		optionsSync.setAll(options);
@@ -88,7 +90,7 @@ function generateTokenInputRow(hostName, value) {
 			value={hostName}
 		/>
 	);
-	hostnameInput.onchange = (event) => updateHostName(hostName, event);
+	hostnameInput.addEventListener('change', event => updateHostName(hostName, event));
 
 	const tokenInput = (
 		<input
@@ -101,10 +103,10 @@ function generateTokenInputRow(hostName, value) {
 			value={value}
 		/>
 	);
-	tokenInput.onchange = (event) => updateTokenValue(hostName || hostnameInput.value, event);
+	tokenInput.addEventListener('change', event => updateTokenValue(hostName || hostnameInput.value, event));
 
 	const removeButton = <button type="button">X</button>;
-	removeButton.onclick = () => removeHost(hostName);
+	removeButton.addEventListener('click', () => removeHost(hostName));
 
 	return (
 		<div style={{display: 'flex', marginBottom: '8px'}}>
@@ -114,37 +116,35 @@ function generateTokenInputRow(hostName, value) {
 }
 
 function addPersonalKeyRow() {
-	// get the hostname of the active tab
+	// Get the hostname of the active tab
 	chrome.tabs.query({
 		active: true,
 		currentWindow: true
-	}, function(tabs) {
-		var tab = tabs[0];
-		var url = tab.url;
-		var l = document.createElement("a");
+	}, tabs => {
+		const {url} = tabs[0];
+		const l = document.createElement('a');
 		l.href = url;
 
 		const currHost = l.hostname;
 
 		optionsSync.getAll().then(options => {
-			if(options.personalTokens[currHost]) {
-				// if they already have a value for the host, make an empty input
+			if (options.personalTokens[currHost]) {
+				// If they already have a value for the host, make an empty input
 				tokenInputList.appendChild(generateTokenInputRow('', ''));
 			} else {
-				// append input with hostname already filled
+				// Append input with hostname already filled
 				tokenInputList.appendChild(generateTokenInputRow(currHost, ''));
 			}
 		});
-		
 	});
 }
 
 const addButton = <button type="button">Add token</button>;
-addButton.onclick = addPersonalKeyRow;
+addButton.addEventListener('click', addPersonalKeyRow);
 
-document.querySelector('#token-wrapper').appendChild(addButton)
+document.querySelector('#token-wrapper').appendChild(addButton);
 
-// init token input
+// Init token input
 updateTokenForm();
 
 optionsSync.syncForm('#options-form');


### PR DESCRIPTION
I work on both github enterprise and on public github so I have to be able to provide different personal access tokens for each github hostname. This adds a UI to allow for the addition of different personal access tokens for different host names.

<img width="447" alt="screen shot 2018-06-18 at 4 34 43 pm" src="https://user-images.githubusercontent.com/8468455/41560945-94a189ae-7316-11e8-96b9-a62dd7a1ceba.png">

I also wrote migration code for existing access tokens to be compatible with this new format.

Other small change:
- [Fix endpoints for enterprise.](https://github.com/sindresorhus/refined-github/compare/master...gdaunton:multiple-access-tokens?expand=1#diff-3faba07a085e46b436222272e149d81cR14) I found that enterprise apis require the endpoint to be preceded by the version of the api. This is different from the public apis which default to the most recent. [Doc ref](https://developer.github.com/enterprise/2.13/v3/enterprise-admin/#endpoint-urls)
