### PR TITLE
Run hide-active-deployments on new comments

### DIFF
--- a/source/features/hide-inactive-deployments.js
+++ b/source/features/hide-inactive-deployments.js
@@ -1,13 +1,13 @@
 import select from 'select-dom';
 import * as pageDetect from '../libs/page-detect';
-import observeEl from '../libs/simplified-element-observer';
+import onNewComments from '../libs/on-new-comments';
 
 export default function () {
 	if (!pageDetect.isPR()) {
 		return;
 	}
 
-	observeEl('.js-discussion', () => {
+	onNewComments(() => {
 		const deployments = select.all('.discussion-item .deployment-meta');
 		deployments.pop(); // Don't hide the last deployment, even if it is inactive
 


### PR DESCRIPTION
This uses the new on-new-comments lib to also run the feature when "Load
more ..." (hidden items) is clicked.

Closes #1245. Thanks to @bfred-it for the idea!