### PR TITLE
Fix 1px space between file headers & diff toolbar

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -664,7 +664,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 /* Sticky file headers on pull request diff view */
 .pull-request-tab-content .diff-view .file-header {
 	position: sticky;
-	top: 60px;
+	top: 59px;
 	z-index: 10;
 }
 


### PR DESCRIPTION
GitHub recently started using an alpha color on the border shadow on the sticky pr toolbar. This causes an ugly gap as you scroll over diffs:

<img width="103" alt="skjermbilde 2018-08-10 kl 12 51 10" src="https://user-images.githubusercontent.com/81981/43954608-6d6fcae8-9c9d-11e8-828e-7314d842edfb.png">

This fixes it:

<img width="91" alt="skjermbilde 2018-08-10 kl 12 58 57" src="https://user-images.githubusercontent.com/81981/43954617-75734d6e-9c9d-11e8-9324-2684fc2034b2.png">
