### PR TITLE
Show followers you know

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -134,6 +134,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [The current repository's build/CI status is always visible next to its name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Review counts are shown and colored in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
 - [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
+- [Followers you know are shown on profile pages.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
 
 ### Declutter
 

--- a/source/content.js
+++ b/source/content.js
@@ -76,6 +76,7 @@ import hideNavigationHoverHighlight from './features/hide-navigation-hover-highl
 import displayIssueSuggestions from './features/display-issue-suggestions';
 import addPullRequestHotkey from './features/add-pull-request-hotkey';
 import openSelectionInNewTab from './features/add-selection-in-new-tab';
+import showFollowersYouKnow from './features/show-followers-you-know';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -291,6 +292,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isUserProfile()) {
 		enableFeature(addGistsLink);
+		enableFeature(showFollowersYouKnow);
 	}
 }
 

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -57,8 +57,10 @@ export default async () => {
 	if (stargazers.length === 0) {
 		return;
 	}
-	container.append(<div class="border-top py-3 clearfix">
-		<h2 class="mb-1 h4">{getHeading(stargazers)}</h2>
-		{stargazers.map(renderAvatar)}
-	</div>);
+	container.append(
+		<div class="border-top py-3 clearfix">
+			<h2 class="mb-1 h4">{getHeading(stargazers)}</h2>
+			{stargazers.map(renderAvatar)}
+		</div>
+	);
 };

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -24,13 +24,19 @@ const fetchStargazers = async () => {
 	return stargazers;
 };
 
-const avatarHeight = 35;
+const avatarSize = 35;
 const renderAvatar = ({link, description, avatar}) => (
-	<a href={link} title={description} class="avatar-group-item mr-1">
+	<a href={link}
+		aria-label={description}
+		class="tooltipped tooltipped-n avatar-group-item mr-1"
+	>
 		<img
 			class="avatar"
-			src={`${avatar}?s=${avatarHeight * window.devicePixelRatio}`}
-			alt={description} height={avatarHeight} />
+			src={`${avatar}?s=${avatarSize * window.devicePixelRatio}`}
+			alt={description}
+			height={avatarSize}
+			width={avatarSize}
+		/>
 	</a>
 );
 

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -1,0 +1,58 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import domify from '../libs/domify';
+import {getCleanPathname} from '../libs/page-detect';
+import {getUsername} from '../libs/utils';
+
+const extractUserData = element => {
+	const image = element.querySelector('img');
+	const imageUrl = new URL(image.src);
+	const link = element.querySelector('a').href;
+	return {
+		avatar: `${imageUrl.origin}${imageUrl.pathname}`,
+		description: image.alt,
+		link
+	};
+};
+
+const fetchStargazers = async () => {
+	const url = `${location.origin}/${getCleanPathname()}/followers/you_know`;
+	const response = await fetch(url, {credentials: 'same-origin'});
+	const dom = domify(await response.text());
+	const userCards = [...dom.querySelectorAll('.follow-list-item')];
+	const stargazers = userCards.map(extractUserData);
+	return stargazers;
+};
+
+const avatarHeight = 35;
+const renderAvatar = ({link, description, avatar}) => (
+	<a href={link} title={description} class="avatar-group-item mr-1">
+		<img
+			class="avatar"
+			src={`${avatar}?s=${avatarHeight * window.devicePixelRatio}`}
+			alt={description} height={avatarHeight} />
+	</a>
+);
+
+const getHeading = stargazers =>
+	stargazers.length === 1 ?
+		`Follower you know` :
+		`${stargazers.length} Followers you know`;
+
+export default async () => {
+	if (getCleanPathname().startsWith(getUsername())) {
+		return;
+	}
+	const stargazers = await fetchStargazers();
+	if (stargazers.length === 0) {
+		return;
+	}
+	const container = select('[itemtype="http://schema.org/Person"]');
+	if (!container) {
+		return;
+	}
+	container.append(<div class="border-top py-3 clearfix">
+		<h2 class="mb-1 h4">{getHeading(stargazers)}</h2>
+		{stargazers.map(renderAvatar)}
+	</div>);
+};

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -30,11 +30,6 @@ const renderAvatar = image => {
 	);
 };
 
