### PR TITLE
Add `cycle-lists-with-keyboard-shortcuts` feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,4 @@ source/features/indented-code-wrapping.tsx @notlmn
 source/features/open-issue-to-latest-comment.tsx @dotconnor
 source/features/highest-rated-comment.tsx @lubien
 source/features/clean-issue-filters.tsx @notlmn
+source/features/cycle-lists-with-keyboard-shortcuts.tsx @notlmn

--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Link to file itself in the history pages](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
 - [See an automatic changelog for each tag or release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+- [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 
 ### Previously part of Refined GitHub
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -105,6 +105,7 @@ import './features/show-asset-download-count';
 import './features/open-issue-to-latest-comment';
 import './features/highest-rated-comment';
 import './features/clean-issue-filters';
+import './features/cycle-lists-with-keyboard-shortcuts';
 
 import './features/scrollable-code-and-blockquote.css';
 import './features/center-reactions-popup.css';

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -1,0 +1,67 @@
+import select from 'select-dom';
+import delegate from 'delegate-it';
+import features from '../libs/features';
+
+function init(): void {
+	let selectableItems: HTMLElement[] = [];
+	let lastSelectableItemIndex: number;
+
+	function populateSelectableItems(): void {
+		requestAnimationFrame(() => {
+			selectableItems = select.all([
+				'.js-active-navigation-container .select-menu-list:not([hidden]) .js-navigation-item:not([hidden])', // All selectable items in the current tab
+				'.js-active-navigation-container .js-new-label-modal:not(.d-none) .js-navigation-item', // "Create label" button, when selecting labels
+				'.js-active-navigation-container a.js-navigation-item.js-label-options' // "Edit labels" link, when selecting labels
+			].join(','));
+
+			lastSelectableItemIndex = selectableItems.length - 1;
+		});
+	}
+
+	function performSwapFocus(event: KeyboardEvent, from: number, to: number): void {
+		event.preventDefault();
+		event.stopPropagation();
+
+		selectableItems[from].classList.remove('navigation-focus');
+		selectableItems[from].setAttribute('aria-selected', 'false');
+		selectableItems[to].classList.add('navigation-focus');
+		selectableItems[to].setAttribute('aria-selected', 'true');
+
+		selectableItems[to].scrollIntoView({
+			block: 'nearest'
+		});
+	}
+
+	function handleKeyDown(event: KeyboardEvent): void {
+		if (selectableItems.length === 0) { // Empty projects and milestones list
+			return;
+		}
+
+		if (selectableItems[0].matches('.navigation-focus') && event.key === 'ArrowUp') {
+			performSwapFocus(event, 0, lastSelectableItemIndex);
+		} else if (selectableItems[lastSelectableItemIndex].matches('.navigation-focus') && event.key === 'ArrowDown') {
+			performSwapFocus(event, lastSelectableItemIndex, 0);
+		}
+	}
+
+	// Input fields for projects and milestones are added dynamically to the page
+	// GitHub triggers events on the document element for us, which can be used to detect new input elements
+	delegate(document, '.js-filterable-field', 'filterable:change', event => {
+		populateSelectableItems();
+
+		const input = event.delegateTarget as HTMLElement;
+		input.addEventListener('keydown', handleKeyDown);
+	});
+}
+
+features.add({
+	id: 'cycle-lists-with-keyboard-shortcuts',
+	description: 'Cycle "select lists" (labels, etc) when selecting them with the `↑` and `↓` keys.',
+	init,
+	load: features.onAjaxedPages,
+	include: [
+		features.isPRConversation,
+		features.isIssue,
+		features.isCompare
+	]
+});

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -56,7 +56,7 @@ function init(): void {
 
 features.add({
 	id: 'cycle-lists-with-keyboard-shortcuts',
-	description: 'Cycle "select lists" (labels, etc) when selecting them with the `↑` and `↓` keys.',
+	description: 'Cycle "popover lists" (labels, milestones, etc) when selecting them with the `↑` and `↓` keys.',
 	init,
 	load: features.onAjaxedPages,
 	include: [

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -57,6 +57,7 @@ function init(): void {
 features.add({
 	id: 'cycle-lists-with-keyboard-shortcuts',
 	description: 'Cycle "popover lists" (labels, milestones, etc) when selecting them with the `↑` and `↓` keys.',
+	screenshot: 'https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif',
 	init,
 	load: features.onAjaxedPages,
 	include: [

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -56,6 +56,7 @@ interface GlobalEventHandlersEventMap {
 	'focusin': UIEvent; // Drop when it reaches W3C Recommendation https://github.com/Microsoft/TSJS-lib-generator/pull/369
 	'rgh:view-markdown-source': CustomEvent;
 	'rgh:view-markdown-rendered': CustomEvent;
+	'filterable:change': CustomEvent;
 }
 
 declare namespace JSX {


### PR DESCRIPTION
Closes #1450.

- Makes use of custom events emitted by GitHub to detect and add events to input elements.
- As opposed to #2008, this PR adds `keydown` event listeners to only search fields, which is also what GitHub uses (you cannot use up and down arrow keys to navigate when the search field is not focused).
- Supports cycling through labels, projects, milestones and all other sidebar elements, even when a search filter is applied.

## Preview

![labels-cycling](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)

## Test
Can be tested on any issue or PR that you have permissions to edit.
