### PR TITLE
[bug] Fix null pointer error on GHE Projects page

### DIFF
--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -259,6 +259,7 @@ async function updateUnreadIndicator() {
 	if (!statusMark) {
 		return;
 	}
+
 	const hasRealNotifications = icon.matches('[data-ga-click$=":unread"]');
 	const rghUnreadCount = (await getNotifications()).length;
 

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -256,6 +256,9 @@ async function updateUnreadIndicator() {
 	}
 
 	const statusMark = icon.querySelector('.mail-status');
+	if (!statusMark) {
+		return;
+	}
 	const hasRealNotifications = icon.matches('[data-ga-click$=":unread"]');
 	const rghUnreadCount = (await getNotifications()).length;
 


### PR DESCRIPTION
For some reason a few pages in GHE, mainly projects, has different markup for the notification icon which doesn't have the `mail-class` list resulting in an error when we try to reference this `statusMark.classList.toggle('unread', hasUnread);` later.

Sample wrong markup:
```html
<a href="X" class="notification-indicator d-md-none mr-3" aria-label="Create new project">
  <svg height="22" class="octicon octicon-plus" viewBox="0 0 12 16" version="1.1" width="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 9H7v5H5V9H0V7h5V2h2v5h5v2z"></path></svg>
</a>
```

GHE hasn't had notifications until a recent release, so likely a miss on their end.

<!--

The more the merrier! 🍻 Thanks for contributing!

1. List some URLs that reviewers can use to test your PR

2. Make sure you specify the issue you're fixing/closing, if any, following this format:

Fixes #123
Closes #56

-->
