### PR TITLE
Reduce issue/PR filter button padding when batch-open-issues is active

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -600,9 +600,11 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 }
 
 /* For `open-all-selected`: space out button */
-:root .rgh-open-all-selected {
-	padding-right: 15px;
-	padding-left: 15px;
+:root .rgh-open-all-selected,
+.rgh-open-all-selected ~ .select-menu .btn-link {
+	/* default is 15px, reduce to fit in one line #1830 */
+	padding-right: 12px;
+	padding-left: 12px;
 }
 
 /* Fix for GHE More Dropdown items positioning */

--- a/source/content.css
+++ b/source/content.css
@@ -599,10 +599,9 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	color: var(--github-red) !important;
 }
 
-/* For `open-all-selected`: space out button */
+/* For `open-all-selected`: set a reduced padding for all buttons for #1830 */
 :root .rgh-open-all-selected,
-.rgh-open-all-selected ~ .select-menu .btn-link {
-	/* default is 15px, reduce to fit in one line #1830 */
+.rgh-open-all-selected ~ .select-menu .select-menu-button {
 	padding-right: 12px;
 	padding-left: 12px;
 }


### PR DESCRIPTION
So that everything fits in one line. Closes #1830.

Before:

![screenshot_2019-03-05_23-29-36](https://user-images.githubusercontent.com/202916/53842364-8a0d7b00-3f9f-11e9-92fc-8219a63c23e0.png)

After:

![screenshot_2019-03-06_08-18-37](https://user-images.githubusercontent.com/202916/53862792-ba2d3c00-3fe8-11e9-96f3-2c6dfa566c02.png)

This can be tested in any repo, but as mentioned in #1830, it will only make a difference (prevent overflow) in repos with many PRs that you have push access to.