### PR TITLE
Improve error logging

### DIFF
--- a/source/libs/utils.js
+++ b/source/libs/utils.js
@@ -43,7 +43,7 @@ export const enableFeature = async fn => {
 		log('✅', filename);
 	} catch (error) {
 		console.log('❌', filename);
-		throw error;
+		console.error(error);
 	}
 };
 


### PR DESCRIPTION
Before/after screenshot follow

# Fixes

Firefox does not display extension errors, so messages related to the tokens are lost

<img width="586" alt="fx-before" src="https://user-images.githubusercontent.com/1402241/50686774-4951be00-1051-11e9-9944-0dc84d8733d3.png">
<img width="586" alt="fx-after" src="https://user-images.githubusercontent.com/1402241/50686777-4b1b8180-1051-11e9-82b9-e20080bc980c.png">


# Improves

`Uncaught error (in promise)` text is dropped in Chrome


<img width="496" alt="chr-before" src="https://user-images.githubusercontent.com/1402241/50686809-69817d00-1051-11e9-94ca-9090259f1bb5.png">

<img width="496" alt="chr-after" src="https://user-images.githubusercontent.com/1402241/50686811-6a1a1380-1051-11e9-98a3-0b28ce67be9e.png">
