### PR TITLE
Make `hide-useless-newsfeed-events` more reliable

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -160,7 +160,7 @@ a .commit-ref:hover span {
 	opacity: 1;
 }
 
-/* 
+/*
 For `hide-useless-newsfeed-events`
 Hide news items when people:
 pushed to a branch

--- a/source/content.css
+++ b/source/content.css
@@ -160,17 +160,19 @@ a .commit-ref:hover span {
 	opacity: 1;
 }
 
-/* Hide news items when people:
+/* 
+For `hide-useless-newsfeed-events`
+Hide news items when people:
 pushed to a branch
 deleted a branch
 added someone as a collaborator
 forked a repo
 followed someone
 */
-.rgh-no-useless-events .push,
-.rgh-no-useless-events .fork,
-.rgh-no-useless-events .delete,
-.rgh-no-useless-events .follow {
+.rgh-no-useless-events .news .push,
+.rgh-no-useless-events .news .fork,
+.rgh-no-useless-events .news .delete,
+.rgh-no-useless-events .news .follow {
 	display: none !important;
 }
 

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -1,4 +1,3 @@
-import select from 'select-dom';
 import features from '../libs/features';
 
 function init() {

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import features from '../libs/features';
 
 function init() {
-	select('.news').classList.add('rgh-no-useless-events');
+	document.body.classList.add('rgh-no-useless-events');
 }
 
 features.add({


### PR DESCRIPTION
`.news` might not be available on domReady in the new dashboard
