### PR TITLE
Format titles on single issue / PR pages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [Highlight any `code` and references like #1 in the issue/PR titles](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 
 ### More shortcuts
 

--- a/readme.md
+++ b/readme.md
@@ -179,7 +179,6 @@ GitHub Enterprise is also supported. More info in the options.
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
-- [Highlight any `code` and references like #1 in the issue/PR titles](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 
 ### More shortcuts
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -51,7 +51,7 @@ import './features/wait-for-build';
 import './features/hide-inactive-deployments';
 import './features/pull-request-hotkey';
 import './features/quick-review-buttons';
-import './features/linkify-issues-in-titles';
+import './features/format-discussion-titles';
 import './features/embed-gist-inline';
 import './features/extend-status-labels';
 import './features/highlight-closing-prs-in-open-issues';

--- a/source/features/format-discussion-titles.tsx
+++ b/source/features/format-discussion-titles.tsx
@@ -25,8 +25,8 @@ function init(): void {
 }
 
 features.add({
-	id: 'linkify-issues-in-titles',
-	description: 'Make issue/PR references in issue/PR titles clickable',
+	id: 'format-discussion-titles',
+	description: 'Make issue/PR references in issue/PR titles clickable and parse `code in backticks` that appear as Markdown',
 	include: [
 		features.isPR,
 		features.isIssue

--- a/source/features/format-discussion-titles.tsx
+++ b/source/features/format-discussion-titles.tsx
@@ -27,6 +27,7 @@ function init(): void {
 features.add({
 	id: 'format-discussion-titles',
 	description: 'Make issue/PR references in issue/PR titles clickable and parse `code in backticks` that appear as Markdown',
+	screenshot: 'https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png',
 	include: [
 		features.isPR,
 		features.isIssue

--- a/source/features/linkify-issues-in-titles.tsx
+++ b/source/features/linkify-issues-in-titles.tsx
@@ -1,16 +1,25 @@
 import select from 'select-dom';
+import zipTextNodes from 'zip-text-nodes';
 import features from '../libs/features';
 import observeEl from '../libs/simplified-element-observer';
+import parseBackticks from '../libs/parse-backticks';
 import {linkifyIssuesInDom} from './linkify-urls-in-code';
 
 function init(): void {
 	observeEl(
 		select('#partial-discussion-header')!.parentElement!,
 		() => {
-			const title = select('.js-issue-title:not(.refined-linkified-title)');
-			if (title) {
+			const title = select('.js-issue-title')!;
+
+			if (!title.classList.contains('refined-linkified-title')) {
 				title.classList.add('refined-linkified-title');
 				linkifyIssuesInDom(title);
+			}
+
+			const fragment = parseBackticks(title.textContent!);
+
+			if (fragment.children.length > 0) {
+				zipTextNodes(title, fragment);
 			}
 		});
 }

--- a/source/features/linkify-issues-in-titles.tsx
+++ b/source/features/linkify-issues-in-titles.tsx
@@ -9,17 +9,17 @@ function init(): void {
 	observeEl(
 		select('#partial-discussion-header')!.parentElement!,
 		() => {
-			const title = select('.js-issue-title')!;
+			const title = select('.js-issue-title:not(.rgh-formatted-title)');
 
-			if (!title.classList.contains('refined-linkified-title')) {
-				title.classList.add('refined-linkified-title');
+			if (title) {
+				title.classList.add('rgh-formatted-title');
 				linkifyIssuesInDom(title);
-			}
 
-			const fragment = parseBackticks(title.textContent!);
+				const fragment = parseBackticks(title.textContent!);
 
-			if (fragment.children.length > 0) {
-				zipTextNodes(title, fragment);
+				if (fragment.children.length > 0) {
+					zipTextNodes(title, fragment);
+				}
 			}
 		});
 }


### PR DESCRIPTION
Closes #1984

### Test
1. For issues: All issues present on https://github.com/HardikModha/github-playground/issues

2. For PR pages: All PRs present on https://github.com/HardikModha/github-playground/pulls

3. Also tested the feature by updating the issue / PR title. (https://github.com/HardikModha/github-playground/issues/9)