### PR TITLE
Remove special styling for unread notifications indicator

### DIFF
--- a/source/features/mark-unread.css
+++ b/source/features/mark-unread.css
@@ -9,8 +9,3 @@
 .rgh-unread .notification-actions .age {
 	width: 150px; /* Align with GH's notifications */
 }
-
-/* Change color of marker if there are only discussion marked as unread */
-.notification-indicator[data-ga-click$=':read'] .unread {
-	background: linear-gradient(#34d058, #28a745);
-}


### PR DESCRIPTION
Now that Github supports marking notifications as unread, that bit of CSS only changes the colour of the notifications indicator for notifications that are marked as unread by refined-github, not Github. I think it probably makes sense to be consistent with Github's own unread notifications styling.