### PR TITLE
Fix errors on repo search pages 

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -125,7 +125,7 @@ async function init() {
 		enableFeature(hideUselessNewsfeedEvents);
 	}
 
-	if (pageDetect.isRepo() && !pageDetect.isRepoSearch()) {
+	if (pageDetect.isRepo()) {
 		safeOnAjaxedPages(async () => {
 			// Wait for the tab bar to be loaded
 			await safeElementReady('.pagehead + *');

--- a/source/content.js
+++ b/source/content.js
@@ -125,7 +125,7 @@ async function init() {
 		enableFeature(hideUselessNewsfeedEvents);
 	}
 
-	if (pageDetect.isRepo()) {
+	if (pageDetect.isRepo() && !pageDetect.isRepoSearch()) {
 		safeOnAjaxedPages(async () => {
 			// Wait for the tab bar to be loaded
 			await safeElementReady('.pagehead + *');

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -110,3 +110,5 @@ export const isTrending = () => location.pathname.startsWith('/trending');
 export const isUserProfile = () => Boolean(getCleanPathname()) && !isGist() && !isReserved(getCleanPathname()) && !getCleanPathname().includes('/');
 
 export const isOwnUserProfile = () => isUserProfile() && getCleanPathname().startsWith(getUsername());
+
+export const isRepoSearch = () => /^search/.test(getRepoPath());

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -112,4 +112,4 @@ export const isUserProfile = () => Boolean(getCleanPathname()) && !isGist() && !
 
 export const isOwnUserProfile = () => isUserProfile() && getCleanPathname().startsWith(getUsername());
 
-export const isRepoSearch = () => /^search/.test(getRepoPath());
+export const isRepoSearch = () => location.pathname.endsWith('/search');

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -93,7 +93,8 @@ export const isRepo = () => /^[^/]+\/[^/]+/.test(getCleanPathname()) &&
 	!isReserved(getOwnerAndRepo().ownerName) &&
 	!isNotifications() &&
 	!isDashboard() &&
-	!isGist();
+	!isGist() &&
+	!isRepoSearch();
 
 export const isRepoRoot = () => /^(tree[/][^/]+)?$/.test(getRepoPath());
 

--- a/source/libs/page-detect.js
+++ b/source/libs/page-detect.js
@@ -112,4 +112,4 @@ export const isUserProfile = () => Boolean(getCleanPathname()) && !isGist() && !
 
 export const isOwnUserProfile = () => isUserProfile() && getCleanPathname().startsWith(getUsername());
 
-export const isRepoSearch = () => location.pathname.endsWith('/search');
+export const isRepoSearch = () => location.pathname.slice(1).split('/')[2] === 'search';

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -415,5 +415,6 @@ test('isRepoSearch', urlMatcherMacro, pageDetect.isRepoSearch, [
 	'https://github.com/sindresorhus/refined-github/search?q=diff&unscoped_q=diff&type=Issues',
 	'https://github.com/sindresorhus/refined-github/search'
 ], [
-	'https://github.com/sindresorhus/refined-github'
+	'https://github.com/sindresorhus/refined-github',
+	'https://github.com/sindresorhus/search'
 ]);

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -334,7 +334,8 @@ test('isRepo', urlMatcherMacro, pageDetect.isRepo, [
 	'https://github.com/sindresorhus/notifications/notifications',
 	'https://github.com/orgs/test/dashboard',
 	'https://github.com/settings/profile',
-	'https://github.com/trending/developers'
+	'https://github.com/trending/developers',
+	'https://github.com/sindresorhus/refined-github/search?q=diff'
 ]);
 
 test('isRepoRoot', urlMatcherMacro, pageDetect.isRepoRoot, [
@@ -407,4 +408,12 @@ test('isUserProfile', urlMatcherMacro, pageDetect.isUserProfile, [
 	'https://github.com/watching',
 	'https://github.com/sindresorhus/refined-github',
 	'https://gist.github.com/bfred-it'
+]);
+
+test('isRepoSearch', urlMatcherMacro, pageDetect.isRepoSearch, [
+	'https://github.com/sindresorhus/refined-github/search?q=diff',
+	'https://github.com/sindresorhus/refined-github/search?q=diff&unscoped_q=diff&type=Issues',
+	'https://github.com/sindresorhus/refined-github/search'
+], [
+	'https://github.com/sindresorhus/refined-github'
 ]);


### PR DESCRIPTION
Exclude addMoreDropdown & addReleasesTab & removeProjectsTab from loading on the repo search page.

Fixes #1637.