### PR TITLE
Fix: Open linkified URLs in a new tab

### DIFF
--- a/source/features/linkify-urls-in-code.tsx
+++ b/source/features/linkify-urls-in-code.tsx
@@ -19,6 +19,7 @@ const options = {
 	baseUrl: '',
 	attributes: {
 		rel: 'noreferrer noopener',
+		target: '_blank',
 		class: linkifiedURLClass // Necessary to avoid also shortening the links
 	}
 };


### PR DESCRIPTION
Hello :wave:,

Linkified URLs and issues in the code will be opened in a new browser tab following the `target='_blank'` attribute addition. This was, I feel, required as the links being opened on the same page caused disruption while browsing and reading the code.

Cheers