### PR TITLE
Restore toolbar button-hiding feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 	"stylelint": {
 		"extends": "stylelint-config-xo",
 		"rules": {
+			"selector-type-no-unknown": null,
 			"declaration-no-important": null,
 			"property-no-vendor-prefix": null,
 			"property-blacklist": null,

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
 - Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
 - The file hover effect in the repo file browser is removed.
-- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53628976-6799fb80-3c47-11e9-96de-84c041763e79.png) (each one has a keyboard shortcut).
+- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
 - The `Projects` tab is hidden from repositories and profiles when there are no projects.
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).

--- a/readme.md
+++ b/readme.md
@@ -144,7 +144,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/38087982-6c87f268-3384-11e8-9776-7ba48bdde80c.png)
 - Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
 - The file hover effect in the repo file browser is removed.
-- Unnecessary buttons in the comment box toolbar are hidden (each one has a keyboard shortcut).
+- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53628976-6799fb80-3c47-11e9-96de-84c041763e79.png) (each one has a keyboard shortcut).
 - Obvious tooltips are removed.
 - The `Projects` tab is hidden from repositories and profiles when there are no projects.
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).

--- a/source/content.css
+++ b/source/content.css
@@ -92,11 +92,9 @@
 }
 
 /* Hide unnecessary comment toolbar items */
-md-mention,
-md-ref,
-md-header,
-md-bold,
-md-italic {
+:root md-mention,
+:root md-ref,
+markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
 	display: none;
 }
 

--- a/source/content.css
+++ b/source/content.css
@@ -92,9 +92,11 @@
 }
 
 /* Hide unnecessary comment toolbar items */
-.toolbar-item[data-prefix='@'],
-.toolbar-item[data-prefix='#'],
-.toolbar-item[data-prefix='`'] {
+md-mention,
+md-ref,
+md-header,
+md-bold,
+md-italic {
 	display: none;
 }
 


### PR DESCRIPTION
It was halved by https://github.com/sindresorhus/refined-github/pull/1587 and later broken by their custom-element-based buttons.