### PR TITLE
Fix hiding of useless comments under Linux

### DIFF
--- a/source/features/hide-useless-comments.js
+++ b/source/features/hide-useless-comments.js
@@ -14,6 +14,10 @@ export default function () {
 			continue;
 		}
 
+		if (select.exists('a', commentText)) {
+			continue;
+		}
+
 		// Ensure that they're not by VIPs (owner, collaborators, etc)
 		const comment = commentText.closest('.js-timeline-item');
 		if (select.exists('.timeline-comment-label', comment)) {

--- a/source/features/hide-useless-comments.js
+++ b/source/features/hide-useless-comments.js
@@ -14,7 +14,9 @@ export default function () {
 			continue;
 		}
 
-		if (select.exists('a', commentText)) {
+		// Comments that contain useful images shouldn't be removed
+		const image = select('a', commentText);
+		if (select.exists('img', image)) {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.js
+++ b/source/features/hide-useless-comments.js
@@ -15,8 +15,7 @@ export default function () {
 		}
 
 		// Comments that contain useful images shouldn't be removed
-		const image = select('a', commentText);
-		if (select.exists('img', image)) {
+		if (select.exists('a img', commentText)) {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.js
+++ b/source/features/hide-useless-comments.js
@@ -10,7 +10,7 @@ export default function () {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
 		// Find useless comments
-		if (!/^([+-]\d+!*|👍|🙏|👎|👌)+$/.test(commentText.textContent.trim())) {
+		if (!/^([+-]\d+!*|👍|🙏|👎|👌|)+$/.test(commentText.textContent.trim())) {
 			continue;
 		}
 

--- a/source/features/linkify-branch-refs.js
+++ b/source/features/linkify-branch-refs.js
@@ -1,6 +1,6 @@
-import { h } from 'dom-chef';
+import {h} from 'dom-chef';
 import select from 'select-dom';
-import { safeElementReady, wrap } from '../libs/utils';
+import {safeElementReady, wrap} from '../libs/utils';
 import * as pageDetect from '../libs/page-detect';
 
 function inPR() {
@@ -17,30 +17,19 @@ function inPR() {
 	const urls = new Map();
 	for (const el of select.all('.commit-ref[title], .base-ref[title], .head-ref[title]')) {
 		const [repo, branch] = el.title.split(':');
-		const branchName = el.textContent.trim();
-
-		if (branchName !== deletedBranch) {
-			urls.set(
-				el.textContent.trim(),
-				`/${repo}/tree/${encodeURIComponent(branch)}`
-			);
-		} else {
-			urls.set(
-				el.textContent.trim(),
-				`/${repo}`
-			);
-		}
+		urls.set(
+			el.textContent.trim(),
+			`/${repo}/tree/${encodeURIComponent(branch)}`
+		);
 	}
 
 	for (const el of select.all('.commit-ref')) {
 		const branchName = el.textContent.trim();
 
-		if (branchName !== 'unknown repository') {
-			if (branchName === deletedBranch) {
-				el.title = 'Deleted';
-				el.style.textDecoration = 'line-through';
-			}
-
+		if (branchName === deletedBranch) {
+			el.title = 'Deleted';
+			el.style.textDecoration = 'line-through';
+		} else if (branchName !== 'unknown repository') {
 			wrap(el, <a href={urls.get(branchName)}></a>);
 		}
 	}
@@ -49,7 +38,7 @@ function inPR() {
 async function inQuickPR() {
 	const el = await safeElementReady('.branch-name');
 	if (el) {
-		const { ownerName, repoName } = pageDetect.getOwnerAndRepo();
+		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
 		const branchUrl = `/${ownerName}/${repoName}/tree/${el.textContent}`;
 		wrap(el.closest('.branch-name'), <a href={branchUrl}></a>);
 	}

--- a/source/features/linkify-branch-refs.js
+++ b/source/features/linkify-branch-refs.js
@@ -1,6 +1,6 @@
-import {h} from 'dom-chef';
+import { h } from 'dom-chef';
 import select from 'select-dom';
-import {safeElementReady, wrap} from '../libs/utils';
+import { safeElementReady, wrap } from '../libs/utils';
 import * as pageDetect from '../libs/page-detect';
 
 function inPR() {
@@ -17,19 +17,30 @@ function inPR() {
 	const urls = new Map();
 	for (const el of select.all('.commit-ref[title], .base-ref[title], .head-ref[title]')) {
 		const [repo, branch] = el.title.split(':');
-		urls.set(
-			el.textContent.trim(),
-			`/${repo}/tree/${encodeURIComponent(branch)}`
-		);
+		const branchName = el.textContent.trim();
+
+		if (branchName !== deletedBranch) {
+			urls.set(
+				el.textContent.trim(),
+				`/${repo}/tree/${encodeURIComponent(branch)}`
+			);
+		} else {
+			urls.set(
+				el.textContent.trim(),
+				`/${repo}`
+			);
+		}
 	}
 
 	for (const el of select.all('.commit-ref')) {
 		const branchName = el.textContent.trim();
 
-		if (branchName === deletedBranch) {
-			el.title = 'Deleted';
-			el.style.textDecoration = 'line-through';
-		} else if (branchName !== 'unknown repository') {
+		if (branchName !== 'unknown repository') {
+			if (branchName === deletedBranch) {
+				el.title = 'Deleted';
+				el.style.textDecoration = 'line-through';
+			}
+
 			wrap(el, <a href={urls.get(branchName)}></a>);
 		}
 	}
@@ -38,7 +49,7 @@ function inPR() {
 async function inQuickPR() {
 	const el = await safeElementReady('.branch-name');
 	if (el) {
-		const {ownerName, repoName} = pageDetect.getOwnerAndRepo();
+		const { ownerName, repoName } = pageDetect.getOwnerAndRepo();
 		const branchUrl = `/${ownerName}/${repoName}/tree/${el.textContent}`;
 		wrap(el.closest('.branch-name'), <a href={branchUrl}></a>);
 	}


### PR DESCRIPTION
Closes #1536.

The fix is surprisingly simple.

The textContent of the comment is empty (under Linux) if only one or more g-emojis were used. So we can simply check for an empty string.