### PR TITLE
Wrap code in comments

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -1119,6 +1119,7 @@ body > .footer li a {
 	text-align: center;
 }
 
+
 /* Improve dropdown expansion animation (e.g. top-right dropdown in comments) */
 /* It normally pops in from the center */
 .dropdown-menu-sw {

--- a/source/content.css
+++ b/source/content.css
@@ -1119,6 +1119,12 @@ body > .footer li a {
 	text-align: center;
 }
 
+/* Enable word wrap on code in comments (with line numbers only) */
+.discussion-item-body .blob-num ~ .blob-code-inner, /* Embedded code */
+.discussion-item-body .blob-num ~ .blob-code .blob-code-inner { /* Review diffs and suggestions */
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
 
 /* Improve dropdown expansion animation (e.g. top-right dropdown in comments) */
 /* It normally pops in from the center */


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/1908

Anything else missing?

I avoided wrapping plain <code>```</code> blocks because it might get hard to read without line numbers.