### PR TITLE
Bring back fix-squash-and-merge-message

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -14,12 +14,16 @@ new OptionsSync().define({
 	migrations: [
 		options => {
 			options.disabledFeatures = (options.disabledFeatures as string)
+				.replace('milestone-navigation', '') // #1767
+				.replace('op-labels', '') // #1776
+				.replace('delete-fork-link', '') // #1791
+				.replace('exclude-filter-shortcut', '') // #1831
+				.replace('diff-view-without-whitespace-option', 'faster-pr-diff-options') // #1799
 				.replace('make-headers-sticky', '') // #1863
 				.replace('jump-to-bottom', '') // #1879
 				.replace('hide-readme-header', '') // #1883
 				.replace(/commented-menu-item|yours-menu-item/, 'global-discussion-list-filters') // #1883
 				.replace('show-recently-pushed-branches-on-more-pages', 'recently-pushed-branches-enhancements') // #1909
-				.replace('fix-squash-and-merge-message', '') // #1934
 				.replace('fix-squash-and-merge-title', 'sync-pr-commit-title') // #1934
 			; // eslint-disable-line semi-style
 		},

--- a/source/content.ts
+++ b/source/content.ts
@@ -48,6 +48,7 @@ import './features/star-repo-hotkey';
 import './features/toggle-files-button';
 import './features/scroll-to-top-on-collapse';
 import './features/sync-pr-commit-title';
+import './features/fix-squash-and-merge-message';
 import './features/open-ci-details-in-new-tab';
 import './features/wait-for-build';
 import './features/hide-inactive-deployments';

--- a/source/features/fix-squash-and-merge-message.tsx
+++ b/source/features/fix-squash-and-merge-message.tsx
@@ -1,0 +1,23 @@
+import select from 'select-dom';
+import features from '../libs/features';
+
+function init(): false | void {
+	const button = select('.merge-message .btn-group-squash [type=button]');
+	if (!button) {
+		return false;
+	}
+
+	button.addEventListener('click', () => {
+		const description = select('.comment-form-textarea[name=\'pull_request[body]\']')!.textContent;
+		select<HTMLTextAreaElement>('#merge_message_field')!.value = description!;
+	});
+}
+
+features.add({
+	id: 'fix-squash-and-merge-message',
+	include: [
+		features.isPRConversation
+	],
+	load: features.onAjaxedPages,
+	init
+});


### PR DESCRIPTION
The `fix-squash-and-merge-message` feature was recently removed from refined-github.
I asked about this and the reply was that it would not return.
See https://github.com/sindresorhus/refined-github/commit/9be9440699d2b8040af0c7c26ae524169b3cd0b8

But I am not the only one that uses this very helpful feature, @bharathwaaj https://github.com/sindresorhus/refined-github/pull/1934#issuecomment-490053460, and I would assume there are more that would like to see this come back.

So I am opening this PR to start a discussion about why the `fix-squash-and-merge-message` was removed and if we can bring it back in some form.

Thank you!