### PR TITLE
Prevent file header from covering review comment on deeplink

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -706,7 +706,6 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 
 /* Similar fix to above for deeplinks to reviews */
 .review-comment:target {
-	/* stylelint-disable time-min-milliseconds */
 	animation: sticky-review-comment-target-fixer 0s 0.1ms backwards;
 }
 @keyframes sticky-review-comment-target-fixer {

--- a/source/content.css
+++ b/source/content.css
@@ -704,7 +704,7 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	transform: translateY(-45px);
 }
 
-/* Similar fix to above for deeplinks to reviews */
+/* Similar fix to the above, for deep links to reviews */
 .review-comment:target {
 	animation: sticky-review-comment-target-fixer 0s 0.1ms backwards;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -704,6 +704,18 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	transform: translateY(-45px);
 }
 
+/* Similar fix to above for deeplinks to reviews */
+.review-comment:target {
+	/* stylelint-disable time-min-milliseconds */
+	animation: sticky-review-comment-target-fixer 0s 0.1ms backwards;
+}
+@keyframes sticky-review-comment-target-fixer {
+	from {
+		transform: translateY(-35px);
+		opacity: 0;
+	}
+}
+
 /* Remove annoying "helpful" banner on the issue tracker listing */
 .issues-listing .mb-4.js-notice {
 	display: none !important;


### PR DESCRIPTION
fixes #1570 

![screenshot from 2018-10-23 21-59-00](https://user-images.githubusercontent.com/3723666/47401902-1e71f200-d711-11e8-90fc-74a7ab669a96.png)

CSS caped from a previous fix. (#974)