### PR TITLE
Hide the project tab in profiles and orgs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ GitHub Enterprise is also supported. More info in the options.
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
-- The `Projects` repository tab is hidden when there are no projects
+- The `Projects` tab is hidden from repositories, user profiles and organization profiles when there are no projects
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
 - [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - [Forks are hidden from a user's Repositories list (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ GitHub Enterprise is also supported. More info in the options.
 - The file hover effect in the repo file browser is removed.
 - Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
-- The `Projects` tab is hidden from repositories, user profiles and organization profiles when there are no projects
+- The `Projects` tab is hidden from repositories and profiles when there are no projects.
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
 - [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - [Forks are hidden from a user's Repositories list (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -44,6 +44,16 @@ async function init() {
 		.user-profile-nav + *
 	`); // Wait for the tab bar to be loaded
 
+	const projectsTab = select([
+		'[data-hotkey="g b"]', // In organizations and repos
+		'.user-profile-nav [href$="?tab=projects"]' // In user profiles
+	].join());
+
+	if (!projectsTab) {
+		// Projects aren't enabled here
+		return;
+	}
+
 	addNewProjectLink();
 
 	// If there's a settings tab, the current user can disable the projects,
@@ -55,12 +65,8 @@ async function init() {
 		return;
 	}
 
-	const projectsTab = select([
-		'[data-hotkey="g b"]:not(.selected)', // In organizations and repos
-		'.user-profile-nav [href$="?tab=projects"]:not(.selected)' // In user profiles
-	].join());
-
-	if (projectsTab && select('.Counter', projectsTab).textContent.trim() === '0') {
+	// Only remove the tab if it's not the current page and if it has 0 projects
+	if (!projectsTab.matches('.selected') && select('.Counter', projectsTab).textContent.trim() === '0') {
 		projectsTab.remove();
 	}
 }

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -1,46 +1,75 @@
+/*
+The `Projects` tab is hidden from repositories, user profiles and organization profiles when there are no projects
+
+New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
+*/
+
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
 import features from '../libs/features';
-import {getRepoURL} from '../libs/utils';
 import {safeElementReady} from '../libs/dom-utils';
-
-const removeProjectsTab = () => {
-	// Only those who can create a project will see the 'Settings' tab
-	// so, do not remove the 'Projects' tab if the 'Settings' tab exists
-	if (select.exists('.js-repo-nav [data-selected-links^="repo_settings"]')) {
-		return false;
-	}
-
-	const projectsTab = select('.js-repo-nav [data-selected-links^="repo_projects"]');
-	if (projectsTab && projectsTab.querySelector('.Counter, .counter').textContent === '0') {
-		projectsTab.remove();
-		return true;
-	}
-};
+import {isOwnUserProfile, isUserProfile} from '../libs/page-detect';
 
 const addNewProjectLink = onetime(() => {
-	const newIssueLink = select('.HeaderMenu .dropdown-item[href$="/issues/new"]');
-	if (newIssueLink) {
-		newIssueLink.after(
-			<a class="dropdown-item" href={`/${getRepoURL()}/projects/new`}>
-				New project
-			</a>
-		);
+	if (isOwnUserProfile()) {
+		// The link already exists
+		return;
 	}
+
+	if (isUserProfile() && select.exists('[href*="contact/report-abuse?report="]')) {
+		// This is an org; if there's a Report Abuse link, we're not part of the org, so we can't create projects
+		return;
+	}
+
+	// We can't detect whether we can create projects on a repo,
+	// so we're just gonna show a potentially-404 link. 🤷
+
+	const path = location.pathname.split('/', 3);
+	const base = path.length > 2 ? path.join('/') : '/orgs' + path.join('/');
+	select('.HeaderMenu [href="/new"]').parentElement.append(
+		// URLs patterns:
+		// https://github.com/orgs/USER/projects/new
+		// https://github.com/USER/REPO/projects/new
+		<a class="dropdown-item" href={base + '/projects/new'}>
+			New project
+		</a>
+	);
 });
 
 async function init() {
-	await safeElementReady('.pagehead + *'); // Wait for the tab bar to be loaded
-	if (removeProjectsTab()) {
-		addNewProjectLink();
+	await safeElementReady(`
+		.orghead + *,
+		.repohead + *,
+		.user-profile-nav + *
+	`); // Wait for the tab bar to be loaded
+
+	addNewProjectLink();
+
+	// If there's a settings tab, the current user can disable the projects,
+	// so the tab should not be hidden
+	if (select.exists([
+		'.js-repo-nav [data-selected-links^="repo_settings"]', // In repos
+		'.pagehead-tabs-item[href$="/settings/profile"]' // In organizations
+	].join())) {
+		return;
+	}
+
+	const projectsTab = select([
+		'[data-hotkey="g b"]:not(.selected)', // In organizations and repos
+		'.user-profile-nav [href$="?tab=projects"]:not(.selected)' // In user profiles
+	].join());
+
+	if (projectsTab && select('.Counter', projectsTab).textContent.trim() === '0') {
+		projectsTab.remove();
 	}
 }
 
 features.add({
 	id: 'remove-projects-tab',
 	include: [
-		features.isRepo
+		features.isRepo,
+		features.isUserProfile
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -1,5 +1,5 @@
 /*
-The `Projects` tab is hidden from repositories, user profiles and organization profiles when there are no projects
+The `Projects` tab is hidden from repositories and profiles when there are no projects
 
 New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
 */

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -1,6 +1,7 @@
 /* eslint-disable unicorn/prefer-starts-ends-with */
 /* The tested var might not be a string */
 
+import select from 'select-dom';
 import {check as isReserved} from 'github-reserved-names';
 import {getUsername, getCleanPathname, getRepoPath, getOwnerAndRepo} from './utils';
 
@@ -47,7 +48,12 @@ export const isNewIssue = (): boolean => /^issues\/new/.test(getRepoPath() as st
 
 export const isNotifications = (): boolean => /^([^/]+[/][^/]+\/)?notifications/.test(getCleanPathname());
 
-export const isOwnUserProfile = (): boolean => isUserProfile() && getCleanPathname() === getUsername();
+export const isOrganizationProfile = (): boolean => select.exists('.orghead');
+
+export const isOwnUserProfile = (): boolean => getCleanPathname() === getUsername();
+
+// If there's a Report Abuse link, we're not part of the org
+export const isOwnOrganizationProfile = (): boolean => isOrganizationProfile() && !select.exists('[href*="contact/report-abuse?report="]');
 
 export const isProject = (): boolean => /^projects\/\d+/.test(getRepoPath() as string);
 
@@ -86,7 +92,4 @@ export const isSingleFile = (): boolean => /^blob\//.test(getRepoPath() as strin
 
 export const isTrending = (): boolean => location.pathname === '/trending' || location.pathname.startsWith('/trending/');
 
-export const isUserProfile = (): boolean => {
-	const path = getCleanPathname();
-	return Boolean(path) && !isGist() && !isReserved(path) && !path.includes('/');
-};
+export const isUserProfile = (): boolean => select.exists('.user-profile-nav');

--- a/test/page-detect.ts
+++ b/test/page-detect.ts
@@ -354,16 +354,6 @@ test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
 	'https://github.com/jaredhanson/node-trending/tree/master/lib/trending'
 ]);
 
-test('isUserProfile', urlMatcherMacro, pageDetect.isUserProfile, [
-	'https://github.com/sindresorhus'
-], [
-	'https://github.com/',
-	'https://github.com/settings',
-	'https://github.com/watching',
-	'https://github.com/sindresorhus/refined-github',
-	'https://gist.github.com/bfred-it'
-]);
-
 test('isRepoSearch', urlMatcherMacro, pageDetect.isRepoSearch, [
 	'https://github.com/sindresorhus/refined-github/search?q=diff',
 	'https://github.com/sindresorhus/refined-github/search?q=diff&unscoped_q=diff&type=Issues',


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/984
Fixes #1757 

# Test

The tab is hidden if:

- it's 0, and
- you’re not on a Project page, and
- you can't disable projects (i.e. you’re not the owner)

The "New project" is added if:

- the project tab normally appears, and:
  - repos: all
  - orgs: only if you belong to the organization and thus can create projects


## Try

- Repo with 0 Projects tab: https://github.com/bfred-it-obsolete/test
- Repo with projects: https://github.com/babel/babel
- Organization: https://github.com/bfred-it-obsolete
- Organization with projects: https://github.com/rust-lang
- Organization you belong to ("New project" will appear)
- Organization you own (the tab will not be hidden)
- Profile: https://github.com/bfred-it
- Your own profile ~~(the tab will not be hidden)~~

