### PR TITLE
Highlight permalinked line in `view-markdown-source`

### DIFF
--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -93,7 +93,7 @@ async function init(): Promise<false | void> {
 
 	// Add support for permalinks to the code
 	if (location.hash.startsWith('#L')) {
-		showSource();
+		await showSource();
 		// Enable highlighting
 		window.dispatchEvent(new HashChangeEvent('hashchange', {
 			oldURL: location.href,

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -94,6 +94,10 @@ async function init(): Promise<false | void> {
 	// Add support for permalinks to the code
 	if (location.hash.startsWith('#L')) {
 		showSource();
+		// Enable highlighting
+		const originalHash = location.hash;
+		location.hash = '';
+		location.hash = originalHash;
 	}
 }
 

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -94,7 +94,8 @@ async function init(): Promise<false | void> {
 	// Add support for permalinks to the code
 	if (location.hash.startsWith('#L')) {
 		await showSource();
-		// Enable highlighting
+
+		// Enable selected line highlight
 		window.dispatchEvent(new HashChangeEvent('hashchange', {
 			oldURL: location.href,
 			newURL: location.href

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -95,9 +95,10 @@ async function init(): Promise<false | void> {
 	if (location.hash.startsWith('#L')) {
 		showSource();
 		// Enable highlighting
-		const originalHash = location.hash;
-		location.hash = '';
-		location.hash = originalHash;
+		window.dispatchEvent(new HashChangeEvent('hashchange', {
+			oldURL: location.href,
+			newURL: location.href
+		}));
 	}
 }
 


### PR DESCRIPTION
It seems like f7e0d05b0f09c46833c2411ab12997c73963958d from https://github.com/sindresorhus/refined-github/pull/1873 does not highlight the selected lines currently:

<img width="701" alt="Screen Shot 2019-07-13 at 14 39 14" src="https://user-images.githubusercontent.com/1935696/61171730-13e7d900-a57c-11e9-8871-3ff36a9c625b.png">

Switching out the hash once to an empty string and back to the original value causes the highlight to be applied.

cc @bfred-it

