### PR TITLE
Add `edit-readme` feature

### DIFF
--- a/source/content.ts
+++ b/source/content.ts
@@ -129,6 +129,7 @@ import './features/cycle-lists-with-keyboard-shortcuts';
 import './features/forked-to';
 import './features/submit-review-as-single-comment';
 import './features/mark-files-as-viewed';
+import './features/edit-readme';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -11,7 +11,7 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	// Detect if you are on a page with access.
+	// The button already exists on repos you can push to.
 	if (select.exists('a[aria-label="Edit this file"]')) {
 		return false;
 	}
@@ -20,13 +20,11 @@ async function init(): Promise<void | false> {
 	const readmeName = readmeHeader.textContent!.trim();
 	const path = select('.breadcrumb')!.textContent!.trim().split('/').slice(1).join('/');
 	readmeHeader.after(
-		<div id="rgh-readme-buttons">
-			<a href={`/${getRepoURL()}/edit/${currentBranch}/${path}${readmeName}`}
-				className="Box-btn-octicon btn-octicon float-right"
-				aria-label="Edit this file">
-				{icons.edit()}
-			</a>
-		</div>
+		<a href={`/${getRepoURL()}/edit/${currentBranch}/${path}${readmeName}`}
+			className="Box-btn-octicon btn-octicon float-right"
+			aria-label="Edit this file">
+			{icons.edit()}
+		</a>
 	);
 }
 
@@ -34,7 +32,8 @@ features.add({
 	id: __featureName__,
 	description: 'Quickly edit a repository’s README from the repository root',
 	include: [
-		features.isRepo
+		features.isRepoRoot,
+		features.isRepoTree
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
-import {getRepoURL} from '../libs/utils';
+import {getRepoURL, getCurrentBranch} from '../libs/utils';
 
 async function init(): Promise<void | false> {
 	// Detect if we are on the repo homepage, and readme file exists.
@@ -16,11 +16,9 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const currentBranch = select('#branch-select-menu .css-truncate-target')!.textContent!.trim();
-	const readmeName = readmeHeader.textContent!.trim();
-	const path = select('.breadcrumb')!.textContent!.trim().split('/').slice(1).join('/');
+	const readmePath = select('.js-tagsearch-popover')!.dataset.tagsearchPath;
 	readmeHeader.after(
-		<a href={`/${getRepoURL()}/edit/${currentBranch}/${path}${readmeName}`}
+		<a href={`/${getRepoURL()}/edit/${getCurrentBranch()}/${readmePath}`}
 			className="Box-btn-octicon btn-octicon float-right"
 			aria-label="Edit this file">
 			{icons.edit()}

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -1,0 +1,41 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+import * as icons from '../libs/icons';
+import {getRepoURL} from '../libs/utils';
+
+async function init(): Promise<void | false> {
+	// Detect if we are on the repo homepage, and readme file exists.
+	const readmeHeader = select('#readme .Box-header h3');
+	if (!readmeHeader) {
+		return false;
+	}
+
+	// Detect if you are on a page with access.
+	if (select.exists('a[aria-label="Edit this file"]')) {
+		return false;
+	}
+
+	const currentBranch = select('#branch-select-menu .css-truncate-target')!.textContent!.trim();
+	const readmeName = readmeHeader.textContent!.trim();
+	const path = select('.breadcrumb')!.textContent!.trim().split('/').slice(1).join('/');
+	readmeHeader.after(
+		<div id="rgh-readme-buttons">
+			<a href={`/${getRepoURL()}/edit/${currentBranch}/${path}${readmeName}`}
+				className="Box-btn-octicon btn-octicon float-right"
+				aria-label="Edit this file">
+				{icons.edit()}
+			</a>
+		</div>
+	);
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Quickly edit a repository’s README from the repository root',
+	include: [
+		features.isRepo
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -5,7 +5,6 @@ import * as icons from '../libs/icons';
 import {getRepoURL, getCurrentBranch} from '../libs/utils';
 
 async function init(): Promise<void | false> {
-	// Detect if we are on the repo homepage, and readme file exists.
 	const readmeHeader = select('#readme .Box-header h3');
 	if (!readmeHeader) {
 		return false;
@@ -28,9 +27,8 @@ async function init(): Promise<void | false> {
 
 features.add({
 	id: __featureName__,
-	description: 'Quickly edit a repository’s README from the repository root',
+	description: 'Quickly edit a repository’s README when previewed in a directory',
 	include: [
-		features.isRepoRoot,
 		features.isRepoTree
 	],
 	load: features.onAjaxedPages,


### PR DESCRIPTION
# Description
Quickly edit a repository's README from the repository root.

# Closes 
Closes https://github.com/sindresorhus/refined-github/issues/2225

# Screenshot
![image](https://user-images.githubusercontent.com/55841/61160737-f295d700-a500-11e9-8f7b-a742e5d81e7e.png)

# Test
1. Open any repo with a readme where you don't have admin rights to.
2. Scroll to the readme.
3. Click the edit button.

_Test with readme in subfolder:_
1. Go to https://github.com/davidbailey/tum/tree/master/handbook#readme.
2. Click edit button.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2225: Restore `edit-readme-button` on all repos](https://issuehunt.io/repos/51769689/issues/2225)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->