### PR TITLE
Add link to forked repo below the original

### DIFF
--- a/source/content.ts
+++ b/source/content.ts
@@ -102,6 +102,7 @@ import './features/tag-changelog-link';
 import './features/link-to-file-in-file-history';
 import './features/clean-sidebar';
 import './features/open-issue-to-latest-comment';
+import './features/forked-to';
 
 import './features/scrollable-code-and-blockquote.css';
 import './features/center-reactions-popup.css';

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -1,0 +1,41 @@
+import './more-dropdown.css';
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+
+async function init(): Promise<void> {
+	const forkDialog = select<HTMLElement>('details-dialog[src*="/fork"]')!;
+	const forkFragmentUrl = forkDialog.getAttribute('src')!;
+
+	const forkFragment = select<HTMLElement>('include-fragment', forkDialog)!;
+	forkFragment.addEventListener('load', () => onFragmentLoaded(forkDialog));
+	forkFragment.setAttribute('src', forkFragmentUrl); // This will load the fork fragment.
+}
+
+function onFragmentLoaded(parent: HTMLElement): void {
+	const pageheader = select<HTMLElement>('.pagehead h1.public')!;
+
+	for (const forkElm of select.all<HTMLElement>('.octicon-repo-forked', parent)) {
+		const forkName = forkElm.parentNode!.textContent!.trim();
+
+		pageheader.append(
+			<span className={'fork-flag'} data-repository-hovercards-enabled>
+				<span className={'text'}>forked to&nbsp;
+					<a data-hovercard-type="repository" data-hovercard-url={`/${forkName}/hovercard`} href={`/${forkName}`}>
+						{forkName}
+					</a>
+				</span>
+			</span>
+		);
+	}
+}
+
+features.add({
+	id: 'forked-to',
+	description: 'Add link to forked repo below the original',
+	include: [
+		features.isRepo
+	],
+	load: features.onAjaxedPages,
+	init
+});


### PR DESCRIPTION
### Description
Add links to the forked repos below the original repo. For users and organizations.

### Closes
Closes #1129
Supersedes  #1108

### Screenshots
**Original repo:**
![image](https://user-images.githubusercontent.com/55841/58664597-41135b80-832f-11e9-8089-e76b2bb77134.png)

**User forked repo:**
![image](https://user-images.githubusercontent.com/55841/58664623-4f617780-832f-11e9-8363-38d170b8b431.png)

**Organization forked repo:**
![image](https://user-images.githubusercontent.com/55841/58664651-5ee0c080-832f-11e9-995e-b98f45dfd6d0.png)

**Hover card:**
![image](https://user-images.githubusercontent.com/55841/58664934-0f4ec480-8330-11e9-979a-7e3b0c833c56.png)


### Test
1. Open any repo and click on the <kbd>Fork</kbd> button.
2. Fork the repo.
3. Go back to the original repo. 
4. Below the repo name, a link to your fork will presented.
