### PR TITLE
Add the add open all issues or PRs button

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1019,3 +1019,8 @@ body > .footer li a {
 	padding-top: 4px !important;
 	padding-bottom: 4px !important;
 }
+
+.rgh-open-all-issues-button {
+	background: #0366d6 !important;
+    margin: 5px 0 5px;
+}

--- a/source/content.js
+++ b/source/content.js
@@ -76,6 +76,7 @@ import hideNavigationHoverHighlight from './features/hide-navigation-hover-highl
 import displayIssueSuggestions from './features/display-issue-suggestions';
 import addPullRequestHotkey from './features/add-pull-request-hotkey';
 import openSelectionInNewTab from './features/add-selection-in-new-tab';
+import addOpenAllButton from './features/add-open-all-button';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -188,6 +189,7 @@ function ajaxedPagesHandler() {
 	enableFeature(addDownloadFolderButton);
 	enableFeature(linkifyBranchRefs);
 	enableFeature(openAllSelected);
+	enableFeature(addOpenAllButton);
 
 	if (pageDetect.isIssueSearch() || pageDetect.isPRSearch()) {
 		enableFeature(addYoursMenuItem);

--- a/source/features/add-open-all-button.js
+++ b/source/features/add-open-all-button.js
@@ -10,9 +10,9 @@ export default function () {
 	}
 
 	const buttonText = pageDetect.isIssueSearch() ? `Open all issues` : `Open all PRs`;
-	const openAllButton = <button id="openAllButton" onClick={openAll} class="btn btn-primary float-right rgh-open-all-issues-button" role="button" data-hotkey="c">{buttonText}</button>
+	const openAllButton = <button id="openAllButton" onClick={openAll} class="btn btn-primary float-right rgh-open-all-issues-button" role="button" data-hotkey="o">{buttonText}</button>;
 
-	if (select.exists('.issues-listing') && select.all('.link-gray-dark').length) {
+	if (select.exists('.issues-listing') && select.all('.link-gray-dark').length !== 0) {
 		select('.issues-listing>.subnav').append(openAllButton);
 	}
 }

--- a/source/features/add-open-all-button.js
+++ b/source/features/add-open-all-button.js
@@ -1,0 +1,18 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import * as pageDetect from '../libs/page-detect';
+
+export default function () {
+	function openAll() {
+		select.all('.link-gray-dark').forEach(link => {
+			window.open(link.href);
+		});
+	}
+
+	const buttonText = pageDetect.isIssueSearch() ? `Open all issues` : `Open all PRs`;
+	const openAllButton = <button id="openAllButton" onClick={openAll} class="btn btn-primary float-right rgh-open-all-issues-button" role="button" data-hotkey="c">{buttonText}</button>
+
+	if (select.exists('.issues-listing') && select.all('.link-gray-dark').length) {
+		select('.issues-listing>.subnav').append(openAllButton);
+	}
+}

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -58,7 +58,7 @@ export const isIssue = () => /^issues\/\d+/.test(getRepoPath());
 
 export const isIssueList = () => /^(issues$|pulls$|labels\/)/.test(getRepoPath());
 
-export const isIssueSearch = () => location.pathname.startsWith('/issues');
+export const isIssueSearch = () => location.pathname.endsWith('/issues');
 
 export const isLabel = () => /^labels\/\w+/.test(getRepoPath());
 
@@ -82,7 +82,7 @@ export const isPRCommit = () => /^pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(getRe
 
 export const isPRFiles = () => /^pull\/\d+\/files/.test(getRepoPath());
 
-export const isPRSearch = () => location.pathname.startsWith('/pulls');
+export const isPRSearch = () => location.pathname.endsWith('/pulls');
 
 export const isQuickPR = () => isCompare() && /[?&]quick_pull=1(&|$)/.test(location.search);
 


### PR DESCRIPTION
Using extensively the issues and PRs with combinations of filters, I very often come across the need to open all the filtered PRs or issues. This PR adds a new button to open either all issues if you are in the issues page or all the PRs.

### Notes:

 - The button will be hidden if no PRs or issues are found.
 - A hot key `o` is added to the Open button as a shortcut


> *Important*: I have found as part of this PR a bug in the `pageDetect` logic for issues list and PR list and is fixed now

![screen shot 2018-07-09 at 7 47 21 pm](https://user-images.githubusercontent.com/550726/42469904-ed65ffa2-83b0-11e8-9dd4-378423231a2f.png)

![screen shot 2018-07-09 at 7 42 54 pm](https://user-images.githubusercontent.com/550726/42469836-c6bd39ce-83b0-11e8-993d-47c580d58a23.png)
