### PR TITLE
Restore `branch-buttons` feature

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -649,8 +649,13 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	float: left;
 	margin-left: 5px;
 	margin-right: 5px;
-	margin-bottom: 10px; /* Eases wrapping with on long breadcrumbs */
 }
+
+/* Hide `New pull request1 button` near file list */
+.file-navigation .new-pull-request-btn {
+	display: none;
+}
+
 /* Undo conflicting GitHub style */
 :root .rgh-branch-buttons .BtnGroup {
 	margin-bottom: 0;


### PR DESCRIPTION
These buttons have been missing:

<img width="369" alt="Screenshot 2019-03-23 at 02 39 10" src="https://user-images.githubusercontent.com/1402241/54846654-53fa2600-4d17-11e9-9eb0-2b501b2f9a6e.png">

# Test

https://github.com/babel/babel/tree/v7.4.2
https://github.com/sindresorhus/refined-github/blob/a759d4346e5ac4a98c9fdb2734cdae625de0f309/source/content.css
https://github.com/babel/babel/blob/master/.editorconfig