### PR TITLE
Fix `show-names` features when bots are on the page

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -7,7 +7,7 @@ import {getUsername} from '../libs/utils';
 
 async function init(): Promise<false | void> {
 	// `a` selector needed to skip commits by non-GitHub users
-	const usernameElements = select.all('.js-discussion a.author:not(.rgh-fullname):not([href*="/apps/"])');
+	const usernameElements = select.all('.js-discussion a.author:not(.rgh-fullname):not([href*="/apps/"]):not([href*="/marketplace/"])');
 
 	const usernames = new Set();
 	const myUsername = getUsername();


### PR DESCRIPTION
show-names fails when the link is to the marketplace.

~~fixes []() #1978~~

<!--

The more the merrier! 🍻 Thanks for contributing!

1. List some URLs that reviewers can use to test your PR

2. Make sure you specify the issue you're fixing/closing, if any, following this format:

Fixes #123
Closes #56

-->
