### PR TITLE
Edit GHE GraphQL endpoint

### DIFF
--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -49,7 +49,7 @@ const api3 = location.hostname === 'github.com' ?
 	`${location.origin}/api/v3/`;
 const api4 = location.hostname === 'github.com' ?
 	'https://api.github.com/graphql' :
-	`${location.origin}/api/graphql/`;
+	`${location.origin}/api/graphql`;
 
 function fetch3(query: string, personalToken: string) {
 	const headers: HeadersInit = {


### PR DESCRIPTION
Closes #1703

`api/graphql/` to `api/graphql`

ref: https://developer.github.com/enterprise/2.15/v4/guides/forming-calls/#the-graphql-endpoint

receive error message
{
    "message": "Not Found",
    "documentation_url": "https://developer.github.com/enterprise/2.15/v4"
}

