### PR TITLE
Copy Prev/Next buttons to bottom of commit page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,6 +175,7 @@ And [many more…](source/content.css)
 - [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
 - Visit your profile by pressing <kbd>g</kbd> <kbd>m</kbd>.
 - Cycle through PR tabs by pressing <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
+- [Go to the next or previous commit from the bottom of the commit page](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
 
 ### Previously part of Refined GitHub
 

--- a/source/content.js
+++ b/source/content.js
@@ -11,6 +11,7 @@ import enableCopyOnY from './features/copy-on-y';
 import addReactionParticipants from './features/reactions-avatars';
 import showRealNames from './features/show-names';
 import addCopyFilePathToPRs from './features/copy-file-path';
+import addPrevNextButtonsToPRs from './features/prev-next-commit-buttons';
 import addFileCopyButton from './features/copy-file';
 // - import copyMarkdown from './features/copy-markdown';
 import linkifyCode from './features/linkify-urls-in-code';
@@ -277,6 +278,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRFiles() || pageDetect.isPRCommit()) {
 		enableFeature(addCopyFilePathToPRs);
+		enableFeature(addPrevNextButtonsToPRs);
 		enableFeature(preserveWhitespaceOptionInNav);
 		enableFeature(addQuickReviewButtons);
 	}

--- a/source/features/prev-next-commit-buttons.js
+++ b/source/features/prev-next-commit-buttons.js
@@ -1,0 +1,20 @@
+/*
+When reviewing a long commit in a PR, it's annoying to have to scroll back to
+the top of the page to hit the "Next" button to go to the next commit.
+
+This feature duplicates the Prev/Next buttons and inserts them at the bottom of
+the page too.
+*/
+import select from 'select-dom';
+
+export default async () => {
+	const originalPrevNext = select('.commit .BtnGroup.float-right');
+	if (!originalPrevNext) {
+		return;
+	}
+
+	const prevNext = originalPrevNext.cloneNode(true);
+	const files = select('#files');
+
+	files.after(prevNext);
+};


### PR DESCRIPTION
When reviewing a long commit in a PR, it's annoying to have to scroll
back to the top of the page to hit the "Next" button to go to the next
commit. Here we duplicate the Prev/Next buttons and insert them at the
bottom of the page too.

Fixes #1387

## Demo

<img width="693" alt="screenshot 2018-06-21 22 42 24" src="https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png">
