### PR TITLE
Display disabled review buttons

### DIFF
--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -32,14 +32,15 @@ function init() {
 	for (const radio of radios) {
 		const tooltip = radio.parentElement.getAttribute('aria-label');
 
-		const button =
+		const button = (
 			<button
 				name="pull_request_review[event]"
 				value={radio.value}
 				class={`btn btn-sm ${btnClassMap[radio.value] || ''} ${tooltip ? 'tooltipped tooltipped-nw tooltipped-no-delay' : ''}`}
 				aria-label={tooltip || ''}>
 				{radio.nextSibling.textContent.trim()}
-			</button>;
+			</button>
+		);
 
 		if (radio.disabled) {
 			button.setAttribute('disabled', 'disabled');

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -30,16 +30,19 @@ function init() {
 
 	// Generate the new buttons
 	for (const radio of radios) {
-		if (!radio.disabled) {
-			container.append(
-				<button
-					name="pull_request_review[event]"
-					value={radio.value}
-					class={`btn btn-sm ${btnClassMap[radio.value] || ''}`}>
-					{radio.nextSibling.textContent.trim()}
-				</button>
-			);
+		const tooltip = radio.parentElement.getAttribute("aria-label");
+		const button =
+			<button
+				name="pull_request_review[event]"
+				value={radio.value}
+				class={`btn btn-sm ${btnClassMap[radio.value] || ''} ${tooltip ? 'tooltipped tooltipped-nw tooltipped-no-delay' : ''}`}
+				aria-label={tooltip || ''}>
+				{radio.nextSibling.textContent.trim()}
+			</button>;
+		if (radio.disabled) {
+			button.setAttribute('disabled', 'disabled')
 		}
+		container.append(button);
 	}
 
 	// Comment button must be last; cancel button must be first

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -38,7 +38,7 @@ function init() {
 				value={radio.value}
 				class={`btn btn-sm ${btnClassMap[radio.value] || ''} ${tooltip ? 'tooltipped tooltipped-nw tooltipped-no-delay' : ''}`}
 				aria-label={tooltip || ''}>
-				{radio.nextSibling.textContent.trim()}
+				{radio.nextSibling}
 			</button>
 		);
 

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -30,7 +30,8 @@ function init() {
 
 	// Generate the new buttons
 	for (const radio of radios) {
-		const tooltip = radio.parentElement.getAttribute("aria-label");
+		const tooltip = radio.parentElement.getAttribute('aria-label');
+
 		const button =
 			<button
 				name="pull_request_review[event]"
@@ -39,9 +40,11 @@ function init() {
 				aria-label={tooltip || ''}>
 				{radio.nextSibling.textContent.trim()}
 			</button>;
+
 		if (radio.disabled) {
-			button.setAttribute('disabled', 'disabled')
+			button.setAttribute('disabled', 'disabled');
 		}
+
 		container.append(button);
 	}
 


### PR DESCRIPTION
Enables the display of the disabled review buttons and takes the
aria-label of the label and turns it into a tooltip. Had to make the
tooltip go to the 'nw' to have it not cut off the screen.

![image](https://user-images.githubusercontent.com/857700/52762149-e94d2080-2fdb-11e9-947e-f7befdd93e9d.png)

dom-chef doesn't seem to support `disabled={radio.disabled}` as it was
including it even when false, unlike React which ignores false
properties, hence the extra lines for making them disabled still.

Closes #1646.