### PR TITLE
Restore lock icons on private orgs

### DIFF
--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -12,7 +12,7 @@ async function init(): Promise<false | void> {
 	}
 
 	let publicOrgs = await api.v3(`users/${getUsername()}/orgs`);
-	publicOrgs = publicOrgs.map((orgData: AnyObject) => `/${orgData.login}`);
+	publicOrgs = Object.values(publicOrgs).map((orgData: AnyObject) => `/${orgData.login}`);
 
 	for (const org of orgs) {
 		if (!publicOrgs.includes(org.pathname)) {

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -12,7 +12,7 @@ async function init(): Promise<false | void> {
 	}
 
 	let publicOrgs = await api.v3(`users/${getUsername()}/orgs`);
-	publicOrgs = Object.values(publicOrgs).map((orgData: AnyObject) => `/${orgData.login}`);
+	publicOrgs = publicOrgs.map((orgData: AnyObject) => `/${orgData.login}`);
 
 	for (const org of orgs) {
 		if (!publicOrgs.includes(org.pathname)) {

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -102,9 +102,8 @@ export const v3 = mem(async (
 	const apiResponse: JsonObject = textContent.length > 0 ? JSON.parse(textContent) : {};
 
 	if (response.ok || ignoreHTTPStatus) {
-		return Object.assign([], {
+		return Object.assign(apiResponse, {
 			status: response.status,
-			...apiResponse,
 			ok: response.ok
 		});
 	}

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -102,11 +102,11 @@ export const v3 = mem(async (
 	const apiResponse: JsonObject = textContent.length > 0 ? JSON.parse(textContent) : {};
 
 	if (response.ok || ignoreHTTPStatus) {
-		return {
+		return Object.assign([], {
 			status: response.status,
 			...apiResponse,
 			ok: response.ok
-		};
+		});
 	}
 
 	throw getError(apiResponse);


### PR DESCRIPTION
## What

Fixes #2210 

## Notes

After some digging, it seems as though the response from GitHub's API changed a bit(?), and some of the keys in the response aren't iterable. 🤔 

This just uses an explicit `Object.values` around the `publicOrgs` response object. 😄

### Before

<img width="271" alt="Screen Shot 2019-07-07 at 3 39 56 PM" src="https://user-images.githubusercontent.com/8808097/60774727-8add2780-a0cd-11e9-8cea-32ff01e97b6d.png">

### After

<img width="271" alt="Screen Shot 2019-07-07 at 3 40 08 PM" src="https://user-images.githubusercontent.com/8808097/60774729-903a7200-a0cd-11e9-914c-04da345601d7.png">

