### PR TITLE
Make sure release count is always shown

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -1,15 +1,9 @@
 import {addContextMenu} from 'webext-domain-permission-toggle';
 import {addToFutureTabs} from 'webext-dynamic-content-scripts';
-import {handleCacheCalls} from './libs/cache';
+import './libs/cache';
 import './options-storage';
 
 browser.runtime.onMessage.addListener(async message => {
-	const messageCode = message.code || '';
-
-	if (messageCode === 'set-cache' || messageCode === 'get-cache') {
-		return handleCacheCalls(message);
-	}
-
 	if (!message || message.action !== 'openAllInTabs') {
 		return;
 	}

--- a/source/background.ts
+++ b/source/background.ts
@@ -1,9 +1,15 @@
 import {addContextMenu} from 'webext-domain-permission-toggle';
 import {addToFutureTabs} from 'webext-dynamic-content-scripts';
-import './libs/cache';
+import {handleCacheCalls} from './libs/cache';
 import './options-storage';
 
 browser.runtime.onMessage.addListener(async message => {
+	const messageCode = message.code || '';
+
+	if (messageCode === 'set-cache' || messageCode === 'get-cache') {
+		return handleCacheCalls(message);
+	}
+
 	if (!message || message.action !== 'openAllInTabs') {
 		return;
 	}

--- a/source/libs/cache.ts
+++ b/source/libs/cache.ts
@@ -56,20 +56,18 @@ if (location.pathname === '/_generated_background_page.html') {
 			const [cached] = document.cookie.split('; ')
 				.filter(item => item.startsWith(key + '='));
 			if (cached) {
-        const [, value] = cached.split('=');
+				const [, value] = cached.split('=');
 				console.log('CACHE: found', key, value);
-        return JSON.parse(value)
-			} else {
-				console.log('CACHE: not found', key);
-        return
+				return JSON.parse(value);
 			}
+
+			console.log('CACHE: not found', key);
 		} else if (code === 'set-cache') {
 			console.log('CACHE: setting', key, value);
 
 			// Store as JSON to preserve data type
 			// otherwise Booleans and Numbers become strings
 			document.cookie = `${key}=${JSON.stringify(value)}; max-age=${expiration ? expiration * 3600 * 24 : ''}`;
-    }
-    return
+		}
 	});
 }

--- a/source/libs/cache.ts
+++ b/source/libs/cache.ts
@@ -45,35 +45,30 @@ export function set<TValue extends any = any>(key: string, value: TValue, expira
 }
 
 /* Accept messages in background page */
-export const handleCacheCalls = async (
-	request: CacheRequest,
-): Promise<any> => {
-	if (!request) {
-		return;
-	}
-
-	const {code, key, value, expiration} = request;
-	if (code === 'get-cache') {
-		const [cached] = document.cookie
-			.split('; ')
-			.filter(item => item.startsWith(key + '='));
-		if (cached) {
-			const [, value] = cached.split('=');
-			console.log('CACHE: found', key, value);
-			return value;
+if (!browser.runtime.getBackgroundPage) {
+	browser.runtime.onMessage.addListener((request: CacheRequest, _sender, sendResponse) => {
+		if (!request) {
+			return;
 		}
 
-		console.log('CACHE: not found', key);
-		return undefined;
-	}
+		const {code, key, value, expiration} = request;
+		if (code === 'get-cache') {
+			const [cached] = document.cookie.split('; ')
+				.filter(item => item.startsWith(key + '='));
+			if (cached) {
+				const [, value] = cached.split('=');
+				sendResponse(JSON.parse(value));
+				console.log('CACHE: found', key, value);
+			} else {
+				sendResponse();
+				console.log('CACHE: not found', key);
+			}
+		} else if (code === 'set-cache') {
+			console.log('CACHE: setting', key, value);
 
-	if (code === 'set-cache') {
-		console.log('CACHE: setting', key, value);
-
-		// Store as JSON to preserve data type
-		// otherwise Booleans and Numbers become strings
-		document.cookie = `${key}=${JSON.stringify(value)}; max-age=${
-			expiration ? expiration * 3600 * 24 : ''
-		}`;
-	}
-};
+			// Store as JSON to preserve data type
+			// otherwise Booleans and Numbers become strings
+			document.cookie = `${key}=${JSON.stringify(value)}; max-age=${expiration ? expiration * 3600 * 24 : ''}`;
+		}
+	});
+}

--- a/source/libs/cache.ts
+++ b/source/libs/cache.ts
@@ -45,8 +45,8 @@ export function set<TValue extends any = any>(key: string, value: TValue, expira
 }
 
 /* Accept messages in background page */
-if (!browser.runtime.getBackgroundPage) {
-	browser.runtime.onMessage.addListener((request: CacheRequest, _sender, sendResponse) => {
+if (location.pathname === '/_generated_background_page.html') {
+	browser.runtime.onMessage.addListener(async (request: CacheRequest) => {
 		if (!request) {
 			return;
 		}
@@ -56,12 +56,12 @@ if (!browser.runtime.getBackgroundPage) {
 			const [cached] = document.cookie.split('; ')
 				.filter(item => item.startsWith(key + '='));
 			if (cached) {
-				const [, value] = cached.split('=');
-				sendResponse(JSON.parse(value));
+        const [, value] = cached.split('=');
 				console.log('CACHE: found', key, value);
+        return JSON.parse(value)
 			} else {
-				sendResponse();
 				console.log('CACHE: not found', key);
+        return
 			}
 		} else if (code === 'set-cache') {
 			console.log('CACHE: setting', key, value);
@@ -69,6 +69,7 @@ if (!browser.runtime.getBackgroundPage) {
 			// Store as JSON to preserve data type
 			// otherwise Booleans and Numbers become strings
 			document.cookie = `${key}=${JSON.stringify(value)}; max-age=${expiration ? expiration * 3600 * 24 : ''}`;
-		}
+    }
+    return
 	});
 }


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

![Gif of Fix](https://i.imgur.com/279Ljrp.gif)

Closes #2077 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

The cache lib was defining its own `browser.runtime.onMessage.addListener` and there can only be one of these. The solution to this was to make the background script delegate the message to the cache lib function if necessary.

# Test
You can view this fix in action at https://github.com/mulberrysymbols/mulberry-symbols
<!-- List some URLs that reviewers can use to test your PR -->
