### PR TITLE
sorting params issues/pr affecting top navbar

### DIFF
--- a/source/features/sort-issues-by-update-time.tsx
+++ b/source/features/sort-issues-by-update-time.tsx
@@ -29,8 +29,8 @@ function getDefaultQuery(link, search) {
 function init() {
 	// Get issues links that don't already have a specific sorting applied
 	for (const link of select.all<HTMLAnchorElement>(`
-		[href*="/issues"]:not([href*="sort%3A"]):not(.issues-reset-query),
-		[href*="/pulls" ]:not([href*="sort%3A"]):not(.issues-reset-query)
+		a[href*="/issues"]:not([href*="sort%3A"]):not(.issues-reset-query),
+		a[href*="/pulls" ]:not([href*="sort%3A"]):not(.issues-reset-query)
 	`)) {
 		// Pick only links to lists, not single issues
 		// + skip pagination links


### PR DESCRIPTION
I did this by narrowing down selectors to links. the sorting still works. Open issues tab.

fixes #1253
it's strongly emphasised that the bug should be fixed, with the suggestion that the whole behaviour of feature could be refined in what it manifests.

<!--

The more the merrier! 🍻 Thanks for contributing!

1. List some URLs that reviewers can use to test your PR

2. Make sure you specify the issue you're fixing/closing, if any, following this format:

Fixes #123
Closes #56

-->
