### PR TITLE
check for the existance of a “Mark as unread” button

### DIFF
--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -38,7 +38,8 @@ function stripHash(url) {
 
 function addMarkUnreadButton() {
 	const container = select('.js-thread-subscription-status');
-	if (container) {
+	const markUnreadButtonExists = select('.rgh-btn-mark-unread');
+	if (container && !markUnreadButtonExists) {
 		const button = <button class="btn btn-sm rgh-btn-mark-unread">Mark as unread</button>;
 		button.addEventListener('click', markUnread, {
 			once: true

--- a/source/features/mark-unread.js
+++ b/source/features/mark-unread.js
@@ -38,8 +38,7 @@ function stripHash(url) {
 
 function addMarkUnreadButton() {
 	const container = select('.js-thread-subscription-status');
-	const markUnreadButtonExists = select('.rgh-btn-mark-unread');
-	if (container && !markUnreadButtonExists) {
+	if (container && !select.exists('.rgh-btn-mark-unread')) {
 		const button = <button class="btn btn-sm rgh-btn-mark-unread">Mark as unread</button>;
 		button.addEventListener('click', markUnread, {
 			once: true


### PR DESCRIPTION
Fixes #1673 

This adds a check before adding a “Mark as unread” button before attempting to add another one which stops situations like this
<img width="292" alt="screen shot 2018-12-18 at 10 14 05" src="https://user-images.githubusercontent.com/11544418/50148024-6a738a00-02af-11e9-9f2a-7063466e38d7.png">
