### PR TITLE
Add mark files as viewed feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
 - [Format selected text with a key press when writing comments.](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif)
 - [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
-- [Mark all files as viewed when approving a PR](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+- [Mark all files as viewed when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 
 ### Previously part of Refined GitHub
 

--- a/readme.md
+++ b/readme.md
@@ -218,6 +218,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
 - [Format selected text with a key press when writing comments.](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif)
 - [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
+- [Mark all files as viewed when approving a PR](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 
 ### Previously part of Refined GitHub
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -128,6 +128,7 @@ import './features/minimize-upload-bar';
 import './features/cycle-lists-with-keyboard-shortcuts';
 import './features/forked-to';
 import './features/submit-review-as-single-comment';
+import './features/mark-files-as-viewed';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/mark-files-as-viewed.tsx
+++ b/source/features/mark-files-as-viewed.tsx
@@ -1,0 +1,20 @@
+import select from 'select-dom';
+import delegate from 'delegate-it';
+import features from '../libs/features';
+
+function markAllFilesAsViewed(): void {
+	select.all('.js-reviewed-checkbox').forEach(c => c.click());
+}
+
+function init(): void {
+	delegate('.form-actions button[value="approve"]', 'click', () => markAllFilesAsViewed());
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Mark all files as viewed when approving a PR',
+	include: [
+		features.isPR
+	],
+	init
+});

--- a/source/features/mark-files-as-viewed.tsx
+++ b/source/features/mark-files-as-viewed.tsx
@@ -3,7 +3,9 @@ import delegate from 'delegate-it';
 import features from '../libs/features';
 
 function markAllFilesAsViewed(): void {
-	select.all('.js-reviewed-checkbox').forEach(c => c.click());
+	for (const checkbox of select.all('.js-reviewed-checkbox')) {
+		checkbox.click();
+	}
 }
 
 function init(): void {


### PR DESCRIPTION
Whenever I approve a PR I’d love to have all of the changed files marked as viewed.

# Test

https://github.com/lukaszklis/refined-github-mark-files-as-viewed/pull/1/files (can grant collaborators privileges upon request)