### PR TITLE
Fix missing `options.css`

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -1,3 +1,4 @@
+import './options.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import linkifyUrls from 'linkify-urls';

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -86,7 +86,7 @@ module.exports = (_env: string, argv: Record<string, boolean | number | string>)
 			})
 		}),
 		new MiniCssExtractPlugin({
-			filename: 'content.css'
+			filename: '[name].css'
 		}),
 		new SizePlugin(),
 		new CopyWebpackPlugin([


### PR DESCRIPTION
Options page was missing its `.css` file.

# Test
Open extension options.

### Before:
<img src="https://user-images.githubusercontent.com/10238474/60940941-f7cb0a00-a2e5-11e9-8041-a539ba57196a.png" width="50%"><img src="https://user-images.githubusercontent.com/10238474/60941001-34970100-a2e6-11e9-8575-be44f065055a.png" width="50%">

### After:
<img src="https://user-images.githubusercontent.com/10238474/60941150-b129df80-a2e6-11e9-82bf-eeb9008817a0.png" width="50%"><img src="https://user-images.githubusercontent.com/10238474/60941092-7d4eba00-a2e6-11e9-8afb-1d0c0dcb7d05.png" width="50%">
