### PR TITLE
Avoid duplicate releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
     script: npm run create-git-tag
     on:
       branch: master
-      condition: ("$TRAVIS_EVENT_TYPE" = cron) && ($(git tag -l --points-at HEAD) = "")
+      condition: ($TRAVIS_EVENT_TYPE = cron) && ($(git tag -l --points-at HEAD) = "")
 
 # Setup Travis to be able to push git tags to GitHub
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ deploy:
       tags: true
       condition: $TRAVIS_TAG = hotfix
 
-  - # Creates versioned git tag on daily Travis cronjobs if it has recent commits
+  - # Creates versioned git tag on daily Travis cronjobs if HEAD isn't already tagged
     provider: script
     skip_cleanup: true
     script: npm run create-git-tag
     on:
       branch: master
-      condition: $(npm run can-release --silent)
+      condition: ("$TRAVIS_EVENT_TYPE" = cron) && ($(git tag -l --points-at HEAD) = "")
 
 # Setup Travis to be able to push git tags to GitHub
 after_success:

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
 		"release": "run-s build prerelease:* release:*",
 		"create-git-tag": "git tag $(utc-version) && git push --tags",
 		"prerelease:source-url": "echo https://github.com/$TRAVIS_REPO_SLUG/tree/$TRAVIS_COMMIT > distribution/SOURCE_URL",
-		"prerelease:version": "dot-json distribution/manifest.json version $TRAVIS_TAG",
-		"can-release": "if [ \"$TRAVIS_EVENT_TYPE\" = cron ] && [ $(git rev-list -n 1 --since=\"26 hours ago\" master) ]; then echo :ship-it:; else false; fi"
+		"prerelease:version": "dot-json distribution/manifest.json version $TRAVIS_TAG"
 	},
 	"dependencies": {
 		"copy-text-to-clipboard": "^2.0.0",


### PR DESCRIPTION
Thanks to Google everyone can be a git/shell wizard 🧙‍♂️

Fixes #1995 

Documentation: 
- https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on
- https://stackoverflow.com/a/33733020/288906
- https://stackoverflow.com/a/3826705/288906

Tested with:

```sh
TRAVIS_EVENT_TYPE=cron
if [[ ($TRAVIS_EVENT_TYPE = cron) && ($(git tag -l --points-at HEAD) = "") ]]
then 
	echo :ship-it:
fi
```

Further simplifications welcome