### PR TITLE
Fix top position for sticky discussion-sidebar

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1038,6 +1038,7 @@ body > .footer li a {
 /* Make sidebar sticky */
 .rgh-sticky-sidebar {
 	position: sticky;
+	top: 60px !important;
 	z-index: 26 !important;
 }
 

--- a/source/content.css
+++ b/source/content.css
@@ -1038,7 +1038,7 @@ body > .footer li a {
 /* Make sidebar sticky */
 .rgh-sticky-sidebar {
 	position: sticky;
-	top: 60px !important;
+	top: 60px !important; /* Matches sticky header's height */
 	z-index: 26 !important;
 }
 

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -5,7 +5,7 @@ import * as pageDetect from '../libs/page-detect';
 
 function updateStickiness() {
 	const sidebar = select('.discussion-sidebar');
-	const sidebarHeight = sidebar.offsetHeight + 25;
+	const sidebarHeight = sidebar.offsetHeight + 25 + 60; // Matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebarHeight < window.innerHeight);
 }
 

--- a/source/features/make-discussion-sidebar-sticky.js
+++ b/source/features/make-discussion-sidebar-sticky.js
@@ -5,7 +5,7 @@ import * as pageDetect from '../libs/page-detect';
 
 function updateStickiness() {
 	const sidebar = select('.discussion-sidebar');
-	const sidebarHeight = sidebar.offsetHeight + 25 + 60; // Matches sticky header's height
+	const sidebarHeight = sidebar.offsetHeight + 25 + 60; // 60 matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebarHeight < window.innerHeight);
 }
 


### PR DESCRIPTION
The `60px` comes from the `gh-header-sticky` height introduced [here](https://blog.github.com/changelog/2019-01-04-sticky-coversation-headers/).

---
Before:
![image](https://user-images.githubusercontent.com/846943/51093108-f938d100-179f-11e9-9924-2eaae444433c.png)

---
After:
![image](https://user-images.githubusercontent.com/846943/51093157-ba574b00-17a0-11e9-8e88-dc982736c386.png)
