### PR TITLE
Remove coma from release number

### DIFF
--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -20,7 +20,7 @@ let storageMap = browser.storage.local.get(repoKey);
 async function updateReleasesCount() {
 	if (pageDetect.isRepoRoot()) {
 		const releasesCountEl = select('.numbers-summary a[href$="/releases"] .num');
-		const releasesCount = Number(releasesCountEl ? releasesCountEl.textContent : 0);
+		const releasesCount = Number(releasesCountEl ? releasesCountEl.textContent.replace(/,/g, '') : 0);
 		storageMap = {[repoKey]: releasesCount};
 		browser.storage.local.set(storageMap);
 		return releasesCount;


### PR DESCRIPTION
Following up this issue: https://github.com/isaacs/github/issues/1301

Remove the coma from releases numbe as it blocks reading of the release number by 'Number' class and results in showing 'NaN'.

![2018-07-13-163642_573x239_scrot](https://user-images.githubusercontent.com/8191198/42697277-f1d97e44-86ba-11e8-8207-94bd3d4aa4ed.png)
