### PR TITLE
Remove GitHub Enterprise support notice on Firefox

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -50,11 +50,8 @@
 
 	<hr>
 
-	<p class="no-firefox">
+	<p>
 		If you're a GitHub Enterprise user, visit your Enterprise site, right-click on <a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Refined GitHub's icon in the toolbar</a> and select <strong>Enable Refined GitHub on this domain</strong>.
-	</p>
-	<p class="only-firefox">
-		<a href="https://github.com/sindresorhus/refined-github/issues/840#issuecomment-349936195" target="_blank">GitHub Enterprise is not yet supported in Firefox</a>.
 	</p>
 </form>
 <script src="browser-polyfill.min.js"></script>


### PR DESCRIPTION
As reported in https://github.com/sindresorhus/refined-github/issues/840#issuecomment-431700557

@bfred-it should we also add a notice saying that it works on FF now?