### PR TITLE
Fix reactions avatars for bots

### DIFF
--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -12,7 +12,7 @@ function getParticipants(container) {
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')
-		.replace(/\[bot\]/, '')
+		.replace(/\[bot\]/g, '')
 		.split(', ')
 		.filter(username => username !== currentUser)
 		.map(username => ({

--- a/source/features/reactions-avatars.js
+++ b/source/features/reactions-avatars.js
@@ -12,6 +12,7 @@ function getParticipants(container) {
 		.replace(/ reacted with.*/, '')
 		.replace(/,? and /, ', ')
 		.replace(/, \d+ more/, '')
+		.replace(/\[bot\]/, '')
 		.split(', ')
 		.filter(username => username !== currentUser)
 		.map(username => ({


### PR DESCRIPTION
Because when a bot reacts to a message, the avatar's url is not valid.

**Before:**

Invalid url `https://github.com/dependabot[bot].png?size=22.000000476837158` is called:

![chrome_2018-08-18_20-28-53](https://user-images.githubusercontent.com/2103975/44302373-aad5f200-a327-11e8-89bd-2574570f5c58.png)

**After:**

Valid url `https://github.com/dependabot.png?size=22.000000476837158` is called:

![chrome_2018-08-18_20-44-44](https://user-images.githubusercontent.com/2103975/44302375-ab6e8880-a327-11e8-9544-797932b3c61c.png)

You can see a live example [here](https://github.com/Kocal/jsdoc-vuejs/pull/108).