### PR TITLE
Fix formatting in `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- Thanks for contributing! 🍄 -->
 
 Closes 
-<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10`
+<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->
 
 
 # Test


### PR DESCRIPTION
There was an unclosed comment in the pull request template under the 'closed' text. This unclosed comment ended up commenting out everything underneath it.

<!-- Thanks for contributing! 🍄 -->
