### PR TITLE
Fix console errors for a few features

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -8,7 +8,7 @@ function init() {
 	const comments = select.all('.timeline-comment-header:not(.rgh-timestamp-tree-link)');
 
 	for (const comment of comments) {
-		const timestampEl = select('relative-time', comment);
+		const timestampEl = select('relative-time', comment.closest('.discussion-item-review') || comment);
 		const timestamp = timestampEl.attributes['datetime'].value; // eslint-disable-line dot-notation
 		const href = `/${getRepoURL()}/tree/HEAD@{${timestamp}}`;
 

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -4,6 +4,10 @@ import features from '../libs/features';
 
 function init() {
 	const checkbox = select<HTMLInputElement>('[name="collab_privs"]');
+	if (!checkbox) {
+		return;
+	}
+
 	const warning = (
 		<div class="flash flash-error mt-3">
 			<strong>Note:</strong> Maintainers may require changes. It’s easier and faster to allow them to make direct changes before merging.

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -17,7 +17,7 @@ export const isCommitList = (): boolean => /^commits\//.test(getRepoPath());
 
 export const isCompare = (): boolean => /^compare/.test(getRepoPath());
 
-export const isDashboard = (): boolean => /^$|^(orgs[/][^/]+[/])?dashboard([/]|$)/.test(getCleanPathname());
+export const isDashboard = (): boolean => !isGist() && /^$|^(orgs[/][^/]+[/])?dashboard([/]|$)/.test(getCleanPathname());
 
 // TODO: change name to clarify what discussion this is
 export const isDiscussion = (): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());


### PR DESCRIPTION
Fixes #1811 

One of them was because on review comments the time appears elsewhere:

<img width="459" alt="" src="https://user-images.githubusercontent.com/1402241/54008917-b72a7b00-41a3-11e9-83fc-f437f391de58.png">

I think it's ok for now. I think eventually we'll have to move that icon into the dropdown menu for each comment. GitHub didn't have that before.