### PR TITLE
Show drag and drop area on release page

### DIFF
--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -6,11 +6,12 @@ markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
 }
 
 /* Remove upload message on comment box */
-file-attachment.is-default .upload-enabled .drag-and-drop {
+/* `.js-upload-markdown-image` excludes non-comment attachment drop areas #2086 */
+file-attachment.js-upload-markdown-image.is-default .drag-and-drop {
 	display: none !important;
 }
 
-file-attachment.is-default textarea {
+file-attachment.js-upload-markdown-image.is-default textarea {
 	border-bottom-style: solid;
 	border-radius: 3px;
 }

--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -6,7 +6,7 @@ markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
 }
 
 /* Remove upload message on comment box */
-file-attachment.is-default .drag-and-drop {
+file-attachment.is-default .upload-enabled .drag-and-drop {
 	display: none !important;
 }
 


### PR DESCRIPTION
The visible drag and drop area is the only method of attaching files to a release. It looks like the selector meant to hide the message on discussions accidentally applies to also releases.

The drag and drop area for releases was hidden in #2068.

# Before

<img width="761" alt="Screenshot 2019-05-27 at 20 45 50" src="https://user-images.githubusercontent.com/19264/58433762-4f5c4000-80c1-11e9-96ae-55d19233f33d.png">


# After

<img width="817" alt="Screenshot 2019-05-27 at 20 44 47" src="https://user-images.githubusercontent.com/19264/58433777-571be480-80c1-11e9-83d1-63817e9296fb.png">

# Test

As an admin of refined-github, you can check the behaviour on https://github.com/sindresorhus/refined-github/releases/new?tag=19.5.26.1924