### PR TITLE
Fix branch link broken with `/` in the branch name

### DIFF
--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -7,17 +7,7 @@ import features from '../libs/features';
 import {isRepoRoot} from '../libs/page-detect';
 import {groupSiblings} from '../libs/group-buttons';
 import getDefaultBranch from '../libs/get-default-branch';
-import {getRepoURL, getRepoPath, getOwnerAndRepo, getCurrentBranch} from '../libs/utils';
-
-function replaceBranch(currentBranch: string, newBranch: string): string {
-	// Should be either `/tree/<branch>` or `/blob/<branch>/<filePath>`
-	const repoPath = getRepoPath()!;
-	// Replace the first matched branch name to the new one
-	const newBranchRepoPath = repoPath.replace(currentBranch, newBranch);
-
-	// Join the repo url with new branch repo path
-	return `/${getRepoURL()}/${newBranchRepoPath}`;
-}
+import {getRepoURL, getOwnerAndRepo, getCurrentBranch, replaceBranch} from '../libs/utils';
 
 async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 	const {ownerName, repoName} = getOwnerAndRepo();

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -7,15 +7,7 @@ import features from '../libs/features';
 import {isRepoRoot} from '../libs/page-detect';
 import {groupSiblings} from '../libs/group-buttons';
 import getDefaultBranch from '../libs/get-default-branch';
-import {getRepoURL, getOwnerAndRepo} from '../libs/utils';
-
-function getCurrentBranch(): string {
-	const commitLink = select('link[rel="alternate"]')!;
-	// Will be something like https://github.com/sindresorhus/refined-github/commits/master.atom
-	const href = commitLink.getAttribute('href')!;
-	const group = /\/commits\/(.+)\.atom$/.exec(href)!;
-	return group[1];
-}
+import {getRepoURL, getOwnerAndRepo, getCurrentBranch} from '../libs/utils';
 
 async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 	const {ownerName, repoName} = getOwnerAndRepo();
@@ -48,7 +40,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 
 	const link = <a className="btn btn-sm btn-outline tooltipped tooltipped-ne">{icons.tag()}</a> as unknown as HTMLAnchorElement;
 
