### PR TITLE
Add display: none; to remove-diff-signs.css

### DIFF
--- a/source/features/remove-diff-signs.css
+++ b/source/features/remove-diff-signs.css
@@ -1,4 +1,5 @@
 .rgh-remove-diff-signs .blob-code-inner::before, /* Inline review blocks in PRs */
 .rgh-remove-diff-signs .blob-code-marker-cell::before { /* Commit page */
 	content: none;
+	display: none;
 }


### PR DESCRIPTION
I have found that running v19.6.26 in Chrome 75.0.3770.100 on our GitHub Enterprise instance running 2.16, `content: none;` does not work to remove the diff marker, but `display: none;` does. Also, it appears to throw off the indentation wildly and inconsistently, so for now I've disabled that feature.

An addition line looks like this on GHE 2.16:
```html
<td class="blob-code blob-code-addition blob-code-marker-cell" data-code-marker="+">
  </td>
```
Whereas it's a span on Github.com:
```html
<span class="blob-code-inner blob-code-marker" data-code-marker="+"><br></span>
```
