### PR TITLE
Update `trending-menu-item`

### DIFF
--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -5,12 +5,12 @@ import {safeElementReady} from '../libs/dom-utils';
 
 async function init() {
 	const selectedClass = isTrending() ? 'selected' : '';
-	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"]');
-	if (!issuesLink) {
+	const exploreLink = await safeElementReady('.HeaderNavlink[href="/explore"]');
+	if (!exploreLink) {
 		return false;
 	}
 
-	issuesLink.parentNode.after(
+	exploreLink.parentElement.before(
 		<li>
 			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
 		</li>
@@ -18,10 +18,7 @@ async function init() {
 
 	// Explore link highlights /trending urls by default, remove that behavior
 	if (isTrending()) {
-		const exploreLink = await safeElementReady('.HeaderNavlink[href="/explore"]');
-		if (exploreLink) {
-			exploreLink.classList.remove('selected');
-		}
+		exploreLink.classList.remove('selected');
 	}
 }
 

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -1,6 +1,5 @@
 import React from 'dom-chef';
 import features from '../libs/features';
-import {isTrending} from '../libs/page-detect';
 import {safeElementReady} from '../libs/dom-utils';
 
 async function init() {
@@ -14,11 +13,6 @@ async function init() {
 			<a href="/trending" className={exploreLink.className} data-hotkey="g t">Trending</a>
 		</li>
 	);
-
-	// Explore link highlights /trending urls by default, remove that behavior
-	if (isTrending()) {
-		exploreLink.classList.remove('selected');
-	}
 }
 
 features.add({

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -4,7 +4,6 @@ import {isTrending} from '../libs/page-detect';
 import {safeElementReady} from '../libs/dom-utils';
 
 async function init() {
-	const selectedClass = isTrending() ? 'selected' : '';
 	const exploreLink = await safeElementReady('.HeaderNavlink[href="/explore"]');
 	if (!exploreLink) {
 		return false;
@@ -12,7 +11,7 @@ async function init() {
 
 	exploreLink.parentElement.before(
 		<li>
-			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
+			<a href="/trending" className={exploreLink.className} data-hotkey="g t">Trending</a>
 		</li>
 	);
 

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -5,20 +5,20 @@ import {safeElementReady} from '../libs/dom-utils';
 
 async function init() {
 	const selectedClass = isTrending() ? 'selected' : '';
-	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"], .header-nav-link[href="/issues"]');
+	const issuesLink = await safeElementReady('.HeaderNavlink[href="/issues"]');
 	if (!issuesLink) {
 		return false;
 	}
 
 	issuesLink.parentNode.after(
-		<li class="header-nav-item">
-			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink px-lg-2 py-2 py-lg-0 ${selectedClass}`} data-hotkey="g t">Trending</a>
+		<li>
+			<a href="/trending" class={`js-selected-navigation-item HeaderNavlink px-2 ${selectedClass}`} data-hotkey="g t">Trending</a>
 		</li>
 	);
 
 	// Explore link highlights /trending urls by default, remove that behavior
 	if (isTrending()) {
-		const exploreLink = await safeElementReady('a[href="/explore"]');
+		const exploreLink = await safeElementReady('.HeaderNavlink[href="/explore"]');
 		if (exploreLink) {
 			exploreLink.classList.remove('selected');
 		}


### PR DESCRIPTION
The current class mismatch causes this jump when resizing the window.

![d](https://user-images.githubusercontent.com/1402241/54269316-1e876700-45b8-11e9-9fa3-c9b6c9d034e7.gif)

Also the `selected` class doesn't have any effect anymore, so it's good to drop it