### PR TITLE
Fix targeted comment highlight

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -456,29 +456,26 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* Highlight linked comment */
-:root .timeline-comment:target {
+:root [id^="issuecomment"]:target .comment {
 	border-color: #e5d999;
 }
-:root .timeline-comment:target.current-user::before {
+:root [id^="issuecomment"]:target .comment.current-user::before {
 	border-right-color: #e5d999;
 }
-:root .timeline-comment:target.current-user::after {
-	border-right-color: #fffded;
+:root [id^="issuecomment"]:target .comment.current-user::after {
+	border-right-color: #fffdef;
 }
-:root .timeline-comment:target .timeline-comment-header {
+:root [id^="issuecomment"]:target .timeline-comment-header {
 	background-color: #fffdef;
 	border-bottom-color: #e5d999;
 }
-:root .timeline-comment:target .timeline-comment-label {
-	border-color: #e5d999;
-}
-:root .timeline-comment:target .reaction-summary-item {
-	border-right-color: #e5d999;
-}
-:root .timeline-comment:target .comment-reactions.has-reactions {
+:root [id^="issuecomment"]:target .comment-reactions.has-reactions {
 	border-top-color: #e5d999;
 }
-:root .timeline-comment:target .previewable-comment-form .comment-form-head.tabnav {
+:root [id^="issuecomment"]:target .reaction-summary-item {
+	border-right-color: #e5d999;
+}
+:root [id^="issuecomment"]:target .previewable-comment-form .comment-form-head.tabnav {
 	color: #e5d999;
 	background-color: #fffdef;
 	border-bottom-color: #e5d999;

--- a/source/content.css
+++ b/source/content.css
@@ -456,26 +456,26 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* Highlight linked comment */
-:root [id^="issuecomment"]:target .timeline-comment {
+:root [id^='issuecomment']:target .timeline-comment {
 	border-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .timeline-comment.current-user::before {
+:root [id^='issuecomment']:target .timeline-comment.current-user::before {
 	border-right-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .timeline-comment.current-user::after {
+:root [id^='issuecomment']:target .timeline-comment.current-user::after {
 	border-right-color: #fffdef;
 }
-:root [id^="issuecomment"]:target .timeline-comment-header {
+:root [id^='issuecomment']:target .timeline-comment-header {
 	background-color: #fffdef;
 	border-bottom-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .comment-reactions.has-reactions {
+:root [id^='issuecomment']:target .comment-reactions.has-reactions {
 	border-top-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .reaction-summary-item {
+:root [id^='issuecomment']:target .reaction-summary-item {
 	border-right-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .previewable-comment-form .comment-form-head.tabnav {
+:root [id^='issuecomment']:target .previewable-comment-form .comment-form-head.tabnav {
 	color: #e5d999;
 	background-color: #fffdef;
 	border-bottom-color: #e5d999;

--- a/source/content.css
+++ b/source/content.css
@@ -456,13 +456,13 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 }
 
 /* Highlight linked comment */
-:root [id^="issuecomment"]:target .comment {
+:root [id^="issuecomment"]:target .timeline-comment {
 	border-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .comment.current-user::before {
+:root [id^="issuecomment"]:target .timeline-comment.current-user::before {
 	border-right-color: #e5d999;
 }
-:root [id^="issuecomment"]:target .comment.current-user::after {
+:root [id^="issuecomment"]:target .timeline-comment.current-user::after {
 	border-right-color: #fffdef;
 }
 :root [id^="issuecomment"]:target .timeline-comment-header {


### PR DESCRIPTION
Fixes #1404.

The fix uses a sloppy `[id^="issuecomment"]` selector, there is also another option to use `.js-minimizable-comment-group` but that makes highlighting on inline commit comments look bad.

[example](https://github.com/sindresorhus/refined-github/pull/1393#commitcomment-29673209)
![image](https://user-images.githubusercontent.com/37769974/42644283-cfeff8fa-8618-11e8-8c1d-67ae5bd553d9.png)
![image](https://user-images.githubusercontent.com/37769974/42644312-e4c263b2-8618-11e8-9f6f-8409b65885c8.png)

--------------------------

Let me know if I should use the attribute selector or class selector (I prefer the latter one as its still something than nothing)!