### PR TITLE
Revert "Drop `hide-issue-list-autocomplete`"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,7 @@ GitHub Enterprise is also supported. More info in the options.
 - Obvious tooltips are removed.
 - The `Projects` repository tab is hidden when there are no projects
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
+- [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - [Forks are hidden from a user's Repositories list (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 - [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
 
@@ -197,7 +198,6 @@ And [many more…](source/content.css)
 - [Implemented by GitHub](https://blog.github.com/changelog/2018-11-05-related-issues/): [Avoid opening duplicate issues thanks to the list of possibly-related issues.](https://user-images.githubusercontent.com/29176678/37566899-85953e6e-2abf-11e8-9f0e-52d18c87bbe3.gif)
 - [Implemented by GitHub](https://blog.github.com/changelog/2018-11-16-copy-file-paths-in-diffs/): [Copy the path of a PR file.](https://cloud.githubusercontent.com/assets/4201088/26023064/18c9c77c-37d2-11e7-8926-b0a05a2706ae.png)
 - [Implemented by GitHub](https://blog.github.com/changelog/2018-11-26-searching-by-user-from-a-profile-page/): [Search a user profile page when visiting it.](https://user-images.githubusercontent.com/1402241/35185441-24ad4b1e-fe37-11e7-9e1b-0dc09fc1ada2.png)
-- Implemented by GitHub: [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 
 
 ## Customization

--- a/source/background.js
+++ b/source/background.js
@@ -23,7 +23,6 @@ new OptionsSync().define({
 			options.disabledFeatures = options.disabledFeatures.replace('display-issue-suggestions', ''); // #1611
 			options.disabledFeatures = options.disabledFeatures.replace('open-all-selected', 'batch-open-issues'); // #1402
 			options.disabledFeatures = options.disabledFeatures.replace('copy-file-path', ''); // #1628
-			options.disabledFeatures = options.disabledFeatures.replace('hide-issue-list-autocomplete', ''); // #1657
 		},
 		OptionsSync.migrations.removeUnused
 	]

--- a/source/content.js
+++ b/source/content.js
@@ -77,6 +77,7 @@ import addSwapBranchesOnCompare from './features/add-swap-branches-on-compare';
 import showFollowersYouKnow from './features/show-followers-you-know';
 import hideCommentsFaster from './features/hide-comments-faster';
 import linkifyCommitSha from './features/linkify-commit-sha';
+import hideIssueListAutocomplete from './features/hide-issue-list-autocomplete';
 import showUserTopRepositories from './features/show-user-top-repositories';
 import userProfileFollowerBadge from './features/user-profile-follower-badge';
 import usefulNotFoundPage from './features/useful-not-found-page';
@@ -250,6 +251,7 @@ function ajaxedPagesHandler() {
 
 	if (pageDetect.isIssueList()) {
 		enableFeature(addFilterCommentsByYou);
+		enableFeature(hideIssueListAutocomplete);
 		enableFeature(excludeFilterShortcut);
 	}
 

--- a/source/features/hide-issue-list-autocomplete.js
+++ b/source/features/hide-issue-list-autocomplete.js
@@ -1,0 +1,5 @@
+import select from 'select-dom';
+
+export default function () {
+	select('.subnav-search').setAttribute('autocomplete', 'off');
+}


### PR DESCRIPTION
Reverts sindresorhus/refined-github#1657

🤷‍♂️

I'm actually not seeing `autocomplete=off` in the repo issue search anymore.

<img width="1005" alt="" src="https://user-images.githubusercontent.com/1402241/49813157-6cae8380-fd99-11e8-96a0-6e249b677aae.png">
