### PR TITLE
Fix alignment of subnav items

### DIFF
--- a/source/features/tags-dropdown.css
+++ b/source/features/tags-dropdown.css
@@ -1,8 +1,3 @@
-/* Add spacing between buttons when user change edit the current tag */
-.float-right + .rgh-tags-dropdown {
-	margin-right: 10px;
-}
-
 /* Drop unneeded elements */
 :root .rgh-tags-dropdown .select-menu-tab,
 :root .rgh-tags-dropdown .select-menu-header {

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -13,8 +13,8 @@ async function init(): Promise<false | void> {
 	const {ownerName, repoName} = getOwnerAndRepo();
 
 	return select('.subnav')!.append(
-		<div className="rgh-tags-dropdown float-right d-flex flex-shrink-0 flex-items-center mb-3">
-			<details className="details-reset details-overlay select-menu branch-select-menu position-relative ml-3">
+		<div className="rgh-tags-dropdown float-right d-flex flex-shrink-0 flex-items-center">
+			<details className="details-reset details-overlay select-menu branch-select-menu position-relative">
 				<summary className="btn select-menu-button css-truncate" data-hotkey="w" title="Find tags" aria-haspopup="menu">
 					Select tag&nbsp;
 				</summary>

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -10,7 +10,7 @@
 }
 
 /* Move `New issue` button back to the right */
-.subnav .btn-primary {
+.subnav .float-right {
 	order: 100;
 	margin-left: 20px;
 }


### PR DESCRIPTION
Closes #2013.

- Aligned subnav items based on their classes.
- Removed margin on tags selector.

## Before

### Labels
![image](https://user-images.githubusercontent.com/37769974/58863929-6ad2d680-86d1-11e9-8426-f79c43bffff3.png)

### Releases
![image](https://user-images.githubusercontent.com/37769974/58863899-58f13380-86d1-11e9-88ae-8df8fb0c335c.png)


## After

### Labels
![image](https://user-images.githubusercontent.com/37769974/58863956-7cb47980-86d1-11e9-9783-0b48934cd2ce.png)

### Releases
![image](https://user-images.githubusercontent.com/37769974/58863986-8c33c280-86d1-11e9-9d9a-62d04cbf6d31.png)


## Test
- https://github.com/sindresorhus/refined-github/labels
- https://github.com/sindresorhus/refined-github/releases
