### PR TITLE
Link to current branch in More's Compare and Commits links

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -5,7 +5,7 @@ import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
 import {getRepoURL} from '../libs/utils';
-import {isEnterprise} from '../libs/page-detect';
+import {isEnterprise, isCompare, isReleasesOrTags} from '../libs/page-detect';
 import {appendBefore} from '../libs/dom-utils';
 
 const repoUrl = getRepoURL();
@@ -31,26 +31,19 @@ async function init(): Promise<void> {
 		createDropdown();
 	}
 
+	let ref = '';
+	const pathnameParts = location.pathname.split('/');
+	if (isCompare() && location.pathname.includes('...')) {
+		[ref] = pathnameParts[4].split('...');
+	} else {
+		ref = pathnameParts[isReleasesOrTags() ? 5 : 4];
+	}
+
 	let compareUrl = `/${repoUrl}/compare`;
 	let commitsUrl = `/${repoUrl}/commits`;
-	let tree = '';
-	const urlParts = location.pathname.split('/');
-	if (urlParts[3] === 'tree') { // On repo page
-		tree = urlParts[4];
-	} else if (urlParts[3] === 'compare' && urlParts[4]) { // On compare page
-		if (urlParts[4].includes('...')) {
-			tree = urlParts[4].split('...')[0];
-		} else {
-			tree = urlParts[4];
-		}
-	} else if (urlParts[3] === 'commits') { // On commits page
-		tree = urlParts[4];
-	} else if (urlParts[3] === 'releases' && urlParts[4] === 'tag') { // On tag page
-		tree = urlParts[5];
-	}
-	if (tree) {
-		compareUrl += `/${tree}`;
-		commitsUrl += `/${tree}`;
+	if (ref) {
+		compareUrl += `/${ref}`;
+		commitsUrl += `/${ref}`;
 	}
 
 	const menu = select('.reponav-dropdown .dropdown-menu')!;

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -31,10 +31,32 @@ async function init(): Promise<void> {
 		createDropdown();
 	}
 
+	let compareUrl = `/${repoUrl}/compare`;
+	let commitsUrl = `/${repoUrl}/commits`;
+	let tree = '';
+	const urlParts = location.pathname.split('/');
+	if (urlParts[3] === 'tree') { // On repo page
+		tree = urlParts[4];
+	} else if (urlParts[3] === 'compare' && urlParts[4]) { // On compare page
+		if (urlParts[4].includes('...')) {
+			tree = urlParts[4].split('...')[0];
+		} else {
+			tree = urlParts[4];
+		}
+	} else if (urlParts[3] === 'commits') { // On commits page
+		tree = urlParts[4];
+	} else if (urlParts[3] === 'releases' && urlParts[4] === 'tag') { // On tag page
+		tree = urlParts[5];
+	}
+	if (tree) {
+		compareUrl += `/${tree}`;
+		commitsUrl += `/${tree}`;
+	}
+
 	const menu = select('.reponav-dropdown .dropdown-menu')!;
 
 	menu.append(
-		<a href={`/${repoUrl}/compare`} className="rgh-reponav-more dropdown-item">
+		<a href={compareUrl} className="rgh-reponav-more dropdown-item">
 			{icons.darkCompare()} Compare
 		</a>,
 
@@ -43,7 +65,7 @@ async function init(): Promise<void> {
 				{icons.dependency()} Dependencies
 			</a>,
 
-		<a href={`/${repoUrl}/commits`} className="rgh-reponav-more dropdown-item">
+		<a href={commitsUrl} className="rgh-reponav-more dropdown-item">
 			{icons.history()} Commits
 		</a>,
 

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -4,8 +4,8 @@ import select from 'select-dom';
 import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
-import {getRepoURL} from '../libs/utils';
-import {isEnterprise, isCompare, isReleasesOrTags} from '../libs/page-detect';
+import {getRepoURL, getRef} from '../libs/utils';
+import {isEnterprise} from '../libs/page-detect';
 import {appendBefore} from '../libs/dom-utils';
 
 const repoUrl = getRepoURL();
@@ -31,16 +31,9 @@ async function init(): Promise<void> {
 		createDropdown();
 	}
 
-	let ref = '';
-	const pathnameParts = location.pathname.split('/');
-	if (isCompare() && location.pathname.includes('...')) {
-		[ref] = pathnameParts[4].split('...');
-	} else {
-		ref = pathnameParts[isReleasesOrTags() ? 5 : 4];
-	}
-
 	let compareUrl = `/${repoUrl}/compare`;
 	let commitsUrl = `/${repoUrl}/commits`;
+	const ref = getRef();
 	if (ref) {
 		compareUrl += `/${ref}`;
 		commitsUrl += `/${ref}`;

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
-import {isRepo, isPR, isPRCommit, isIssue, isReleasesOrTags} from './page-detect';
+import {isRepo, isPR, isPRCommit, isIssue} from './page-detect';
 
 export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
@@ -46,8 +46,6 @@ export const getRef = (): string | undefined => {
 	const pathnameParts = location.pathname.split('/');
 	if (['commits', 'blob', 'tree', 'blame'].includes(pathnameParts[3])) {
 		ref = pathnameParts[4];
-	} else if (isReleasesOrTags()) {
-		ref = pathnameParts[5];
 	} else if (isPRCommit()) {
 		ref = pathnameParts[6];
 	}

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
-import {isRepo, isPR, isIssue} from './page-detect';
+import {isRepo, isPR, isIssue, isCompare, isReleasesOrTags} from './page-detect';
 
 export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
@@ -38,6 +38,21 @@ export const getOwnerAndRepo = (): {
 } => {
 	const [, ownerName, repoName] = location.pathname.split('/', 3);
 	return {ownerName, repoName};
+};
+
+export const getRef = (): string | undefined => {
+	let ref;
+
+	const pathnameParts = location.pathname.split('/');
+	if (['commits', 'blob', 'tree', 'blame'].includes(pathnameParts[3])) {
+		ref = pathnameParts[4];
+	} else if (isCompare() && pathnameParts[4]) {
+		[ref] = pathnameParts[4].split('...');
+	} else if (isReleasesOrTags()) {
+		ref = pathnameParts[5];
+	}
+
+	return ref;
 };
 
 export const parseTag = (tag: string): {version: string; namespace: string} => {

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
-import {isRepo, isPR, isIssue, isCompare, isReleasesOrTags} from './page-detect';
+import {isRepo, isPR, isPRCommit, isIssue, isCompare, isReleasesOrTags} from './page-detect';
 
 export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
@@ -50,6 +50,8 @@ export const getRef = (): string | undefined => {
 		[ref] = pathnameParts[4].split('...');
 	} else if (isReleasesOrTags()) {
 		ref = pathnameParts[5];
+	} else if (isPRCommit()) {
+		ref = pathnameParts[6];
 	}
 
 	return ref;

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
-import {isRepo, isPR, isPRCommit, isIssue} from './page-detect';
+import {isRepo, isPR, isIssue} from './page-detect';
 
 export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
@@ -46,8 +46,6 @@ export const getRef = (): string | undefined => {
 	const pathnameParts = location.pathname.split('/');
 	if (['commits', 'blob', 'tree', 'blame'].includes(pathnameParts[3])) {
 		ref = pathnameParts[4];
-	} else if (isPRCommit()) {
-		ref = pathnameParts[6];
 	}
 
 	return ref;

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -41,14 +41,12 @@ export const getOwnerAndRepo = (): {
 };
 
 export const getRef = (): string | undefined => {
-	let ref;
-
 	const pathnameParts = location.pathname.split('/');
 	if (['commits', 'blob', 'tree', 'blame'].includes(pathnameParts[3])) {
-		ref = pathnameParts[4];
+		return pathnameParts[4];
 	}
 
-	return ref;
+	return undefined;
 };
 
 export const parseTag = (tag: string): {version: string; namespace: string} => {

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -1,6 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
-import {isRepo, isPR, isPRCommit, isIssue, isCompare, isReleasesOrTags} from './page-detect';
+import {isRepo, isPR, isPRCommit, isIssue, isReleasesOrTags} from './page-detect';
 
 export const getUsername = onetime(() => select('meta[name="user-login"]')!.getAttribute('content')!);
 
@@ -46,8 +46,6 @@ export const getRef = (): string | undefined => {
 	const pathnameParts = location.pathname.split('/');
 	if (['commits', 'blob', 'tree', 'blame'].includes(pathnameParts[3])) {
 		ref = pathnameParts[4];
-	} else if (isCompare() && pathnameParts[4]) {
-		[ref] = pathnameParts[4].split('...');
 	} else if (isReleasesOrTags()) {
 		ref = pathnameParts[5];
 	} else if (isPRCommit()) {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -184,7 +184,7 @@ test('getRef', t => {
 
 		'https://github.com/sindresorhus/refined-github/pull/123': undefined,
 		'https://github.com/sindresorhus/refined-github/pull/2105/commits/': undefined,
-		'https://github.com/sindresorhus/refined-github/pull/2105/commits/9df50080dfddee5f7a2a6a1dc4465166339fedfe': '9df50080dfddee5f7a2a6a1dc4465166339fedfe'
+		'https://github.com/sindresorhus/refined-github/pull/2105/commits/9df50080dfddee5f7a2a6a1dc4465166339fedfe': undefined
 	};
 
 	Object.keys(refs).forEach(url => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -172,7 +172,7 @@ test('getRef', t => {
 		'https://github.com/sindresorhus/refined-github/commits/master': 'master',
 		'https://github.com/sindresorhus/refined-github/commits/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
 
-		'https://github.com/sindresorhus/refined-github/releases/tag/v1.2.3': 'v1.2.3',
+		'https://github.com/sindresorhus/refined-github/releases/tag/v1.2.3': undefined,
 
 		'https://github.com/sindresorhus/refined-github/blob/master/readme.md': 'master',
 		'https://github.com/sindresorhus/refined-github/blob/62007c8b944808d1b46d42d5e22fa65883d1eaec/readme.md': '62007c8b944808d1b46d42d5e22fa65883d1eaec',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -164,9 +164,9 @@ test('getRef', t => {
 		'https://github.com/sindresorhus/refined-github/tree/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
 
 		'https://github.com/sindresorhus/refined-github/compare': undefined,
-		'https://github.com/sindresorhus/refined-github/compare/master': 'master',
-		'https://github.com/sindresorhus/refined-github/compare/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
-		'https://github.com/sindresorhus/refined-github/compare/master...test': 'master',
+		'https://github.com/sindresorhus/refined-github/compare/master': undefined,
+		'https://github.com/sindresorhus/refined-github/compare/62007c8b944808d1b46d42d5e22fa65883d1eaec': undefined,
+		'https://github.com/sindresorhus/refined-github/compare/master...test': undefined,
 
 		'https://github.com/sindresorhus/refined-github/commits': undefined,
 		'https://github.com/sindresorhus/refined-github/commits/master': 'master',

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,6 +4,7 @@ import {
 	getDiscussionNumber,
 	getOwnerAndRepo,
 	getRepoPath,
+	getRef,
 	parseTag
 } from '../source/libs/utils';
 
@@ -149,6 +150,44 @@ test('getOwnerAndRepo', t => {
 	Object.keys(ownerAndRepo).forEach(url => {
 		location.href = url;
 		t.deepEqual(ownerAndRepo[url], getOwnerAndRepo());
+	});
+});
+
+test('getRef', t => {
+	const refs: {
+		[url: string]: string | undefined;
+	} = {
+		'https://github.com/sindresorhus/refined-github': undefined,
+		'https://github.com/sindresorhus/refined-github/': undefined,
+
+		'https://github.com/sindresorhus/refined-github/tree/master': 'master',
+		'https://github.com/sindresorhus/refined-github/tree/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
+
+		'https://github.com/sindresorhus/refined-github/compare': undefined,
+		'https://github.com/sindresorhus/refined-github/compare/master': 'master',
+		'https://github.com/sindresorhus/refined-github/compare/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
+		'https://github.com/sindresorhus/refined-github/compare/master...test': 'master',
+
+		'https://github.com/sindresorhus/refined-github/commits': undefined,
+		'https://github.com/sindresorhus/refined-github/commits/master': 'master',
+		'https://github.com/sindresorhus/refined-github/commits/62007c8b944808d1b46d42d5e22fa65883d1eaec': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
+
+		'https://github.com/sindresorhus/refined-github/releases/tag/v1.2.3': 'v1.2.3',
+
+		'https://github.com/sindresorhus/refined-github/blob/master/readme.md': 'master',
+		'https://github.com/sindresorhus/refined-github/blob/62007c8b944808d1b46d42d5e22fa65883d1eaec/readme.md': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
+
+		'https://github.com/sindresorhus/refined-github/wiki/topic': undefined,
+
+		'https://github.com/sindresorhus/refined-github/blame/master/readme.md': 'master',
+		'https://github.com/sindresorhus/refined-github/blame/62007c8b944808d1b46d42d5e22fa65883d1eaec/readme.md': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
+
+		'https://github.com/sindresorhus/refined-github/pull/123': undefined
+	};
+
+	Object.keys(refs).forEach(url => {
+		location.href = url;
+		t.is(refs[url], getRef(), url);
 	});
 });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -182,7 +182,9 @@ test('getRef', t => {
 		'https://github.com/sindresorhus/refined-github/blame/master/readme.md': 'master',
 		'https://github.com/sindresorhus/refined-github/blame/62007c8b944808d1b46d42d5e22fa65883d1eaec/readme.md': '62007c8b944808d1b46d42d5e22fa65883d1eaec',
 
-		'https://github.com/sindresorhus/refined-github/pull/123': undefined
+		'https://github.com/sindresorhus/refined-github/pull/123': undefined,
+		'https://github.com/sindresorhus/refined-github/pull/2105/commits/': undefined,
+		'https://github.com/sindresorhus/refined-github/pull/2105/commits/9df50080dfddee5f7a2a6a1dc4465166339fedfe': '9df50080dfddee5f7a2a6a1dc4465166339fedfe'
 	};
 
 	Object.keys(refs).forEach(url => {


### PR DESCRIPTION
### Description
Include current ref (branch or tag) in compare & commit repo links added in [`more-dropdown`](https://github.com/sindresorhus/refined-github/blob/master/source/features/more-dropdown.tsx#L37-L48). Different pages required different detection to get the current ref (branch or tag).

### Extra
Optionally I can include [the default branch](https://github.com/sindresorhus/refined-github/blob/master/source/libs/get-default-branch.ts), but that requires an extra API call and is not necessary.

### Closes
Closes #1197.

### Test
1. Visit any of the below urls.
2. Open repo tab "More" -> "Compare" or "Commits".
3. See it link to the correct tree (branch or tag).

* https://github.com/BrowserSync/browser-sync ➡ no ref
* https://github.com/BrowserSync/browser-sync/tree/client-ts ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/compare/client-ts ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/compare/62007c8b944808d1b46d42d5e22fa65883d1eaec ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/compare/client-ts...master ➡ compare & commits should link to the left ref.
* https://github.com/BrowserSync/browser-sync/commits/client-ts ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/commits/62007c8b944808d1b46d42d5e22fa65883d1eaec ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/releases/tag/v2.26.3 ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/compare ➡ no ref
* https://github.com/BrowserSync/browser-sync/commits ➡ will default and link to master
* https://github.com/BrowserSync/browser-sync/blob/master/README.md  ➡ compare & commits should link to ref
* https://github.com/BrowserSync/browser-sync/wiki/Release-history ➡ no ref; should not link to "Release-history"