### PR TITLE
Add delete button to files in a PR 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,6 +108,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Click on branch references in pull requests.](https://github.com/sindresorhus/refined-github/issues/1)
 - [Quickly edit a repository's README from the repository root.](https://user-images.githubusercontent.com/170270/27501200-31a1fa20-586c-11e7-9a3f-ce270014bf0a.png)
 - [Quickly delete a forked repo after its pull request has been merged.](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
+- [Quickly delete a file from pull requests.](https://user-images.githubusercontent.com/1402241/42529637-578587e4-847f-11e8-9705-57384a1edd24.png)
 - [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
 - [Open selection in new tab with <kbd>shift</kbd> <kbd>o</kbd> when navigating via <kbd>j</kbd> and <kbd>k</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
 - [Easily toggle whitespace visibility in diffs.](https://cloud.githubusercontent.com/assets/170270/17603894/7b71a166-6013-11e6-81b8-22950ab8bce3.png) *(<kbd>d</kbd> <kbd>w</kbd> hotkey)*

--- a/source/content.js
+++ b/source/content.js
@@ -3,6 +3,7 @@ import {h} from 'dom-chef';
 import select from 'select-dom';
 import domLoaded from 'dom-loaded';
 
+import addDeleteToPrFiles from './features/add-delete-to-pr-files';
 import markUnread from './features/mark-unread';
 import addOpenAllNotificationsButton from './features/open-all-notifications';
 import openAllSelected from './features/open-all-selected';
@@ -283,6 +284,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRFiles()) {
 		enableFeature(extendDiffExpander);
+		enableFeature(addDeleteToPrFiles);
 	}
 
 	if (pageDetect.isSingleFile()) {

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -4,19 +4,18 @@ import * as pageDetect from '../libs/page-detect';
 
 const repoURL = pageDetect.getRepoURL();
 
-// very last link isn't working?
-
 export default function () {
-  const findBranch = select('.head-ref').innerText;
-  const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
+	const findBranch = select('.head-ref').innerText;
+	const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
 
-  const filesInfo = select.all('.file-info');
-  const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title);
+	const filesInfo = select.all('.file-info');
+	const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title);
 
-  const fileActionContainers = select.all('div.BtnGroup');
-  const appendDeleteLinks = fileActionContainers.map((container, index) => {
-    if (index !== 0) {
-      container.prepend(<a href={generateURL[index - 1]} className='btn btn-sm tooltipped tooltipped-s BtnGroup-item' aria-label='Delete this file from the pull request'>Delete </a>)
-    }
-  });
-};
+	const fileActionContainers = select.all('div.BtnGroup');
+	fileActionContainers.map((container, index) => {
+		if (index !== 0) {
+			container.prepend(<a href={generateURL[index - 1]} className="btn btn-sm tooltipped tooltipped-s BtnGroup-item" aria-label="Delete this file from the pull request">Delete</a>);
+		}
+		return container;
+	});
+}

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,10 +1,9 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
-import * as pageDetect from '../libs/page-detect';
+import {getRepoURL} from '../libs/page-detect';
 
 export default function () {
-	const repoURL = pageDetect.getRepoURL();
-
+	const repoURL = getRepoURL();
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	for (const file of select.all('.file-header')) {

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,5 +1,6 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
+import * as icons from '../libs/icons';
 import {getRepoURL} from '../libs/page-detect';
 
 export default function () {
@@ -9,12 +10,12 @@ export default function () {
 	for (const file of select.all('.file-header')) {
 		const fileName = select('.file-info a', file).title;
 		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
-		select('.BtnGroup', file).prepend(
+		select('.octicon-pencil', file).parentElement.after(
 			<a
 				href={url}
-				className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
+				className="btn btn-octicon btn-octicon-danger tooltipped tooltipped-s"
 				aria-label="Delete this file from the pull request">
-				Delete
+				{icons.trashcan()}
 			</a>
 		);
 	}

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -8,18 +8,15 @@ const repoURL = pageDetect.getRepoURL();
 export default function () {
 	const findBranch = select('.head-ref').innerText;
 	const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
-	
+
 	const filesInfo = select.all('.file-info');
 	const generateURL = filesInfo.map(file => `/${repoURL}/delete/${branchName}/${file.children[1].title}`);
 
-	const fileActionContainers = select.all('div.BtnGroup');
+	const fileActionContainers = select.all('div.BtnGroup').slice(1);
 	fileActionContainers.map((container, index) => {
-		if (index !== 0) {
 			container.prepend(<a
-				href={generateURL[index - 1]}
+				href={generateURL[index]}
 				className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
 				aria-label="Delete this file from the pull request">Delete</a>);
-		}
-		return container;
 	});
 }

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,11 +1,10 @@
-// might add to line 278
-
 import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 
 export default function () {
-  const fileActions = select('.file-actions')
-  const deleteFile = fileActions.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>)
-  getBranchName()
-}
+  const fileActions = select.all('.file-actions');
+  console.log(fileActions)
+  const deleteFile = fileActions.map(fileAction => fileAction.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>));
+  getBranchName();
+};

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,0 +1,10 @@
+// might add to line 278
+
+import select from 'select-dom';
+import {h} from 'dom-chef';
+import {getCleanPathname, getRepoBranch, getRepoPath} from '../libs/page-detect';
+
+export default function () {
+  const chevronDown = select('.octicon-chevron-down')
+  chevronDown.before(<button type='button'>Delete</button>)
+}

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -11,10 +11,7 @@ export default function () {
 		const fileName = select('.file-info a', file).title;
 		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
 		select('.octicon-pencil', file).parentElement.after(
-			<a
-				href={url}
-				className="btn btn-octicon btn-octicon-danger tooltipped tooltipped-s"
-				aria-label="Delete this file from the pull request">
+			<a href={url} className="btn-octicon btn-octicon-danger">
 				{icons.trashcan()}
 			</a>
 		);

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -8,8 +8,8 @@ export default function () {
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	for (const file of select.all('.file-header')) {
-		const fileName = select('.file-info a', file).title
-		const url = `/${repoURL}/delete/${branchName}/${fileName}`
+		const fileName = select('.file-info a', file).title;
+		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
 		select('.BtnGroup', file).prepend(
 			<a
 				href={url}

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -2,9 +2,13 @@ import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 
+const repoURL = pageDetect.getRepoURL();
+
 export default function () {
   const fileActions = select.all('.file-actions');
   console.log(fileActions)
   const deleteFile = fileActions.map(fileAction => fileAction.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>));
-  getBranchName();
+  const findBranch = select('.head-ref').innerText;
+  const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
+  // select('.delete-file').href = 'https://github.com/' + repoUrl + '/delete/' + branchName + fileName
 };

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -3,10 +3,11 @@ import select from 'select-dom';
 import * as pageDetect from '../libs/page-detect';
 
 export default function () {
+	const repoURL = pageDetect.getRepoURL();
+	
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	for (const file of select.all('.file-header')) {
-		const repoURL = pageDetect.getRepoURL();
 		const fileName = select('.file-info a', file).title;
 		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
 		select('.BtnGroup', file).prepend(

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,20 +1,24 @@
 import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
+import {getCleanPathname, isEnterprise} from '../libs/page-detect';
 
 const repoURL = pageDetect.getRepoURL();
 
 export default function () {
 	const findBranch = select('.head-ref').innerText;
 	const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
-
+	
 	const filesInfo = select.all('.file-info');
-	const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title);
+	const generateURL = filesInfo.map(file => `/${repoURL}/delete/${branchName}/${file.children[1].title}`);
 
 	const fileActionContainers = select.all('div.BtnGroup');
 	fileActionContainers.map((container, index) => {
 		if (index !== 0) {
-			container.prepend(<a href={generateURL[index - 1]} className="btn btn-sm tooltipped tooltipped-s BtnGroup-item" aria-label="Delete this file from the pull request">Delete</a>);
+			container.prepend(<a
+				href={generateURL[index - 1]}
+				className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
+				aria-label="Delete this file from the pull request">Delete</a>);
 		}
 		return container;
 	});

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -2,12 +2,11 @@ import {h} from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from '../libs/page-detect';
 
-const repoURL = pageDetect.getRepoURL();
-
 export default function () {
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	for (const file of select.all('.file-header')) {
+		const repoURL = pageDetect.getRepoURL();
 		const fileName = select('.file-info a', file).title;
 		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
 		select('.BtnGroup', file).prepend(

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -2,24 +2,15 @@ import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 
-// https://github.com/<username>/<repo>/delete/<branch>/<filename>
-
 const repoURL = pageDetect.getRepoURL();
 
 export default function () {
-  let fileName
-  const fileActions = select.all('.file-actions');
-  const deleteFile = fileActions.map(fileAction => fileAction.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>));
   const findBranch = select('.head-ref').innerText;
   const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
-  const deleteLinks = select.all('.delete-file')
-  const getFileName = (e) => {
-    fileName = e.path[2].children[1].childNodes[3].innerText
-  }
 
-  deleteLinks.map(deleteLink => deleteLink.addEventListener('click', (e) => getFileName(e)));
+  const filesInfo = Array.from(select.all('.file-info'));
+  const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title)
 
-  // need to map through deleteLinks and update href for getAll
-  //right now this only adds an href to the first delete-file element
-  select('.delete-file').href = 'https://github.com/' + repoUrl + '/delete/' + branchName + '/' + fileName;
+  const fileActionContainers = select.all('div.BtnGroup');
+  const appendDeleteLinks = fileActionContainers.map((container, index) => container.prepend(<a href={generateURL[index]} className='btn btn-sm tooltipped tooltipped-s BtnGroup-item' aria-label='Delete this file from the pull request'>Delete </a>));
 };

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -4,7 +4,7 @@ import * as pageDetect from '../libs/page-detect';
 
 export default function () {
 	const repoURL = pageDetect.getRepoURL();
-	
+
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	for (const file of select.all('.file-header')) {

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -7,14 +7,16 @@ const repoURL = pageDetect.getRepoURL();
 export default function () {
 	const branchName = select('.head-ref').textContent.split(':').pop();
 
-	const filesInfo = select.all('.file-info');
-	const generateURL = filesInfo.map(file => `/${repoURL}/delete/${branchName}/${file.children[1].title}`);
-
-	const fileActionContainers = select.all('div.BtnGroup').slice(1);
-	fileActionContainers.forEach((container, index) => {
-		container.prepend(<a
-			href={generateURL[index]}
-			className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
-			aria-label="Delete this file from the pull request">Delete</a>);
-	});
+	for (const file of select.all('.file-header')) {
+		const fileName = select('.file-info a', file).title
+		const url = `/${repoURL}/delete/${branchName}/${fileName}`
+		select('.BtnGroup', file).prepend(
+			<a
+				href={url}
+				className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
+				aria-label="Delete this file from the pull request">
+				Delete
+			</a>
+		);
+	}
 }

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -2,13 +2,24 @@ import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
 
+// https://github.com/<username>/<repo>/delete/<branch>/<filename>
+
 const repoURL = pageDetect.getRepoURL();
 
 export default function () {
+  let fileName
   const fileActions = select.all('.file-actions');
-  console.log(fileActions)
   const deleteFile = fileActions.map(fileAction => fileAction.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>));
   const findBranch = select('.head-ref').innerText;
   const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
-  // select('.delete-file').href = 'https://github.com/' + repoUrl + '/delete/' + branchName + fileName
+  const deleteLinks = select.all('.delete-file')
+  const getFileName = (e) => {
+    fileName = e.path[2].children[1].childNodes[3].innerText
+  }
+
+  deleteLinks.map(deleteLink => deleteLink.addEventListener('click', (e) => getFileName(e)));
+
+  // need to map through deleteLinks and update href for getAll
+  //right now this only adds an href to the first delete-file element
+  select('.delete-file').href = 'https://github.com/' + repoUrl + '/delete/' + branchName + '/' + fileName;
 };

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -6,5 +6,5 @@ import {getCleanPathname, getRepoBranch, getRepoPath} from '../libs/page-detect'
 
 export default function () {
   const chevronDown = select('.octicon-chevron-down')
-  chevronDown.before(<button type='button'>Delete</button>)
+  chevronDown.before(<a href='#'>Delete </a>)
 }

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -4,13 +4,19 @@ import * as pageDetect from '../libs/page-detect';
 
 const repoURL = pageDetect.getRepoURL();
 
+// very last link isn't working?
+
 export default function () {
   const findBranch = select('.head-ref').innerText;
   const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
 
-  const filesInfo = Array.from(select.all('.file-info'));
-  const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title)
+  const filesInfo = select.all('.file-info');
+  const generateURL = filesInfo.map(file => 'https://github.com/' + repoURL + '/delete/' + branchName + '/' + file.children[1].title);
 
   const fileActionContainers = select.all('div.BtnGroup');
-  const appendDeleteLinks = fileActionContainers.map((container, index) => container.prepend(<a href={generateURL[index]} className='btn btn-sm tooltipped tooltipped-s BtnGroup-item' aria-label='Delete this file from the pull request'>Delete </a>));
+  const appendDeleteLinks = fileActionContainers.map((container, index) => {
+    if (index !== 0) {
+      container.prepend(<a href={generateURL[index - 1]} className='btn btn-sm tooltipped tooltipped-s BtnGroup-item' aria-label='Delete this file from the pull request'>Delete </a>)
+    }
+  });
 };

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -2,9 +2,10 @@
 
 import select from 'select-dom';
 import {h} from 'dom-chef';
-import {getCleanPathname, getRepoBranch, getRepoPath} from '../libs/page-detect';
+import * as pageDetect from '../libs/page-detect';
 
 export default function () {
-  const chevronDown = select('.octicon-chevron-down')
-  chevronDown.before(<a href='#'>Delete </a>)
+  const fileActions = select('.file-actions')
+  const deleteFile = fileActions.append(<a href='#' className='delete-file' aria-label='Delete this file from the pull request'>Delete </a>)
+  getBranchName()
 }

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,17 +1,14 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import * as icons from '../libs/icons';
-import {getRepoURL} from '../libs/page-detect';
 
 export default function () {
-	const repoURL = getRepoURL();
-	const branchName = select('.head-ref').textContent.split(':').pop();
+	for (const {parentElement: editLink} of select.all('.file-header .octicon-pencil')) {
+		// Transform the `edit` URL into a `delete` url
+		const deleteUrl = editLink.pathname.replace(/^(\/[^/]+\/[^/]+\/)edit/, '$1delete');
 
-	for (const file of select.all('.file-header')) {
-		const fileName = select('.file-info a', file).title;
-		const url = `/${repoURL}/delete/${branchName}/${fileName}`;
-		select('.octicon-pencil', file).parentElement.after(
-			<a href={url} className="btn-octicon btn-octicon-danger">
+		editLink.after(
+			<a href={deleteUrl} className="btn-octicon btn-octicon-danger">
 				{icons.trashcan()}
 			</a>
 		);

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,7 +1,6 @@
 import select from 'select-dom';
 import {h} from 'dom-chef';
 import * as pageDetect from '../libs/page-detect';
-import {getCleanPathname, isEnterprise} from '../libs/page-detect';
 
 const repoURL = pageDetect.getRepoURL();
 
@@ -13,10 +12,10 @@ export default function () {
 	const generateURL = filesInfo.map(file => `/${repoURL}/delete/${branchName}/${file.children[1].title}`);
 
 	const fileActionContainers = select.all('div.BtnGroup').slice(1);
-	fileActionContainers.map((container, index) => {
-			container.prepend(<a
-				href={generateURL[index]}
-				className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
-				aria-label="Delete this file from the pull request">Delete</a>);
+	fileActionContainers.forEach((container, index) => {
+		container.prepend(<a
+			href={generateURL[index]}
+			className="btn btn-sm tooltipped tooltipped-s BtnGroup-item"
+			aria-label="Delete this file from the pull request">Delete</a>);
 	});
 }

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -5,8 +5,7 @@ import * as pageDetect from '../libs/page-detect';
 const repoURL = pageDetect.getRepoURL();
 
 export default function () {
-	const findBranch = select('.head-ref').innerText;
-	const branchName = findBranch.includes(':') ? findBranch.split(':')[1] : findBranch;
+	const branchName = select('.head-ref').textContent.split(':').pop();
 
 	const filesInfo = select.all('.file-info');
 	const generateURL = filesInfo.map(file => `/${repoURL}/delete/${branchName}/${file.children[1].title}`);

--- a/source/features/add-delete-to-pr-files.js
+++ b/source/features/add-delete-to-pr-files.js
@@ -1,5 +1,5 @@
-import select from 'select-dom';
 import {h} from 'dom-chef';
+import select from 'select-dom';
 import * as pageDetect from '../libs/page-detect';
 
 const repoURL = pageDetect.getRepoURL();

--- a/source/libs/icons.js
+++ b/source/libs/icons.js
@@ -6,6 +6,8 @@ export const info = () => <svg aria-hidden="true" class="octicon octicon-info" w
 
 export const edit = () => <svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"/></svg>;
 
+export const trashcan = () => <svg aria-hidden="true" class="octicon octicon-trashcan" height="16" width="12"><path d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>;
+
 export const openIssue = () => <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>;
 
 export const closedIssue = () => <svg aria-hidden="true" class="octicon octicon-issue-closed" height="16" viewBox="0 0 16 16" width="16"><path d="M7 10h2v2H7v-2zm2-6H7v5h2V4zm1.5 1.5l-1 1L12 9l4-4.5-1-1L12 7l-1.5-1.5zM8 13.7A5.71 5.71 0 0 1 2.3 8c0-3.14 2.56-5.7 5.7-5.7 1.83 0 3.45.88 4.5 2.2l.92-.92A6.947 6.947 0 0 0 8 1C4.14 1 1 4.14 1 8s3.14 7 7 7 7-3.14 7-7l-1.52 1.52c-.66 2.41-2.86 4.19-5.48 4.19v-.01z"/></svg>;


### PR DESCRIPTION
This PR fixes #1127. The issue was to add a delete button for individual files in a PR. We implemented this functionality by adding `add-delete-to-pr-files.js` to the features directory, importing that file into `content.js` and added line 287 to `content.js` to add the delete button functionality to the extension. The delete button appears to the left of the "Copy path" button on the toolbar of each file. When clicked, the button takes you to the correct page to delete that specific file from the PR. No tests were affected and we removed all linter errors.

Contributors: @jacklaird0, @ericmellow, @meloncatty

<img width="1004" alt="after" src="https://user-images.githubusercontent.com/11744547/42348229-e0e205e4-8065-11e8-9ecc-bfcb8d68b107.png">
