### PR TITLE
Enable discussion list features on new URLs

### DIFF
--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -8,7 +8,7 @@ function init(): void {
 	const defaultQuery = 'is:open archived:false ';
 
 	// Without this, the Issues page also displays PRs, and viceversa
-	const type = location.pathname === '/issues' ? 'is:issue ' : 'is:pr ';
+	const type = location.pathname.split('/', 2)[1] === 'issues' ? 'is:issue ' : 'is:pr ';
 
 	const links = [
 		['Commented', `commenter:${getUsername()}`],

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -23,7 +23,7 @@ export const isEnterprise = (): boolean => location.hostname !== 'github.com' &&
 
 export const isGist = (): boolean => location.hostname.startsWith('gist.') || location.pathname.startsWith('gist/');
 
-export const isGlobalDiscussionList = (): boolean => location.pathname === '/issues' || location.pathname === '/pulls';
+export const isGlobalDiscussionList = (): boolean => ['issues', 'pulls'].includes(location.pathname.split('/', 2)[1]);
 
 export const isGlobalSearchResults = (): boolean => location.pathname === '/search' && new URLSearchParams(location.search).get('q') !== null;
 

--- a/test/page-detect.ts
+++ b/test/page-detect.ts
@@ -171,9 +171,14 @@ test('isRepoDiscussionList', urlMatcherMacro, pageDetect.isRepoDiscussionList, [
 
 test('isGlobalDiscussionList', urlMatcherMacro, pageDetect.isGlobalDiscussionList, [
 	'https://github.com/issues',
+	'https://github.com/issues?q=is%3Apr+is%3Aopen',
+	'https://github.com/issues/assigned',
+	'https://github.com/issues/mentioned',
 	'https://github.com/pulls',
 	'https://github.com/pulls?q=issues',
-	'https://github.com/issues?q=is%3Apr+is%3Aopen'
+	'https://github.com/pulls/assigned',
+	'https://github.com/pulls/mentioned',
+	'https://github.com/pulls/review-requested'
 ], [
 	'https://github.com/issuesorter',
 	'https://github.com/sindresorhus/refined-github/issues',


### PR DESCRIPTION
# Description

GitHub included some new urls at the global discussion list for PR and issues:

* https://github.com/issues
  * https://github.com/issues/assigned
  * https://github.com/issues/mentioned
* https://github.com/pulls
  * https://github.com/pulls/assigned
  * https://github.com/pulls/mentioned
  * https://github.com/pulls/review-requested

Those are not matched by the `isGlobalDiscussionList` page-detect. And therefor breaking `global-discussion-list-filters` feature (and probably also `sort-issues-by-update-time`).

# Closes
#2134

# Test

1. Disable feature `sort-issues-by-update-time`
2. Go to https://github.com/pulls
3. See "Commented" and "Yours" buttons
4. Select "Assigned"
5. You will be redirect to https://github.com/pulls/assigned
6. See "Commented" and "Yours" buttons **appear again**
