### PR TITLE
Improve dropdown expansion animation

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1073,3 +1073,9 @@ body > .footer li a {
 	padding: 54px;
 	text-align: center;
 }
+
+/* Improve dropdown expansion animation (e.g. top-right dropdown in comments) */
+/* It normally pops in from the center */
+.dropdown-menu-sw {
+	transform-origin: 90% top;
+}


### PR DESCRIPTION
Details matter.

The selector is pretty generic but it serves as a default and it will be overridden by anything GitHub possibly applies via any `.class` selector. 


# Before

![zoom in from center](https://user-images.githubusercontent.com/1402241/51130874-abd06880-1860-11e9-81d5-88345236d2d7.gif)

# After

![zoom in from top right](https://user-images.githubusercontent.com/1402241/51130873-ab37d200-1860-11e9-8307-72bcedf00046.gif)