### PR TITLE
Also show closing commit in issue header

### DIFF
--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -19,11 +19,9 @@ function add() {
 				<a
 					href={link}
 					class="btn btn-outline btn-sm border-blue rgh-closing-pr tooltipped tooltipped-se"
-					aria-label={infoBubble.getAttribute('aria-label')}>{
-						ref.matches('.issue-num') ?
-							<>{icons.openPullRequest()} {ref.textContent}</> :
-							<>{icons.commit()} {ref.textContent}</>
-					}
+					aria-label={infoBubble.getAttribute('aria-label')}>
+						{ref.matches('.issue-num') ? icons.openPullRequest() : icons.commit()}
+						{' ' + ref.textContent}
 				</a>
 			</div>
 		);

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -5,16 +5,25 @@ import observeEl from '../libs/simplified-element-observer';
 import * as icons from '../libs/icons';
 
 function add() {
-	for (const infoBubble of select.all('[aria-label*="will close when"]')) {
-		const prLink = select<HTMLAnchorElement>('.discussion-item-ref-title a', infoBubble.parentElement.parentElement);
-		const issueNumber = select('.issue-num', prLink).textContent;
+	for (const infoBubble of select.all(`
+		[aria-label*="will close when"],
+		[aria-label*="will close once"]
+	`)) {
+		const ref = infoBubble
+			.closest('.discussion-item')
+			.querySelector('.issue-num, .commit-id');
+		const link = (ref.closest('[href]') as HTMLAnchorElement).href;
+
 		select('.gh-header-meta .TableObject-item').after(
 			<div class="TableObject-item">
 				<a
-					href={prLink.href}
+					href={link}
 					class="btn btn-outline btn-sm border-blue rgh-closing-pr tooltipped tooltipped-se"
-					aria-label={infoBubble.getAttribute('aria-label')}>
-					{icons.openPullRequest()}&nbsp;{issueNumber}
+					aria-label={infoBubble.getAttribute('aria-label')}>{
+						ref.matches('.issue-num') ?
+							<>{icons.openPullRequest()} {ref.textContent}</> :
+							<>{icons.commit()} {ref.textContent}</>
+					}
 				</a>
 			</div>
 		);

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -20,8 +20,8 @@ function add() {
 					href={link}
 					class="btn btn-outline btn-sm border-blue rgh-closing-pr tooltipped tooltipped-se"
 					aria-label={infoBubble.getAttribute('aria-label')}>
-						{ref.matches('.issue-num') ? icons.openPullRequest() : icons.commit()}
-						{' ' + ref.textContent}
+					{ref.matches('.issue-num') ? icons.openPullRequest() : icons.commit()}
+					{' ' + ref.textContent}
 				</a>
 			</div>
 		);

--- a/source/libs/icons.tsx
+++ b/source/libs/icons.tsx
@@ -34,6 +34,8 @@ export const chevronDown = (): SVGElement => <svg aria-hidden="true" class="octi
 
 export const chevronLeft = (): SVGElement => <svg aria-hidden="true" class="octicon octicon-chevron-left" height="16" width="8"><path fill-rule="evenodd" d="M5.5 3L7 4.5 3.25 8 7 11.5 5.5 13l-5-5z"/></svg>;
 
+export const commit = (): SVGElement => <svg aria-hidden="true" class="octicon octicon-git-commit" width="14" height="16" ><path d="M10.86 7c-.45-1.72-2-3-3.86-3-1.86 0-3.41 1.28-3.86 3H0v2h3.14c.45 1.72 2 3 3.86 3 1.86 0 3.41-1.28 3.86-3H14V7h-3.14zM7 10.2c-1.22 0-2.2-.98-2.2-2.2 0-1.22.98-2.2 2.2-2.2 1.22 0 2.2.98 2.2 2.2 0 1.22-.98 2.2-2.2 2.2z"/></svg>;
+
 export const externalLink = (): SVGElement => <svg aria-hidden="true" class="octicon octicon-link-external" width="12" height="16"><path fill-rule="evenodd" d="M11 10h1v3c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h3v1H1v10h10v-3zM6 2l2.25 2.25L5 7.5 6.5 9l3.25-3.25L12 8V2H6z"/></svg>;
 
 export const branch = (): SVGElement => <svg aria-hidden="true" class="octicon octicon-git-branch" height="16" width="10"><path fill-rule="evenodd" d="M10 5c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v.3c-.02.52-.23.98-.63 1.38-.4.4-.86.61-1.38.63-.83.02-1.48.16-2 .45V4.72a1.993 1.993 0 0 0-1-3.72C.88 1 0 1.89 0 3a2 2 0 0 0 1 1.72v6.56c-.59.35-1 .99-1 1.72 0 1.11.89 2 2 2 1.11 0 2-.89 2-2 0-.53-.2-1-.53-1.36.09-.06.48-.41.59-.47.25-.11.56-.17.94-.17 1.05-.05 1.95-.45 2.75-1.25S8.95 7.77 9 6.73h-.02C9.59 6.37 10 5.73 10 5zM2 1.8c.66 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2C1.35 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2zm0 12.41c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm6-8c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>;


### PR DESCRIPTION
You can close issues by just referencing them in commits. Live demo: https://github.com/sindresorhus/refined-github/issues/1827

<img width="308" alt="" src="https://user-images.githubusercontent.com/1402241/53860046-a4386f00-401a-11e9-999f-4b382b92bceb.png">

Closing commits are already supported by [`extend-status-labels`](https://github.com/sindresorhus/refined-github/pull/1078)