### PR TITLE
Avoid breaking "Jump to bottom" link in two lines

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -986,6 +986,11 @@ body > .footer li a {
 	cursor: pointer;
 }
 
+/* For 'add-jump-to-bottom-link' feature */
+#rgh-jump-to-bottom-link {
+	display: inline-block; /* Avoid breaking link in two lines */
+}
+
 /* Remove the useless "Continuous integration has not been set up" message on PRs */
 .branch-action-item.marketplace-product-callout {
 	display: none;

--- a/source/features/add-jump-to-bottom-link.js
+++ b/source/features/add-jump-to-bottom-link.js
@@ -4,14 +4,14 @@ import observeEl from '../libs/simplified-element-observer';
 
 function add() {
 	const meta = select('.gh-header-meta > .TableObject-item--primary');
-	const jumpToBottomLink = select('#refined-github-jump-to-bottom-link');
+	const jumpToBottomLink = select('#rgh-jump-to-bottom-link');
 	if (!meta || jumpToBottomLink) {
 		return;
 	}
 
 	meta.append(
 		' · ',
-		<a href="#partial-timeline" id="refined-github-jump-to-bottom-link">Jump to bottom</a>
+		<a href="#partial-timeline" id="rgh-jump-to-bottom-link">Jump to bottom</a>
 	);
 }
 


### PR DESCRIPTION
# Before

<img width="1032" alt="before" src="https://user-images.githubusercontent.com/1402241/45544583-505a8380-b84a-11e8-92fa-020c56f326af.png">

# After

<img width="1033" alt="after" src="https://user-images.githubusercontent.com/1402241/45544613-5e100900-b84a-11e8-87e6-297a4d73a182.png">
