### PR TITLE
Improve API error handling

### DIFF
--- a/source/features/add-branch-buttons.js
+++ b/source/features/add-branch-buttons.js
@@ -24,7 +24,7 @@ async function getTagLink() {
 		latestParsedRelease = tags.sort(compareVersions).pop();
 	} else {
 		const {ownerName, repoName} = getOwnerAndRepo();
-		const {data} = await api.v4(`{
+		const {repository} = await api.v4(`{
 			repository(owner: "${ownerName}", name: "${repoName}") {
 				refs(first: 1, refPrefix: "refs/tags/", orderBy: {
 					field: TAG_COMMIT_DATE,
@@ -36,8 +36,8 @@ async function getTagLink() {
 				}
 			}
 		}`);
-		if (data.repository.refs.nodes.length > 0) {
-			latestParsedRelease = data.repository.refs.nodes[0].name;
+		if (repository.refs.nodes.length > 0) {
+			latestParsedRelease = repository.refs.nodes[0].name;
 		}
 	}
 

--- a/source/features/show-names.js
+++ b/source/features/show-names.js
@@ -46,7 +46,7 @@ async function addNames() {
 	}
 }
 
-export default function () {
-	addNames();
+export default async function () {
+	await addNames();
 	onNewComments(addNames);
 }

--- a/source/features/show-names.js
+++ b/source/features/show-names.js
@@ -27,7 +27,7 @@ async function addNames() {
 		return;
 	}
 
-	const {data} = await api.v4(
+	const names = await api.v4(
 		'{' +
 			[...usernames].map(user =>
 				escapeForGql(user) + `: user(login: "${user}") {name}`
@@ -36,7 +36,7 @@ async function addNames() {
 	);
 
 	for (const usernameEl of usernameElements) {
-		const {name} = data[escapeForGql(usernameEl.textContent)] || {};
+		const {name} = names[escapeForGql(usernameEl.textContent)] || {};
 		if (name) {
 			// If it's a regular comment author, add it outside <strong>
 			// otherwise it's something like "User added some commits"

--- a/source/features/user-profile-follower-badge.js
+++ b/source/features/user-profile-follower-badge.js
@@ -11,8 +11,11 @@ export default async function () {
 		return;
 	}
 
-	const response = await api.v3(`users/${getCleanPathname()}/following/${getUsername()}`, {accept404: true});
-	if (response === true) {
+	const {status} = await api.v3(
+		`users/${getCleanPathname()}/following/${getUsername()}`,
+		{accept404: true}
+	);
+	if (status === 204) {
 		select('.vcard-names-container.py-3.js-sticky.js-user-profile-sticky-fields').after(badge);
 	}
 }

--- a/source/libs/api.js
+++ b/source/libs/api.js
@@ -14,11 +14,11 @@ a Promise that resolves into an object.
 
 If the response body is empty, you'll receive an object like {status: 200}
 
-The second argument is an options object, it lets you defined accepted error codes, like:
+The second argument is an options object,
+it lets you define accept a 404 error code as a valid response, like:
 
 {
 	accept404: true
-	accept500: true
 }
 
 so the call will not throw an error but it will return as usual.
@@ -64,7 +64,7 @@ function fetch4(query, personalToken) {
 }
 
 // Main function: handles cache, options, errors
-async function call(fetch, query, options = {}) {
+async function call(fetch, query, options = {accept404: false}) {
 	if (cache.has(query)) {
 		return cache.get(query);
 	}
@@ -95,7 +95,7 @@ async function call(fetch, query, options = {}) {
 		);
 	}
 
-	if (response.ok || options['accept' + response.status]) {
+	if (response.ok || (options.accept404 === true && response.status === 404)) {
 		cache.set(query, fetch === fetch4 ? data : result);
 		return result;
 	}


### PR DESCRIPTION
- Throw real errors to the console
- Detect errors sent by the GraphQL endpoint
- Consistently return an `object`, instead of `object`|`boolean`
- Add minimal documentation
- Accept any status via option; code is actually shorter: `if (options['accept' + response.status])`
- Improve readability of existing error messages
- Actually catch 404 errors; it defaulted to `accept404:true`

## Tests

- "Follows you" feature: visit the profile of someone who follows you (find them in your [followers tab](https://github.com/bfred-it?tab=followers))
- "Default branch": visit a branch of [a project you've never seen before](https://github.com/GhostText/GhostText/tree/phoenix-text)
- "Full names": can you read my full name next to my username?

## PRs that need to be updated after merge

- https://github.com/sindresorhus/refined-github/pull/1677
- https://github.com/sindresorhus/refined-github/pull/1641
- https://github.com/sindresorhus/refined-github/pull/1399

## Why

- Real errors will resurface next to the feature that caused them
- Because permissions error handling [trickled into a feature](https://github.com/sindresorhus/refined-github/pull/1677/commits/a626a2ecdb673a4f414b6fa3ef52f65ff159ae18) and that probably shouldn't happen.
- I hated to constantly see `const`**`{data}`**`= await api.v4()`

## GraphQL error example

<img width="585" alt="RefinedGitHubAPIError: GraphQL: Could not resolve to a User with the login of '404'. Could not resolve to a User with the login of 'npm'." src="https://user-images.githubusercontent.com/1402241/50372600-f6651900-0603-11e9-8ed6-0174d350442b.png">

## Drawbacks

GraphQL calls might still be partially working, but if we throw the error they won't work at all.

<details><summary>e.g.</summary><img src="https://user-images.githubusercontent.com/1402241/50372665-1e08b100-0605-11e9-984f-3aeeb334aec8.jpg"></details>
