### PR TITLE
Drop some TypeScript type assertions

### DIFF
--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -3,8 +3,8 @@ import select from 'select-dom';
 import copyToClipboard from 'copy-text-to-clipboard';
 import features from '../libs/features';
 
-function handleClick({target: button}: React.MouseEvent) {
-	const file = (button as HTMLButtonElement).closest('.Box');
+function handleClick({currentTarget: button}: React.MouseEvent<HTMLButtonElement>) {
+	const file = button.closest('.Box');
 
 	const content = select.all('.blob-code-inner', file!)
 		.map(blob => blob.innerText) // Must be `.innerText`

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -16,7 +16,7 @@ function listener(event: KeyboardEvent) {
 	if (
 		event.key === 'Escape' && // Catch `Esc` key
 		isLineSelected() &&
-		!(event.target as Element).closest('textarea, input') // If a field isn’t focused
+		!(event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLInputElement) // If a field isn’t focused
 	) {
 		location.hash = '#no-line'; // Update UI, without `scroll-to-top` behavior
 		history.replaceState({}, document.title, location.pathname); // Drop remaining # from url

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -16,7 +16,7 @@ const observer = new MutationObserver(([{addedNodes}]) => {
 
 	// Observe the new ajaxed-in containers
 	for (const node of addedNodes) {
-		if ((node as Element).tagName === 'DIV') {
+		if (node instanceof HTMLDivElement) {
 			observer.observe(node, {childList: true});
 		}
 	}

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -45,13 +45,13 @@ function init() {
 	}
 }
 
-function unhide(event: React.MouseEvent) {
+function unhide(event: React.MouseEvent<HTMLButtonElement>) {
 	for (const comment of select.all('.rgh-hidden-comment')) {
 		comment.hidden = false;
 	}
 
 	select('.rgh-hidden-comment')!.scrollIntoView();
-	(event.target as Element).parentElement!.remove();
+	event.currentTarget.parentElement!.remove();
 }
 
 features.add({

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -12,7 +12,7 @@ function add() {
 		const ref = infoBubble
 			.closest('.discussion-item')!
 			.querySelector('.issue-num, .commit-id')!;
-		const link = (ref.closest('[href]') as HTMLAnchorElement).href;
+		const link = ref.closest('a')!.href;
 
 		select('.gh-header-meta .TableObject-item')!.after(
 			<div className="TableObject-item">

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -86,7 +86,7 @@ async function markRead(urls: string|string[]): Promise<void> {
 	await setNotifications(updated);
 }
 
-async function markUnread({target}: React.MouseEvent): Promise<void> {
+async function markUnread({currentTarget}: React.MouseEvent): Promise<void> {
 	const participants: Participant[] = select.all('.participant-avatar').slice(0, 3).map(el => ({
 		username: el.getAttribute('aria-label')!,
 		avatar: el.querySelector('img')!.src
@@ -124,9 +124,8 @@ async function markUnread({target}: React.MouseEvent): Promise<void> {
 	await setNotifications(unreadNotifications);
 	await updateUnreadIndicator();
 
-	// TODO: move type to function parameters, if elegant
-	(target as HTMLButtonElement).setAttribute('disabled', 'disabled');
-	(target as HTMLButtonElement).textContent = 'Marked as unread';
+	currentTarget.setAttribute('disabled', 'disabled');
+	currentTarget.textContent = 'Marked as unread';
 }
 
 function getNotification(notification: Notification): Element {
@@ -301,8 +300,8 @@ async function updateUnreadIndicator(): Promise<void> {
 	}
 }
 
-async function markNotificationRead({target}: DelegateEvent): Promise<void> {
-	const {href} = (target as Element)
+async function markNotificationRead({delegateTarget}: DelegateEvent): Promise<void> {
+	const {href} = delegateTarget
 		.closest('li.js-notification')!
 		.querySelector<HTMLAnchorElement>('a.js-notification-target')!;
 	await markRead(href);
@@ -311,10 +310,17 @@ async function markNotificationRead({target}: DelegateEvent): Promise<void> {
 
 async function markAllNotificationsRead(event: DelegateEvent): Promise<void> {
 	event.preventDefault();
-	const repoGroup = (event.target as Element).closest('.boxed-group')!;
+	const repoGroup = event.delegateTarget.closest('.boxed-group')!;
 	const urls = select.all<HTMLAnchorElement>('a.js-notification-target', repoGroup).map(a => a.href);
 	await markRead(urls);
 	await updateUnreadIndicator();
+}
+
+async function markVisibleNotificationsRead({delegateTarget}: DelegateEvent) {
+	const group = delegateTarget.closest('.boxed-group')!;
+	const repo = select('.notifications-repo-link', group)!.textContent;
+	const notifications = await getNotifications();
+	setNotifications(notifications.filter(({repository}) => repository !== repo));
 }
 
 function addCustomAllReadBtn(): void {
@@ -396,12 +402,7 @@ async function init(): Promise<void> {
 			delegate('.btn-link.delete-note', 'click', markNotificationRead),
 			delegate('.js-mark-all-read', 'click', markAllNotificationsRead),
 			delegate('.js-delete-notification button', 'click', updateUnreadIndicator),
-			delegate('.js-mark-visible-as-read', 'submit', async event => {
-				const group = (event.target as Element).closest('.boxed-group')!;
-				const repo = select('.notifications-repo-link', group)!.textContent;
-				const notifications = await getNotifications();
-				setNotifications(notifications.filter(({repository}) => repository !== repo));
-			})
+			delegate('.js-mark-visible-as-read', 'submit', markVisibleNotificationsRead)
 		);
 	} else if (pageDetect.isPR() || pageDetect.isIssue()) {
 		await markRead(location.href);

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-alert */
 import React from 'dom-chef';
 import select from 'select-dom';
+import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
 import {groupButtons} from '../libs/group-buttons';
@@ -8,13 +9,8 @@ import {groupButtons} from '../libs/group-buttons';
 const confirmationRequiredCount = 10;
 const unreadNotificationsClass = '.unread .js-notification-target';
 
-function openNotifications({target}: Event) {
-	// Homemade delegate event, simplifies addEventListener deduplication
-	if (!(target as Element).closest('.rgh-open-notifications-button')) {
-		return;
-	}
-
-	const container = (target as Element).closest('.boxed-group, .notification-center');
+function openNotifications({delegateTarget}: DelegateEvent) {
+	const container = delegateTarget.closest('.boxed-group, .notification-center');
 
 	// Ask for confirmation
 	const unreadNotifications = select.all<HTMLAnchorElement>(unreadNotificationsClass, container!);
@@ -91,7 +87,7 @@ function update(): void {
 
 function init() {
 	document.addEventListener('refined-github:mark-unread:notifications-added', update);
-	document.addEventListener('click', openNotifications);
+	delegate('.rgh-open-notifications-button', 'click', openNotifications);
 	update();
 }
 

--- a/source/features/scroll-to-top-on-collapse.tsx
+++ b/source/features/scroll-to-top-on-collapse.tsx
@@ -5,8 +5,8 @@ import features from '../libs/features';
 function init() {
 	const toolbar = select('.pr-toolbar')!;
 
-	delegate('.js-diff-progressive-container', '.file', 'details:toggled', ({target}: DelegateEvent<Event>) => {
-		const elOffset = (target as Element).getBoundingClientRect().top;
+	delegate('.js-diff-progressive-container', '.file', 'details:toggled', ({delegateTarget}: DelegateEvent) => {
+		const elOffset = delegateTarget.getBoundingClientRect().top;
 		const toolbarHeight = toolbar.getBoundingClientRect().top;
 
 		// Bring element in view if it's above the PR toolbar

--- a/source/features/upload-button.tsx
+++ b/source/features/upload-button.tsx
@@ -23,9 +23,9 @@ function addButtons() {
 	}
 }
 
-function triggerUploadUI({target}: DelegateEvent) {
-	(target as Element)
-		.closest('form')!
+function triggerUploadUI({delegateTarget}: DelegateEvent<Event, HTMLButtonElement>) {
+	delegateTarget
+		.form!
 		.querySelector<HTMLElement>('.js-manual-file-chooser')! // Find <input [type=file]>
 		.click(); // Open UI
 }

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
-import delegate from 'delegate-it';
+import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 import observeEl from '../libs/simplified-element-observer';
 import * as prCiStatus from '../libs/pr-ci-status';
@@ -58,7 +58,7 @@ function disableForm(disabled = true) {
 	}
 }
 
-async function handleMergeConfirmation(event: Event) {
+async function handleMergeConfirmation(event: DelegateEvent<Event, HTMLButtonElement>) {
 	const checkbox = getCheckbox();
 	if (checkbox && checkbox.checked) {
 		event.preventDefault();
@@ -73,7 +73,7 @@ async function handleMergeConfirmation(event: Event) {
 			disableForm(false);
 
 			if (status === prCiStatus.SUCCESS) {
-				(event.target as HTMLButtonElement).click();
+				event.delegateTarget.click();
 			}
 		}
 	}

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import onetime from 'onetime';
 import {isRepo, isPR, isIssue} from './page-detect';
 
-export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content') as string);
+export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
 export const getDiscussionNumber = () => (isPR() || isIssue()) && getCleanPathname().split('/')[3];
 


### PR DESCRIPTION
In most cases, `target` could be replaced for `currentTarget`, which is correctly typed. Even `currentTarget` is typed by `React.Event` as `EventTarget & TElement`

Currently untested

_Related open TypeScript PRs:_ https://github.com/sindresorhus/refined-github/pull/1947 https://github.com/sindresorhus/refined-github/pull/1943 https://github.com/sindresorhus/refined-github/pull/1936

