### PR TITLE
Mention recently added features in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -183,6 +183,8 @@ GitHub Enterprise is also supported. More info in the options.
 - [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [Wrapped code in diff views is aligned at the indented level of original line.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
+- [Limit the number of characters that can be used as a commit title while editing files or merging PRs.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 
 ### More shortcuts
 


### PR DESCRIPTION
Add images to `indented-code-wrapping` and `limit-title-commit-length` features, mentioning them in the readme.

From https://github.com/sindresorhus/refined-github/pull/2115#issuecomment-506672071 and https://github.com/sindresorhus/refined-github/pull/1989#issuecomment-506671210.