### PR TITLE
Update discussion-sidebar z-index

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1022,6 +1022,12 @@ body > .footer li a {
 	padding-bottom: 4px !important;
 }
 
+/* Make sidebar sticky */
+.rgh-sticky-sidebar {
+	position: sticky;
+	z-index: 26 !important;
+}
+
 /* Adding a lock icon to private organizations */
 .rgh-private-org {
 	position: relative;

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -6,7 +6,13 @@ import * as pageDetect from '../libs/page-detect';
 function updateStickiness() {
 	const sidebar = select('.discussion-sidebar');
 	const sidebarHeight = sidebar.offsetHeight + 25;
-	sidebar.style.position = sidebarHeight < window.innerHeight ? 'sticky' : null;
+	if (sidebarHeight < window.innerHeight) {
+		sidebar.style.position = 'sticky';
+		sidebar.style.zIndex = 26;
+	} else {
+		sidebar.style.position = null;
+		sidebar.style.zIndex = null;
+	}
 }
 
 const handler = debounce(updateStickiness, {wait: 100});

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -6,13 +6,7 @@ import * as pageDetect from '../libs/page-detect';
 function updateStickiness() {
 	const sidebar = select('.discussion-sidebar');
 	const sidebarHeight = sidebar.offsetHeight + 25;
-	if (sidebarHeight < window.innerHeight) {
-		sidebar.style.position = 'sticky';
-		sidebar.style.zIndex = 26;
-	} else {
-		sidebar.style.position = null;
-		sidebar.style.zIndex = null;
-	}
+	sidebar.classList.toggle('rgh-sticky-sidebar', sidebarHeight < window.innerHeight);
 }
 
 const handler = debounce(updateStickiness, {wait: 100});


### PR DESCRIPTION
Fixes #1647

Before:
![screen shot 2018-11-30 at 11 39 38 am](https://user-images.githubusercontent.com/8822835/49302970-75987e80-f496-11e8-9f0b-2da7cbfb5764.png)

After:
![screen shot 2018-11-30 at 11 39 51 am](https://user-images.githubusercontent.com/8822835/49302972-79c49c00-f496-11e8-856e-e78232718ab1.png)

`z-index` set to 26, since the comment titles have 25