### PR TITLE
Change dashboard style again

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ GitHub Enterprise is also supported. More info in the options.
 
 ### Declutter
 
-- [Newsfeed events take up less space.](https://user-images.githubusercontent.com/1402241/53853757-b6f27a00-4001-11e9-9879-a75228b3df90.png)
+- [Newsfeed events take up less space and "User starred X repos" groups are now always expanded.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
 - Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
 - The file hover effect in the repo file browser is removed.
 - [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).

--- a/source/content.css
+++ b/source/content.css
@@ -819,19 +819,32 @@ body > .footer li a {
 	display: none;
 }
 
-/* Add background and border to non-grouped events */
-.dashboard .border-gray.flex-items-baseline.py-3 {
+/* Add background and border Whole list */
+.dashboard .js-all-activity-header + div {
 	background-color: #fff;
 	border: 1px solid #d1d5da;
 	border-radius: 3px;
-	padding: 16px !important;
 	margin-top: 8px !important;
+}
 
-	/* Align avatar with first 2 lines */
-	align-items: flex-start !important;
+/* Drop "box" style for all events */
+.dashboard .js-all-activity-header + div .Box {
+	padding: 0 !important;
+	border: none;
+	background: none;
+}
+
+/* Restore "row"-like spacing for all events */
+.dashboard .body > .border-bottom {
+	margin: 0;
+	padding-left: 16px;
+	padding-right: 16px;
 }
 
 /* Align avatar with first 2 lines */
+.dashboard .flex-items-baseline.py-3 {
+	align-items: flex-start !important;
+}
 .dashboard .body .mr-3 + div {
 	margin-top: -5px;
 	margin-bottom: -5px;
@@ -846,22 +859,21 @@ body > .footer li a {
 .dashboard .repo .f6.text-gray {
 	display: none;
 }
-/* Drop "box" style for activities in non-grouped events */
-.dashboard .body .border-gray .Box.p-3.mt-2, /* Starred */
-.dashboard .body .border-gray .Box.p-3.my-2 { /* Made public */
-	margin-top: 0 !important;
-	padding: 0 !important;
-	border: none;
-	background: none;
-}
 
 /* Grouped events: Make repo name smaller */
 .dashboard .Details .flex-items-baseline .text-bold.text-gray-dark {
 	font-size: 1em !important;
 }
-/* Grouped events: Hide separator */
-.Details.js-news-feed-event-group {
-	border-bottom: none !important;
+
+/* Grouped events: Show separator */
+.dashboard-rollup-items .body {
+	border-top: 1px solid #e1e4e8;
+	margin-top: 8px;
+}
+
+/* Grouped events: Bring horizontal lines to right border */
+.js-news-feed-event-group {
+	padding-right: 0 !important;
 }
 
 /* Grouped events: Keep open */
@@ -881,6 +893,7 @@ body > .footer li a {
 	display: none;
 }
 
+/* Fade out last line */
 .dashboard .flex-items-baseline .f6.mt-2 {
 	opacity: 0.5;
 }


### PR DESCRIPTION
Fixes #1859 and follows #1824.

I think I got to a good point. This matches the "Recent activity" box style at the top of the page.

<img width="562" alt="Screenshot 2019-03-15 at 08 58 39" src="https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png">

And it also works decently for organization events:

<img width="549" alt="Screenshot 2019-03-15 at 09 02 00" src="https://user-images.githubusercontent.com/1402241/54401122-43d3bc80-4701-11e9-8215-b317512bc3a5.png">

Comment events still show a lot of duplicate info, but I don't look at them enough (or at all) to care to improve it (and maintain it)