### PR TITLE
Fix console errors

### DIFF
--- a/source/libs/fetch-dom.ts
+++ b/source/libs/fetch-dom.ts
@@ -1,15 +1,13 @@
 import domify from 'doma';
 import pMemoize from 'p-memoize';
 
-const cachedFetch = pMemoize(fetch);
-
 async function fetchDom(url: string): Promise<DocumentFragment>;
 async function fetchDom<TElement extends Element>(url: string, selector: string): Promise<TElement>;
 async function fetchDom(url: string, selector?: string): Promise<Node> {
 	const urlObject = new URL(url, location.origin);
-	const response = await cachedFetch(String(urlObject));
+	const response = await fetch(String(urlObject));
 	const dom = domify(await response.text());
 	return selector ? dom.querySelector(selector)! : dom;
 }
 
-export default fetchDom;
+export default pMemoize(fetchDom);

--- a/source/libs/fetch-dom.ts
+++ b/source/libs/fetch-dom.ts
@@ -1,6 +1,9 @@
 import domify from 'doma';
 import pMemoize from 'p-memoize';
 
+// TODO: wait for https://github.com/sindresorhus/p-memoize/issues/9
+const memo = pMemoize as <T = VoidFunction>(fn: T) => T;
+
 async function fetchDom(url: string): Promise<DocumentFragment>;
 async function fetchDom<TElement extends Element>(url: string, selector: string): Promise<TElement>;
 async function fetchDom(url: string, selector?: string): Promise<Node> {
@@ -10,4 +13,4 @@ async function fetchDom(url: string, selector?: string): Promise<Node> {
 	return selector ? dom.querySelector(selector)! : dom;
 }
 
-export default pMemoize(fetchDom);
+export default memo(fetchDom);

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -78,7 +78,7 @@ export const isRepo = (): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname()) &&
 	!isRepoSearch();
 
 export const isRepoDiscussionList = (): boolean =>
-	/^(issues|pulls)($|\/$|\/(?!\d+))/.test(getRepoPath()!) || // `issues/bfred-it` is a list but `issues/1` isn't
+	/^(issues|pulls)($|\/$|\/(?!\d+|new))/.test(getRepoPath()!) || // `issues/bfred-it` is a list but `issues/1` isn't
 	/^labels\/.+/.test(getRepoPath()!);
 
 export const isRepoRoot = (): boolean => /^(tree[/][^/]+)?$/.test(getRepoPath()!);

--- a/test/page-detect.ts
+++ b/test/page-detect.ts
@@ -161,6 +161,7 @@ test('isRepoDiscussionList', urlMatcherMacro, pageDetect.isRepoDiscussionList, [
 ], [
 	'http://github.com/sindresorhus/ava',
 	'https://github.com',
+	'https://github.com/sindresorhus/refined-github/issues/new',
 	'https://github.com/sindresorhus/refined-github/issues/170',
 	'https://github.com/sindresorhus/refined-github/pull/148',
 	'http://github.com/sindresorhus/issues',


### PR DESCRIPTION
Fixes #2056

<details>
<summary>Edit: type issues solved</summary>

There's a type issue with `p-memoize` though: https://github.com/sindresorhus/p-memoize/issues/9

```ts
source/features/ci-link.tsx:10:30 - error TS2558: Expected 0 type arguments, but got 1.

10  const icon = await fetchDom<HTMLElement>(url, '.commit-build-statuses');
                                ~~~~~~~~~~~

source/features/show-followers-you-know.tsx:9:20 - error TS2554: Expected 2 arguments, but got 1.

9  const dom = await fetchDom(url);
                     ~~~~~~~~~~~~~

source/features/tag-changelog-link.tsx:21:10 - error TS2554: Expected 2 arguments, but got 1.

21      return fetchDom(nextPageLink.href);
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~

source/features/tag-changelog-link.tsx:26:10 - error TS2554: Expected 2 arguments, but got 1.

26      return fetchDom(`/${getRepoURL()}/tags?after=${tag}`);
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 4 errors.
```

</details>