### PR TITLE
Decode tag before extracting version and namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10827,6 +10827,11 @@
 				"semver": "^5.0.3"
 			}
 		},
+		"semver-regex": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.0.tgz",
+			"integrity": "sha512-xJqZonbAohJmpogzq1Mx7DB4DT3LO+sG5J4i/rcRyZ527dcUqsTVb5T0vM5gwOBf3KO0v7i94EpbdvwSukJyAQ=="
+		},
 		"serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"onetime": "^5.0.0",
 		"p-memoize": "^3.0.0",
 		"select-dom": "^5.0.2",
+		"semver-regex": "^3.1.0",
 		"shorten-repo-url": "^1.5.1",
 		"tiny-version-compare": "^1.0.0",
 		"type-fest": "^0.4.1",

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -30,12 +30,12 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
-	const tag = select<HTMLAnchorElement>('[href*="/releases/tag/"]', element)!.pathname.match(/\/releases\/tag\/(.*)/)![1];
+	const tag = decodeURIComponent(select<HTMLAnchorElement>('[href*="/releases/tag/"]', element)!.pathname.match(/\/releases\/tag\/(.*)/)![1]);
 	return {
 		element,
 		tag,
 		commit: select('[href*="/commit/"]', element)!.textContent!.trim(),
-		...parseTag(decodeURIComponent(tag)) // `version`, `namespace`
+		...parseTag(tag) // `version`, `namespace`
 	};
 }
 

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import tinyVersionCompare from 'tiny-version-compare';
+import semverRegex from 'semver-regex';
 import features from '../libs/features';
 import fetchDom from '../libs/fetch-dom';
 import * as icons from '../libs/icons';
@@ -58,6 +59,10 @@ async function init(): Promise<void | false> {
 	// Look for tags in the current page and the next page
 	const pages = [document, await getNextPage()];
 	const allTags = select.all(tagsSelectors, pages).map(parseTags);
+
+	if (allTags.every(tag => semverRegex().test(tag.version))) {
+		allTags.sort((tagA, tagB) => tinyVersionCompare(tagB.version, tagA.version));
+	}
 
 	for (const [index, container] of allTags.entries()) {
 		const previousTag = getPreviousTag(index, allTags);

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -31,12 +31,12 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
-	const tag = decodeURIComponent(select<HTMLAnchorElement>('[href*="/releases/tag/"]', element)!.pathname.match(/\/releases\/tag\/(.*)/)![1]);
+	const tag = select<HTMLAnchorElement>('[href*="/releases/tag/"]', element)!.pathname.match(/\/releases\/tag\/(.*)/)![1];
 	return {
 		element,
 		tag,
 		commit: select('[href*="/commit/"]', element)!.textContent!.trim(),
-		...parseTag(tag) // `version`, `namespace`
+		...parseTag(decodeURIComponent(tag)) // `version`, `namespace`
 	};
 }
 
@@ -75,8 +75,8 @@ async function init(): Promise<void | false> {
 					<li className={lastLink.className}>
 						<a
 							className="muted-link tooltipped tooltipped-n"
-							aria-label={'See changes since ' + previousTag}
-							href={`/${getRepoURL()}/compare/${encodeURIComponent(previousTag)}...${encodeURIComponent(allTags[index].tag)}`}
+							aria-label={'See changes since ' + decodeURIComponent(previousTag)}
+							href={`/${getRepoURL()}/compare/${previousTag}...${allTags[index].tag}`}
 						>
 							{icons.diff()} Changelog
 						</a>

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -35,7 +35,7 @@ function parseTags(element: HTMLElement): TagDetails {
 		element,
 		tag,
 		commit: select('[href*="/commit/"]', element)!.textContent!.trim(),
-		...parseTag(tag) // `version`, `namespace`
+		...parseTag(decodeURIComponent(tag)) // `version`, `namespace`
 	};
 }
 

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -70,8 +70,8 @@ async function init(): Promise<void | false> {
 					<li className={lastLink.className}>
 						<a
 							className="muted-link tooltipped tooltipped-n"
-							aria-label={'See changes since ' + decodeURIComponent(previousTag)}
-							href={`/${getRepoURL()}/compare/${previousTag}...${allTags[index].tag}`}
+							aria-label={'See changes since ' + previousTag}
+							href={`/${getRepoURL()}/compare/${encodeURIComponent(previousTag)}...${encodeURIComponent(allTags[index].tag)}`}
 						>
 							{icons.diff()} Changelog
 						</a>


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/pull/1998#issuecomment-492285094

Tested it on 

1. https://github.com/parcel-bundler/parcel/releases (Namespaced tags)
2. https://github.com/facebook/react/releases (Tags with the beta, alpha versions)