### PR TITLE
Various fixes for `global-discussion-list-filters` feature

### DIFF
--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -5,7 +5,14 @@ import {getUsername} from '../libs/utils';
 
 function init() {
 	const defaultQuery = 'is:open archived:false ';
-	const type = location.pathname === '/issues' ? ' is:issue' : ''; // Without this, the Issues page also displays PRs
+
+	// Without this, the Issues page also displays PRs, and viceversa
+	const types: { [path: string]: string } = {
+		'/issues': 'is:issue ',
+		'/pulls': 'is:pr '
+	};
+	const type = types[location.pathname] || '';
+
 	const links = [
 		['Commented', `commenter:${getUsername()}`],
 		['Yours', `user:${getUsername()}`]
@@ -13,7 +20,7 @@ function init() {
 
 	for (const [label, query] of links) {
 		// Create link
-		const url = new URLSearchParams([['q', defaultQuery + query + type]]);
+		const url = new URLSearchParams([['q', type + defaultQuery + query]]);
 		const link = <a href={`?${url}`} className="subnav-item">{label}</a>;
 
 		// Create regex for current query, including possible spaces around it

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -7,7 +7,7 @@ function init() {
 	const defaultQuery = 'is:open archived:false ';
 
 	// Without this, the Issues page also displays PRs, and viceversa
-	const type = location.pathname === '/issues' ? 'is:issues ' : 'is:pr ';
+	const type = location.pathname === '/issues' ? 'is:issue ' : 'is:pr ';
 
 	const links = [
 		['Commented', `commenter:${getUsername()}`],

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -19,9 +19,9 @@ function init() {
 		const url = new URLSearchParams([['q', type + defaultQuery + query]]);
 		const link = <a href={`?${url}`} className="subnav-item">{label}</a>;
 
-		// Create regex for current query, including possible spaces around it
-		const queryRegex = new RegExp(`(^|\\s)${query}(\\s|$)`);
-		const isCurrentPage = queryRegex.test(new URLSearchParams(location.search).get('q')!);
+		const isCurrentPage = new RegExp(`(^|\\s)${query}(\\s|$)`).test(
+			new URLSearchParams(location.search).get('q')!
+		);
 
 		// Highlight it, if that's the current page
 		if (isCurrentPage && !select.exists('.subnav-links .selected')) {

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -7,11 +7,7 @@ function init() {
 	const defaultQuery = 'is:open archived:false ';
 
 	// Without this, the Issues page also displays PRs, and viceversa
-	const types: { [path: string]: string } = {
-		'/issues': 'is:issue ',
-		'/pulls': 'is:pr '
-	};
-	const type = types[location.pathname] || '';
+	const type = location.pathname === '/issues' ? 'is:issues ' : 'is:pr ';
 
 	const links = [
 		['Commented', `commenter:${getUsername()}`],

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -17,7 +17,7 @@ function init() {
 		const link = <a href={`?${url}`} className="subnav-item">{label}</a>;
 
 		// Create regex for current query, including possible spaces around it
-		const queryRegex = new RegExp(`(^|\\s)?${query}(\\s|$)?`);
+		const queryRegex = new RegExp(`(^|\\s)${query}(\\s|$)`);
 		const isCurrentPage = queryRegex.test(new URLSearchParams(location.search).get('q')!);
 
 		// Highlight it, if that's the current page

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -5,7 +5,7 @@ import {getUsername} from '../libs/utils';
 
 function init() {
 	const defaultQuery = 'is:open archived:false ';
-	const type = location.pathname === '/issues' ? ' is:issues' : ''; // Without this, the Issues page also displays PRs
+	const type = location.pathname === '/issues' ? ' is:issue' : ''; // Without this, the Issues page also displays PRs
 	const links = [
 		['Commented', `commenter:${getUsername()}`],
 		['Yours', `user:${getUsername()}`]

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -16,7 +16,7 @@ function init() {
 		const url = new URLSearchParams([['q', defaultQuery + query + type]]);
 		const link = <a href={`?${url}`} className="subnav-item">{label}</a>;
 
-		// Create regex for current query, including possible spaces around it, to drop it in .replace()
+		// Create regex for current query, including possible spaces around it
 		const queryRegex = new RegExp(`(^|\\s)?${query}(\\s|$)?`);
 		const isCurrentPage = queryRegex.test(new URLSearchParams(location.search).get('q')!);
 
@@ -27,7 +27,7 @@ function init() {
 			// Other links will keep the current query, that's not what we want
 			for (const otherLink of select.all<HTMLAnchorElement>('.subnav-links a')) {
 				const search = new URLSearchParams(otherLink.search);
-				search.set('q', search.get('q')!.replace(queryRegex, ''));
+				search.set('q', search.get('q')!.split(' ').filter(s => s !== query).join(' '));
 				otherLink.search = String(search);
 			}
 		}

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -17,7 +17,7 @@ function init() {
 	for (const [label, query] of links) {
 		// Create link
 		const url = new URLSearchParams([['q', type + defaultQuery + query]]);
-		const link = <a href={`?${url}`} className="subnav-item">{label}</a>;
+		const link = <a href={`${location.pathname}?${url}`} className="subnav-item">{label}</a>;
 
 		const isCurrentPage = new RegExp(`(^|\\s)${query}(\\s|$)`).test(
 			new URLSearchParams(location.search).get('q')!


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/1919

Links to reproduce: global [Pull Requests](https://github.com/pulls) or [Issues](https://github.com/issues), then click either the `Commented` or `Yours` button.

Things this PR fixes:

1. In the global Issues page, the proper parameter is put in the URL so the filter is correct (i.e. pull requests don't appear as well).

2. When in a `Commented` or `Yours` query, the added query parameter is removed correctly from the rest of the buttons URLs (`Created`, `Assigned`, `Mentioned` and `Review requests`). The previous behaviors removed one space too many leading to parameters joined together. Fixes #1919.

3. When the query parameters contained a malformed query, the `Commented` or `Yours` buttons don't light up. For example, if the query contains `commented:username-and-something-else`, the regex doesn't match now, as opposed to it matching previously and highlighting the `Commented` button.

4. In the global Pull Requests page, the `Commented` and `Yours` buttons also include in the query the parameter `is:pr`, as was done for `is:issue` (fix 1) in the Issues page.

These fixes are listed in the order of the commits.

cc @bfred-it