### PR TITLE
Fix `reactions-avatars` for new elements

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -76,6 +76,6 @@ features.add({
 	include: [
 		features.hasComments
 	],
-	load: features.onAjaxedPages,
+	load: features.onNewComments,
 	init
 });


### PR DESCRIPTION
This PR fixes #1888 by changing the `load` definition of the `reactions-avatars` feature from `onAjaxedPages` to `onNewComments`.

As mentioned in the issue, a page to test this would be [sindresorhus/eslint-plugin-unicorn#169](https://github.com/sindresorhus/eslint-plugin-unicorn/issues/169), search for "hidden items" and click the according element to reveal new comments and have their reaction avatars attached.