### PR TITLE
Fix latest tag link

### DIFF
--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -5,9 +5,8 @@ import * as api from '../libs/api';
 import * as icons from '../libs/icons';
 import {appendBefore} from '../libs/utils';
 import {groupSiblings} from '../libs/group-buttons';
-import {getOwnerAndRepo} from '../libs/page-detect';
 import getDefaultBranch from '../libs/get-default-branch';
-import {getRepoURL, isRepoRoot} from '../libs/page-detect';
+import {getRepoURL, isRepoRoot, getOwnerAndRepo} from '../libs/page-detect';
 
 async function getTagLink() {
 	const tags = select

--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -43,7 +43,7 @@ export const enableFeature = async fn => {
 		log('✅', filename);
 	} catch (error) {
 		console.log('❌', filename);
-		console.error(error);
+		throw error;
 	}
 };
 


### PR DESCRIPTION
Fixes #1654 

<img width="264" alt="screenshot 2018-12-13 at 15 54 02" src="https://user-images.githubusercontent.com/1402241/49927826-6e8b5a80-fef1-11e8-8001-ece2afd88944.png">

# Tests

Repo with non-standard tags: https://github.com/PointCloudLibrary/pcl
Repo with standard tags: https://github.com/sindresorhus/negative-zero (shouldn't trigger an API call)
Repo without tags: https://github.com/sindresorhus/refined-github (shouldn't trigger an API call)