### PR TITLE
Don't show names for GitHub apps (again)

### DIFF
--- a/source/features/show-names.js
+++ b/source/features/show-names.js
@@ -23,7 +23,7 @@ const fetchName = async username => {
 
 export default () => {
 	const myUsername = getUsername();
-	const commentsList = select.all('.js-discussion .author:not(.rgh-fullname):not([href^="/apps/"])');
+	const commentsList = select.all('.js-discussion .author:not(.rgh-fullname):not([href*="/apps/"])');
 
 	// {sindresorhus: [a.author, a.author], otheruser: [a.author]}
 	const usersOnPage = groupBy(commentsList, el => el.textContent);


### PR DESCRIPTION
This fixes #1549. This feature was initially added in #959, but was [broken by GitHub](https://github.com/sindresorhus/refined-github/issues/1549#issuecomment-426314655).