### PR TITLE
Hide comment box upload message

### DIFF
--- a/source/features/upload-button.css
+++ b/source/features/upload-button.css
@@ -1,6 +1,6 @@
 /* Remove upload message on comment box */
 .rgh-has-upload-field .is-default .drag-and-drop {
-	display: none;
+	display: none !important;
 }
 
 .rgh-has-upload-field .is-default textarea {


### PR DESCRIPTION
## What

Closes #1992 

## Notes

@bfred-it mentioned [here](https://github.com/sindresorhus/refined-github/issues/1992#issuecomment-487345168) that

> the **!important** is required now because they have a utility class on it