### PR TITLE
Meta: Run tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
 	"private": true,
 	"scripts": {
-		"lint": "xo && stylelint source/*.css",
-		"lint-fix": "xo --fix; stylelint --fix source/*.css",
-		"test": "npm run lint && ava && run-s build",
+		"lint": "run-p --silent lint:*",
+		"lint:js": "xo",
+		"lint:css": "stylelint source/*.css",
+		"lint-fix": "run-p --silent 'lint:* -- --fix'",
+		"test": "run-p --silent test:js lint:* build",
+		"test:js": "ava",
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
 		"release:amo": "cd distribution && web-ext-submit",


### PR DESCRIPTION
`real` time almost halved:

```diff
  ❯ time npm run test
  ...

-        11.83 real        19.58 user         1.91 sys
+         6.42 real        24.42 user         2.35 sys
```