### PR TITLE
Don't bypass GitHub Actions checks

### DIFF
--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -4,7 +4,7 @@ import fetchDom from '../libs/fetch-dom';
 
 async function init(): Promise<void> {
 	// If anything errors, RGH will display the error next to the feature name
-	await Promise.all(select.all('.merge-status-item [href^="/apps/"]').map(bypass));
+	await Promise.all(select.all('.merge-status-item [href^="/apps/"]:not([href^="/apps/github-actions"])').map(bypass));
 }
 
 async function bypass(check: HTMLElement): Promise<void> {


### PR DESCRIPTION
#1636 and #1693 were created to bypass the annoying _new page_ Checks and it's working properly.

However, for GitHub Actions, we actually don't want to bypass the Checks page.
Below, every `Details` link are redirecting to https://developer.github.com/actions/ and it's pretty useless:
![2019-05-26_16-02](https://user-images.githubusercontent.com/2103975/58382908-70913380-7fd0-11e9-8f30-4b11d435101e.png)

We want `Details` links to be untouched, so they are still redirecting to the good Check page:
![2019-05-26_16-03](https://user-images.githubusercontent.com/2103975/58382916-8acb1180-7fd0-11e9-9033-77b70faae150.png)


# Test
See the checks at the bottom of https://github.com/actions/zeit-now/pull/4.
