### PR TITLE
Update TS to 3.5 (has errors)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13150,9 +13150,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.4.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.4.tgz",
-			"integrity": "sha512-xt5RsIRCEaf6+j9AyOBgvVuAec0i92rgCaS3S+UVf5Z/vF2Hvtsw08wtUTJqp4djwznoAgjSxeCcU4r+CcDBJA==",
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
 			"dev": true
 		},
 		"uid2": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
 		"ts-loader": "^6.0.4",
 		"ts-node": "^8.3.0",
 		"type-fest": "^0.5.2",
-		"typescript": "^3.4.4",
+		"typescript": "^3.5.2",
 		"web-ext": "^3.0.0",
 		"web-ext-submit": "^3.0.0",
 		"webpack": "^4.35.0",


### PR DESCRIPTION
Code with errors: 

https://github.com/sindresorhus/refined-github/blob/bb094f2d7ebbcad474559cfd5565d400c8dc7605/source/libs/permission-events-polyfill.ts#L14-L21

TS 3.5 seems to not work in this very specific case. The types seem correct until the last step:

<img width="527" alt="" src="https://user-images.githubusercontent.com/1402241/59959947-d818a100-94f2-11e9-9b98-f384dba5d11a.png">

but then the function parameters aren't automatically inferred:

<img width="559" alt="" src="https://user-images.githubusercontent.com/1402241/59959946-d818a100-94f2-11e9-98d2-158bee4d55a3.png">

But in 3.4 the type was:

<img width="608" alt="" src="https://user-images.githubusercontent.com/1402241/59960151-64789300-94f6-11e9-9596-0cc060f79e1e.png">

It works for simple examples but not in this case (maybe due to regressions in namespace handling)