### PR TITLE
Fix UI jumping when repo forked

### DIFF
--- a/source/features/forked-to.css
+++ b/source/features/forked-to.css
@@ -1,0 +1,3 @@
+.rgh-forked {
+	position: absolute;
+}

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -1,3 +1,4 @@
+import './forked-to.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import cache from 'webext-storage-cache';


### PR DESCRIPTION
The UI jumps when a repo has been forked:

![Kapture 2019-07-08 at 13 58 01](https://user-images.githubusercontent.com/1935696/60808402-7e69d500-a188-11e9-9247-b71b8370e6f4.gif)


Setting `position: absolute` on the `.rgh-forked` element removes it from the document flow and prevents pushing the other content further down the page.

The design seems still acceptable:

**After:**

<img src=https://user-images.githubusercontent.com/1935696/60808251-1d420180-a188-11e9-8294-d1c35b2cea0b.png width=300>

**Before:**

<img src=https://user-images.githubusercontent.com/1935696/60808253-1d420180-a188-11e9-82c0-286c38633f4b.png width=300>

# Test

Visit a URL of a repo that you forked and watch the UI jump.
