### PR TITLE
Add move description feature

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1075,3 +1075,7 @@ body > .footer li a {
 .UnderlineNav-item:nth-last-child(n+7) ~ * {
 	margin-right: 6px;
 }
+
+.repo-description {
+	display: grid;
+}

--- a/source/content.ts
+++ b/source/content.ts
@@ -1,6 +1,7 @@
 import select, {SelectDom} from 'select-dom';
 import 'webext-dynamic-content-scripts';
 
+import './features/move-description';
 import './features/useful-not-found-page';
 import './features/trending-menu-item';
 import './features/hide-useless-newsfeed-events';

--- a/source/features/move-description.tsx
+++ b/source/features/move-description.tsx
@@ -1,0 +1,50 @@
+import {getOwnerAndRepo} from '../libs/utils';
+import React from 'dom-chef';
+import select from 'select-dom';
+import * as api from '../libs/api';
+import features from '../libs/features';
+
+async function init() {
+	const container = select('.repohead-details-container');
+	if (!container) {
+		return false;
+	}
+
+	const {ownerName, repoName} = getOwnerAndRepo();
+	const userInfo = await api.v4(
+		`{
+			repository(owner: "${ownerName}", name: "${repoName}") {
+				description
+				repositoryTopics(first: 100) {
+				  nodes {
+					id
+					resourcePath
+					topic {
+					  name
+					  id
+					}
+				  }
+				}
+			}
+		}`
+	);
+	const repo = select('.repohead-details-container > .public');
+	const description = (
+		<div class="repo-description">
+			{repo}
+			<span class="text-gray-dark mr-2" itemprop="about">
+				{userInfo.repository.description}
+			</span>
+		</div>
+	);
+	container.appendChild(description);
+
+	const originalDesc = select("div.repository-content > div > div.f4 > span")
+	originalDesc.remove()
+}
+
+features.add({
+	id: 'move-description',
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/move-description.tsx
+++ b/source/features/move-description.tsx
@@ -11,7 +11,9 @@ async function init() {
 	}
 
 	const originalDesc = select("div.repository-content > div > div.f4 > span");
-	originalDesc.remove();
+	if (originalDesc) {
+		originalDesc.remove();
+	}
 
 	const {ownerName, repoName} = getOwnerAndRepo();
 	const userInfo = await api.v4(

--- a/source/features/move-description.tsx
+++ b/source/features/move-description.tsx
@@ -10,6 +10,9 @@ async function init() {
 		return false;
 	}
 
+	const originalDesc = select("div.repository-content > div > div.f4 > span");
+	originalDesc.remove();
+
 	const {ownerName, repoName} = getOwnerAndRepo();
 	const userInfo = await api.v4(
 		`{
@@ -38,9 +41,6 @@ async function init() {
 		</div>
 	);
 	container.appendChild(description);
-
-	const originalDesc = select("div.repository-content > div > div.f4 > span")
-	originalDesc.remove()
 }
 
 features.add({

--- a/source/features/move-description.tsx
+++ b/source/features/move-description.tsx
@@ -18,16 +18,6 @@ async function init() {
 		`{
 			repository(owner: "${ownerName}", name: "${repoName}") {
 				description
-				repositoryTopics(first: 100) {
-				  nodes {
-					id
-					resourcePath
-					topic {
-					  name
-					  id
-					}
-				  }
-				}
 			}
 		}`
 	);


### PR DESCRIPTION
Moves the description from the Code page under the tabs to the top level next to the repository name. This is partially based on [this redesign](http://tonsky.me/blog/github-redesign), without the tags moving

I tried moving the tags like tonsky, but they didn't really fit properly, especially when a repo has more than like, 3 tags. Tag length also matters. If anyone has any better ideas I can try to implement it. 

Before
![screenshot_2019-03-03 sindresorhus refined-github 1](https://user-images.githubusercontent.com/1534535/53699559-dfcb0300-3da6-11e9-8410-a4ab2eb06c1e.png)

After
![screenshot_2019-03-03 sindresorhus refined-github](https://user-images.githubusercontent.com/1534535/53699562-e22d5d00-3da6-11e9-85dd-493383a70659.png)

