### PR TITLE
hide-useless-comments: rename "undo" to "show"

### DIFF
--- a/source/features/hide-useless-comments.js
+++ b/source/features/hide-useless-comments.js
@@ -43,7 +43,7 @@ export default function () {
 		select('.discussion-timeline-actions').prepend(
 			<p class="rgh-useless-comments-note">
 				{`${uselessCount} useless comment${uselessCount > 1 ? 's were' : ' was'} hidden. `}
-				<button class="btn-link text-emphasized" onClick={unhide}>Undo</button>
+				<button class="btn-link text-emphasized" onClick={unhide}>Show</button>
 			</p>
 		);
 	}


### PR DESCRIPTION
"Undo" sounds like a state change that would be persisted (this is especially relevant now that GitHub added native support for manually hiding comments).

By using "Show" instead, hopefully it's clearer that only the person clicking the link will see the hidden comments. It's also more explicit than "Undo", which is a nice bonus.