### PR TITLE
Add `parse-backticks` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [The PR/issues search box expands when focused.](https://user-images.githubusercontent.com/1402241/48473156-7ab8c500-e82a-11e8-95c7-a39b0529fe1b.gif)
 - [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
+- [\`Code in backticks\` is highlighted in issue titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
 
 And [many more…](source/content.css)
 

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [The PR/issues search box expands when focused.](https://user-images.githubusercontent.com/1402241/48473156-7ab8c500-e82a-11e8-95c7-a39b0529fe1b.gif)
 - [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
-- [\`Code in backticks\` is highlighted in issue titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [Text wrapped in backticks in issue titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
 
 And [many more…](source/content.css)
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -65,6 +65,7 @@ import './features/hide-issue-list-autocomplete';
 import './features/show-recently-pushed-branches-on-more-pages';
 import './features/create-release-shortcut';
 import './features/patch-diff-links';
+import './features/parse-backticks';
 import './features/swap-branches-on-compare';
 import './features/reactions-avatars';
 import './features/show-names';

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,3 +1,7 @@
+/*
+`code in backticks` that appears in issue titles will be parsed as Markdown
+https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png
+*/
 import select from 'select-dom';
 import React from 'dom-chef';
 import features from '../libs/features';

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,0 +1,40 @@
+import select from 'select-dom';
+import React from 'dom-chef';
+import features from '../libs/features';
+import getTextNodes from '../libs/get-text-nodes';
+
+const splittingRegex = /`(.*?)`/g;
+
+function splitTextReducer(frag, text, index) {
+	if (index % 2 && text.length >= 1) {
+		// Code is always in odd positions
+		frag.append(<code>{text}</code>);
+	} else if (text.length > 0) {
+		frag.append(text);
+	}
+
+	return frag;
+}
+
+function init() {
+	for (const title of select.all('.issues-listing .js-navigation-open')) {
+		for (const node of getTextNodes(title)) {
+			const frag = node.textContent
+				.split(splittingRegex)
+				.reduce(splitTextReducer, new DocumentFragment());
+
+			if (frag.children.length > 0) {
+				node.replaceWith(frag);
+			}
+		}
+	}
+}
+
+features.add({
+	id: 'parse-backticks',
+	include: [
+		features.isIssueList
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -5,15 +5,22 @@ import getTextNodes from '../libs/get-text-nodes';
 
 const splittingRegex = /`(.*?)`/g;
 
-function splitTextReducer(frag, text, index) {
+function splitTextReducer(fragment, text, index) {
+	// Code is always in odd positions
 	if (index % 2 && text.length >= 1) {
-		// Code is always in odd positions
-		frag.append(<code>{text}</code>);
+		// `span.sr-only` keeps the backticks copy-pastable but invisible
+		fragment.append(
+			<code>
+				<span class="sr-only">`</span>
+				{text}
+				<span class="sr-only">`</span>
+			</code>
+		);
 	} else if (text.length > 0) {
-		frag.append(text);
+		fragment.append(text);
 	}
 
-	return frag;
+	return fragment;
 }
 
 function init() {

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -24,6 +24,8 @@ function init() {
 				.reduce(splitTextReducer, new DocumentFragment());
 
 			if (frag.children.length > 0) {
+				node.parentElement.classList.add('markdown-body');
+				node.parentElement.style.lineHeight = 'inherit';
 				node.replaceWith(frag);
 			}
 		}


### PR DESCRIPTION
This feature will convert \`code\` into `code` where applicable. **Currently it only looks for it in issue titles,** but it can be expanded (hence the very generic name)

The style is TBD. 

- Should the backticks stay?
- Should the text size be increased? 
- Should the background be turned gray?

**Edit: no, yes, yes; see next comment**

# Test

https://github.com/sindresorhus/np/issues

# Before

<img width="497" alt="before" src="https://user-images.githubusercontent.com/1402241/54806919-7d369a00-4cb6-11e9-8962-b58ec7f0b2e6.png">

# After

<details><summary>Edit: discarded, see next comment</summary>
<img width="508" alt="after" src="https://user-images.githubusercontent.com/1402241/54806920-7d369a00-4cb6-11e9-8ac5-5b4653d32fda.png">

