### PR TITLE
Hide comments in fewer clicks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,7 +180,8 @@ And [many more…](source/content.css)
 - [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
 - Visit your profile by pressing <kbd>g</kbd> <kbd>m</kbd>.
 - Cycle through PR tabs by pressing <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
-- [Go to the next or previous commit from the bottom of the commit page](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+- [Go to the next or previous commit from the bottom of the commit page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+- [Hide comments in fewer clicks.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
 
 ### Previously part of Refined GitHub
 

--- a/source/content.js
+++ b/source/content.js
@@ -136,6 +136,7 @@ async function init() {
 	enableFeature(hideNavigationHoverHighlight);
 	enableFeature(monospaceTextareas);
 	enableFeature(openSelectionInNewTab);
+	enableFeature(hideCommentsFaster);
 
 	// TODO: Enable this when we've improved how copying Markdown works
 	// See #522
@@ -278,7 +279,6 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit() || pageDetect.isDiscussion()) {
 		enableFeature(addReactionParticipants);
 		enableFeature(showRealNames);
-		enableFeature(hideCommentsFaster);
 	}
 
 	if (pageDetect.isCommitList()) {

--- a/source/content.js
+++ b/source/content.js
@@ -79,6 +79,7 @@ import displayIssueSuggestions from './features/display-issue-suggestions';
 import addPullRequestHotkey from './features/add-pull-request-hotkey';
 import openSelectionInNewTab from './features/add-selection-in-new-tab';
 import showFollowersYouKnow from './features/show-followers-you-know';
+import hideCommentsFaster from './features/hide-comments-faster';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -272,6 +273,7 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit() || pageDetect.isDiscussion()) {
 		enableFeature(addReactionParticipants);
 		enableFeature(showRealNames);
+		enableFeature(hideCommentsFaster);
 	}
 
 	if (pageDetect.isCommitList()) {

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -1,12 +1,20 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
-import onetime from 'onetime';
-import {onDeferredComments} from '../libs/events';
+import delegate from 'delegate';
+import * as pageDetect from '../libs/page-detect';
 
-function createMenu(hideButton) {
+function handleMenuOpening(event) {
+	const hideButton = select('.js-comment-hide-button', event.delegateTarget.parentElement);
+	if (!hideButton) {
+		// User unable to hide or menu already created
+		return;
+	}
+
+	// Disable default behavior
+	hideButton.classList.remove('js-comment-hide-button');
+
 	const comment = hideButton.closest('.unminimized-comment');
 	const form = select('.js-comment-minimize', comment);
-	const details = hideButton.closest('details');
 
 	// Generate dropdown items
 	for (const reason of select.all('[name="classifier"] :not([value=""])', comment)) {
@@ -27,29 +35,17 @@ function createMenu(hideButton) {
 
 	// Imitate existing menu
 	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
-	details.append(form);
 
-	// Hide this menu when the existing menu closes
-	details.addEventListener('toggle', () => {
-		form.hidden = true;
-	});
-	return form;
-}
-
-function createMenus() {
-	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
-		hideButton.classList.remove('js-comment-hide-button'); // Disable default behavior
-
-		// The menu will be generated on the first click.
-		// On successive clicks it will just be shown
-		const getMenu = onetime(() => createMenu(hideButton));
-		hideButton.addEventListener('click', () => {
-			getMenu().hidden = false;
-		});
-	}
+	// Show menu on top of moreMenu when "Hide" is clicked
+	// Hide it when moreMenu closes
+	const moreMenu = hideButton.closest('details');
+	hideButton.addEventListener('click', () => form.removeAttribute('hidden'));
+	moreMenu.addEventListener('toggle', () => form.setAttribute('hidden', true));
+	moreMenu.append(form);
 }
 
 export default function () {
-	onDeferredComments(createMenus);
-	createMenus();
+	if (pageDetect.isPR() || pageDetect.isIssue() || pageDetect.isCommit() || pageDetect.isDiscussion()) {
+		delegate('summary[aria-label="Show more options"]', 'click', handleMenuOpening);
+	}
 }

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -5,43 +5,38 @@ import * as icons from '../libs/icons';
 function createMenu(hideButton) {
 	const comment = hideButton.closest('.unminimized-comment');
 	const form = select('.js-comment-minimize', comment);
-	const reasons = select('[name="classifier"]', comment);
-
-	// Drop submit button
-	select('button', form).remove();
 
 	// Generate dropdown items
-	for (const reason of reasons.options) {
-		if (reason.value) {
-			form.append(
-				<button
-					name="classifier"
-					value={reason.value}
-					class="dropdown-item btn-link"
-					role="menuitem">
-					{reason.textContent}
-				</button>
-			);
-		}
+	for (const reason of select.all('[name="classifier"] :not([value=""])', comment)) {
+		form.append(
+			<button
+				name="classifier"
+				value={reason.value}
+				class="dropdown-item btn-link"
+				role="menuitem">
+				{reason.textContent}
+			</button>
+		);
 	}
 
-	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
-	reasons.remove();
-	const menu = (
-		<details class="rgh-hide-comment-menu details-overlay details-reset position-relative d-inline-block js-dropdown-details d-none">
+	// Drop previous form controls
+	select('.btn', form).remove();
+	select('[name="classifier"]', form).remove();
+
+	return (
+		<details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details d-none">
 			<summary class="btn-link timeline-comment-action" aria-haspopup="true">
 				{icons.fold()}
 			</summary>
-			{form}
+			<div class="dropdown-menu dropdown-menu-sw text-gray-dark show-more-popover anim-scale-in">{form}</div>
 		</details>
 	);
-	select('.timeline-comment-actions', comment).append(menu);
-	return menu;
 }
 
 export default function () {
 	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
 		const menu = createMenu(hideButton);
+		hideButton.closest('.timeline-comment-actions').append(menu);
 		hideButton.classList.remove('js-comment-hide-button');
 		hideButton.addEventListener('click', () => {
 			menu.classList.remove('d-none');

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -1,12 +1,12 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
+import onetime from 'onetime';
 import {onDeferredComments} from '../libs/events';
 
 function createMenu(hideButton) {
 	const comment = hideButton.closest('.unminimized-comment');
 	const form = select('.js-comment-minimize', comment);
-	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
-	form.hidden = true;
+	const details = hideButton.closest('details');
 
 	// Generate dropdown items
 	for (const reason of select.all('[name="classifier"] :not([value=""])', comment)) {
@@ -25,19 +25,26 @@ function createMenu(hideButton) {
 	select('.btn', form).remove();
 	select('[name="classifier"]', form).remove();
 
+	// Imitate existing menu
+	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
+	details.append(form);
+
+	// Hide this menu when the existing menu closes
+	details.addEventListener('toggle', () => {
+		form.hidden = true;
+	});
 	return form;
 }
 
 function createMenus() {
 	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
-		const menu = createMenu(hideButton);
-		hideButton.closest('.dropdown-menu').after(menu);
-		hideButton.classList.remove('js-comment-hide-button');
+		hideButton.classList.remove('js-comment-hide-button'); // Disable default behavior
+
+		// The menu will be generated on the first click.
+		// On successive clicks it will just be shown
+		const getMenu = onetime(() => createMenu(hideButton));
 		hideButton.addEventListener('click', () => {
-			menu.hidden = false;
-		});
-		hideButton.closest('details').addEventListener('toggle', () => {
-			menu.hidden = true;
+			getMenu().hidden = false;
 		});
 	}
 }

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -1,6 +1,7 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
 import * as icons from '../libs/icons';
+import {onDeferredComments} from '../libs/events';
 
 function createMenu(hideButton) {
 	const comment = hideButton.closest('.unminimized-comment');
@@ -33,7 +34,7 @@ function createMenu(hideButton) {
 	);
 }
 
-export default function () {
+function createMenus() {
 	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
 		const menu = createMenu(hideButton);
 		hideButton.closest('.timeline-comment-actions').append(menu);
@@ -44,4 +45,9 @@ export default function () {
 			menu.open = true;
 		});
 	}
+}
+
+export default function () {
+	onDeferredComments(createMenus);
+	createMenus();
 }

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -1,0 +1,51 @@
+import {h} from 'dom-chef';
+import select from 'select-dom';
+import * as icons from '../libs/icons';
+
+function createMenu(hideButton) {
+	const comment = hideButton.closest('.unminimized-comment');
+	const form = select('.js-comment-minimize', comment);
+	const reasons = select('[name="classifier"]', comment);
+
+	// Drop submit button
+	select('button', form).remove();
+
+	// Generate dropdown items
+	for (const reason of reasons.options) {
+		if (reason.value) {
+			form.append(
+				<button
+					name="classifier"
+					value={reason.value}
+					class="dropdown-item btn-link"
+					role="menuitem">
+					{reason.textContent}
+				</button>
+			);
+		}
+	}
+
+	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
+	reasons.remove();
+	const menu = (
+		<details class="rgh-hide-comment-menu details-overlay details-reset position-relative d-inline-block js-dropdown-details d-none">
+			<summary class="btn-link timeline-comment-action" aria-haspopup="true">
+				{icons.fold()}
+			</summary>
+			{form}
+		</details>
+	);
+	select('.timeline-comment-actions', comment).append(menu);
+	return menu;
+}
+
+export default function () {
+	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
+		const menu = createMenu(hideButton);
+		hideButton.classList.remove('js-comment-hide-button');
+		hideButton.addEventListener('click', () => {
+			menu.classList.remove('d-none');
+			menu.open = true;
+		});
+	}
+}

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -39,6 +39,7 @@ export default function () {
 		hideButton.closest('.timeline-comment-actions').append(menu);
 		hideButton.classList.remove('js-comment-hide-button');
 		hideButton.addEventListener('click', () => {
+			hideButton.closest('details').open = false;
 			menu.classList.remove('d-none');
 			menu.open = true;
 		});

--- a/source/features/hide-comments-faster.js
+++ b/source/features/hide-comments-faster.js
@@ -1,11 +1,12 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
-import * as icons from '../libs/icons';
 import {onDeferredComments} from '../libs/events';
 
 function createMenu(hideButton) {
 	const comment = hideButton.closest('.unminimized-comment');
 	const form = select('.js-comment-minimize', comment);
+	form.classList.add('dropdown-menu', 'dropdown-menu-sw', 'text-gray-dark', 'show-more-popover', 'anim-scale-in');
+	form.hidden = true;
 
 	// Generate dropdown items
 	for (const reason of select.all('[name="classifier"] :not([value=""])', comment)) {
@@ -24,25 +25,19 @@ function createMenu(hideButton) {
 	select('.btn', form).remove();
 	select('[name="classifier"]', form).remove();
 
-	return (
-		<details class="details-overlay details-reset position-relative d-inline-block js-dropdown-details d-none">
-			<summary class="btn-link timeline-comment-action" aria-haspopup="true">
-				{icons.fold()}
-			</summary>
-			<div class="dropdown-menu dropdown-menu-sw text-gray-dark show-more-popover anim-scale-in">{form}</div>
-		</details>
-	);
+	return form;
 }
 
 function createMenus() {
 	for (const hideButton of select.all('.unminimized-comment .js-comment-hide-button')) {
 		const menu = createMenu(hideButton);
-		hideButton.closest('.timeline-comment-actions').append(menu);
+		hideButton.closest('.dropdown-menu').after(menu);
 		hideButton.classList.remove('js-comment-hide-button');
 		hideButton.addEventListener('click', () => {
-			hideButton.closest('details').open = false;
-			menu.classList.remove('d-none');
-			menu.open = true;
+			menu.hidden = false;
+		});
+		hideButton.closest('details').addEventListener('toggle', () => {
+			menu.hidden = true;
 		});
 	}
 }

--- a/source/libs/events.js
+++ b/source/libs/events.js
@@ -1,0 +1,12 @@
+import select from 'select-dom';
+
+export function onDeferredComments(cb) {
+	for (const loadMore of select.all('.js-ajax-pagination:not(.rgh-deferred-comments)')) {
+		loadMore.classList.add('rgh-deferred-comments');
+		loadMore.addEventListener('page:loaded', () => {
+			cb();
+			onDeferredComments(cb);
+		});
+	}
+}
+

--- a/source/libs/icons.js
+++ b/source/libs/icons.js
@@ -6,6 +6,8 @@ export const info = () => <svg aria-hidden="true" class="octicon octicon-info" w
 
 export const edit = () => <svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"/></svg>;
 
+export const fold = () => <svg aria-hidden="true" class="octicon octicon-pencil" height="16" width="14"><path d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>;
+
 export const trashcan = () => <svg aria-hidden="true" class="octicon octicon-trashcan" height="16" width="12"><path d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>;
 
 export const openIssue = () => <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>;

--- a/source/libs/icons.js
+++ b/source/libs/icons.js
@@ -6,8 +6,6 @@ export const info = () => <svg aria-hidden="true" class="octicon octicon-info" w
 
 export const edit = () => <svg aria-hidden="true" class="octicon octicon-pencil" width="14" height="16"><path d="M0 12v3h3l8-8-3-3L0 12z m3 2H1V12h1v1h1v1z m10.3-9.3l-1.3 1.3-3-3 1.3-1.3c0.39-0.39 1.02-0.39 1.41 0l1.59 1.59c0.39 0.39 0.39 1.02 0 1.41z"/></svg>;
 
-export const fold = () => <svg aria-hidden="true" class="octicon octicon-pencil" height="16" width="14"><path d="M7 9l3 3H8v3H6v-3H4l3-3zm3-6H8V0H6v3H4l3 3 3-3zm4 2c0-.55-.45-1-1-1h-2.5l-1 1h3l-2 2h-7l-2-2h3l-1-1H1c-.55 0-1 .45-1 1l2.5 2.5L0 10c0 .55.45 1 1 1h2.5l1-1h-3l2-2h7l2 2h-3l1 1H13c.55 0 1-.45 1-1l-2.5-2.5L14 5z"/></svg>;
-
 export const trashcan = () => <svg aria-hidden="true" class="octicon octicon-trashcan" height="16" width="12"><path d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>;
 
 export const openIssue = () => <svg aria-hidden="true" class="octicon octicon-issue-opened" height="16" viewBox="0 0 14 16" width="14"><path d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>;


### PR DESCRIPTION
From **5 clicks + 700px mouse movement** to **3 clicks + 100px movement.**

![demo](https://user-images.githubusercontent.com/1402241/42957074-de3d7c7a-8b81-11e8-9e36-56f1bf1d726d.gif)


Fixes #1268
Replaces and closes #1410

- [x] works on regular comments
- [x] works on inline PR comments (in Conversation or Files view)
- [x] works on ajaxed-in comments
	- [x] via `Load more...` (tested on https://github.com/facebook/react/issues/3398)
	- [x] on new comments
- [ ] ~~works when the hide button is always visible (not in a dropdown)~~ (I haven't seen this one)
