### PR TITLE
Use the API to get the default branch

### DIFF
--- a/source/libs/get-default-branch.js
+++ b/source/libs/get-default-branch.js
@@ -1,6 +1,30 @@
+import select from 'select-dom';
 import * as cache from './cache';
 import * as api from './api';
 import {getOwnerAndRepo} from './page-detect';
+
+// This regex should match all of these combinations:
+// "This branch is even with master."
+// "This branch is 1 commit behind master."
+// "This branch is 1 commit ahead of master."
+// "This branch is 1 commit ahead, 27 commits behind master."
+const branchInfoRegex = /([^ ]+)\.$/;
+
+function parseBranchFromDom() {
+	if (select.exists('.repohead h1 .octicon-repo-forked')) {
+		return; // It's a fork, no "default branch" info available #1132
+	}
+
+	// We can find the name in the infobar, available in folder views
+	const branchInfo = select('.branch-infobar');
+	if (!branchInfo) {
+		return;
+	}
+
+	// Parse the infobar
+	const [, branchName] = branchInfo.textContent.trim().match(branchInfoRegex) || [];
+	return branchName; // `string` or undefined
+}
 
 async function fetchFromApi(user, repo) {
 	const response = await api.v3(`repos/${user}/${repo}`);
@@ -12,6 +36,6 @@ async function fetchFromApi(user, repo) {
 export default function () {
 	const {ownerName, repoName} = getOwnerAndRepo();
 	return cache.getSet(`default-branch:${ownerName}/${repoName}`,
-		() => fetchFromApi(ownerName, repoName)
+		() => parseBranchFromDom() || fetchFromApi(ownerName, repoName)
 	);
 }

--- a/source/libs/get-default-branch.js
+++ b/source/libs/get-default-branch.js
@@ -1,0 +1,17 @@
+import * as cache from './cache';
+import * as api from './api';
+import {getOwnerAndRepo} from './page-detect';
+
+async function fetchFromApi(user, repo) {
+	const response = await api.v3(`repos/${user}/${repo}`);
+	if (response && response.default_branch) {
+		return response.default_branch;
+	}
+}
+
+export default function () {
+	const {ownerName, repoName} = getOwnerAndRepo();
+	return cache.getSet(`default-branch:${ownerName}/${repoName}`,
+		() => fetchFromApi(ownerName, repoName)
+	);
+}


### PR DESCRIPTION
Fixes #1173 #1132

This enables the ["see on the default branch" button](https://github.com/sindresorhus/refined-github/pull/1115) in a couple of situations:

- forks
- tags (without visiting a branch first)
- commits (without visiting a branch first)
- files (without visiting a branch+folder first)

# Already supported

https://github.com/sindresorhus/refined-github/tree/visited (branch root)
https://github.com/sindresorhus/refined-github/tree/visited/media (branch folder)

# Newly supported

https://github.com/bfred-it/refined-github/blob/visited/.gitattributes (fork, pre-existing branch)
https://github.com/bfred-it/refined-github/blob/default-branch-api/.gitattributes (fork, new branch)
https://github.com/Microsoft/ChakraCore/tree/v1.11.1 (tag)
https://github.com/Microsoft/vsts-tasks/tree/5ca661d47b0ebc6352d4c7697293f23f4f254971 (commit)
https://github.com/Microsoft/pxt-microbit/blob/FirmwareLink/.vscode/launch.json (file)
