### PR TITLE
Add a task list feature for PR code review

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "mocha.enabled": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "mocha.enabled": false
+}

--- a/source/content.css
+++ b/source/content.css
@@ -1019,3 +1019,29 @@ body > .footer li a {
 	padding-top: 4px !important;
 	padding-bottom: 4px !important;
 }
+
+.rgh-pr-comments-file-header {
+	display: flex;
+	align-items: center;
+}
+.rgh-taskList-completed > *:not(.file-header) {
+	display: none;
+}
+.rgh-taskList-completed .file-header {
+	border-bottom: none !important;
+}
+.rgh-taskList-action {
+	color: #586069;
+}
+.rgh-taskList-action:hover {
+	color: #34d058;
+	cursor: pointer;
+}
+.rgh-taskAction {
+	pointer-events: none;
+	margin: 0 10px;
+	color: inherit;
+}
+.rgh-taskList-completed .file-header .rgh-markTask {
+	color: #34d058;
+}

--- a/source/content.js
+++ b/source/content.js
@@ -78,6 +78,7 @@ import hideNavigationHoverHighlight from './features/hide-navigation-hover-highl
 import displayIssueSuggestions from './features/display-issue-suggestions';
 import addPullRequestHotkey from './features/add-pull-request-hotkey';
 import openSelectionInNewTab from './features/add-selection-in-new-tab';
+import addPullRequestTaskList from './features/add-pull-request-task-list';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -225,6 +226,7 @@ function ajaxedPagesHandler() {
 		enableFeature(toggleAllThingsWithAlt);
 		enableFeature(hideInactiveDeployments);
 		enableFeature(addPullRequestHotkey);
+		enableFeature(addPullRequestTaskList);
 	}
 
 	if (pageDetect.isPR() || pageDetect.isIssue()) {

--- a/source/features/add-pull-request-task-list.js
+++ b/source/features/add-pull-request-task-list.js
@@ -1,0 +1,57 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import {check} from '../libs/icons';
+
+const storageKey = 'cachedLists';
+
+const getCachedTasksList = async () => {
+	const keys = await browser.storage.local.get({
+		[storageKey]: {}
+	});
+	return keys[storageKey];
+};
+
+export default async () => {
+	const pullRequestNumber = select('.gh-header-number').textContent;
+	const cache = await getCachedTasksList() || {};
+
+	function hashCode(s) {
+		return s.split('').reduce((a, b) => {
+			a = ((a << 5) - a) + b.charCodeAt(0);
+			return a & a;
+		}, 0);
+	}
+
+	select.all('.js-timeline-item .discussion-item-body').forEach(discussion => {
+		select.all('.js-comment-container:not(.outdated-comment)', discussion).forEach((fileReview, fileIndex) => {
+			const taskID = `gh-${pullRequestNumber.replace('#', '')}-${fileIndex}-${hashCode(select('.file-header a', fileReview).href)}`;
+			fileReview.setAttribute('id', taskID);
+			if (cache[taskID]) {
+				fileReview.classList.add('rgh-taskList-completed');
+			}
+
+			const _markTask = event => {
+				event.stopPropagation();
+				const targetElement = event.target || event.srcElement;
+				const taskElement = select(`#${targetElement.getAttribute('data-taskID')}`);
+				// Check if the task has been done to see if we want to mark it as done or not
+				if (cache[taskID]) {
+					taskElement.classList.remove('rgh-taskList-completed');
+					delete cache[taskID];
+				} else {
+					taskElement.classList.add('rgh-taskList-completed');
+					cache[taskID] = true;
+				}
+				browser.storage.local.set({[storageKey]: cache});
+			};
+
+			const markTask = check();
+			// Prepare the mark task element with the appropriate attributes
+			markTask.classList.add('rgh-taskAction');
+			const taskHeader = select('.file-header', fileReview);
+			taskHeader.classList.add('rgh-pr-comments-file-header');
+			// Attach the mark and expand tasks element to the header
+			taskHeader.append(<span class="rgh-taskList-action rgh-markTask" data-taskID={taskID} onClick={_markTask}>{markTask}</span>);
+		});
+	});
+};


### PR DESCRIPTION
This idea came to me when I wanted to address the comments of some other PR I have here ( I will get to it @bfred-it :)). Sometimes one can have lots of comments and wants to tackle those in some sort of priority that one decide. This PR adds a task-list kind of behaviour by:

 - Adds a little check mark next to the comment header
 - Clicking on the check mark will mark the task as "completed" and the comment body will collapse
 - You can re-open the task by clicking on the check mark again
 - The task list persists and is stored in the localStorage
 - The approach to make sure the cache works well by creating a unique hash for each task that included the comment url (which will contain in its turn the repo owner, repo name, filename and a commit hash) and I append to that the PR number and an index for the comment as you might have multiple comments on the same file for the same commit hash in the same PR)

![clzx4xeh3i](https://user-images.githubusercontent.com/550726/42687861-1c28d6dc-8692-11e8-963d-510d0983edd7.gif)

### Caveats (need help in those)
 - The task list will appear also in PRs that the user did not open. This can be done easily by getting the username of the person who opened the PR and comparing it to the current username. I can implement that but asking of best practice here to get the current username.
 - When there are mot comments that will be ajaxed in they will not have the checkmark added. I have tried with various `observeEl` but with no luck

![ejwrm8vcbw](https://user-images.githubusercontent.com/550726/42687954-68a23170-8692-11e8-914c-9da8bccb5bf2.gif)
