### PR TITLE
Default repo scope for personal token link

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -27,7 +27,7 @@
 
 	<p>
 		<label>
-			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub" target="_blank">found here</a> (for high rate API calls and private repos)<br>
+			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (for high rate API calls and private repos)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input name="personalToken" spellcheck="false" autocomplete="off" size="40" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
 		</label>


### PR DESCRIPTION
When clicking the 'Personal Token' link found in the options menu, the
repo options are now preselected to avoid the confusion of what
permissions are required.

![image](https://user-images.githubusercontent.com/857700/46450582-9d4dbd80-c757-11e8-8264-b4be68bc937c.png)

This closes #1425 