-	const currentBranch = getCurrentBranch();
+	const currentBranch = getCurrentBranch()!;
 
 	if (currentBranch === latestRelease) {
 		link.classList.add('disabled');
@@ -69,7 +61,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 
 async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 	const defaultBranch = await getDefaultBranch();
-	const currentBranch = getCurrentBranch();
+	const currentBranch = getCurrentBranch()!;
 
 	// Don't show the button if we’re already on the default branch
 	if (defaultBranch === undefined || defaultBranch === currentBranch) {

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -71,7 +71,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 
 async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 	const defaultBranch = await getDefaultBranch();
-	const currentBranch = getCurrentBranch() || defaultBranch;
+	const currentBranch = getCurrentBranch();
 
 	// Don't show the button if we’re already on the default branch
 	if (defaultBranch === undefined || defaultBranch === currentBranch) {

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -7,7 +7,17 @@ import features from '../libs/features';
 import {isRepoRoot} from '../libs/page-detect';
 import {groupSiblings} from '../libs/group-buttons';
 import getDefaultBranch from '../libs/get-default-branch';
-import {getRepoURL, getOwnerAndRepo, getCurrentBranch} from '../libs/utils';
+import {getRepoURL, getRepoPath, getOwnerAndRepo, getCurrentBranch} from '../libs/utils';
+
+function replaceBranch(currentBranch: string, newBranch: string): string {
+	// Should be either `/tree/<branch>` or `/blob/<branch>/<filePath>`
+	const repoPath = getRepoPath()!;
+	// Replace the first matched branch name to the new one
+	const newBranchRepoPath = repoPath.replace(currentBranch, newBranch);
+
+	// Join the repo url with new branch repo path
+	return `/${getRepoURL()}/${newBranchRepoPath}`;
+}
 
 async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 	const {ownerName, repoName} = getOwnerAndRepo();
@@ -49,7 +59,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 		if (isRepoRoot()) {
 			link.href = `/${getRepoURL()}/tree/${latestRelease}`;
 		} else {
-			link.href = location.pathname.replace(currentBranch, latestRelease);
+			link.href = replaceBranch(currentBranch, latestRelease);
 		}
 
 		link.setAttribute('aria-label', 'Visit the latest release');
@@ -72,7 +82,7 @@ async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 	if (isRepoRoot()) {
 		url = `/${getRepoURL()}`;
 	} else {
-		url = location.pathname.replace(currentBranch, defaultBranch);
+		url = replaceBranch(currentBranch, defaultBranch);
 	}
 
 	return (

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -50,7 +50,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 
 	const link = <a className="btn btn-sm btn-outline tooltipped tooltipped-ne">{icons.tag()}</a> as unknown as HTMLAnchorElement;
 
-	const currentBranch = getCurrentBranch()!;
+	const currentBranch = getCurrentBranch();
 
 	if (currentBranch === latestRelease) {
 		link.classList.add('disabled');
@@ -71,7 +71,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 
 async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 	const defaultBranch = await getDefaultBranch();
-	const currentBranch = getCurrentBranch()!;
+	const currentBranch = getCurrentBranch() || defaultBranch;
 
 	// Don't show the button if we’re already on the default branch
 	if (defaultBranch === undefined || defaultBranch === currentBranch) {

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -37,7 +37,7 @@ export const replaceBranch = (currentBranch: string, newBranch: string): string 
 	const newBranchRepoPath = branchAndPathParts.join('/').replace(currentBranch, newBranch);
 
 	return `/${getRepoURL()}/${pageType}/${newBranchRepoPath}`;
-}
+};
 
 export const getCurrentBranch = (): string => {
 	return select<HTMLLinkElement>('link[rel="alternate"]')!
@@ -46,7 +46,7 @@ export const getCurrentBranch = (): string => {
 		.slice(6)
 		.join('/')
 		.replace(/\.atom$/, '');
-}
+};
 
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');
 

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -30,14 +30,14 @@ export const getRepoBranch = (): string | false => {
 	return false;
 };
 
-// Return empty string for default branch
 export const getCurrentBranch = (): string => {
-	return (select('[data-hotkey="g c"]')! as HTMLAnchorElement) // The `Code` tab
-		.pathname // /<user>/<repo>[/tree/<branch/slashed-branch>]
+	return select<HTMLLinkElement>('link[rel="alternate"]')!
+		.href
 		.split('/')
-		.slice(4) // Drops everything and including `tree`
-		.join('/');
-};
+		.slice(6)
+		.join('/')
+		.replace(/\.atom$/, '');
+}
 
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');
 

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -30,6 +30,15 @@ export const getRepoBranch = (): string | false => {
 	return false;
 };
 
+export const getCurrentBranch = (): string | undefined => {
+	const recentCommitsLink = select('link[title^="Recent Commits to"]')!;
+	// Will be something like https://github.com/sindresorhus/refined-github/commits/master.atom
+	const href = recentCommitsLink.getAttribute('href')!;
+	const group = /\/commits\/(.+)\.atom$/.exec(href);
+
+	return group ? group[1] : undefined;
+}
+
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');
 
 export const getOwnerAndRepo = (): {

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -37,7 +37,7 @@ export const getCurrentBranch = (): string | undefined => {
 	const group = /\/commits\/(.+)\.atom$/.exec(href);
 
 	return group ? group[1] : undefined;
-}
+};
 
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');
 

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -30,13 +30,13 @@ export const getRepoBranch = (): string | false => {
 	return false;
 };
 
-export const getCurrentBranch = (): string | undefined => {
-	const recentCommitsLink = select('link[title^="Recent Commits to"]')!;
-	// Will be something like https://github.com/sindresorhus/refined-github/commits/master.atom
-	const href = recentCommitsLink.getAttribute('href')!;
-	const group = /\/commits\/(.+)\.atom$/.exec(href);
-
-	return group ? group[1] : undefined;
+// Return empty string for default branch
+export const getCurrentBranch = (): string => {
+	return (select('[data-hotkey="g c"]')! as HTMLAnchorElement) // The `Code` tab
+		.pathname // /<user>/<repo>[/tree/<branch/slashed-branch>]
+		.split('/')
+		.slice(4) // Drops everything and including `tree`
+		.join('/');
 };
 
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -30,6 +30,15 @@ export const getRepoBranch = (): string | false => {
 	return false;
 };
 
+export const replaceBranch = (currentBranch: string, newBranch: string): string => {
+	// `pageType` will be either `blob' or 'tree'
+	const [pageType, ...branchAndPathParts] = getRepoPath()!.split('/');
+
+	const newBranchRepoPath = branchAndPathParts.join('/').replace(currentBranch, newBranch);
+
+	return `/${getRepoURL()}/${pageType}/${newBranchRepoPath}`;
+}
+
 export const getCurrentBranch = (): string => {
 	return select<HTMLLinkElement>('link[rel="alternate"]')!
 		.href


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2049 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

I took the closet approach I can think of via a `<link>` tag in head which looks like follow.

```html
<link href="https://github.com/sindresorhus/refined-github/commits/master.atom" rel="alternate" title="Recent Commits to refined-github:master" type="application/atom+xml">
```

Looks like every pages have it, and we can get the current branch from it stably. Please let me know if there is any concern.

I tried getting the current branch from the dropdown menu, but they are lazily loaded. Then I tried to get it from the `title` attribute of the dropdown button, it works for branch, but not for tag. I want to have a more general solution so I took this approach.

# Test
<!-- List some URLs that reviewers can use to test your PR -->
https://github.com/kevin940726/refined-github/blob/fix/branch-buttons/.travis.yml