### PR TITLE
Do not remove diff signs from DOM unless GitHub feature is not supported

### DIFF
--- a/source/features/remove-diff-signs.js
+++ b/source/features/remove-diff-signs.js
@@ -6,10 +6,11 @@ function removeDiffSigns() {
 	// Return early for GitHub DOMs that exclude + and - when copying from diffs.
 	// Continue to support older GitHub versions such as users running GitHub Enterprise.
 	if (['deletion', 'context', 'addition'].some(name =>
-		select.exists('.blob-code-marker-' + name)
+		select.exists(`.blob-code-marker-${name}`)
 	)) {
 		return;
 	}
+
 	for (const line of select.all('.diff-table > tbody > tr:not(.refined-github-diff-signs)')) {
 		line.classList.add('refined-github-diff-signs');
 		for (const code of select.all('.blob-code-inner', line)) {

--- a/source/features/remove-diff-signs.js
+++ b/source/features/remove-diff-signs.js
@@ -3,6 +3,13 @@ import select from 'select-dom';
 import observeEl from '../libs/simplified-element-observer';
 
 function removeDiffSigns() {
+	// Return early for GitHub DOMs that exclude + and - when copying from diffs.
+	// Continue to support older GitHub versions such as users running GitHub Enterprise.
+	if (['deletion', 'context', 'addition'].some(name =>
+		select.exists('.blob-code-marker-' + name)
+	)) {
+		return;
+	}
 	for (const line of select.all('.diff-table > tbody > tr:not(.refined-github-diff-signs)')) {
 		line.classList.add('refined-github-diff-signs');
 		for (const code of select.all('.blob-code-inner', line)) {


### PR DESCRIPTION
This resolves https://github.com/sindresorhus/refined-github/issues/1444 so that diffs on GitHub.com are only modified if the new GitHub diff sign selection feature is not supported. This means legacy versions of GitHub will continue to support the feature via Refined GitHub and newer GitHub DOMs will use the built in support provided by GitHub.com.

This ensures that users of both GitHub.com and GitHub Enterprise (older versions) can use Refined GitHub without disabling the remove-diff-sign feature.

Also this will ensure that if GitHub reverted the change Refined GitHub will continue to work as expected.