### PR TITLE
Linkify commit SHA on PR commit page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Copy a file's content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
 - [Copy the path of a PR file.](https://cloud.githubusercontent.com/assets/4201088/26023064/18c9c77c-37d2-11e7-8926-b0a05a2706ae.png)
 - [Quickly access a commit's `.patch` and `.diff` files.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
+- [Navigate from PR commit to raw commit by clicking the commit hash.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
 - [Browse a repository at the time of each comment.](https://user-images.githubusercontent.com/1402241/32310022-7fef6174-bf5d-11e7-960f-5041a8f073ac.png)
 - [Visit a user's public gists from their profile.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
 - [Jump to the bottom of a discussion page with a click.](https://user-images.githubusercontent.com/4331946/34298950-93876584-e720-11e7-898a-96f85e31aefe.png)

--- a/source/content.js
+++ b/source/content.js
@@ -80,6 +80,7 @@ import addPullRequestHotkey from './features/add-pull-request-hotkey';
 import openSelectionInNewTab from './features/add-selection-in-new-tab';
 import addSwapBranchesOnCompare from './features/add-swap-branches-on-compare';
 import showFollowersYouKnow from './features/show-followers-you-know';
+import linkifyCommitSha from './features/linkify-commit-sha';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -299,6 +300,10 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isUserProfile()) {
 		enableFeature(addGistsLink);
 		enableFeature(showFollowersYouKnow);
+	}
+
+	if (pageDetect.isPRCommit()) {
+		enableFeature(linkifyCommitSha);
 	}
 }
 

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -1,7 +1,6 @@
 import {h} from 'dom-chef';
-import * as pageDetect from '../libs/page-detect';
-import { wrap } from '../libs/utils';
 import select from 'select-dom';
+import {wrap} from '../libs/utils';
 
 export default function () {
 	let commitUrl = location.pathname.replace(/\/$/, '');

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -1,0 +1,14 @@
+import {h} from 'dom-chef';
+import * as pageDetect from '../libs/page-detect';
+import { wrap } from '../libs/utils';
+import select from 'select-dom';
+
+export default function () {
+	let commitUrl = location.pathname.replace(/\/$/, '');
+	commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
+
+	const el = select('.sha-block:not(.patch-diff-links) .sha');
+	if (el) {
+		wrap(el, <a href={commitUrl}></a>);
+	}
+}

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -3,11 +3,8 @@ import select from 'select-dom';
 import {wrap} from '../libs/utils';
 
 export default function () {
-	let commitUrl = location.pathname.replace(/\/$/, '');
-	commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
-
 	const el = select('.sha.user-select-contain');
 	if (el) {
-		wrap(el, <a href={commitUrl}/>);
+		wrap(el, <a href={location.pathname.replace(/\/pull\/\d+\/commits/, '/commit')}/>);
 	}
 }

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -6,7 +6,7 @@ export default function () {
 	let commitUrl = location.pathname.replace(/\/$/, '');
 	commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
 
-	const el = select('.sha-block:not(.patch-diff-links) .sha');
+	const el = select('.sha.user-select-contain');
 	if (el) {
 		wrap(el, <a href={commitUrl}></a>);
 	}

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -8,6 +8,6 @@ export default function () {
 
 	const el = select('.sha.user-select-contain');
 	if (el) {
-		wrap(el, <a href={commitUrl}></a>);
+		wrap(el, <a href={commitUrl}/>);
 	}
 }

--- a/source/features/linkify-commit-sha.js
+++ b/source/features/linkify-commit-sha.js
@@ -5,6 +5,6 @@ import {wrap} from '../libs/utils';
 export default function () {
 	const el = select('.sha.user-select-contain');
 	if (el) {
-		wrap(el, <a href={location.pathname.replace(/\/pull\/\d+\/commits/, '/commit')}/>);
+		wrap(el, <a href={location.pathname.replace(/pull\/\d+\/commits/, 'commit')}/>);
 	}
 }


### PR DESCRIPTION
Resolves #1053 

For example, [this PR commit page](https://github.com/sindresorhus/refined-github/pull/1045/commits/b7137144f3df9a77f80c78ca63bf43322b2cf621) now links to the ["raw" commit page](https://github.com/sindresorhus/refined-github/commit/b7137144f3df9a77f80c78ca63bf43322b2cf621).

![image](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)

---

- [x] Initial implementation https://github.com/sindresorhus/refined-github/commit/b533ffa5820d825e1730c62d11acb2edbfb2d7dd
- [x] Get advice whether this is done right (this is my first contribution to Refined GitHub, or any Chrome extension fot that matter)
- [x] Add to README