### PR TITLE
Add mobile detection / Profile Gists nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"element-ready": "^3.0.0",
 		"github-injection": "^1.0.1",
 		"github-reserved-names": "^1.0.14",
+		"is-mobile": "^1.0.0",
 		"linkify-issues": "^1.3.0",
 		"linkify-urls": "^2.0.0",
 		"onetime": "^2.0.1",

--- a/source/features/add-gists-link-to-profile.js
+++ b/source/features/add-gists-link-to-profile.js
@@ -1,22 +1,24 @@
 import {h} from 'dom-chef';
 import select from 'select-dom';
-import {getCleanPathname, isEnterprise} from '../libs/page-detect';
+import {getCleanPathname, isEnterprise, isMobile} from '../libs/page-detect';
 import api from '../libs/api';
 
 export default async () => {
-	const container = select('body.page-profile .UnderlineNav-body');
+	const containerSelector = isMobile() ? '.reponav.js-reponav' : 'body.page-profile .UnderlineNav-body';
+	const container = select(containerSelector);
 
 	if (!container) {
 		return;
 	}
+	const linkClass = isMobile() ? 'reponav-item js-selected-navigation-item' : 'UnderlineNav-item';
 
 	const username = getCleanPathname();
 	const href = isEnterprise() ? `/gist/${username}` : `https://gist.github.com/${username}`;
-	const link = <a href={href} class="UnderlineNav-item" role="tab" aria-selected="false">Gists </a>;
+	const link = <a href={href} className={linkClass} role="tab" aria-selected="false">Gists </a>;
 	container.append(link);
 
 	const userData = await api(`users/${username}`);
 	if (userData.public_gists) {
-		link.append(<span class="Counter">{userData.public_gists}</span>);
+		link.append(<span className={'Counter'}>{userData.public_gists}</span>);
 	}
 };

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -2,7 +2,6 @@
 /* eslint-disable unicorn/prefer-starts-ends-with, The tested var might not be a string */
 
 import {check as isReserved} from 'github-reserved-names';
-export {isMobile as isMobile} from 'is-mobile';
 
 // Drops leading and trailing slash to avoid /\/?/ everywhere
 export const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, '');
@@ -108,3 +107,5 @@ export const isSingleFile = () => /^blob\//.test(getRepoPath());
 export const isTrending = () => location.pathname.startsWith('/trending');
 
 export const isUserProfile = () => Boolean(getCleanPathname()) && !isGist() && !isReserved(getCleanPathname()) && !getCleanPathname().includes('/');
+
+export {isMobile} from 'is-mobile';

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -2,6 +2,7 @@
 /* eslint-disable unicorn/prefer-starts-ends-with, The tested var might not be a string */
 
 import {check as isReserved} from 'github-reserved-names';
+export {isMobile as isMobile} from 'is-mobile';
 
 // Drops leading and trailing slash to avoid /\/?/ everywhere
 export const getCleanPathname = () => location.pathname.replace(/^[/]|[/]$/g, '');


### PR DESCRIPTION
Adds an `isMobile` check. This will be used to improve the extension's support for Firefox Mobile (see #1496).

Also fixes the "Gists" link not appearing on profiles (on mobile)