### PR TITLE
Improve clickability of reaction buttons in Firefox

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -45,7 +45,7 @@ function add(): void {
 
 			// Without this, Firefox will follow the link instead of submitting the reaction button
 			if (!navigator.userAgent.includes('Firefox/')) {
-				(avatar as any).href = `/${participant.username}`
+				(avatar as any).href = `/${participant.username}`;
 			}
 
 			participant.container.append(avatar);

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -37,11 +37,18 @@ function add(): void {
 		const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
 		for (const participant of flatParticipants) {
-			participant.container.append(
-				<a href={`/${participant.username}`}>
-					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`}/>
+			const avatar = (
+				<a>
+					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`} />
 				</a>
 			);
+
+			// Without this, Firefox will follow the link instead of submitting the reaction button
+			if (!navigator.userAgent.includes('Firefox/')) {
+				(avatar as any).href = `/${participant.username}`
+			}
+
+			participant.container.append(avatar);
 		}
 
 		list.classList.add('rgh-reactions');

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -36,19 +36,17 @@ function add(): void {
 		const participantByReaction = [...list.children as HTMLCollectionOf<HTMLElement>].map(getParticipants);
 		const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
-		for (const participant of flatParticipants) {
-			const avatar = (
+		for (const {container, username} of flatParticipants) {
+			container.append(
 				<a>
-					<img src={`/${participant.username}.png?size=${window.devicePixelRatio * 20}`} />
+					<img src={`/${username}.png?size=${window.devicePixelRatio * 20}`} />
 				</a>
 			);
 
 			// Without this, Firefox will follow the link instead of submitting the reaction button
 			if (!navigator.userAgent.includes('Firefox/')) {
-				(avatar as any).href = `/${participant.username}`;
+				(container.lastElementChild as HTMLAnchorElement).href = `/${username}`;
 			}
-
-			participant.container.append(avatar);
 		}
 
 		list.classList.add('rgh-reactions');


### PR DESCRIPTION
Clicking on the avatars in Firefox brings you to their profile. So I dropped the link on those avatars. Also the `a` is used in the styles so I just left it there to avoid having to change the styles as well.