### PR TITLE
Auto load contribution activities

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -155,6 +155,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Pressing `Cancel` on an inline comment opens a prompt to prevent accidental cancelling.
 - The `+` and `-` signs in diffs are made unselectable for easier copy-pasting.
 - The news feeds automagically expands when you scroll down.
+- The contribution activities automagically expands when you scroll down.
 - The default sort order of milestones is changed to `Closest due date`.
 - The default sort order of issues and pull requests is changed to `Recently updated`.
 - [The `Expand diff` button is widened.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)

--- a/source/content.js
+++ b/source/content.js
@@ -16,7 +16,7 @@ import addFileCopyButton from './features/copy-file';
 // - import copyMarkdown from './features/copy-markdown';
 import linkifyCode from './features/linkify-urls-in-code';
 import autoLoadMoreNews from './features/auto-load-more-news';
-import autoLoadComntributionActivities from './features/auto-load-contribution-activities';
+import autoLoadContributionActivities from './features/auto-load-contribution-activities';
 import addOPLabels from './features/op-labels';
 import addMoreDropdown from './features/more-dropdown';
 import addReleasesTab from './features/add-releases-tab';
@@ -303,7 +303,7 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isUserProfile()) {
 		enableFeature(addGistsLink);
 		enableFeature(showFollowersYouKnow);
-		enableFeature(autoLoadComntributionActivities);
+		enableFeature(autoLoadContributionActivities);
 	}
 
 	if (pageDetect.isPRCommit()) {

--- a/source/content.js
+++ b/source/content.js
@@ -16,6 +16,7 @@ import addFileCopyButton from './features/copy-file';
 // - import copyMarkdown from './features/copy-markdown';
 import linkifyCode from './features/linkify-urls-in-code';
 import autoLoadMoreNews from './features/auto-load-more-news';
+import autoLoadComntributionActivities from './features/auto-load-contribution-activities';
 import addOPLabels from './features/op-labels';
 import addMoreDropdown from './features/more-dropdown';
 import addReleasesTab from './features/add-releases-tab';
@@ -302,6 +303,7 @@ function ajaxedPagesHandler() {
 	if (pageDetect.isUserProfile()) {
 		enableFeature(addGistsLink);
 		enableFeature(showFollowersYouKnow);
+		enableFeature(autoLoadComntributionActivities);
 	}
 
 	if (pageDetect.isPRCommit()) {

--- a/source/features/auto-load-contribution-activities.js
+++ b/source/features/auto-load-contribution-activities.js
@@ -1,0 +1,53 @@
+/*
+This feature adds auto loading of the contribution activities in the user profile
+*/
+
+import select from 'select-dom';
+import debounce from 'debounce-fn';
+import observeEl from '../libs/simplified-element-observer';
+
+let btn;
+
+const loadMore = debounce(() => {
+	btn.click();
+	btn.textContent = 'loading...';
+
+	// If GH hasn't loaded the JS, the click will not load anything.
+	// We can detect if it worked by looking at the button's state,
+	// and then trying again (auto-debounced)
+	if (!btn.disabled) {
+		loadMore();
+	}
+}, {wait: 200});
+
+const inView = new IntersectionObserver(([{isIntersecting}]) => {
+	if (isIntersecting) {
+		loadMore();
+	}
+});
+
+const findButton = () => {
+	// If the old button is still there, leave
+	if (btn && document.contains(btn)) {
+		return;
+	}
+
+	// Forget the old button
+	inView.disconnect();
+
+	// Watch the new button, or stop everything
+	btn = select('.ajax-pagination-btn');
+	if (btn) {
+		inView.observe(btn);
+	}
+};
+
+export default () => {
+	const form = select('.ajax-pagination-form');
+	if (form) {
+		// If GH hasn't loaded the JS,
+		// the fake click will submit the form without ajax.
+		form.addEventListener('submit', event => event.preventDefault());
+		observeEl('#js-contribution-activity', findButton);
+	}
+};


### PR DESCRIPTION
This feature adds auto loading of the contribution activities in the user profile

It basically is a copy of `auto-load-more-news`, I just adjusted the observed element.
I also removed the `rootMargin` ([reference](https://github.com/sindresorhus/refined-github/pull/505#issuecomment-309273098)) because I liked it more to actually see the button, but that could be easily adjusted. 

Closes #861 