### PR TITLE
do not cover up fork/star/other extension buttons behind the "recently pushed branches" indicator

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -755,13 +755,11 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	position: relative;
 }
 [data-url$='recently_touched_branches_list'] {
-	min-width: 430px; /* Always cover the repo watch/star/forks actions */
 	max-height: 42px; /* Only cover the actions when there are multiple branches + :hover */
 	position: absolute;
 	top: -117px;
 	right: 0;
 	z-index: 32; /* Set z-index higher than ul.pagehead-actions */
-	background: var(--github-gray-background);
 	white-space: nowrap;
 	animation: rgh-slide-in-right 0.3s ease-out;
 }


### PR DESCRIPTION
fix #1433

It now looks like:

![image](https://user-images.githubusercontent.com/1976/45144087-f5ea6480-b171-11e8-9b27-6863eba5c993.png)
