### PR TITLE
Drop z-index push on search filters

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -688,10 +688,6 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	/* Must be above .modal-backdrop (z-index 20) #1317 */
 	z-index: 25;
 }
-.subnav-search-context .select-menu-modal {
-	/* Bump Filters menu to be above header */
-	z-index: 26 !important;
-}
 .issues-listing .table-list-header .select-menu-list {
 	/* Since the header is sticky, filters must now fit the viewport */
 	max-height: calc(100vh - 150px);


### PR DESCRIPTION
It breaks the native `z-index: 99`

<img width="229" alt="" src="https://user-images.githubusercontent.com/1402241/46848612-73faf480-ce1d-11e8-825f-af692e792a20.png">

and keeps the dropdown below the invisible backdrop which sits at `z-index: 80`

<img width="203" alt="" src="https://user-images.githubusercontent.com/1402241/46848614-78bfa880-ce1d-11e8-895f-50dc351662f8.png">
