### PR TITLE
Let users disable `hide-watch-and-fork-count`

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1085,7 +1085,7 @@ body > .footer li a {
 [action='/notifications/subscribe'] .btn-with-count {
 	border-radius: 0.25em; /* Matches GitHub's default */
 }
-.social-count[href$='/network/members'].rgh-hide-watch-and-fork-count,
-.social-count[href$='/watchers'].rgh-hide-watch-and-fork-count {
+.rgh-hide-watch-and-fork-count .social-count[href$='/network/members'],
+.rgh-hide-watch-and-fork-count .social-count[href$='/watchers'] {
 	display: none;
 }

--- a/source/content.css
+++ b/source/content.css
@@ -1085,7 +1085,7 @@ body > .footer li a {
 [action='/notifications/subscribe'] .btn-with-count {
 	border-radius: 0.25em; /* Matches GitHub's default */
 }
-.social-count[href$='/network/members'],
-.social-count[href$='/watchers'] {
+.social-count[href$='/network/members'].rgh-hide-watch-and-fork-count,
+.social-count[href$='/watchers'].rgh-hide-watch-and-fork-count {
 	display: none;
 }

--- a/source/content.ts
+++ b/source/content.ts
@@ -88,6 +88,7 @@ import './features/warn-pr-from-master';
 import './features/split-issue-pr-search-results';
 import './features/preview-hidden-comments';
 import './features/collapsible-content-button';
+import './features/hide-watch-and-fork-count';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -1,0 +1,13 @@
+import features from '../libs/features';
+import select from 'select-dom';
+
+function init() {
+	for (const btn of select.all('.social-count[href$="/network/members"], .social-count[href$="/watchers"]')) {
+		btn.classList.add('rgh-hide-watch-and-fork-count');
+	}
+}
+
+features.add({
+	id: 'hide-watch-and-fork-count',
+	init
+});

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -1,13 +1,13 @@
 import features from '../libs/features';
-import select from 'select-dom';
 
 function init() {
-	for (const btn of select.all('.social-count[href$="/network/members"], .social-count[href$="/watchers"]')) {
-		btn.classList.add('rgh-hide-watch-and-fork-count');
-	}
+	document.body.classList.add('rgh-hide-watch-and-fork-count');
 }
 
 features.add({
 	id: 'hide-watch-and-fork-count',
+	include: [
+		features.isRepo
+	],
 	init
 });


### PR DESCRIPTION
I add a new class `hide-watch-and-fork-count`.
Or maybe should I just use `btn.style.display = 'none'`?

Closes #1843