-const getHeading = stargazers =>
-	stargazers.length === 1 ?
-		`Follower you know` :
-		`Followers you know`;
-
 export default async () => {
 	if (getCleanPathname().startsWith(getUsername())) {
 		return;
@@ -49,7 +44,7 @@ export default async () => {
 	}
 	container.append(
 		<div class="border-top py-3 clearfix">
-			<h2 class="mb-1 h4">{getHeading(stargazers)}</h2>
+			<h2 class="mb-1 h4">Followers you know</h2>
 			{stargazers.map(renderAvatar)}
 		</div>
 	);

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -33,7 +33,7 @@ const renderAvatar = image => {
 const getHeading = stargazers =>
 	stargazers.length === 1 ?
 		`Follower you know` :
-		`${stargazers.length} Followers you know`;
+		`Followers you know`;
 
 export default async () => {
 	if (getCleanPathname().startsWith(getUsername())) {

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -4,41 +4,31 @@ import domify from '../libs/domify';
 import {getCleanPathname} from '../libs/page-detect';
 import {getUsername} from '../libs/utils';
 
-const extractUserData = element => {
-	const image = element.querySelector('img');
-	const imageUrl = new URL(image.src);
-	const link = element.querySelector('a').href;
-	return {
-		avatar: `${imageUrl.origin}${imageUrl.pathname}`,
-		description: image.alt,
-		link
-	};
-};
-
 const fetchStargazers = async () => {
 	const url = `${location.origin}/${getCleanPathname()}/followers/you_know`;
 	const response = await fetch(url, {credentials: 'same-origin'});
 	const dom = domify(await response.text());
-	const userCards = [...dom.querySelectorAll('.follow-list-item')];
-	const stargazers = userCards.map(extractUserData);
-	return stargazers;
+	return select.all('.follow-list-item .avatar', dom);
 };
 
 const avatarSize = 35;
-const renderAvatar = ({link, description, avatar}) => (
-	<a href={link}
-		aria-label={description}
-		class="tooltipped tooltipped-n avatar-group-item mr-1"
-	>
-		<img
-			class="avatar"
-			src={`${avatar}?s=${avatarSize * window.devicePixelRatio}`}
-			alt={description}
-			height={avatarSize}
-			width={avatarSize}
-		/>
-	</a>
-);
+const renderAvatar = image => {
+	const src = new URL(image.src);
+	src.searchParams.set('s', avatarSize * window.devicePixelRatio);
+	image.src = src;
+	image.width = avatarSize;
+	image.height = avatarSize;
+
+	return (
+		<a
+			href={image.parentElement.href}
+			aria-label={image.alt.substr(1)}
+			class="tooltipped tooltipped-n avatar-group-item mr-1"
+		>
+			{image}
+		</a>
+	);
+};
 
 const getHeading = stargazers =>
 	stargazers.length === 1 ?

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -13,7 +13,9 @@ const fetchStargazers = async () => {
 
 const avatarSize = 35;
 const renderAvatar = image => {
-	image.src = image.src.replace(/\bs=\d+/, `s=${avatarSize * window.devicePixelRatio}`);
+	const src = new URL(image.src);
+	src.searchParams.set('s', avatarSize * window.devicePixelRatio);
+	image.src = src;
 	image.width = avatarSize;
 	image.height = avatarSize;
 

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -49,12 +49,12 @@ export default async () => {
 	if (getCleanPathname().startsWith(getUsername())) {
 		return;
 	}
-	const stargazers = await fetchStargazers();
-	if (stargazers.length === 0) {
-		return;
-	}
 	const container = select('[itemtype="http://schema.org/Person"]');
 	if (!container) {
+		return;
+	}
+	const stargazers = await fetchStargazers();
+	if (stargazers.length === 0) {
 		return;
 	}
 	container.append(<div class="border-top py-3 clearfix">

--- a/source/features/show-followers-you-know.js
+++ b/source/features/show-followers-you-know.js
@@ -13,9 +13,7 @@ const fetchStargazers = async () => {
 
 const avatarSize = 35;
 const renderAvatar = image => {
-	const src = new URL(image.src);
-	src.searchParams.set('s', avatarSize * window.devicePixelRatio);
-	image.src = src;
+	image.src = image.src.replace(/\bs=\d+/, `s=${avatarSize * window.devicePixelRatio}`);
 	image.width = avatarSize;
 	image.height = avatarSize;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)

What inspired me to make this, is the twitter's profile page:

![image](https://user-images.githubusercontent.com/2906365/42009766-c8da63cc-7a59-11e8-9ba6-52e8fc0a1b31.png)


The reason I think this is important is same as #1392. Social proof is useful for discovering people. This updated profile page can show how you are connected to a particular person. If you have friends in common, then that friend might be able to introduce you.
Or, if you don't know why this profile is worth following, the person in common can explain.

"Who to follow" is another feature I like on twitter. I was thinking how I could make it work for github, but I have not found a way just yet. Maybe it's the people, who the person you just followed, follows. It's very useful for people discovery 👍 