### PR TITLE
Fix: Unwanted scroll bar in quotes with an Emoji

### DIFF
--- a/source/features/scrollable-code-and-blockquote.css
+++ b/source/features/scrollable-code-and-blockquote.css
@@ -5,6 +5,13 @@
 	overflow-y: auto;
 }
 
+/*
+A tiny scroll bar appears when the last paragraph of a quote contains an Emoji.
+*/
+.comment-body blockquote > :last-child g-emoji {
+	line-height: 1.33;
+}
+
 .comment-body details blockquote,
 .comment-body details pre,
 .comment-body blockquote blockquote,

--- a/source/features/scrollable-code-and-blockquote.css
+++ b/source/features/scrollable-code-and-blockquote.css
@@ -5,9 +5,7 @@
 	overflow-y: auto;
 }
 
-/*
-A tiny scroll bar appears when the last paragraph of a quote contains an Emoji.
-*/
+/* A tiny scroll bar appears when the last paragraph of a quote contains an Emoji */
 .comment-body blockquote > :last-child g-emoji {
 	line-height: 1.33;
 }


### PR DESCRIPTION
## Comparison
Might be a little hard to tell, but the Emoji is clipped on the bottom.
[Comparison with a slider](https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=6d42935a-a612-11e9-b9b8-0edaf8f81e27)

#### Before:
![Before](https://user-images.githubusercontent.com/10238474/61181181-41d82680-a62b-11e9-8bd2-c7568296e536.png)
#### After:
![After](https://user-images.githubusercontent.com/10238474/61181134-77304480-a62a-11e9-98fb-008ad331296d.png)

## Test
https://github.com/sindresorhus/refined-github/issues/1900#issuecomment-511180163
