### PR TITLE
Remove unused permission

### DIFF
--- a/source/manifest.json
+++ b/source/manifest.json
@@ -13,7 +13,6 @@
 	},
 	"permissions": [
 		"storage",
-		"clipboardWrite",
 		"contextMenus",
 		"activeTab",
 		"https://api.github.com/*"


### PR DESCRIPTION
It was added in https://github.com/sindresorhus/refined-github/commit/d17ad257b70a665f8bfe47fd14ba04509b20abb9

> Indicates the extension or app uses document.execCommand('copy') or document.execCommand('cut'). This permission is required for hosted apps; it's recommended for extensions and packaged apps.
> \- https://developer.chrome.com/apps/declare_permissions

It's not required and it seems to work fine without it.

More here: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard