### PR TITLE
Replace `delegate-it` with inline handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3752,11 +3752,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
-		"delegate-it": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/delegate-it/-/delegate-it-1.0.1.tgz",
-			"integrity": "sha512-cMaabYx6aspJ9gEprkUhK2yJn8A+3Iluy/WHtwDfeif0LYJMsJGvfI1KQqdPqFLE+pOCTeZ7G03ogQESxy6H1w=="
-		},
 		"depd": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 	"dependencies": {
 		"copy-text-to-clipboard": "^1.0.4",
 		"debounce-fn": "^1.0.0",
-		"delegate-it": "^1.0.1",
 		"dom-chef": "^3.6.0",
 		"dom-loaded": "^1.0.1",
 		"element-ready": "^3.0.0",

--- a/source/features/add-co-authored-by.tsx
+++ b/source/features/add-co-authored-by.tsx
@@ -1,8 +1,8 @@
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getOwnerAndRepo, getDiscussionNumber, getOP} from '../libs/utils';
+import {getEventDelegator} from '../libs/dom-utils';
 
 let coAuthors;
 
@@ -35,7 +35,11 @@ async function fetchCoAuthoredData() {
 	return userInfo.repository.pullRequest.commits.nodes.map(node => node.commit.author);
 }
 
-function addCoAuthors() {
+function addCoAuthors(event) {
+	if (!getEventDelegator(event, '.merge-message [type=button]')) {
+		return;
+	}
+
 	const field = select<HTMLTextAreaElement>('#merge_message_field');
 	if (field.value.includes('Co-authored-by: ')) {
 		// Don't affect existing information
@@ -55,7 +59,7 @@ function addCoAuthors() {
 async function init() {
 	coAuthors = await fetchCoAuthoredData();
 
-	delegate('.discussion-timeline-actions', '.merge-message [type=button]', 'click', addCoAuthors);
+	select('.discussion-timeline-actions').addEventListener('click', addCoAuthors);
 }
 
 features.add({

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -1,5 +1,5 @@
-import delegate from 'delegate-it';
 import features from '../libs/features';
+import {getEventDelegator} from '../libs/dom-utils';
 
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
@@ -11,9 +11,14 @@ const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 function init() {
 	// The `open` attribute is added after this handler is run,
 	// so the selector is inverted
-	delegate('.details-overlay:not([open]) > summary', 'click', event => {
+	document.addEventListener('click', event => {
+		const delegateTarget = getEventDelegator(event, '.details-overlay:not([open]) > summary');
+		if (!delegateTarget) {
+			return;
+		}
+
 		// What comes after <summary> is the dropdown
-		observer.observe(event.delegateTarget.nextElementSibling);
+		observer.observe(delegateTarget.nextElementSibling);
 	});
 }
 

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -6,9 +6,9 @@ https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c
 
 import React from 'dom-chef';
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
+import {getEventDelegator} from '../libs/dom-utils';
 
 // Wraps string in at least 2 \n on each side,
 // as long as the field doesn't already have them.
@@ -32,7 +32,7 @@ function smartBlockWrap(content: string, field: HTMLTextAreaElement) {
 }
 
 function init() {
-	delegate('.rgh-collapsible-content-btn', 'click', addContentToDetails);
+	document.addEventListener('click', addContentToDetails);
 	for (const anchor of select.all('md-ref')) {
 		anchor.after(
 			<button type="button" class="toolbar-item tooltipped tooltipped-n rgh-collapsible-content-btn" aria-label="Add collapsible content">
@@ -43,7 +43,12 @@ function init() {
 }
 
 function addContentToDetails(event) {
-	const field = event.delegateTarget.form['comment[body]'];
+	const delegateTarget = getEventDelegator(event, '.rgh-collapsible-content-btn');
+	if (!delegateTarget) {
+		return;
+	}
+
+	const field = delegateTarget.form['comment[body]'];
 
 	// Don't indent <summary> because indentation will not be automatic on multi-line content
 	const newContent = `

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -1,7 +1,7 @@
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
 import indentTextarea from '../libs/indent-textarea';
+import {getEventDelegator} from '../libs/dom-utils';
 
 // Element.blur() will reset the tab focus to the start of the document.
 // This places it back next to the blurred field
@@ -19,11 +19,11 @@ function blurAccessibly(field) {
 }
 
 function init() {
-	delegate('.js-comment-field', 'keydown', event => {
-		const field: HTMLTextAreaElement = event.delegateTarget;
+	document.addEventListener('keydown', event => {
+		const field: HTMLTextAreaElement = getEventDelegator(event, '.js-comment-field');
 
 		// Don't do anything if the suggester box is active
-		if (select.exists('.suggester:not([hidden])', field.form)) {
+		if (!field || select.exists('.suggester:not([hidden])', field.form)) {
 			return;
 		}
 

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -1,16 +1,21 @@
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
+import {getEventDelegator} from '../libs/dom-utils';
 
 function expandDiff(event) {
 	// Skip if the user clicked directly on the icon
 	if (!event.target.closest('.js-expand')) {
-		select<HTMLAnchorElement>('.js-expand', event.delegateTarget).click();
+		return;
+	}
+
+	const delegateTarget = getEventDelegator(event, '.js-expandable-line');
+	if (!delegateTarget) {
+		select<HTMLAnchorElement>('.js-expand', delegateTarget).click();
 	}
 }
 
 function init() {
-	delegate('.diff-view', '.js-expandable-line', 'click', expandDiff);
+	select('.diff-view').addEventListener('click', expandDiff);
 }
 
 features.add({

--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -1,10 +1,15 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
+import {getEventDelegator} from '../libs/dom-utils';
 
 function handleMenuOpening(event) {
-	const hideButton = select('.js-comment-hide-button', event.delegateTarget.parentElement);
+	const delegateTarget = getEventDelegator(event, '.timeline-comment-action');
+	if (!delegateTarget) {
+		return;
+	}
+
+	const hideButton = select('.js-comment-hide-button', delegateTarget.parentElement);
 	if (!hideButton) {
 		// User unable to hide or menu already created
 		return;
@@ -56,7 +61,7 @@ function handleMenuOpening(event) {
 }
 
 function init() {
-	delegate('.timeline-comment-action', 'click', handleMenuOpening);
+	document.addEventListener('click', handleMenuOpening);
 }
 
 features.add({

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -4,17 +4,17 @@ import select from 'select-dom';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
 import {groupButtons} from '../libs/group-buttons';
+import {getEventDelegator} from '../libs/dom-utils';
 
 const confirmationRequiredCount = 10;
 const unreadNotificationsClass = '.unread .js-notification-target';
 
-function openNotifications({target}) {
-	// Homemade delegate event, simplifies addEventListener deduplication
-	if (!target.closest('.rgh-open-notifications-button')) {
+function openNotifications(event) {
+	if (!getEventDelegator(event, '.rgh-open-notifications-button')) {
 		return;
 	}
 
-	const container = target.closest('.boxed-group, .notification-center');
+	const container = event.target.closest('.boxed-group, .notification-center');
 
 	// Ask for confirmation
 	const unreadNotifications = select.all<HTMLAnchorElement>(unreadNotificationsClass, container);

--- a/source/features/scroll-to-top-on-collapse.tsx
+++ b/source/features/scroll-to-top-on-collapse.tsx
@@ -1,12 +1,16 @@
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
+import {getEventDelegator} from '../libs/dom-utils';
 
 function init() {
 	const toolbar = select('.pr-toolbar');
 
-	delegate('.js-diff-progressive-container', '.file', 'details:toggled', ({target}) => {
-		const elOffset = target.getBoundingClientRect().top;
+	select('.js-diff-progressive-container').addEventListener('details:toggled', event => {
+		if (!getEventDelegator(event, '.file')) {
+			return;
+		}
+
+		const elOffset = (event.target as Element).getBoundingClientRect().top;
 		const toolbarHeight = toolbar.getBoundingClientRect().top;
 
 		// Bring element in view if it's above the PR toolbar

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -1,9 +1,9 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
 import observeEl from '../libs/simplified-element-observer';
+import {getEventDelegator} from '../libs/dom-utils';
 
 function addButton() {
 	const filesHeader = select('.commit-tease');
@@ -24,7 +24,12 @@ function addButton() {
 function init() {
 	const repoContent = select('.repository-content');
 	observeEl(repoContent, addButton);
-	delegate('.rgh-toggle-files', 'click', ({delegateTarget}) => {
+	document.addEventListener('click', event => {
+		const delegateTarget = getEventDelegator(event, '.rgh-toggle-files');
+		if (!delegateTarget) {
+			return;
+		}
+
 		delegateTarget.setAttribute('aria-expanded', !repoContent.classList.toggle('rgh-files-hidden'));
 	});
 }

--- a/source/features/upload-button.tsx
+++ b/source/features/upload-button.tsx
@@ -1,8 +1,8 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import delegate from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
+import {getEventDelegator} from '../libs/dom-utils';
 
 function addButtons() {
 	for (const toolbar of select.all('form:not(.rgh-has-upload-field) markdown-toolbar')) {
@@ -23,8 +23,12 @@ function addButtons() {
 	}
 }
 
-function triggerUploadUI({target}) {
-	target
+function triggerUploadUI(event) {
+	if (!getEventDelegator(event, '.rgh-upload-btn')) {
+		return;
+	}
+
+	event.target
 		.closest('form')
 		.querySelector('.js-manual-file-chooser') // Find <input [type=file]>
 		.click(); // Open UI
@@ -32,7 +36,7 @@ function triggerUploadUI({target}) {
 
 function init() {
 	addButtons();
-	delegate('.rgh-upload-btn', 'click', triggerUploadUI);
+	document.addEventListener('click', triggerUploadUI);
 }
 
 features.add({

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -1,11 +1,11 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
-import delegate from 'delegate-it';
 import features from '../libs/features';
 import observeEl from '../libs/simplified-element-observer';
 import * as prCiStatus from '../libs/pr-ci-status';
 import * as icons from '../libs/icons';
+import {getEventDelegator} from '../libs/dom-utils';
 
 let waiting;
 
@@ -59,6 +59,10 @@ function disableForm(disabled = true) {
 }
 
 async function handleMergeConfirmation(event) {
+	if (!getEventDelegator(event, '.js-merge-commit-button')) {
+		return;
+	}
+
 	const checkbox = getCheckbox();
 	if (checkbox && checkbox.checked) {
 		event.preventDefault();
@@ -96,11 +100,13 @@ function init() {
 	prCiStatus.addEventListener(showCheckboxIfNecessary);
 
 	// One of the merge buttons has been clicked
-	delegate(container, '.js-merge-commit-button', 'click', handleMergeConfirmation);
+	container.addEventListener('click', handleMergeConfirmation);
 
 	// Cancel wait when the user presses the Cancel button
-	delegate(container, '.commit-form-actions button:not(.js-merge-commit-button)', 'click', () => {
-		disableForm(false);
+	container.addEventListener('click', event => {
+		if (!getEventDelegator(event, '.commit-form-actions button:not(.js-merge-commit-button)')) {
+			disableForm(false);
+		}
 	});
 
 	// Warn user if it's not yet submitted.

--- a/source/libs/dom-utils.ts
+++ b/source/libs/dom-utils.ts
@@ -2,6 +2,11 @@ import select from 'select-dom';
 import domLoaded from 'dom-loaded';
 import elementReady from 'element-ready';
 
+export const getEventDelegator = (event, selector) => {
+	const delegate = event.target.closest(selector);
+	return delegate && event.currentTarget.contains(delegate);
+};
+
 /*
  * Automatically stops checking for an element to appear once the DOM is ready.
  */


### PR DESCRIPTION
Discuss only. Probably won't ever merge.

[This comment](https://github.com/zenorocha/delegate/pull/31#issuecomment-470862364) made me think that `delegate` is actually just plain listener + `closest`+`contains`, which can almost be inlined, without having to manage the events into a library with WeakMaps all over: https://github.com/bfred-it/delegate-it/blob/master/index.ts

However this adds about 60 lines, which is approximately the actual LOCs of `delegate-it`. **Maybe not worth the extra complexity we pull into RGH**, but it was worth a try.

`mark-unread` is probably what benefits the most, considering we don't have to do anything funny to _destroy_ the listeners.

This is untested and maybe incomplete since `delegate(selector)` is translated to `select.all().map()`, which if necessary here would lengthen the code even further.