### PR TITLE
In discussions, always link the "Closed" label to the closing event

### DIFF
--- a/source/features/extend-status-labels.tsx
+++ b/source/features/extend-status-labels.tsx
@@ -26,7 +26,7 @@ function init(): false | void {
 	const label = select('.gh-header-meta .State')!;
 
 	if (lastActionLink) {
-		const isMerged = lastActionLink.closest('.discussion-item-merged');
+		const isMerged = lastActionRef.matches('.discussion-item-merged');
 		label.append(isMerged ? ' as ' : ' in ', lastActionLink.cloneNode(true));
 	}
 

--- a/source/features/extend-status-labels.tsx
+++ b/source/features/extend-status-labels.tsx
@@ -8,33 +8,27 @@ function init(): false | void {
 		return false;
 	}
 
-	// Get the latest status update
-	const lastActionRef = select.all(`
+	const lastStatusChange = select.all(`
 		.discussion-item-closed,
 		.discussion-item-reopened,
 		.discussion-item-merged
 	`).pop();
 
 	// Leave if the issue/PR was never closed or if it was reopened
-	if (!lastActionRef || lastActionRef.matches('.discussion-item-reopened')) {
+	if (!lastStatusChange || lastStatusChange.matches('.discussion-item-reopened')) {
 		return false;
 	}
 
-	// Find reference to a commit/PR
-	const lastActionLink = select('[href*="/pull/"], [href*="/commit/"], code', lastActionRef);
-
 	const label = select('.gh-header-meta .State')!;
+	const lastActionLink = select('[href*="/pull/"], [href*="/commit/"], code', lastStatusChange);
 
 	if (lastActionLink) {
-		const isMerged = lastActionRef.matches('.discussion-item-merged');
+		const isMerged = lastStatusChange.matches('.discussion-item-merged');
 		label.append(isMerged ? ' as ' : ' in ', lastActionLink.cloneNode(true));
 	}
 
-	// Select the label inside the action ref and from there search an ID upwards
-	const closestIdSelector = '#' + select('.discussion-item-header', lastActionRef)!.closest('[id]')!.id;
-
 	// Link label to event in timeline
-	wrap(label, <a href={closestIdSelector}/>);
+	wrap(label, <a href={'#' + select('[id]', lastStatusChange)!.id}/>);
 }
 
 features.add({


### PR DESCRIPTION
Recap: Besides linking to a concrete PR/commit, the `extend-status-labels` feature also puts an anchor to the closing note on the status label (which I find really handy since the most valuable/helpful comments are often right before the closing note).

However, those anchors are currently not set when an issue was *not* closed by a PR/commit (e.g. #2005).

This PR changes that behavior by not bailing out prematurely when no commit/PR was found. Instead it always puts the anchor to the closing note and adds the `in #xxxx` label + link if needed.