### PR TITLE
Ignore organizations from `show-names`

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -7,7 +7,7 @@ import {getUsername} from '../libs/utils';
 
 async function init(): Promise<false | void> {
 	// `a` selector needed to skip commits by non-GitHub users
-	const usernameElements = select.all('.js-discussion a.author:not(.rgh-fullname):not([href*="/apps/"]):not([href*="/marketplace/"])');
+	const usernameElements = select.all('.js-discussion a.author:not(.rgh-fullname):not([href*="/apps/"]):not([href*="/marketplace/"]):not([data-hovercard-type="organization"])');
 
 	const usernames = new Set<string>();
 	const myUsername = getUsername();


### PR DESCRIPTION
Currently, when an organization creates an event in a discussion, it will be picked up by `show-names`, but organizations aren't users, so the current implementation can't get its real name, and fails from the graphql error.

This just ignores organizations, you should know the organization from its name.

Test: https://github.com/rust-lang/rfcs/pull/2544