### PR TITLE
Add minimal 80ch and 120ch column markers in the file editor

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -523,6 +523,11 @@ div.inline-comment-form .form-actions,
 	font-variant-ligatures: normal;
 }
 
+/* Add minimal 80ch and 120ch column markers in the file editor */
+pre.CodeMirror-line {
+	background: linear-gradient(to right, transparent 80ch, #fcfcfc 80ch, #fcfcfc 120ch, #f9f9f9 120ch) content-box;
+}
+
 /* Remove Marketplace marketing box on PRs */
 .js-marketplace-callout-container {
 	display: none !important;


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/1484

Test it on https://github.com/sindresorhus/refined-github/edit/master/source/features/mark-unread.js

<img width="986" alt="" src="https://user-images.githubusercontent.com/1402241/46848006-e7026c00-ce19-11e8-9ba4-bc4216786702.png">

Very, very minimal column markers. Barely visible but:

- Easy to disable (`pre.CodeMirror-line {background: none}`)
- Easy to change (copy-paste the one-liner in our Custom CSS and change colors and distances)