### PR TITLE
Feature: Add the Co-authored-by trailer to commit messages

### DIFF
--- a/source/content.js
+++ b/source/content.js
@@ -85,6 +85,7 @@ import setDefaultRepositoriesTypeToSources from './features/set-default-reposito
 import markPrivateOrgs from './features/mark-private-orgs';
 import navigatePagesWithArrowKeys from './features/navigate-pages-with-arrow-keys';
 import bypassChecksTravis from './features/bypass-checks-travis';
+import addCoAuthoredBy from './features/add-co-authored-by.js';
 
 import * as pageDetect from './libs/page-detect';
 import {safeElementReady, enableFeature, safeOnAjaxedPages, injectCustomCSS} from './libs/utils';
@@ -232,6 +233,7 @@ function ajaxedPagesHandler() {
 		enableFeature(hideInactiveDeployments);
 		enableFeature(addPullRequestHotkey);
 		enableFeature(addQuickReviewButtons);
+		enableFeature(addCoAuthoredBy);
 	}
 
 	if (pageDetect.isPR() || pageDetect.isIssue()) {

--- a/source/features/add-co-authored-by.js
+++ b/source/features/add-co-authored-by.js
@@ -37,7 +37,7 @@ async function addCoAuthoredBy() {
 	const coAuthors = [...usernames].reduce((coAuthorString, username) => {
 		const {name, databaseId, email} = data[escapeForGql(username)] || {};
 		const commitEmail = email || `${databaseId}+${username}@users.noreply.github.com`;
-		return coAuthorString + `Co-Authored-By: ${name} <${commitEmail}>\n`;
+		return coAuthorString + `Co-authored-by: ${name} <${commitEmail}>\n`;
 	}, '');
 
 	const commitMessageElements = select.all('textarea[name="commit_message');

--- a/source/features/add-co-authored-by.js
+++ b/source/features/add-co-authored-by.js
@@ -1,0 +1,53 @@
+import select from 'select-dom';
+import * as api from '../libs/api';
+import {getUsername, escapeForGql} from '../libs/utils';
+import onNewComments from '../libs/on-new-comments';
+
+async function addCoAuthoredBy() {
+	const usernameElements = select.all('.js-discussion .author:not(.rgh-fullname):not([href*="/apps/"])');
+
+	const usernames = new Set();
+	const myUsername = getUsername();
+	for (const el of usernameElements) {
+		el.classList.add('rgh-fullname');
+		const username = el.textContent;
+		if (username !== myUsername && username !== 'ghost') {
+			usernames.add(el.textContent);
+		}
+
+		// Drop 'commented' label to shorten the copy
+		const commentedNode = el.parentNode.nextSibling;
+		if (commentedNode && commentedNode.textContent.includes('commented')) {
+			commentedNode.remove();
+		}
+	}
+
+	if (usernames.size === 0) {
+		return;
+	}
+
+	const {data} = await api.v4(
+		'{' +
+			[...usernames].map(user =>
+				escapeForGql(user) + `: user(login: "${user}") {databaseId, name, email}`
+			) +
+		'}'
+	);
+
+	const coAuthors = [...usernames].reduce((coAuthorString, username) => {
+		const {name, databaseId, email} = data[escapeForGql(username)] || {};
+		const commitEmail = email || `${databaseId}+${username}@users.noreply.github.com`;
+		return coAuthorString + `Co-Authored-By: ${name} <${commitEmail}>\n`;
+	}, '');
+
+	const commitMessageElements = select.all('textarea[name="commit_message');
+	for (const messageEl of commitMessageElements) {
+		const oldMessage = messageEl.value.replace( /Co-Authored-By:.*/m, '' ).trim();
+		messageEl.value = `${oldMessage}\n\n${coAuthors}`;
+	}
+}
+
+export default function () {
+	addCoAuthoredBy();
+	onNewComments(addCoAuthoredBy);
+}


### PR DESCRIPTION
Pull Requests aren't just built by the people who write the code, they're also built by the people who design, test, review, and comment on the PR.

When merging PRs on open source projects, I like to credit everyone involved in the PR, and the [Co-authored-by trailer](https://blog.github.com/2018-01-29-commit-together-with-co-authors/) is super helpful to do exactly that.

This PR automatically generates the Co-authored-by trailer from the people who've commented on the PR.