### PR TITLE
Fix `indented-code-wrapping`

### DIFF
--- a/source/features/indented-code-wrapping.css
+++ b/source/features/indented-code-wrapping.css
@@ -1,3 +1,9 @@
+/* GitHub adds negative text indentation, reset it */
+.rgh-code-wrapping-enabled .soft-wrap .blob-code {
+	text-indent: 0;
+	padding-left: 10px;
+}
+
 .rgh-code-wrapping-enabled .blob-code-inner {
 	white-space: pre-wrap;
 }

--- a/source/features/indented-code-wrapping.tsx
+++ b/source/features/indented-code-wrapping.tsx
@@ -12,6 +12,7 @@ function run(): void {
 
 	for (const table of tables) {
 		table.classList.add('rgh-softwrapped-code');
+		const tabSize = parseInt(table.style.getPropertyValue('--tab-size') || document.documentElement.style.getPropertyValue('tab-size'), 10);
 
 		for (const line of select.all('.blob-code-inner:not(.blob-code-hunk)', table)) {
 			if (line.textContent!.length < 20) {
@@ -36,6 +37,16 @@ function run(): void {
 
 			// Code suggestions already had some padding
 			const extraPadding = line.classList.contains('px-2') ? '8px + ' : '';
+
+			// If there is mixed indentation on a line, spaces before a tab are collapsed with the following tab until `spaceCount` is more than `tabSize`
+			// So, ignore any number of spaces that are below `tabSize` or more than any multiple of `tabSize`
+			if (tabCount > 0) {
+				if (spaceCount > tabSize) {
+					spaceCount %= tabSize;
+				} else {
+					spaceCount = 0;
+				}
+			}
 
 			// Move the whole line where it is supposed to be, then unindent the start of the line to compensate for indentation, preserving spaces
 			// We might get `--tab-size` from compatible extensions like `github-custom-tab-size`

--- a/source/features/indented-code-wrapping.tsx
+++ b/source/features/indented-code-wrapping.tsx
@@ -70,7 +70,8 @@ features.add({
 	include: [
 		features.isPRFiles,
 		features.isCommit,
-		features.isPRConversation
+		features.isPRConversation,
+		features.isCompare
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/indented-code-wrapping.tsx
+++ b/source/features/indented-code-wrapping.tsx
@@ -55,7 +55,6 @@ function init(): void {
 
 features.add({
 	id: 'indented-code-wrapping',
-	disabled: 'https://github.com/sindresorhus/refined-github/issues/2085',
 	description: 'Wrap code inside all code blocks to match indentation',
 	include: [
 		features.isPRFiles,


### PR DESCRIPTION
Closes #2085.
Fixes #2089.

- Assumes that spaces always come after tabs, but other way around too.
- Works for dynamic `tab-size` values too, like when using "GitHub Custom Tab Size".
- But as mentioned in https://github.com/sindresorhus/refined-github/issues/2085#issuecomment-498032629, wrapped text would not be at the same level of the actual line, it would be where the last tab character ended.

### Test
- https://github.com/eclipse/omr/commit/75c09985f5d5dd6cfd7c9d1e4f4d56e9406a45c4#diff-3990e65f3237ed46d278a1a8aefbaeeaR389 from https://github.com/sindresorhus/refined-github/issues/2085#issue-448919803.
- https://github.com/sindresorhus/electron-context-menu/pull/76#discussion_r289699052 from https://github.com/sindresorhus/refined-github/issues/2085#issuecomment-500191824.
- https://github.com/vatesfr/xen-orchestra/commit/b4e40ec5e7e6e24b163a3855df377da25f3edbdb#diff-37458fb9e51d193ef360403ba893e2e2R45 from https://github.com/sindresorhus/refined-github/issues/2089#issue-449259004.
