### PR TITLE
Make "Copy file" feature work again

### DIFF
--- a/source/features/copy-file.js
+++ b/source/features/copy-file.js
@@ -9,8 +9,8 @@ export default function () {
 		code.classList.add('rgh-copy-file');
 		const file = code.closest('.file');
 
-		const content = select.all('tr', file)
-			.map(tr => tr.innerText)
+		const content = select.all('.blob-code-inner', file)
+			.map(blob => blob.innerText)
 			.map(line => line === '\n' ? '' : line)
 			.join('\n');
 


### PR DESCRIPTION
GitHub changed some things about the DOM structure of their code highlighter which broke the selector I added in #1559. I changed the selector which hopefully fixes #1603. Please test this extensively, I want this to be my last PR fixing problems with this feature. :smile: