### PR TITLE
Wider search field

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -166,7 +166,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [The `Expand diff` button is widened.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 - [Dropdown menus are automatically closed when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
 - [Inactive deployments in PR timelines are hidden.](https://github.com/sindresorhus/refined-github/issues/1144)
-- [The PR/issues search box expands when focused.](https://user-images.githubusercontent.com/1402241/48473156-7ab8c500-e82a-11e8-95c7-a39b0529fe1b.gif)
+- [The PR/issues search box is wider.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
 - [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 

--- a/source/content.css
+++ b/source/content.css
@@ -501,6 +501,25 @@ div.inline-comment-form .form-actions,
 	width: auto;
 }
 
+/* Hide `Filters` text in repo lists */
+.issues-listing .subnav-search-context summary {
+	display: flex;
+	width: 2.4em;
+	text-indent: -10000px;
+}
+
+/* Hide `Filters` text in repo lists: center dropdown triangle */
+.issues-listing .subnav-search-context summary:after {
+	float: right;
+	margin-top: 0.6em;
+	transform: scale(1.2);
+}
+
+/* Hide icons in `Labels`/`Milestones` buttons */
+.issues-listing .subnav-item svg {
+	display: none;
+}
+
 /* Remove Marketplace marketing box on PRs */
 .js-marketplace-callout-container {
 	display: none !important;

--- a/source/content.css
+++ b/source/content.css
@@ -480,46 +480,25 @@ div.inline-comment-form .form-actions,
 	padding: 6px 9px;
 }
 
-/* Extend issue search input width when focused */
-.subnav-search {
-	width: 320px; /* Original width on GitHub */
+/* Expand issue search field width */
+.issues-listing .subnav,
+.issues-listing .subnav-search,
+.issues-listing .subnav-search-input,
+.issues-listing .subnav [role="search"],
+:not(.repository-content) > .issues-listing .subnav > .float-right { /* Global search field container */
+	flex-grow: 1;
+	display: flex;
 }
-.subnav-search .subnav-search-input {
-	position: relative;
-	z-index: 2;
-	transition: 0.2s ease-out;
-	transition-property: width, padding-left;
+
+/* Move `New issue` button back to the right */
+.issues-listing .subnav .btn-primary {
+	order: 100;
+	margin-left: 20px
 }
-.subnav-search .subnav-search-input:focus {
-	width: 900px;
-}
-.subnav-search .subnav-search-icon {
-	z-index: 2; /* Ensure that it stays over the input */
-}
-.float-right .subnav-search {
-	width: 420px; /* Original: 500px; Decrease the size of the search box to fit 'Yours' menu item */
-}
-.float-right .subnav-search-input {
-	width: 100%;
-	float: right;
-}
-.float-right .subnav-search-input:focus {
-	padding-left: 8px;
-}
-.float-right .subnav-search-input:focus + .subnav-search-icon {
-	display: none; /* When aligned right, the icon will stay in the wrong position, so hide it */
-}
-/* Seach field on the projects page */
-.project-header-controls,
-.project-header-search,
-.project-header-search .subnav-search,
-.project-header-search .subnav-search-input:focus {
-	width: 100%;
-}
-@media (min-width: 1012px) {
-	.project-header-search {
-		padding-left: 24px;
-	}
+
+/* Reset width of search field in global lists */
+.issues-listing .subnav-search-input-wide {
+	width: auto;
 }
 
 /* Remove Marketplace marketing box on PRs */

--- a/source/content.css
+++ b/source/content.css
@@ -484,7 +484,7 @@ div.inline-comment-form .form-actions,
 .issues-listing .subnav,
 .issues-listing .subnav-search,
 .issues-listing .subnav-search-input,
-.issues-listing .subnav [role="search"],
+.issues-listing .subnav [role='search'],
 :not(.repository-content) > .issues-listing .subnav > .float-right { /* Global search field container */
 	flex-grow: 1;
 	display: flex;
@@ -493,7 +493,7 @@ div.inline-comment-form .form-actions,
 /* Move `New issue` button back to the right */
 .issues-listing .subnav .btn-primary {
 	order: 100;
-	margin-left: 20px
+	margin-left: 20px;
 }
 
 /* Reset width of search field in global lists */
@@ -509,7 +509,7 @@ div.inline-comment-form .form-actions,
 }
 
 /* Hide `Filters` text in repo lists: center dropdown triangle */
-.issues-listing .subnav-search-context summary:after {
+.issues-listing .subnav-search-context summary::after {
 	float: right;
 	margin-top: 0.6em;
 	transform: scale(1.2);


### PR DESCRIPTION
Before/after. Negligible change in the global list page, but those filters on `/pulls` are starting to feel too many, maybe they should be turned into a dropdown.

![before](https://user-images.githubusercontent.com/1402241/55058982-a9805b00-50a8-11e9-87f5-c8dcd50f99ab.png)
![after](https://user-images.githubusercontent.com/1402241/55058985-aa18f180-50a8-11e9-9d0b-0456d33ee93f.png)



# Test

Global: https://github.com/pulls
Repo: https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc