### PR TITLE
Fix period on default branch

### DIFF
--- a/source/libs/get-default-branch.ts
+++ b/source/libs/get-default-branch.ts
@@ -23,7 +23,7 @@ function parseBranchFromDom(): string | undefined {
 
 	// Parse the infobar
 	const matches = branchInfoRegex.exec(branchInfo.textContent!.trim());
-	return matches ? matches[0] : undefined;
+	return matches ? matches[1] : undefined;
 }
 
 async function fetchFromApi(user: string, repo: string): Promise<any> {


### PR DESCRIPTION
### Fixes:
(master **is** the default branch)
![image](https://user-images.githubusercontent.com/10238474/61306457-55cf8400-a7f5-11e9-9a01-85ea958e3d0b.png)

```js
branchInfoRegex = /([^ ]+)\.$/;
branchInfoRegex.exec($('.branch-infobar').textContent.trim());

(2) ["master.", "master", index: 108, input: "Pull request↵        ↵      ↵        ↵        Comp…↵      This branch is 64 commits ahead of master.", groups: undefined]
```

### Test
I think you need to have a clean cache for this repo, and go to https://github.com/pymedusa/Medusa/tree/develop,
then you can visit the default branch https://github.com/pymedusa/Medusa
