### PR TITLE
Add `oldest-newest-commit-list` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -106,6 +106,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Add co-authors when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
 - [Search for issues and PRs separately in the top search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
 - [View the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
+- [Add Oldest and Newest buttons to commit list pagination.](https://user-images.githubusercontent.com/9721664/56057052-920ec680-5d66-11e9-9ab8-a8df22e8bc10.png)
 
 ### More actions
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -94,6 +94,7 @@ import './features/hide-watch-and-fork-count';
 import './features/resolve-conflicts';
 import './features/follow-file-renames';
 import './features/edit-files-faster';
+import './features/oldest-newest-commit-list';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/oldest-newest-commit-list.tsx
+++ b/source/features/oldest-newest-commit-list.tsx
@@ -1,8 +1,8 @@
 import React from 'dom-chef';
+import select from 'select-dom';
 import * as api from '../libs/api';
 import features from '../libs/features';
-import select from 'select-dom';
-import { getRepoURL } from '../libs/utils';
+import {getRepoURL} from '../libs/utils';
 
 const commitsResponsePerPage = 30;
 const commitListPerPage = 35;
@@ -11,16 +11,16 @@ const lastPageRegex = /next.*page=(\d+)/;
 
 async function getLastPage(): Promise<number> {
 	const url = `${api.api3}repos/${getRepoURL()}/commits?sha=`;
-	const response = await fetch(url, { method: 'head' });
+	const response = await fetch(url, {method: 'head'});
 
 	const paginationLinks = response.headers.get('link') || '';
 	const lastPageMatches = paginationLinks.match(lastPageRegex);
 
-	return lastPageMatches ? +lastPageMatches[1] : 1;
+	return lastPageMatches ? Number(lastPageMatches[1]) : 1;
 }
 
 function calculateLastPage(lastPage: number, lastPageItems: number) {
-	const totalCommits = (lastPage - 1) * commitsResponsePerPage + lastPageItems;
+	const totalCommits = ((lastPage - 1) * commitsResponsePerPage) + lastPageItems;
 
 	return Math.ceil(totalCommits / commitListPerPage);
 }
@@ -29,14 +29,14 @@ async function getLastPageUrl(): Promise<string> {
 	const lastPage = await getLastPage();
 	const response = await api.v3(`repos/${getRepoURL()}/commits?sha=&page=${lastPage}`);
 
-	const commitListLastPage = calculateLastPage(+lastPage, response.length);
+	const commitListLastPage = calculateLastPage(Number(lastPage), response.length);
 
 	return `${location.pathname}?page=${commitListLastPage}`;
 }
 
-function createButton(text: string, link: string, disabled: boolean): HTMLElement {
+function createButton(text: string, link: string, disabled: boolean): Element {
 	const button = (
-		<a rel="nofollow" class="btn btn-outline BtnGroup-item" href={link}>
+		<a rel="nofollow" className="btn btn-outline BtnGroup-item" href={link}>
 			{text}
 		</a>
 	);
@@ -52,18 +52,18 @@ async function addButtonsToPaginate(buttonGroup: HTMLElement) {
 	const firstPageUrl = location.pathname;
 	const lastPageUrl = await getLastPageUrl();
 
-	const newerButton = buttonGroup.firstElementChild;
-	const olderButton = buttonGroup.lastElementChild;
+	const newerButton = buttonGroup.firstElementChild as Element;
+	const olderButton = buttonGroup.lastElementChild as Element;
 
 	const newestButton = createButton(
 		'< Newest',
 		firstPageUrl,
-		!!newerButton.getAttribute('disabled')
+		Boolean(newerButton.getAttribute('disabled'))
 	);
 	const oldestButton = createButton(
 		'Oldest >',
 		lastPageUrl,
-		!!olderButton.getAttribute('disabled')
+		Boolean(olderButton.getAttribute('disabled'))
 	);
 
 	buttonGroup.prepend(newestButton);

--- a/source/features/oldest-newest-commit-list.tsx
+++ b/source/features/oldest-newest-commit-list.tsx
@@ -1,0 +1,88 @@
+import React from 'dom-chef';
+import * as api from '../libs/api';
+import features from '../libs/features';
+import select from 'select-dom';
+import { getRepoURL } from '../libs/utils';
+
+const commitsResponsePerPage = 30;
+const commitListPerPage = 35;
+
+const lastPageRegex = /next.*page=(\d+)/;
+
+async function getLastPage(): Promise<number> {
+	const url = `${api.api3}repos/${getRepoURL()}/commits?sha=`;
+	const response = await fetch(url, { method: 'head' });
+
+	const paginationLinks = response.headers.get('link') || '';
+	const lastPageMatches = paginationLinks.match(lastPageRegex);
+
+	return lastPageMatches ? +lastPageMatches[1] : 1;
+}
+
+function calculateLastPage(lastPage: number, lastPageItems: number) {
+	const totalCommits = (lastPage - 1) * commitsResponsePerPage + lastPageItems;
+
+	return Math.ceil(totalCommits / commitListPerPage);
+}
+
+async function getLastPageUrl(): Promise<string> {
+	const lastPage = await getLastPage();
+	const response = await api.v3(`repos/${getRepoURL()}/commits?sha=&page=${lastPage}`);
+
+	const commitListLastPage = calculateLastPage(+lastPage, response.length);
+
+	return `${location.pathname}?page=${commitListLastPage}`;
+}
+
+function createButton(text: string, link: string, disabled: boolean): HTMLElement {
+	const button = (
+		<a rel="nofollow" class="btn btn-outline BtnGroup-item" href={link}>
+			{text}
+		</a>
+	);
+
+	if (disabled) {
+		button.classList.add('disabled');
+	}
+
+	return button;
+}
+
+async function addButtonsToPaginate(buttonGroup: HTMLElement) {
+	const firstPageUrl = location.pathname;
+	const lastPageUrl = await getLastPageUrl();
+
+	const newerButton = buttonGroup.firstElementChild;
+	const olderButton = buttonGroup.lastElementChild;
+
+	const newestButton = createButton(
+		'< Newest',
+		firstPageUrl,
+		!!newerButton.getAttribute('disabled')
+	);
+	const oldestButton = createButton(
+		'Oldest >',
+		lastPageUrl,
+		!!olderButton.getAttribute('disabled')
+	);
+
+	buttonGroup.prepend(newestButton);
+	buttonGroup.append(oldestButton);
+}
+
+async function init() {
+	const buttonGroup = select('.paginate-container .BtnGroup');
+
+	if (!buttonGroup) {
+		return;
+	}
+
+	await addButtonsToPaginate(buttonGroup);
+}
+
+features.add({
+	id: 'oldest-newest-commit-list',
+	include: [features.isCommitList],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -55,7 +55,7 @@ export class RefinedGitHubAPIError extends Error {
 
 const settings = new OptionsSync().getAll();
 
-const api3 = location.hostname === 'github.com' ?
+export const api3 = location.hostname === 'github.com' ?
 	'https://api.github.com/' :
 	`${location.origin}/api/v3/`;
 const api4 = location.hostname === 'github.com' ?


### PR DESCRIPTION
This feature adds two new links (Oldest and Newest) to the commit list pagination.
The `api3` url is now exposed because I didn't want to make too many changes to support `head` requests.

# Test
https://github.com/sindresorhus/refined-github/commits/master

# Before
![image](https://user-images.githubusercontent.com/9721664/56057035-858a6e00-5d66-11e9-9927-d6144e637b76.png)

# After
![image](https://user-images.githubusercontent.com/9721664/56057052-920ec680-5d66-11e9-9ab8-a8df22e8bc10.png)

