### PR TITLE
Restore "Open All" on issues/PRs list (`batch-open-issues`)

### DIFF
--- a/source/features/batch-open-issues.tsx
+++ b/source/features/batch-open-issues.tsx
@@ -36,7 +36,7 @@ function init(): void | false {
 		return false;
 	}
 
-	const filtersBar = select('.table-list-header .table-list-header-toggle:not(.states)');
+	const filtersBar = select('.table-list-header-toggle:not(.states)');
 	if (filtersBar) {
 		filtersBar.prepend(
 			<button


### PR DESCRIPTION
GitHub has removed the `.table-list-header` class. Fixes #2004

This should be easily testable by opening any list of issues with more than one issue :smile:
<!--

The more the merrier! 🍻 Thanks for contributing!

1. List some URLs that reviewers can use to test your PR

2. Make sure you specify the issue you're fixing/closing, if any, following this format:

Fixes #123
Closes #56

-->