### PR TITLE
Update readme to include the Brave browser

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [**Chrome** extension][link-cws] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?label=%20">][link-cws]
 - [**Firefox** add-on][link-amo] [<img valign="middle" src="https://img.shields.io/amo/v/refined-github-.svg?label=%20">][link-amo]
 - **Opera** extension: Use [this Opera extension](https://addons.opera.com/en/extensions/details/download-chrome-extension-9/) to install the Chrome version.
+- [**Brave** extension][link-cws] [<img valign="middle" src="https://img.shields.io/chrome-web-store/v/hlepfoohegkhhmjieoechaddaejaokhf.svg?label=%20">][link-cws]
 
 
 ## Highlights


### PR DESCRIPTION
[Brave](https://brave.com/) is built on Chromium which means most chrome extensions work on the Brave browser. 
So I updated the readme to include this.