### PR TITLE
Fix improved shortcut help

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -960,14 +960,8 @@ body > .footer li a {
 	opacity: 0.6;
 }
 
-.rgh-shortcut-circle {
-	display: inline-block;
-	width: 7px;
-	height: 7px;
-	border-radius: 50%;
-	margin-left: 5px;
-	background: #9c95b3;
-	cursor: pointer;
+.rgh-shortcut-box {
+	font-style: italic;
 }
 
 /* For 'add-jump-to-bottom-link' feature */

--- a/source/features/add-diff-view-without-whitespace-option.js
+++ b/source/features/add-diff-view-without-whitespace-option.js
@@ -4,6 +4,8 @@ import * as icons from '../libs/icons';
 import {registerShortcut} from './improve-shortcut-help';
 
 export default function () {
+	registerShortcut('source', 'd w', 'Show/hide whitespaces in diffs');
+
 	const container = select([
 		'.table-of-contents.Details .BtnGroup', // In single commit view
 		'.pr-review-tools > .diffbar-item' // In review view
@@ -34,7 +36,6 @@ export default function () {
 			</a>
 		</div>
 	);
-	registerShortcut('source', 'd w', 'Show/hide whitespaces in diffs');
 
 	// Make space for the new button by removing "Changes from" #655
 	const uselessCopy = select('[data-hotkey="c"]');

--- a/source/features/add-profile-hotkey.js
+++ b/source/features/add-profile-hotkey.js
@@ -3,10 +3,10 @@ import {getUsername} from '../libs/utils';
 import {registerShortcut} from './improve-shortcut-help';
 
 export default function () {
-	const menuItem = select(`#user-links a.dropdown-item[href="/${getUsername()}"]`);
+	registerShortcut('site', 'g m', 'Go to Profile');
 
+	const menuItem = select(`#user-links a.dropdown-item[href="/${getUsername()}"]`);
 	if (menuItem) {
 		menuItem.setAttribute('data-hotkey', 'g m');
-		registerShortcut('site', 'g m', 'Go to Profile');
 	}
 }

--- a/source/features/add-releases-tab.js
+++ b/source/features/add-releases-tab.js
@@ -30,6 +30,8 @@ function updateReleasesCount() {
 }
 
 export default async () => {
+	registerShortcut('repos', 'g r', 'Go to Releases');
+
 	const count = await updateReleasesCount();
 	if (count === 0) {
 		return;
@@ -43,8 +45,6 @@ export default async () => {
 		</a>
 	);
 	select('.reponav-dropdown').before(releasesTab);
-
-	registerShortcut('repos', 'g r', 'Go to Releases');
 
 	if (pageDetect.isReleasesOrTags()) {
 		const selected = select('.reponav-item.selected');

--- a/source/features/add-trending-menu-item.js
+++ b/source/features/add-trending-menu-item.js
@@ -4,6 +4,8 @@ import {safeElementReady} from '../libs/utils';
 import {registerShortcut} from './improve-shortcut-help';
 
 export default async function () {
+	registerShortcut('site', 'g t', 'Go to Trending');
+
 	const selectedClass = pageDetect.isTrending() ? 'selected' : '';
 	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"], .header-nav-link[href="/issues"]');
 	if (!issuesLink) {
@@ -15,7 +17,6 @@ export default async function () {
 			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink px-lg-2 py-2 py-lg-0 ${selectedClass}`} data-hotkey="g t">Trending</a>
 		</li>
 	);
-	registerShortcut('site', 'g t', 'Go to Trending');
 
 	// Explore link highlights /trending urls by default, remove that behavior
 	if (pageDetect.isTrending()) {

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -81,8 +81,8 @@ const addShortcuts = dialog => {
 export default () => {
 	// NOTE: It seems that the dialog get added after 'keydown'
 	// Alternative: Observe the body for the details elemet to be added
-	document.addEventListener('keypress', ({key}) => {
-		if (key !== '?') {
+	document.addEventListener('keypress', ({key, shiftKey}) => {
+		if (!shiftKey || key !== '?') {
 			return;
 		}
 

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -81,8 +81,8 @@ const addShortcuts = dialog => {
 export default () => {
 	// NOTE: It seems that the dialog get added after 'keydown'
 	// Alternative: Observe the body for the details elemet to be added
-	document.addEventListener('keypress', ({key, shiftKey}) => {
-		if (!shiftKey || key !== '?') {
+	document.addEventListener('keypress', ({key}) => {
+		if (key !== '?') {
 			return;
 		}
 

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -50,25 +50,29 @@ const addShortcuts = dialog => {
 	for (const group of select.all('.Box', dialog)) {
 		const title = select('.Box-header > .Box-title', group);
 		const groupId = groups[title.innerText];
-		if (groupId) {
-			const groupList = select('ul', group);
-			for (const shortcut of shortcuts.values()) {
-				if (shortcut.groupId === groupId) {
-					groupList.append(
-						<li class="Box-row d-flex flex-row">
-							<div class="flex-auto">{shortcut.description}</div>
-							<div
-								class="rgh-shortcut-circle tooltipped tooltipped-nw"
-								aria-label="Shortcut added by Refined GitHub"
-							/>
-							<div
-								class="ml-2 no-wrap"
-								dangerouslySetInnerHTML={{__html: splitKeys(shortcut.hotkey)}}
-							/>
-						</li>
-					);
-				}
+		if (!groupId) {
+			continue;
+		}
+
+		const groupList = select('ul', group);
+		for (const shortcut of shortcuts.values()) {
+			if (shortcut.groupId !== groupId) {
+				continue;
 			}
+
+			groupList.append(
+				<li class="Box-row d-flex flex-row">
+					<div class="flex-auto">{shortcut.description}</div>
+					<div
+						class="rgh-shortcut-circle tooltipped tooltipped-nw"
+						aria-label="Shortcut added by Refined GitHub"
+					/>
+					<div
+						class="ml-2 no-wrap"
+						dangerouslySetInnerHTML={{__html: splitKeys(shortcut.hotkey)}}
+					/>
+				</li>
+			);
 		}
 	}
 };
@@ -77,24 +81,26 @@ export default () => {
 	// NOTE: It seems that the dialog get added after 'keydown'
 	// Alternative: Observe the body for the details elemet to be added
 	document.addEventListener('keypress', ({key}) => {
-		if (key === '?') {
-			const dialog = select('details > details-dialog.kb-shortcut-dialog');
-			observeEl(
-				dialog,
-				records => {
-					if (
-						[...records].some(record =>
-							[...record.removedNodes].some(element =>
-								element.matches('.js-details-dialog-spinner')
-							)
-						)
-					) {
-						addShortcuts(dialog);
-						fixKeys(dialog);
-					}
-				},
-				{childList: true}
-			);
+		if (key !== '?') {
+			return;
 		}
+
+		const dialog = select('details > details-dialog.kb-shortcut-dialog');
+		observeEl(
+			dialog,
+			records => {
+				const dialogSpinnerGotRemoved = [...records].some(record =>
+					[...record.removedNodes].some(element =>
+						element.matches('.js-details-dialog-spinner')
+					)
+				);
+
+				if (dialogSpinnerGotRemoved) {
+					addShortcuts(dialog);
+					fixKeys(dialog);
+				}
+			},
+			{childList: true}
+		);
 	});
 };

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -47,7 +47,7 @@ const fixKeys = dialog => {
 };
 
 const addShortcuts = dialog => {
-	for (const group of select.all('.Box', dialog)) {
+	for (const group of select.all('.Box-body .Box', dialog)) {
 		const title = select('.Box-header > .Box-title', group);
 		const groupId = groups[title.innerText];
 		if (!groupId) {
@@ -61,12 +61,13 @@ const addShortcuts = dialog => {
 			}
 
 			groupList.append(
-				<li class="Box-row d-flex flex-row">
-					<div class="flex-auto">{shortcut.description}</div>
+				<li class="Box-row d-flex flex-row rgh-shortcut-box">
 					<div
-						class="rgh-shortcut-circle tooltipped tooltipped-nw"
+						class="flex-auto tooltipped tooltipped-nw"
 						aria-label="Shortcut added by Refined GitHub"
-					/>
+					>
+						{shortcut.description}
+					</div>
 					<div
 						class="ml-2 no-wrap"
 						dangerouslySetInnerHTML={{__html: splitKeys(shortcut.hotkey)}}

--- a/source/features/improve-shortcut-help.js
+++ b/source/features/improve-shortcut-help.js
@@ -49,7 +49,7 @@ const fixKeys = dialog => {
 const addShortcuts = dialog => {
 	for (const group of select.all('.Box-body .Box', dialog)) {
 		const title = select('.Box-header > .Box-title', group);
-		const groupId = groups[title.innerText];
+		const groupId = groups[title.textContent.trim()];
 		if (!groupId) {
 			continue;
 		}


### PR DESCRIPTION
This adds the improvements back to the new shortcut help.

Fixes #1622

There are still some issues for example there is a inconsistency between **Issues** and **Pull requests**

The shortcuts for "Pull request - Conversation tab" is similar to "Issues" and applies both for the PR list and the PR conversation. I don't have the overview for this but there could probably be custom shortcuts that work for both pages.
So I think there needs to be adjustments how the shortcuts are registered
![image](https://user-images.githubusercontent.com/9264728/48583659-f2b8e500-e927-11e8-9234-ea3046d4c534.png)
*(Also I think "Pull request - Conversation tab" is really confusing)*


Also the new structure of the shortcut list would require a different way to indicate `rgh` shortcuts in my opinion. Maybe some different colored border or something.

Also, as mentioned in the issue, I just went with adding a `keypress` listener, but we could also observe the `body` and check if the `details` element was added.
I tried both, the event listener was just the last one I tried so I kept it for now. :smile: 

- [x] Listen to `keyup` or observe `body`
- [ ] How to mark the added shortcuts
- [ ] Handle overlapping groups
- [x] Always register shortcuts?