### PR TITLE
Only show `filter-pr-by-build-status` if the repo has CI

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -5,7 +5,7 @@ import {appendBefore} from '../libs/dom-utils';
 import {getRepoURL, getRepoBranch} from '../libs/utils';
 import fetchDom from '../libs/fetch-dom';
 
-const fetchStatus = onetime(async () => {
+export const fetchCIStatus = onetime(async () => {
 	const url = `/${getRepoURL()}/commits/${getRepoBranch() || ''}`;
 	const icon = await fetchDom<HTMLElement>(url, '.commit-build-statuses');
 
@@ -18,12 +18,12 @@ const fetchStatus = onetime(async () => {
 });
 
 async function init(): Promise<false | void> {
-	const icon = await fetchStatus();
+	const icon = await fetchCIStatus();
 	if (!icon) {
 		return false;
 	}
 
-	if (onetime.callCount(fetchStatus) > 1) {
+	if (onetime.callCount(fetchCIStatus) > 1) {
 		icon.style.animation = 'none';
 	}
 

--- a/source/features/filter-pr-by-build-status.tsx
+++ b/source/features/filter-pr-by-build-status.tsx
@@ -36,9 +36,9 @@ function populateDropDown({currentTarget}: Event): void {
 }
 
 async function init(): Promise<void | false> {
-	const ciStatusIcon = await fetchCIStatus();
+	const hasCI = await fetchCIStatus();
 
-	if (!ciStatusIcon) {
+	if (!hasCI) {
 		return false;
 	}
 

--- a/source/features/filter-pr-by-build-status.tsx
+++ b/source/features/filter-pr-by-build-status.tsx
@@ -2,6 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import {checkInline} from '../libs/icons';
 import features from '../libs/features';
+import {fetchCIStatus} from './ci-link';
 
 function populateDropDown({currentTarget}: Event): void {
 	const searchParam = new URLSearchParams(location.search);
@@ -34,7 +35,13 @@ function populateDropDown({currentTarget}: Event): void {
 	}
 }
 
-function init(): void | false {
+async function init(): Promise<void | false> {
+	const ciStatusIcon = await fetchCIStatus();
+
+	if (!ciStatusIcon) {
+		return false;
+	}
+
 	const reviewsFilter = select('.table-list-header-toggle > details:nth-last-child(3)')!;
 
 	if (!reviewsFilter) {


### PR DESCRIPTION
Closes #2127

# Test
1. https://github.com/sindresorhus/refined-github/pulls (Filter should be present)
2. https://github.com/HardikModha/github-playground/pulls (Filters should not be present)