### PR TITLE
Add `clean-sidebar` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,6 +158,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Forks and watchers counters are hidden.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
 - [Diff signs are hidden.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
 - [Hide milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
+- [Empty sections in the issue/PRs sidebar are hidden.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
 
 
 ### UI improvements

--- a/source/content.ts
+++ b/source/content.ts
@@ -100,6 +100,7 @@ import './features/filter-pr-by-build-status';
 import './features/edit-files-faster';
 import './features/hide-disabled-milestone-sorter';
 import './features/link-to-file-in-file-history';
+import './features/clean-sidebar';
 
 import './features/scrollable-code-and-blockquote.css';
 import './features/center-reactions-popup.css';

--- a/source/features/clean-sidebar.css
+++ b/source/features/clean-sidebar.css
@@ -1,0 +1,3 @@
+.rgh-clean-sidebar {
+	margin-bottom: -5px;
+}

--- a/source/features/clean-sidebar.css
+++ b/source/features/clean-sidebar.css
@@ -1,3 +1,9 @@
-.rgh-clean-sidebar {
+/* Adjust spacing of empty sections */
+.discussion-sidebar-item.rgh-clean-sidebar {
 	margin-bottom: -5px;
+}
+
+/* Remove message under the `Unsubscribe` button */
+.sidebar-notifications .reason {
+	display: none !important;
 }

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -1,0 +1,85 @@
+/*
+Hide all empty sections (or just their "empty" label) in discussion sidebar
+*/
+
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+
+function init(): void {
+	const canEditSidebar = select.exists('.discussion-sidebar .octicon-gear');
+
+	// Reviewers
+	const reviewers = select('[aria-label="Select reviewers"] > .css-truncate')!;
+	if (reviewers.children.length === 0) {
+		if (canEditSidebar) {
+			reviewers.remove();
+		} else {
+			reviewers.closest('.discussion-sidebar-item')!.remove();
+		}
+	}
+
+	// Assignees
+	const assignees = select('.js-issue-assignees')!;
+	if (assignees.children.length === 0) {
+		assignees.closest('.discussion-sidebar-item')!.remove();
+	} else {
+		const assignYourself = select('.js-issue-assign-self');
+		if (assignYourself) {
+			(assignYourself.previousSibling as ChildNode).remove(); // Drop "No one — "
+			select('[aria-label="Select assignees"] summary')!.append(
+				<span style={{fontWeight: 'normal'}}> – {assignYourself}</span>
+			);
+		}
+	}
+
+	// Labels
+	const labels = select('.js-issue-labels')!;
+	if (labels.children.length === 0) {
+		if (canEditSidebar) {
+			labels.remove();
+		} else {
+			labels.closest('.discussion-sidebar-item')!.remove();
+		}
+	} else if (!canEditSidebar) {
+		select('.sidebar-labels div.discussion-sidebar-heading')!.remove();
+	}
+
+	// Projects
+	const projects = select('.sidebar-projects')!;
+	if (projects.children.length === 0) {
+		if (canEditSidebar) {
+			projects.remove();
+		} else {
+			projects.closest('.discussion-sidebar-item')!.remove();
+		}
+	}
+
+	// Milestones
+	const milestones = select('.sidebar-milestone')!;
+	if (!select.exists('.milestone-name', milestones)) {
+		if (canEditSidebar) {
+			const lastTextNode = milestones.lastChild!.lastChild!;
+			if (lastTextNode.textContent!.trim() === 'No milestone') {
+				lastTextNode.remove();
+			} else {
+				throw new Error('Refined GitHub: milestones in sidebar could not be hidden');
+			}
+		} else {
+			milestones.closest('.discussion-sidebar-item')!.remove();
+		}
+	}
+
+	// Notifications
+	select('.sidebar-notifications .discussion-sidebar-heading')!.remove();
+}
+
+features.add({
+	id: 'link-to-file-in-file-history',
+	include: [
+		features.isIssue,
+		features.isPRConversation
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -47,6 +47,7 @@ function clean(): void {
 			select('[aria-label="Select assignees"] summary')!.append(
 				<span style={{fontWeight: 'normal'}}> – {assignYourself}</span>
 			);
+			assignees.closest('.discussion-sidebar-item')!.classList.add('rgh-clean-sidebar');
 		}
 	}
 

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -84,7 +84,7 @@ function clean(): void {
 }
 
 function init(): void {
-	canEditSidebar = select.exists('.discussion-sidebar .octicon-gear');
+	canEditSidebar = select.exists('.sidebar-labels .octicon-gear');
 	clean();
 	observeEl('.discussion-sidebar', clean);
 }

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -2,6 +2,7 @@
 Hide all empty sections (or just their "empty" label) in discussion sidebar
 */
 
+import './clean-sidebar.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
@@ -17,6 +18,7 @@ function cleanSection(selector: string): boolean {
 		const section = list.closest('.discussion-sidebar-item')!;
 		if (canEditSidebar) {
 			list.remove();
+			section.classList.add('rgh-clean-sidebar');
 		} else {
 			section.remove();
 		}
@@ -68,6 +70,7 @@ function clean(): void {
 			const lastTextNode = milestones.lastChild!.lastChild!;
 			if (lastTextNode.textContent!.trim() === 'No milestone') {
 				lastTextNode.remove();
+				milestones.classList.add('rgh-clean-sidebar');
 			} else {
 				throw new Error('Refined GitHub: milestones in sidebar could not be hidden');
 			}

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -5,8 +5,9 @@ Hide all empty sections (or just their "empty" label) in discussion sidebar
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
+import observeEl from '../libs/simplified-element-observer';
 
-function init(): void {
+function clean(): void {
 	const canEditSidebar = select.exists('.discussion-sidebar .octicon-gear');
 
 	// Reviewers
@@ -72,6 +73,11 @@ function init(): void {
 
 	// Notifications
 	select('.sidebar-notifications .discussion-sidebar-heading')!.remove();
+}
+
+function init(): void {
+	clean();
+	observeEl('.discussion-sidebar', clean);
 }
 
 features.add({

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -6,6 +6,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 import observeEl from '../libs/simplified-element-observer';
+import {isPR} from '../libs/page-detect';
 
 let canEditSidebar = false;
 
@@ -27,6 +28,12 @@ function cleanSection(selector: string): boolean {
 }
 
 function clean(): void {
+	if (select.exists('.rgh-clean-sidebar')) {
+		return;
+	}
+
+	select('#partial-discussion-sidebar')!.classList.add('rgh-clean-sidebar');
+
 	// Assignees
 	const assignees = select('.js-issue-assignees')!;
 	if (assignees.children.length === 0) {

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -66,15 +66,11 @@ function clean(): void {
 
 	// Milestones
 	const milestones = select('.sidebar-milestone')!;
-	if (!select.exists('.milestone-name', milestones)) {
+	const milestonesInfo = milestones.lastChild!.lastChild!;
+	if (milestonesInfo.textContent!.trim() === 'No milestone') {
 		if (canEditSidebar) {
-			const lastTextNode = milestones.lastChild!.lastChild!;
-			if (lastTextNode.textContent!.trim() === 'No milestone') {
-				lastTextNode.remove();
-				milestones.classList.add('rgh-clean-sidebar');
-			} else {
-				throw new Error('Refined GitHub: milestones in sidebar could not be hidden');
-			}
+			milestonesInfo.remove();
+			milestones.classList.add('rgh-clean-sidebar');
 		} else {
 			milestones.remove();
 		}

--- a/source/features/hide-tips.css
+++ b/source/features/hide-tips.css
@@ -28,11 +28,6 @@ a.tabnav-extra[href$='mastering-markdown/'] {
 	display: none !important;
 }
 
-/* Remove message under the `Unsubscribe` button */
-.sidebar-notifications .reason {
-	display: none !important;
-}
-
 /* Remove Marketplace marketing box on PRs */
 .js-marketplace-callout-container {
 	display: none !important;


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/421 (hide milestones)
Closes https://github.com/sindresorhus/refined-github/issues/977 (hide projects)
Replaces and closes https://github.com/sindresorhus/refined-github/pull/1945
Replaces and closes https://github.com/sindresorhus/refined-github/pull/1965

~~The code is ugly but sadly each section is at least slightly different :(~~ → ceeca8d 🌈

# Tests

Depends on many variables:

- issues/PRs
- empty/full sections
- can/cannot edit sections

These have a good variety of _PR + cannot edit_ sections: https://github.com/parcel-bundler/parcel/pulls


# Tasks

- [x] Handle sidebar ajax updates
- [x] Adjust spacing
- [x] Documentation

# Screenshots (WIP)

<img width="160" align=top alt="" src="https://user-images.githubusercontent.com/1402241/57199252-856d3f00-6faf-11e9-8365-363bc82a50e7.png"> <img align=top width="160" alt="Screenshot 2019-05-06 at 03 32 53" src="https://user-images.githubusercontent.com/1402241/57199275-b2215680-6faf-11e9-9a25-497ee2d8314d.png"> <img align=top width="160" alt="Screenshot 2019-05-06 at 03 33 01" src="https://user-images.githubusercontent.com/1402241/57199274-b2215680-6faf-11e9-8f5d-794e9d6fa932.png"> 


