### PR TITLE
Various fixes to `forked-to`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10671,6 +10671,14 @@
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-2.1.0.tgz",
 			"integrity": "sha512-xMwL9id1bHn/UfNGFEMFwlULOprQUEOg6vhqSfr6oKxPFB0oSh0zhGq/9/tPSE+cyij2+RW6H8+0Ke4xsPdZ7Q=="
 		},
+		"p-filter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
+			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+			"requires": {
+				"p-map": "^2.0.0"
+			}
+		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -10701,8 +10709,7 @@
 		"p-map": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-			"dev": true
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
 		"p-try": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"linkify-urls": "^2.2.0",
 		"mem": "^5.1.1",
 		"onetime": "^5.0.0",
+		"p-filter": "^2.1.0",
 		"select-dom": "^5.1.0",
 		"shorten-repo-url": "^1.5.1",
 		"tiny-version-compare": "^1.0.0",

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -62,8 +62,8 @@ async function init(): Promise<void> {
 	const pageHeader = select('.pagehead h1.public')!;
 	for (const fork of await getForks()) {
 		pageHeader.append(
-			<span className="fork-flag rgh-forked">forked to&nbsp;
-				<a href={`/${fork}`}>{fork}</a>
+			<span className="fork-flag rgh-forked">
+				forked to <a href={`/${fork}`}>{fork}</a>
 			</span>
 		);
 	}

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -1,43 +1,28 @@
 import React from 'dom-chef';
-import select from 'select-dom';
 import cache from 'webext-storage-cache';
+import select from 'select-dom';
+import pFilter from 'p-filter';
+import onetime from 'onetime';
 import features from '../libs/features';
-import {getRepoURL} from '../libs/utils';
 import {isRepoWithAccess} from '../libs/page-detect';
+import {getRepoURL, getUsername} from '../libs/utils';
 
-const getCacheKey = (repo: string): string => `forked-to:${repo}`;
+const getCacheKey = onetime((): string => `forked-to:${getUsername()}:${findForkedRepo() || getRepoURL()}`);
 
-async function showForks(): Promise<void> {
-	const cached = await getValidatedCache(getSourceRepo());
-	const pageHeader = select('.pagehead h1.public')!;
-	for (const fork of cached.filter(fork => fork !== getRepoURL())) {
-		pageHeader.append(
-			<span className="fork-flag rgh-forked">forked to&nbsp;
-				<a href={`/${fork}`}>{fork}</a>
-			</span>
-		);
+async function save(forks: string[]): Promise<void> {
+	if (forks.length === 0) {
+		return cache.delete(getCacheKey());
 	}
+
+	return cache.set(getCacheKey(), forks, 10);
 }
 
-function rememberCurrentFork(): void {
-	if (!isRepoWithAccess()) {
-		return;
-	}
+async function saveAllForks(): Promise<void> {
+	const forks = select
+		.all('details-dialog[src*="/fork"] .octicon-repo-forked')
+		.map(({nextSibling}) => nextSibling!.textContent!.trim());
 
-	const forkedRepo = findForkedRepo();
-	if (forkedRepo) {
-		addAndStoreCache(forkedRepo, getRepoURL());
-	}
-}
-
-function watchForkDialog(): void {
-	const forkDialog = select('details-dialog[src*="/fork"]')!;
-	select('include-fragment', forkDialog)!.addEventListener('load', () => {
-		const forks = select.all('.octicon-repo-forked', forkDialog).map(forkElement => {
-			return forkElement.parentNode!.textContent!.trim();
-		});
-		addAndStoreCache(getSourceRepo(), ...forks);
-	});
+	save(forks);
 }
 
 function findForkedRepo(): string | undefined {
@@ -49,43 +34,39 @@ function findForkedRepo(): string | undefined {
 	return undefined;
 }
 
-function getSourceRepo(): string {
-	return findForkedRepo() || getRepoURL();
-}
-
 async function validateFork(repo: string): Promise<boolean> {
 	const response = await fetch(location.origin + '/' + repo, {method: 'HEAD'});
 	return response.ok;
 }
 
-async function getValidatedCache(repo: string): Promise<string[]> {
-	const cached = await cache.get<string[]>(getCacheKey(repo)) || [];
-	const validForks = cached.filter(validateFork).sort(undefined);
+async function getForks(): Promise<string[]> {
+	const forks = await cache.get<string[]>(getCacheKey()) || [];
 
-	if (cached.length !== validForks.length) {
-		await cache.set<string[]>(getCacheKey(repo), validForks, 10);
+	// Don't validate current page: it exists; it won't be shown in the list; it will be added later anyway
+	const validForks = await pFilter(forks.filter(fork => fork !== getRepoURL()), validateFork);
+
+	// Add current repo to cache if it's a fork
+	if (isRepoWithAccess() && findForkedRepo()) {
+		save([...validForks, getRepoURL()].sort(undefined));
+	} else {
+		save(validForks);
 	}
 
 	return validForks;
 }
 
-async function addAndStoreCache(repo: string, ...forks: string[]): Promise<void> {
-	const cached = await cache.get<string[]>(getCacheKey(repo)) || [];
-	for (const fork of forks) {
-		if (!cached.includes(fork)) {
-			cached.push(fork);
-		}
-	}
-
-	await cache.set<string[]>(getCacheKey(repo), cached, 10);
-}
-
 async function init(): Promise<void> {
-	watchForkDialog();
+	select('details-dialog[src*="/fork"] include-fragment')!
+		.addEventListener('load', saveAllForks);
 
-	rememberCurrentFork();
-
-	showForks();
+	const pageHeader = select('.pagehead h1.public')!;
+	for (const fork of await getForks()) {
+		pageHeader.append(
+			<span className="fork-flag rgh-forked">forked to&nbsp;
+				<a href={`/${fork}`}>{fork}</a>
+			</span>
+		);
+	}
 }
 
 features.add({


### PR DESCRIPTION
Follows #2153 

Changes:

- Actually validate fork via HTTP request
- Don't validate current page
- Delete cache entry completely when fork is gone
- Avoid merging with existing cache when unnecessary (i.e. when opening the fork dialog)
- Get/validate/update cache in one step before showing the links
- Reduce number of functions

Currently untested

cc @jerone 