### PR TITLE
Let users disable "Drop counters for Watch and Forks"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,6 +152,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Forks are hidden from a user's Repositories list (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 - [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
 - [Tall code blocks and quotes are limited in height.](https://github.com/sindresorhus/refined-github/issues/1123)
+- [The Forks counter is hidden.](https://user-images.githubusercontent.com/1402241/54007795-96abf200-419e-11e9-906f-6dfb32358134.png)
 
 ### UI improvements
 

--- a/readme.md
+++ b/readme.md
@@ -152,7 +152,6 @@ GitHub Enterprise is also supported. More info in the options.
 - [Forks are hidden from a user's Repositories list (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 - [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
 - [Tall code blocks and quotes are limited in height.](https://github.com/sindresorhus/refined-github/issues/1123)
-- [Forks and watchers counters are hidden.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
 
 ### UI improvements
 

--- a/source/content.css
+++ b/source/content.css
@@ -1051,13 +1051,3 @@ body > .footer li a {
 .UnderlineNav-item:nth-last-child(n+7) ~ * {
 	margin-right: 6px;
 }
-
-/* Drop counters for Watch and Forks */
-.btn-with-count[title^='Fork your own'],
-[action='/notifications/subscribe'] .btn-with-count {
-	border-radius: 0.25em; /* Matches GitHub's default */
-}
-.social-count[href$='/network/members'],
-.social-count[href$='/watchers'] {
-	display: none;
-}

--- a/source/content.css
+++ b/source/content.css
@@ -1051,3 +1051,11 @@ body > .footer li a {
 .UnderlineNav-item:nth-last-child(n+7) ~ * {
 	margin-right: 6px;
 }
+
+/* Drop counters for Watch and Forks */
+.btn-with-count[title^='Fork your own'] {
+	border-radius: 0.25em; /* Matches GitHub's default */
+}
+.social-count[href$='/network/members'] {
+	display: none;
+}


### PR DESCRIPTION
We might have overlooked the fact that those numbers are actually links and if we hide them there's no way to access them.

Links currently hidden:

- Watch: https://github.com/sindresorhus/refined-github/watchers
- Fork: https://github.com/sindresorhus/refined-github/network/members

Fork is actually accessible via Insights and generally not useful, but Watchers isn't. Are there any alternatives to restoring these counters?


This reverts commit adb319bf0201276ff73f43b3326a32ac16721df5 and https://github.com/sindresorhus/refined-github/pull/1820