### PR TITLE
Fix branch name alignment in recently-pushed-branches

### DIFF
--- a/source/features/recently-pushed-branches-enhancements.css
+++ b/source/features/recently-pushed-branches-enhancements.css
@@ -32,6 +32,10 @@
 	border-radius: 5px;
 	background-color: #24292e;
 }
+.rgh-recently-pushed-branches .RecentBranches .octicon-git-branch {
+	vertical-align: middle;
+	margin-right: 2px;
+}
 .rgh-recently-pushed-branches .RecentBranches .btn {
 	width: 32px;
 	text-indent: -999999px; /* Hide text */

--- a/source/features/recently-pushed-branches-enhancements.css
+++ b/source/features/recently-pushed-branches-enhancements.css
@@ -45,7 +45,7 @@
 }
 .rgh-recently-pushed-branches .RecentBranches .btn + div {
 	margin-right: 8px;
-	float: left;
+	float: right;
 	font-size: 11px;
 }
 .rgh-recently-pushed-branches .RecentBranches .btn .octicon {

--- a/source/features/recently-pushed-branches-enhancements.css
+++ b/source/features/recently-pushed-branches-enhancements.css
@@ -41,7 +41,7 @@
 }
 .rgh-recently-pushed-branches .RecentBranches .btn + div {
 	margin-right: 8px;
-	float: right;
+	float: left;
 	font-size: 11px;
 }
 .rgh-recently-pushed-branches .RecentBranches .btn .octicon {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/pull/2110#issuecomment-498922194.

Issues:
- It looked misaligned.
- The branch icon was not in alignment with the text.

Before:
![Screen Shot 2019-06-05 at 10 53 35 PM](https://user-images.githubusercontent.com/22439276/58976673-a8c11f00-87e5-11e9-8319-4b16747f1963.png)

After:

![Screen Shot 2019-06-05 at 10 56 05 PM](https://user-images.githubusercontent.com/22439276/58976777-e4f47f80-87e5-11e9-8085-f61b51aba66e.png)