### PR TITLE
Bypass the "Checks" page and go directly to the Travis build when clicking the "Details" links on a PR

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -180,6 +180,7 @@ And [many more…](source/content.css)
 - [Filter PRs that you haven't submitted a review for.](https://user-images.githubusercontent.com/9264728/42569205-0c32a376-8510-11e8-9406-b3ddcf6087ef.png)
 - Use <kbd>←</kbd> and <kbd>→</kbd> to navigate through pages with pagination.
 - [Find a user’s most starred repositories in their profile.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
+- [Bypass the new Checks page to directly see your Travis builds](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
 
 ### Previously part of Refined GitHub
 

--- a/readme.md
+++ b/readme.md
@@ -180,7 +180,7 @@ And [many more…](source/content.css)
 - [Filter PRs that you haven't submitted a review for.](https://user-images.githubusercontent.com/9264728/42569205-0c32a376-8510-11e8-9406-b3ddcf6087ef.png)
 - Use <kbd>←</kbd> and <kbd>→</kbd> to navigate through pages with pagination.
 - [Find a user’s most starred repositories in their profile.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
-- [Bypass the new Checks page to directly see your Travis builds](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
+- [Bypass the "Checks" page and go directly to the Travis build when clicking the "Details" links on a PR](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
 
 ### Previously part of Refined GitHub
 

--- a/source/content.js
+++ b/source/content.js
@@ -84,6 +84,7 @@ import usefulNotFoundPage from './features/useful-not-found-page';
 import setDefaultRepositoriesTypeToSources from './features/set-default-repositories-type-to-sources';
 import markPrivateOrgs from './features/mark-private-orgs';
 import navigatePagesWithArrowKeys from './features/navigate-pages-with-arrow-keys';
+import bypassChecksTravis from './features/bypass-checks-travis';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -309,6 +310,10 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isPRCommit()) {
 		enableFeature(linkifyCommitSha);
+	}
+
+	if (pageDetect.isPRConversation()) {
+		enableFeature(bypassChecksTravis);
 	}
 }
 

--- a/source/features/bypass-checks-travis.js
+++ b/source/features/bypass-checks-travis.js
@@ -13,13 +13,15 @@ async function bypass(check) {
 		credentials: 'include'
 	});
 
-	if (response.ok) {
-		const dom = domify(await response.text());
-		// On errored build check pages, there's a link that points
-		// to the first errored Travis build instead of the current one.
-		// e.g. the failed "PR build" instead of the "branch build"
-		// .text-small selects the right one.
-		const directLink = select('[href^="https://travis-ci.com"].text-small', dom);
-		details.href = directLink.href;
+	if (!response.ok) {
+		return;
 	}
+
+	const dom = domify(await response.text());
+	// On errored build check pages, there's a link that points
+	// to the first errored Travis build instead of the current one.
+	// e.g. the failed "PR build" instead of the "branch build"
+	// .text-small selects the right one.
+	const directLink = select('[href^="https://travis-ci.com"].text-small', dom);
+	details.href = directLink.href;
 }

--- a/source/features/bypass-checks-travis.js
+++ b/source/features/bypass-checks-travis.js
@@ -1,48 +1,21 @@
 import select from 'select-dom';
 import domify from '../libs/domify';
 
-export default () => {
-	const checks = select.all('.merge-status-item');
-	const checkTravisBranch = checks.find(isTravisBranchCheck);
-	const checkTravisPR = checks.find(isTravisPRCheck);
-
-	if (checkTravisBranch) {
-		bypassCheck(checkTravisBranch);
+export default function () {
+	for (const check of select.all('[href="/apps/travis-ci"]')) {
+		const details = select('.status-actions', check.parentNode);
+		bypassCheck(details);
 	}
-	if (checkTravisPR) {
-		bypassCheck(checkTravisPR);
-	}
-};
+}
 
-async function bypassCheck(check) {
-	const details = select('.status-actions', check);
-	const checkUrl = details.getAttribute('href');
-
-	const response = await fetch(checkUrl, {
+async function bypassCheck(details) {
+	const response = await fetch(details.href, {
 		credentials: 'include'
 	});
 
 	if (response.ok) {
 		const dom = domify(await response.text());
-		const links = select.all('[id^="check_run_"] a', dom);
-		const viewMoreLink = links.find(isViewMoreLink);
-
-		if (viewMoreLink) {
-			details.href = viewMoreLink.href;
-			details.rel = viewMoreLink.rel;
-			details.target = viewMoreLink.target;
-		}
+		const directLink = select('[href^="https://travis-ci.com"].text-small', dom);
+		details.href = directLink.href;
 	}
-}
-
-function isTravisPRCheck(check) {
-	return /Travis CI - Pull Request/.test(check.textContent);
-}
-
-function isTravisBranchCheck(check) {
-	return /Travis CI - Branch/.test(check.textContent);
-}
-
-function isViewMoreLink(link) {
-	return /View more details on Travis CI/.test(link.textContent);
 }

--- a/source/features/bypass-checks-travis.js
+++ b/source/features/bypass-checks-travis.js
@@ -15,6 +15,10 @@ async function bypass(check) {
 
 	if (response.ok) {
 		const dom = domify(await response.text());
+		// On errored build check pages, there's a link that points
+		// to the first errored Travis build instead of the current one.
+		// e.g. the failed "PR build" instead of the "branch build"
+		// .text-small selects the right one.
 		const directLink = select('[href^="https://travis-ci.com"].text-small', dom);
 		details.href = directLink.href;
 	}

--- a/source/features/bypass-checks-travis.js
+++ b/source/features/bypass-checks-travis.js
@@ -1,14 +1,14 @@
 import select from 'select-dom';
 import domify from '../libs/domify';
 
-export default function () {
-	for (const check of select.all('[href="/apps/travis-ci"]')) {
-		const details = select('.status-actions', check.parentNode);
-		bypassCheck(details);
-	}
+export default async function () {
+	// If anything errors, RGH will display the error next to the feature name
+	await Promise.all(select.all('[href="/apps/travis-ci"]').map(bypass));
 }
 
-async function bypassCheck(details) {
+async function bypass(check) {
+	const details = select('.status-actions', check.parentNode);
+
 	const response = await fetch(details.href, {
 		credentials: 'include'
 	});

--- a/source/features/bypass-checks-travis.js
+++ b/source/features/bypass-checks-travis.js
@@ -1,0 +1,48 @@
+import select from 'select-dom';
+import domify from '../libs/domify';
+
+export default () => {
+	const checks = select.all('.merge-status-item');
+	const checkTravisBranch = checks.find(isTravisBranchCheck);
+	const checkTravisPR = checks.find(isTravisPRCheck);
+
+	if (checkTravisBranch) {
+		bypassCheck(checkTravisBranch);
+	}
+	if (checkTravisPR) {
+		bypassCheck(checkTravisPR);
+	}
+};
+
+async function bypassCheck(check) {
+	const details = select('.status-actions', check);
+	const checkUrl = details.getAttribute('href');
+
+	const response = await fetch(checkUrl, {
+		credentials: 'include'
+	});
+
+	if (response.ok) {
+		const dom = domify(await response.text());
+		const links = select.all('[id^="check_run_"] a', dom);
+		const viewMoreLink = links.find(isViewMoreLink);
+
+		if (viewMoreLink) {
+			details.href = viewMoreLink.href;
+			details.rel = viewMoreLink.rel;
+			details.target = viewMoreLink.target;
+		}
+	}
+}
+
+function isTravisPRCheck(check) {
+	return /Travis CI - Pull Request/.test(check.textContent);
+}
+
+function isTravisBranchCheck(check) {
+	return /Travis CI - Branch/.test(check.textContent);
+}
+
+function isViewMoreLink(link) {
+	return /View more details on Travis CI/.test(link.textContent);
+}


### PR DESCRIPTION
Will close #1620.

It was too hard to use API v3/v4 to get last checks from a pull request, so I used the easy solution:
  - find Travis branch/PR checks
  - extract `Details` link
  - Make an XHR request
  - Find `View more ...` link

And this is working very well:

![capture d ecran du 2018-11-24 22-27-59](https://user-images.githubusercontent.com/2103975/48973124-ac0a6f80-f038-11e8-9c44-6ee73a4a93f8.png)
