### PR TITLE
 Add `responsive-layout` feature 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- Various pages adapt to smaller window widths.
 
 ### More shortcuts
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -102,6 +102,7 @@ import './features/hide-disabled-milestone-sorter';
 import './features/tag-changelog-link';
 import './features/link-to-file-in-file-history';
 import './features/clean-sidebar';
+import './features/responsive-layout';
 
 import './features/scrollable-code-and-blockquote.css';
 import './features/center-reactions-popup.css';
@@ -117,6 +118,7 @@ import './features/hide-tips.css';
 import './features/hide-readme-header.css';
 import './features/hide-obvious-tooltips.css';
 import './features/clean-discussions.css';
+import './features/responsive-layout.css';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/make-discussion-sidebar-sticky.css
+++ b/source/features/make-discussion-sidebar-sticky.css
@@ -1,5 +1,5 @@
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 60px !important; /* Matches sticky header's height */
-	z-index: 26 !important;
+	z-index: 32 !important; /* Higher than pagehead-actions */
 }

--- a/source/features/responsive-layout.css
+++ b/source/features/responsive-layout.css
@@ -5,10 +5,6 @@
 body.rgh-responsive-layout {
 	min-width: 768px;
 }
-.rgh-responsive-layout .reponav {
-	display: flex;
-	flex-direction: row;
-}
 
 @media (max-width: 1080px) {
 	.rgh-responsive-layout .container {
@@ -24,6 +20,14 @@ body.rgh-responsive-layout {
 	.rgh-responsive-layout .discussion-timeline {
 		width: 100%;
 		max-width: none;
+	}
+	.rgh-responsive-layout .reponav {
+		display: flex;
+		flex-direction: row;
+		flex-wrap: wrap-reverse;
+	}
+	.rgh-responsive-layout .reponav .dropdown-menu {
+		width: 95px;
 	}
 }
 

--- a/source/features/responsive-layout.css
+++ b/source/features/responsive-layout.css
@@ -1,0 +1,121 @@
+/* different pages have various max-sizes set, make them responsive */
+
+/* general */
+
+body.rgh-responsive-layout {
+	min-width: 768px;
+}
+@media (max-width: 1080px) {
+	.rgh-responsive-layout .container {
+		/* container has fixed width set */
+		width: auto;
+		padding-left: 20px;
+		padding-right: 20px;
+	}
+	.rgh-responsive-layout .subnav-search-input-wide {
+		/* font size changes to 16 on small size */
+		font-size: 14px;
+	}
+}
+
+/* issues page */
+
+@media (max-width: 1080px) {
+    .rgh-responsive-layout .reponav {
+        padding: 0;
+    }
+	.rgh-responsive-layout .discussion-timeline {
+		width: calc(100% - 200px);
+		max-width: none;
+		padding-right: 20px;
+	}
+}
+
+
+/* profile page */
+
+.rgh-responsive-layout .user-profile-nav {
+	width: 100% !important;
+}
+.rgh-responsive-layout .profile-timeline-year-list {
+	max-width: 100%;
+}
+.rgh-responsive-layout .js-calendar-graph {
+	overflow: auto;
+	direction: rtl;
+}
+.rgh-responsive-layout .user-profile-following-container .btn {
+	width: 100% !important;
+}
+@media (max-width: 1080px) {
+	.rgh-responsive-layout.user-profile-nav .discussion-timeline {
+		width: 100%;
+	}
+	.rgh-responsive-layout .header-search {
+		min-width: 150px !important;
+	}
+	.rgh-responsive-layout.page-profile .application-main .container-xl {
+		display: flex;
+		flex-direction: column;
+		place-content: stretch;
+	}
+	.rgh-responsive-layout.page-profile .h-card {
+		width: 100%;
+		padding-right: 0 !important;
+		padding-left: 0 !important;
+		display: grid;
+		grid-template-columns: 272px calc(100% - 272px - 40px);
+		grid-gap: 0 40px;
+		grid-template-rows: 72px 155px 45px;
+		padding-bottom: 10px;
+	}
+	.rgh-responsive-layout.page-profile .u-photo,
+	.rgh-responsive-layout.page-profile .user-status-container  {
+		max-width: 272px;
+		grid-column: 1;
+	}
+	.rgh-responsive-layout.page-profile .user-status-container .d-flex {
+		height: 100%;
+	}
+	.rgh-responsive-layout .js-user-status-context {
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	.rgh-responsive-layout .js-user-status-container {
+		flex: 1;
+	}
+	.rgh-responsive-layout.page-profile .vcard-names-container {
+		grid-column: 2;
+		grid-row: 1;
+	}
+	.rgh-responsive-layout.page-profile .u-photo {
+		grid-row: 1/4;
+	}
+	.rgh-responsive-layout.page-profile .js-profile-editable-area {
+		grid-column: 2;
+		grid-row: 2;
+	}
+	.rgh-responsive-layout .user-profile-following-container  {
+		grid-column: 2;
+		grid-row: 3;
+	}
+	.rgh-responsive-layout.page-profile .js-profile-editable-area + .pb-3 {
+		grid-row: 3;
+		grid-column: 2;
+		top: -26px;
+		position: relative;
+	}
+	.rgh-responsive-layout.page-profile .py-3.clearfix {
+		grid-row: 3;
+		grid-column: 2;
+		top: 0;
+	}
+	.rgh-responsive-layout .user-profile-following-container ~ .py-3.clearfix {
+		grid-row: 4;
+	}
+	.rgh-responsive-layout.page-profile .h-card+div {
+		width: 100%;
+		padding-left: 0 !important;
+	}
+}

--- a/source/features/responsive-layout.css
+++ b/source/features/responsive-layout.css
@@ -74,8 +74,12 @@ body.rgh-responsive-layout {
 		display: grid;
 		grid-template-columns: 272px calc(100% - 272px - 40px);
 		grid-gap: 0 40px;
-		grid-template-rows: 72px 155px 45px;
-		padding-bottom: 10px;
+		grid-template-rows: auto auto auto auto auto;
+	}
+	.rgh-responsive-layout.page-profile .h-card .pb-3 .details-overlay {
+		/* block & report link */
+		float: right;
+		padding: 5px 0;
 	}
 	.rgh-responsive-layout.page-profile .u-photo,
 	.rgh-responsive-layout.page-profile .user-status-container  {
@@ -96,6 +100,7 @@ body.rgh-responsive-layout {
 	.rgh-responsive-layout.page-profile .vcard-names-container {
 		grid-column: 2;
 		grid-row: 1;
+		padding-top: 0 !important;
 	}
 	.rgh-responsive-layout.page-profile .u-photo {
 		grid-row: 1/4;
@@ -104,23 +109,22 @@ body.rgh-responsive-layout {
 		grid-column: 2;
 		grid-row: 2;
 	}
+	.rgh-responsive-layout.page-profile .js-profile-editable-area .btn {
+		margin-bottom: 0 !important;
+	}
 	.rgh-responsive-layout .user-profile-following-container  {
-		grid-column: 2;
-		grid-row: 3;
+		grid-column: 1;
+		grid-row: 5;
 	}
 	.rgh-responsive-layout.page-profile .js-profile-editable-area + .pb-3 {
-		grid-row: 3;
+		grid-row: 1;
 		grid-column: 2;
-		top: -26px;
 		position: relative;
 	}
 	.rgh-responsive-layout.page-profile .py-3.clearfix {
-		grid-row: 3;
+		grid-row: 3/6;
 		grid-column: 2;
 		top: 0;
-	}
-	.rgh-responsive-layout .user-profile-following-container ~ .py-3.clearfix {
-		grid-row: 4;
 	}
 	.rgh-responsive-layout.page-profile .h-card+div {
 		width: 100%;

--- a/source/features/responsive-layout.css
+++ b/source/features/responsive-layout.css
@@ -5,6 +5,11 @@
 body.rgh-responsive-layout {
 	min-width: 768px;
 }
+.rgh-responsive-layout .reponav {
+	display: flex;
+	flex-direction: row;
+}
+
 @media (max-width: 1080px) {
 	.rgh-responsive-layout .container {
 		/* container has fixed width set */
@@ -16,18 +21,24 @@ body.rgh-responsive-layout {
 		/* font size changes to 16 on small size */
 		font-size: 14px;
 	}
+	.rgh-responsive-layout .discussion-timeline {
+		width: 100%;
+		max-width: none;
+	}
 }
 
 /* issues page */
 
+.rgh-responsive-layout .new-pr-form .Popover-message {
+	width: 100%;
+}
 @media (max-width: 1080px) {
-    .rgh-responsive-layout .reponav {
-        padding: 0;
-    }
-	.rgh-responsive-layout .discussion-timeline {
+	.rgh-responsive-layout .discussion-sidebar + .discussion-timeline {
 		width: calc(100% - 200px);
-		max-width: none;
 		padding-right: 20px;
+	}
+	.rgh-responsive-layout .timeline-new-comment {
+		max-width: none;
 	}
 }
 
@@ -48,9 +59,6 @@ body.rgh-responsive-layout {
 	width: 100% !important;
 }
 @media (max-width: 1080px) {
-	.rgh-responsive-layout.user-profile-nav .discussion-timeline {
-		width: 100%;
-	}
 	.rgh-responsive-layout .header-search {
 		min-width: 150px !important;
 	}

--- a/source/features/responsive-layout.tsx
+++ b/source/features/responsive-layout.tsx
@@ -3,7 +3,7 @@ import features from '../libs/features';
 
 function init(): void {
 	const body = select('body');
-	if (body) {
+	if (body && !body.classList.contains('page-responsive')) {
 		body.classList.add('rgh-responsive-layout');
 	}
 }

--- a/source/features/responsive-layout.tsx
+++ b/source/features/responsive-layout.tsx
@@ -1,0 +1,15 @@
+import select from 'select-dom';
+import features from '../libs/features';
+
+function init(): void {
+	const body = select('body');
+	if (body) {
+		body.classList.add('rgh-responsive-layout');
+	}
+}
+
+features.add({
+	id: 'responsive-layout',
+	description: 'Make GitHub responsive',
+	init
+});

--- a/source/features/responsive-layout.tsx
+++ b/source/features/responsive-layout.tsx
@@ -1,15 +1,16 @@
-import select from 'select-dom';
 import features from '../libs/features';
 
 function init(): void {
-	const body = select('body');
-	if (body && !body.classList.contains('page-responsive')) {
-		body.classList.add('rgh-responsive-layout');
+	if (document.body) {
+		document.body.classList.add('rgh-responsive-layout');
 	}
 }
 
 features.add({
 	id: 'responsive-layout',
 	description: 'Make GitHub responsive',
+	exclude: [
+		features.isResponsive
+	],
 	init
 });

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -109,3 +109,5 @@ export const hasRichTextEditor = (): boolean =>
 	hasComments() ||
 	isNewIssue() ||
 	isCompare();
+
+export const isResponsive = (): boolean => document.body && document.body.classList.contains('page-responsive');


### PR DESCRIPTION
A lot of pages have different `min-width` set on the body tag (e.g. the profile page with `1280px`), this feature reduces the overall `min-width` to `768px` and adjusts some layouts below `1080px` to allow this.

`768px` has been chosen because in a lot of cases everything "just works". Going further below that would require a lot more additional layouting.

I opted to namespace the styles with the `rgh-responsive-layout` class which is added to the body via JS, so the feature can be easily disabled.

It's disabled by default on pages that are already responsive (containing the `page-responsive` class). It should therefore be future-proof in case of GitHub updating more pages to be responsive by default.

# Examples

<details>
<summary>Profile page of other user</summary>

![Screenshot_2019-05-20 sindresorhus - Overview](https://user-images.githubusercontent.com/2847328/57988837-10136b00-7a93-11e9-811e-ff81bc43ebfa.png)

</details>


<details>
<summary>Profile page of own user</summary>

![Screenshot_2019-05-20 Systemcluster - Overview](https://user-images.githubusercontent.com/2847328/57988836-0f7ad480-7a93-11e9-96d6-2bbdf3cea841.png)

</details>

<details>
<summary>Issue page</summary>

![Screenshot_2019-05-19 mods settings - invalid load order file when using script merger · Issue #1 · Systemcluster The-Witch](https://user-images.githubusercontent.com/2847328/57985711-425da200-7a6c-11e9-8975-383ab54aa37a.png)

</details>

<details>
<summary>Repo page</summary>

![Screenshot_2019-05-19 sindresorhus refined-github](https://user-images.githubusercontent.com/2847328/57985710-425da200-7a6c-11e9-8f45-a9feec7fa702.png)

</details>
