### PR TITLE
Include all linebreaks when copying file

### DIFF
--- a/source/features/copy-file.js
+++ b/source/features/copy-file.js
@@ -9,8 +9,13 @@ export default function () {
 		code.classList.add('rgh-copy-file');
 		const file = code.closest('.file');
 
+		const content = select.all('tr', file)
+			.map(tr => tr.innerText)
+			.map(line => line === '\n' ? '' : line)
+			.join('\n');
+
 		const handleClick = () => {
-			copyToClipboard(code.innerText);
+			copyToClipboard(content);
 		};
 
 		// Prepend to list of buttons


### PR DESCRIPTION
Fixes #1500. https://github.com/denkristoffer/refined-github-reproduction/blob/master/file.js can be used to test the fix.