### PR TITLE
Observe subtree of dashboard news to fix hide-own-stars

### DIFF
--- a/source/features/hide-own-stars.js
+++ b/source/features/hide-own-stars.js
@@ -11,5 +11,8 @@ export default function () {
 				item.style.display = 'none';
 			}
 		}
+	}, {
+		childList: true,
+		subtree: true
 	});
 }


### PR DESCRIPTION
Should probably fix #1619.

I could not test this for myself, but it should work. 🤞

There may be an easy of implementing this feature while using CSS using the [`:has()`](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) selector, which (as of now) is not implemented by any of the browsers.