### PR TITLE
Fix filter-by-pr-status when no Pull Requests exist

### DIFF
--- a/source/features/filter-pr-by-build-status.tsx
+++ b/source/features/filter-pr-by-build-status.tsx
@@ -41,6 +41,11 @@ function populateDropDown({currentTarget}: Event): void {
 }
 
 function init(): void {
+	// If there are no PRs then return
+	if (!select('.table-list-filters')) {
+		return;
+	}
+
 	const reviewsFilter = select('.table-list-header-toggle > details:nth-last-child(3)')!;
 
 	// Copy existing element and adapt its content

--- a/source/features/filter-pr-by-build-status.tsx
+++ b/source/features/filter-pr-by-build-status.tsx
@@ -40,13 +40,12 @@ function populateDropDown({currentTarget}: Event): void {
 	}
 }
 
-function init(): void {
-	// If there are no PRs then return
-	if (!select('.table-list-filters')) {
-		return;
-	}
-
+function init(): void | false {
 	const reviewsFilter = select('.table-list-header-toggle > details:nth-last-child(3)')!;
+
+	if (!reviewsFilter) {
+		return false;
+	}
 
 	// Copy existing element and adapt its content
 	const statusFilter = reviewsFilter.cloneNode(true) as HTMLDetailsElement;


### PR DESCRIPTION
<!--

The more the merrier! 🍻 Thanks for contributing!

1. List some URLs that reviewers can use to test your PR

2. Make sure you specify the issue you're fixing/closing, if any, following this format:

Fixes #123
Closes #56

-->

This addresses the issue called out here: https://github.com/sindresorhus/refined-github/pull/1904#issuecomment-485615635

I didn't want to return on the first selector, as if GH changes the DOM, then we won't realize the feature broke as easily.
