### PR TITLE
Fix `indented-code-wrapping` for Firefox

### DIFF
--- a/source/features/indented-code-wrapping.css
+++ b/source/features/indented-code-wrapping.css
@@ -6,3 +6,12 @@
 	display: block;
 	line-height: 21px; /* `display: block` reduces the line height; this undoes the change */
 }
+
+/*
+ * Inline-blockify all child nodes and reset text-indentation, a fix of Firefox
+ * https://github.com/sindresorhus/refined-github/issues/2085
+ */
+.rgh-code-wrapping-enabled .blob-code-inner * {
+	display: inline-block;
+	text-indent: 0;
+}

--- a/source/features/indented-code-wrapping.css
+++ b/source/features/indented-code-wrapping.css
@@ -4,6 +4,7 @@
 
 .rgh-code-wrapping-enabled span.blob-code-inner {
 	display: block;
+	text-indent: 0; /* Default indentation for all code blocks, see Firefox fix below */
 	line-height: 21px; /* `display: block` reduces the line height; this undoes the change */
 }
 


### PR DESCRIPTION
Quick fix that probably closes #2085. 🤞

Surprisingly, I found this fix while glazing trough the CSS spec for `text-indent` property. Thanks @bfred-it.
![image](https://user-images.githubusercontent.com/37769974/58475257-17a9d280-816b-11e9-8410-b4c644db875c.png)


## Test
https://github.com/eclipse/omr/commit/75c09985f5d5dd6cfd7c9d1e4f4d56e9406a45c4#diff-3990e65f3237ed46d278a1a8aefbaeeaR389


