### PR TITLE
Expand search field on project page to the left

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -549,9 +549,7 @@ div.inline-comment-form .form-actions,
 /* Seach field on the projects page */
 .project-header-controls,
 .project-header-search,
-.project-header-search .subnav-search {
-	width: 100%;
-}
+.project-header-search .subnav-search,
 .project-header-search .subnav-search-input:focus {
 	width: 100%;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -553,7 +553,7 @@ div.inline-comment-form .form-actions,
 .project-header-search .subnav-search-input:focus {
 	width: 100%;
 }
-@media (min-width: 544px) {
+@media (min-width: 1012px) {
 	.project-header-search {
 		padding-left: 24px;
 	}

--- a/source/content.css
+++ b/source/content.css
@@ -547,12 +547,18 @@ div.inline-comment-form .form-actions,
 	display: none; /* When aligned right, the icon will stay in the wrong position, so hide it */
 }
 /* Seach field on the projects page */
-.project-header-search {
-	justify-content: flex-end;
-}
+.project-header-controls,
+.project-header-search,
 .project-header-search .subnav-search {
-	width: auto;
-	flex-shrink: 1;
+	width: 100%;
+}
+.project-header-search .subnav-search-input:focus {
+	width: 100%;
+}
+@media (min-width: 544px) {
+	.project-header-search {
+		padding-left: 24px;
+	}
 }
 
 /* Remove Marketplace marketing box on PRs */

--- a/source/content.css
+++ b/source/content.css
@@ -546,6 +546,14 @@ div.inline-comment-form .form-actions,
 .float-right .subnav-search-input:focus + .subnav-search-icon {
 	display: none; /* When aligned right, the icon will stay in the wrong position, so hide it */
 }
+/* Seach field on the projects page */
+.project-header-search {
+	justify-content: flex-end;
+}
+.project-header-search .subnav-search {
+	width: auto;
+	flex-shrink: 1;
+}
 
 /* Remove Marketplace marketing box on PRs */
 .js-marketplace-callout-container {


### PR DESCRIPTION
Fixes #1672 

We can either expand the search field to the left, or don't expand it at all.

This PR add extending it to the left, which does kinda feel a little weird because it has a search filtering dropdown.