### PR TITLE
[bug] Fix useful-not-found-page on GHE

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -99,7 +99,7 @@ function init() {
 		}
 	}
 
-	select('main > :first-child').after(bar);
+	select('main > :first-child, #parallax_illustration').after(bar);
 
 	// Check parts from right to left; skip the last part
 	for (let i = bar.children.length - 2; i >= 0; i--) {


### PR DESCRIPTION
GHE still has super old 404 page markup and `main` does not exist. Updating the selector allows both GH and GHE to utilize this feature. Tested on GHE 2.16.4.

![image](https://user-images.githubusercontent.com/857700/55169191-5a870400-5142-11e9-98dd-7f9c7bc79b95.png)
