### PR TITLE
Fix `pr-branches` and `remove-projects-tab` features

### DIFF
--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -97,7 +97,7 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
-	// If buttons are already added. Don't add again.
+	// If buttons are already added, don't add again.
 	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
 	if (select.exists('.rgh-branch-buttons')) {
 		return false;

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -121,7 +121,7 @@ async function init(): Promise<false | void> {
 features.add({
 	id: 'branch-buttons',
 	include: [
-		features.isRepoRoot,
+		features.isRepoTree,
 		features.isSingleFile
 	],
 	load: features.onAjaxedPages,

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -128,7 +128,7 @@ features.add({
 	id: 'branch-buttons',
 	include: [
 		features.isRepoRoot,
-		features.isSingleFile,
+		features.isSingleFile
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -121,7 +121,8 @@ async function init(): Promise<false | void> {
 features.add({
 	id: 'branch-buttons',
 	include: [
-		features.isRepo
+		features.isRepoRoot,
+		features.isSingleFile,
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -97,12 +97,6 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
-	// If buttons are already added, don't add again.
-	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
-	if (select.exists('.rgh-branch-buttons')) {
-		return false;
-	}
-
 	const [defaultLink = '', tagLink = ''] = await Promise.all([
 		getDefaultBranchLink(),
 		getTagLink()

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -97,6 +97,12 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
+	// If buttons are already added. Don't add again.
+	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
+	if (select.exists('.rgh-branch-buttons')) {
+		return false;
+	}
+
 	const [defaultLink = '', tagLink = ''] = await Promise.all([
 		getDefaultBranchLink(),
 		getTagLink()

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -73,7 +73,7 @@ function buildQuery(issueIds: string[]) {
 	return `{
 		repository(owner: "${ownerName}", name: "${repoName}") {
 			${issueIds.map(id => `
-				${id}: pullRequest(number: ${String(id).replace('issue_', '')}) {
+				${id}: pullRequest(number: ${id.replace('issue_', '')}) {
 					baseRef {id}
 					headRef {id}
 					baseRefName

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -67,13 +67,13 @@ function normalizeBranchInfo(data: BranchInfo): {
 	};
 }
 
-function buildQuery(numbers: number[]) {
+function buildQuery(issueIds: string[]) {
 	const {ownerName, repoName} = getOwnerAndRepo();
 
 	return `{
 		repository(owner: "${ownerName}", name: "${repoName}") {
-			${numbers.map(number => `
-				${number}: pullRequest(number: ${String(number).replace('issue_', '')}) {
+			${issueIds.map(id => `
+				${id}: pullRequest(number: ${String(id).replace('issue_', '')}) {
 					baseRef {id}
 					headRef {id}
 					baseRefName
@@ -109,7 +109,7 @@ async function init(): Promise<false | void> {
 	}
 
 	const {ownerName} = getOwnerAndRepo();
-	const query = buildQuery(elements.map(pr => Number(pr.id)));
+	const query = buildQuery(elements.map(pr => pr.id));
 	const [data, defaultBranch] = await Promise.all([
 		api.v4(query),
 		getDefaultBranch()

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -32,12 +32,6 @@ function updateReleasesCount() {
 }
 
 async function init(): Promise<false | void> {
-	// If tab item is already added, don't add again.
-	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
-	if (select.exists('.rgh-releases-tab')) {
-		return false;
-	}
-
 	await safeElementReady('.pagehead + *'); // Wait for the tab bar to be loaded
 	const count = await updateReleasesCount();
 	if (count === 0) {
@@ -45,7 +39,7 @@ async function init(): Promise<false | void> {
 	}
 
 	const releasesTab = (
-		<a href={`/${repoUrl}/releases`} className="reponav-item rgh-releases-tab" data-hotkey="g r">
+		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r">
 			{icons.tag()}
 			<span> Releases </span>
 			{count === undefined ? '' : <span className="Counter">{count}</span>}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -32,6 +32,12 @@ function updateReleasesCount() {
 }
 
 async function init(): Promise<false | void> {
+	// If tab item is already added. Don't add again.
+	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
+	if (select.exists('.rgh-releases-tab')) {
+		return false;
+	}
+
 	await safeElementReady('.pagehead + *'); // Wait for the tab bar to be loaded
 	const count = await updateReleasesCount();
 	if (count === 0) {
@@ -39,7 +45,7 @@ async function init(): Promise<false | void> {
 	}
 
 	const releasesTab = (
-		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r">
+		<a href={`/${repoUrl}/releases`} className="reponav-item rgh-releases-tab" data-hotkey="g r">
 			{icons.tag()}
 			<span> Releases </span>
 			{count === undefined ? '' : <span className="Counter">{count}</span>}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -32,7 +32,7 @@ function updateReleasesCount() {
 }
 
 async function init(): Promise<false | void> {
-	// If tab item is already added. Don't add again.
+	// If tab item is already added, don't add again.
 	// https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946
 	if (select.exists('.rgh-releases-tab')) {
 		return false;

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -31,7 +31,7 @@ const addNewProjectLink = onetime(() => {
 	// https://github.com/USER/REPO/projects/new
 	const path = location.pathname.split('/', 3);
 	const base = path.length > 2 ? path.join('/') : '/orgs' + path.join('/');
-	select('.HeaderMenu [href="/new"]')!.parentElement!.append(
+	select('.Header [href="/new"]')!.parentElement!.append(
 		<a className="dropdown-item" href={base + '/projects/new'}>
 			New project
 		</a>


### PR DESCRIPTION
1. `pr-branches`: 
   - An alphanumeric string was being passed to `Number()` causing it to return `NaN` and eventually lead to failure of GraphQL query.
   - https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946

2. `remove-projects-tab`: Selector was renamed from `HeaderMenu` to `Header`.

3. `branch-buttons`: Feature scope was set to `isRepo` so it was breaking on some due to lack of the expected selector. Enabled the features on `isRepoRoot` and `isSingleFile`.

4. `releases-tab`
   - https://github.com/sindresorhus/refined-github/issues/1935#issuecomment-484849946

Fixes #1935
Closes #1935
