### PR TITLE
Fix checkbox selector for mark files as viewed

### DIFF
--- a/source/features/mark-files-as-viewed.tsx
+++ b/source/features/mark-files-as-viewed.tsx
@@ -3,7 +3,7 @@ import delegate from 'delegate-it';
 import features from '../libs/features';
 
 function markAllFilesAsViewed(): void {
-	for (const checkbox of select.all('.js-reviewed-checkbox')) {
+	for (const checkbox of select.all('.js-reviewed-checkbox:not(:checked)')) {
 		checkbox.click();
 	}
 }


### PR DESCRIPTION
This morning when approving a PR I spotted a problem with the ”mark all files as viewed” feature I added in #2218. The selector I used to find ”Viewed” checkboxes did not take into the account that some of them might have already been checked.