### PR TITLE
Fix `preserve-whitespace-option-in-nav` and refactor with URLSearchParams

### DIFF
--- a/source/features/diff-view-without-whitespace-option.tsx
+++ b/source/features/diff-view-without-whitespace-option.tsx
@@ -13,22 +13,22 @@ function init() {
 		return false;
 	}
 
-	const url = new URL(location.href);
-	const hidingWhitespace = url.searchParams.get('w') === '1';
+	const searchParams = new URLSearchParams(location.search);
+	const isHidingWhitespace = searchParams.get('w') === '1';
 
-	if (hidingWhitespace) {
-		url.searchParams.delete('w');
+	if (isHidingWhitespace) {
+		searchParams.delete('w');
 	} else {
-		url.searchParams.set('w', '1');
+		searchParams.set('w', '1');
 	}
 
 	container.after(
 		<div class="diffbar-item refined-github-toggle-whitespace">
-			<a href={url}
+			<a href={'?' + String(searchParams)}
 				data-hotkey="d w"
-				class={`btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${hidingWhitespace ? 'bg-gray-light text-gray-light' : ''}`}
-				aria-label={`${hidingWhitespace ? 'Show' : 'Hide'} whitespace in diffs`}>
-				{hidingWhitespace ? icons.check() : ''}
+				class={`btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${isHidingWhitespace ? 'bg-gray-light text-gray-light' : ''}`}
+				aria-label={`${isHidingWhitespace ? 'Show' : 'Hide'} whitespace in diffs`}>
+				{isHidingWhitespace ? icons.check() : ''}
 				{' '}
 				No Whitespace
 			</a>

--- a/source/features/diff-view-without-whitespace-option.tsx
+++ b/source/features/diff-view-without-whitespace-option.tsx
@@ -24,7 +24,7 @@ function init() {
 
 	container.after(
 		<div class="diffbar-item refined-github-toggle-whitespace">
-			<a href={`?${searchParams`}
+			<a href={`?${searchParams}`}
 				data-hotkey="d w"
 				class={`btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${isHidingWhitespace ? 'bg-gray-light text-gray-light' : ''}`}
 				aria-label={`${isHidingWhitespace ? 'Show' : 'Hide'} whitespace in diffs`}>

--- a/source/features/diff-view-without-whitespace-option.tsx
+++ b/source/features/diff-view-without-whitespace-option.tsx
@@ -24,7 +24,7 @@ function init() {
 
 	container.after(
 		<div class="diffbar-item refined-github-toggle-whitespace">
-			<a href={'?' + String(searchParams)}
+			<a href={`?${searchParams`}
 				data-hotkey="d w"
 				class={`btn btn-sm btn-outline BtnGroup-item tooltipped tooltipped-s ${isHidingWhitespace ? 'bg-gray-light text-gray-light' : ''}`}
 				aria-label={`${isHidingWhitespace ? 'Show' : 'Hide'} whitespace in diffs`}>

--- a/source/features/preserve-whitespace-option-in-nav.tsx
+++ b/source/features/preserve-whitespace-option-in-nav.tsx
@@ -13,9 +13,9 @@ function init() {
 
 	if (hidingWhitespace) {
 		for (const a of navLinks) {
-			const linkUrl = new URL(a.href);
-			linkUrl.searchParams.set('w', '1');
-			a.href = String(linkUrl);
+			const linkUrl = new URLSearchParams(a.search);
+			linkUrl.set('w', '1');
+			a.search = String(linkUrl);
 		}
 	}
 }

--- a/source/features/preserve-whitespace-option-in-nav.tsx
+++ b/source/features/preserve-whitespace-option-in-nav.tsx
@@ -1,22 +1,19 @@
+/*
+When navigating with next/previous in review mode, preserve whitespace option.
+*/
+
 import select from 'select-dom';
 import features from '../libs/features';
 
-// When navigating with next/previous in review mode, preserve whitespace option.
 function init() {
-	const navLinks = select.all<HTMLAnchorElement>('.commit > .BtnGroup.float-right > a.BtnGroup-item');
-	if (navLinks.length === 0) {
+	if (new URLSearchParams(location.search).get('w') !== '1') {
 		return false;
 	}
 
-	const searchParams = new URLSearchParams(location.href);
-	const hidingWhitespace = searchParams.get('w') === '1';
-
-	if (hidingWhitespace) {
-		for (const a of navLinks) {
-			const linkUrl = new URLSearchParams(a.search);
-			linkUrl.set('w', '1');
-			a.search = String(linkUrl);
-		}
+	for (const a of select.all<HTMLAnchorElement>('[data-hotkey="p"], [data-hotkey="n"]')) {
+		const linkUrl = new URLSearchParams(a.search);
+		linkUrl.set('w', '1');
+		a.search = String(linkUrl);
 	}
 }
 

--- a/source/features/sort-issues-by-update-time.tsx
+++ b/source/features/sort-issues-by-update-time.tsx
@@ -39,7 +39,7 @@ function init() {
 			const search = new URLSearchParams(link.search);
 			const existingQuery = search.get('q') || getDefaultQuery(link, search);
 			search.set('q', `${existingQuery} sort:updated-desc`);
-			link.search = search.toString();
+			link.search = String(search);
 		}
 	}
 

--- a/source/features/sort-milestones-by-closest-due-date.tsx
+++ b/source/features/sort-milestones-by-closest-due-date.tsx
@@ -3,12 +3,12 @@ import features from '../libs/features';
 
 function init() {
 	for (const a of select.all<HTMLAnchorElement>('a[href$="/milestones"], a[href*="/milestones?"]')) {
-		const url = new URL(a.href);
+		const searchParams = new URLSearchParams(a.search);
 		// Only if they aren't explicitly sorted differently
-		if (!url.searchParams.get('direction') && !url.searchParams.get('sort')) {
-			url.searchParams.set('direction', 'asc');
-			url.searchParams.set('sort', 'due_date');
-			a.href = String(url);
+		if (!searchParams.get('direction') && !searchParams.get('sort')) {
+			searchParams.set('direction', 'asc');
+			searchParams.set('sort', 'due_date');
+			a.search = String(searchParams);
 		}
 	}
 }


### PR DESCRIPTION
`preserve-whitespace-option-in-nav` was broken because of `new URLSearchParams(location.href)` (it should be `location.search`)