### PR TITLE
Fix default branch displaying as undefined on private repos

### DIFF
--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -43,7 +43,7 @@ async function getDefaultBranchLink() {
 	const currentBranch = select('[data-hotkey="w"] span').textContent;
 
 	// Don't show the button if we’re already on the default branch
-	if (defaultBranch === currentBranch) {
+	if (defaultBranch === undefined || defaultBranch === currentBranch) {
 		return;
 	}
 


### PR DESCRIPTION
Hi! 👋 

Thanks for the AWESOME extension! 🙌 

I noticed a very minor issue:

When I open the default branch of _**a private repo for the first time***_, Refined GitHub shows the default branch button as "undefined".

<img width="285" alt="screen shot 2018-10-12 at 8 24 41 pm" src="https://user-images.githubusercontent.com/2100222/46899367-89454280-ce60-11e8-929f-7e06cfb854d9.png">


\* _this happens right after installing the extension for the first time, AND before switching to a branch other than the default branch. After switching to another branch, Refined Github detects the default branch successfully and caches it, which resolves the issue._

## The expected behavior

If I'm on the default branch already, I don't expect this button to show up.

## Why does this happen?

The get default branch script attempts to extract the default branch from the DOM. When it fails to find it, it uses the GitHub API as a backup. 

The API fallback ~only work for public repos, not private ones~ requires an access token for private repos. When it's not set, or when it fails, we get back "undefined", which isn't handled yet.

## Steps to reproduce

- [ ] Go to the home page of a private repo. E.g. `github.com/owner_name/private_repo`
- [ ] Make sure you have not visited a branch other than the default branch on that repo (Redefined Github caches the default branch from other branches as well). 
- [ ] You should see "undefined" as the default branch button
