### PR TITLE
Remove minimum count in open-all-notifications.js

### DIFF
--- a/source/features/open-all-notifications.js
+++ b/source/features/open-all-notifications.js
@@ -51,7 +51,7 @@ function addOpenReposButton() {
 		}
 
 		const unreadCount = select.all('.unread', repoNotifications).length;
-		if (unreadCount < 2) {
+		if (unreadCount === 0) {
 			continue;
 		}
 
@@ -79,7 +79,7 @@ function addOpenAllButton() {
 
 function addMarkup() {
 	const unreadCount = select.all(unreadNotificationsClass).length;
-	if (unreadCount < 2) {
+	if (unreadCount === 0) {
 		return;
 	}
 


### PR DESCRIPTION
The "open all unread notifications in tabs" feature is very convenient, as it requires a single click to be triggered.

When there's only one notification for a given repository, the icon is not shown, which is understandable, but that forces the same action to be done via a Ctrl+click, or a right click to show the context menu and then "Open in a new tab".

Both options are less convenient than the button provided by this feature, so this change simply removes the minimum of two notifications to show the "open in new tabs" icon. As a side effect, it also makes the notifications page more consistent, since all notification blocks now have the same set of icons. Contrast with the current behavior where some blocks have two icons at the top right, and others have only one:

<img width="272" alt="screenshot 2018-12-01 at 11 04 31" src="https://user-images.githubusercontent.com/478237/49327403-16e80900-f559-11e8-9c03-493f9694595d.png">
