### PR TITLE
Fix the `make-headers-sticky` feature

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -706,7 +706,8 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 .rgh-sticky-header .table-list-header .select-menu-list {
 	max-height: calc(100vh - 150px);
 }
-/* Sticky file headers on pull request diff view */
+/* Sticky file headers on pull request diff view and conversation view */
+.rgh-sticky-header .discussion-timeline .discussion-item-body .file-header,
 .rgh-sticky-header .pull-request-tab-content .diff-view .file-header {
 	top: 59px;
 }

--- a/source/features/make-headers-sticky.tsx
+++ b/source/features/make-headers-sticky.tsx
@@ -16,7 +16,8 @@ function init() {
 features.add({
 	id: 'make-headers-sticky',
 	include: [
-		features.isPRFiles,
+		features.isPR,
+		features.isQuickPR,
 		features.isSingleFile
 	],
 	load: features.onAjaxedPages,

--- a/source/features/make-headers-sticky.tsx
+++ b/source/features/make-headers-sticky.tsx
@@ -16,7 +16,8 @@ function init() {
 features.add({
 	id: 'make-headers-sticky',
 	include: [
-		// TODO: limit to fewer views
+    features.isPRFiles,
+    features.isSingleFile,
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/make-headers-sticky.tsx
+++ b/source/features/make-headers-sticky.tsx
@@ -16,8 +16,8 @@ function init() {
 features.add({
 	id: 'make-headers-sticky',
 	include: [
-    features.isPRFiles,
-    features.isSingleFile,
+		features.isPRFiles,
+		features.isSingleFile
 	],
 	load: features.onAjaxedPages,
 	init


### PR DESCRIPTION
Fixes #1727 

The includes option was set to an empty array, causing it to be excluded from all pages. This changes it so that it's included when `isPRFiles` or `isSingleFile` are true.