### PR TITLE
Updated 404 page detection

### DIFF
--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -5,7 +5,7 @@ import select from 'select-dom';
 import {check as isReserved} from 'github-reserved-names';
 import {getUsername, getCleanPathname, getRepoPath, getOwnerAndRepo} from './utils';
 
-export const is404 = (): boolean => document.title === 'GitHub · Where software is built';
+export const is404 = (): boolean => select.exists('img[alt*="404"]');
 
 export const is500 = (): boolean => document.title === 'Server Error · GitHub';
 


### PR DESCRIPTION
This pull request updates the 404 page detection by checking if the `alt` attribute on the 404 image contains `404`.

Fixes https://github.com/sindresorhus/refined-github/pull/1837#discussion_r263643663

Since we're accessing the DOM, how should we handle the 404 tests?