### PR TITLE
Allow marking draft PRs as unread

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -390,6 +390,9 @@ td.js-line-comments:last-child .timeline-comment-actions .add-reaction-popover::
 	padding-right: 7px;
 	padding-left: 3px;
 }
+.rgh-unread .notification-actions .age {
+	width: 150px; /* Align with GH's notifications */
+}
 
 /* Change color of marker if there are only discussion marked as unread */
 .notification-indicator[data-ga-click$=':read'] .unread {

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -10,7 +10,7 @@ import {getUsername, getOwnerAndRepo} from '../libs/utils';
 
 // TODO: Pull these types out.
 type NotificationType = 'pull-request' | 'issue';
-type NotificationState = 'open' | 'merged' | 'closed';
+type NotificationState = 'open' | 'merged' | 'closed' | 'draft';
 
 interface Participant {
 	username: string;
@@ -39,7 +39,8 @@ const stateIcons = {
 	'pull-request': {
 		open: icons.openPullRequest,
 		closed: icons.closedPullRequest,
-		merged: icons.mergedPullRequest
+		merged: icons.mergedPullRequest,
+		draft: icons.openPullRequest
 	}
 };
 
@@ -102,6 +103,8 @@ async function markUnread({currentTarget}: React.MouseEvent): Promise<void> {
 		state = 'merged';
 	} else if (stateLabel.classList.contains('State--red')) {
 		state = 'closed';
+	} else if (stateLabel.title.includes('Draft')) {
+		state = 'draft';
 	} else {
 		throw new Error('Refined GitHub: A new issue state was introduced?');
 	}
@@ -163,7 +166,8 @@ function getNotification(notification: Notification): Element {
 				<span className={`type-icon type-icon-state-${state}`}>
 					{stateIcons[type][state]()}
 				</span>
-				<a className="css-truncate-target js-notification-target js-navigation-open list-group-item-link" href={url}>
+				<a className="css-truncate-target js-notification-target js-navigation-open list-group-item-link" href={url}
+					data-hovercard-url={`${url}/hovercard?show_subscription_status=true`}>
 					{title}
 				</a>
 			</span>

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -34,7 +34,8 @@ const stateIcons = {
 	issue: {
 		open: icons.openIssue,
 		closed: icons.closedIssue,
-		merged: icons.closedIssue // Required just for TypeScript
+		merged: icons.closedIssue, // Required just for TypeScript
+		draft: icons.closedIssue // Required just for TypeScript
 	},
 	'pull-request': {
 		open: icons.openPullRequest,


### PR DESCRIPTION
Closes #1954

Using the `title` attribute of status label to detect draft PRs, because status label for draft PRs don't have any additional CSS classes added to them.

-----------------------

Also sneaked some code in to align reaction avatars and last updated labels with GitHub's native notifications, this is because GH notifications have additional "Save for later" button, which we don't add.

<details>
<summary>Misaligned avatars</summary>

![image](https://user-images.githubusercontent.com/37769974/56454259-a73db380-636b-11e9-88ff-e856d775c638.png)

</details>

-----------------------

Another minor change is to add hover-card support to notifications marked as unread.
