### PR TITLE
Fix wrong id in edit-files-faster

### DIFF
--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -27,7 +27,7 @@ function init(): void {
 }
 
 features.add({
-	id: 'edit-comments-faster',
+	id: 'edit-files-faster',
 	include: [
 		features.isRepoTree
 	],


### PR DESCRIPTION
I had an issue with this [extension](https://chrome.google.com/webstore/detail/github-vscode-icons/hoccpcefjcgnabbmojbfoflggkecmpgd) and tried to disable the edit-files-faster feature but it did not work.
So i tried to disable every feature on by on and it work when I disabled edit-comments-faster.
And then I notices that the extension logged twice that this feature was disabled, so I took a look in edit-files-faster.tsx. There I saw that the id was wrong, so this PR fixes this issue.
