### PR TITLE
Fix typo in `fix-hidden-comments` feature's ID

### DIFF
--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -34,7 +34,7 @@ const init = (): void => {
 };
 
 features.add({
-	id: 'preview-hiddden-comments',
+	id: 'preview-hidden-comments',
 	description: 'Preview hidden comments inline',
 	include: [
 		features.hasComments


### PR DESCRIPTION
Fixes an issue where clicking the source link in Features list (in about:addons) would result in a 404 due to id being different to the actual source file.

When I loaded my dev copy as a temporary extension in Firefox, changing the ID seemed to result in the feature being disabled. Not sure if there's some way to fix that?