### PR TITLE
Fix selector for add-filter-comments-by-you

### DIFF
--- a/source/features/add-filter-comments-by-you.js
+++ b/source/features/add-filter-comments-by-you.js
@@ -6,14 +6,15 @@ import {getUsername} from '../libs/utils';
 const repoUrl = pageDetect.getRepoURL();
 
 export default function () {
-	select('.subnav-search-context .js-navigation-item:last-child')
+	select('.subnav-search-context li:last-child')
 		.before(
-			<a
-				href={`/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`}
-				class="select-menu-item js-navigation-item">
-				<div class="select-menu-item-text">
-					Everything commented by you
-				</div>
-			</a>
+			<li>
+				<a
+					href={`/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`}
+					class="select-menu-item"
+					role="menuitem">
+						Everything commented by you
+				</a>
+			</li>
 		);
 }


### PR DESCRIPTION
![screenshot from 2018-08-08 13-54-11](https://user-images.githubusercontent.com/3723666/43855216-ece43584-9b12-11e8-8f02-de22fad5fade.png)

the selector works again and I slightly updated the added HTML to match what's being used on the page.

resolves #1466 
