### PR TITLE
Fixed bug `No collapse button on repository's browser file list`

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -908,9 +908,10 @@ body > .footer li a {
 }
 
 /* For 'add-toggle-files-button' feature */
-.rgh-toggle-files {
-	margin-right: -6px;
-	margin-top: -3px;
+:root .rgh-toggle-files {
+	margin: -8px 0;
+	margin-right: -10px;
+	padding: 10px 13px;
 }
 .rgh-files-hidden .commit-tease {
 	border-radius: 3px;

--- a/source/features/add-toggle-files-button.js
+++ b/source/features/add-toggle-files-button.js
@@ -11,7 +11,7 @@ function addButton() {
 	}
 	filesHeader.append(
 		<button
-			class="btn-octicon p-1 pr-2 rgh-toggle-files"
+			class="btn-octicon rgh-toggle-files"
 			aria-label="Toggle files section"
 			aria-expanded="true">
 			{icons.chevronDown()}

--- a/source/features/add-toggle-files-button.js
+++ b/source/features/add-toggle-files-button.js
@@ -5,7 +5,7 @@ import * as icons from '../libs/icons';
 import observeEl from '../libs/simplified-element-observer';
 
 function addButton() {
-	const filesHeader = select('.commit-tease .float-right');
+	const filesHeader = select('.commit-tease');
 	if (!filesHeader || select.exists('.rgh-toggle-files')) {
 		return;
 	}


### PR DESCRIPTION
Collapse button is shown again with this fix. Because append is used it will be added to the end of the container.

Remarks
* I noticed it only works on `isRepoRoot()`, is this still the wanted behaviour?
* When going back to repo root (history back) the button doesn't work (page reload needed), not sure if this has always been the case or a new bug.

Closes #1608 