### PR TITLE
Support `follow-file-renames` on GHE (v2.16.4)

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -19,7 +19,7 @@ async function findRename(
 }
 
 async function init(): Promise<false | void> {
-	const disabledPagination = select.all('.paginate-container [disabled]');
+	const disabledPagination = select.all('.paginate-container [disabled], .paginate-container .disabled');
 
 	if (disabledPagination.length === 0) {
 		return false;


### PR DESCRIPTION
On GHE (v2.16.4) the disabled pagination "buttons" are not buttons, rather span elements

GHE (v2.16.4):
```
<span class="disabled">Newer</span>
```

Github:
```
<button class="btn btn-outline BtnGroup-item" disabled="disabled">Newer</button>
```