### PR TITLE
Extend `open-issue-to-latest-comment` to pinned issues

### DIFF
--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -2,7 +2,7 @@ import select from 'select-dom';
 import features from '../libs/features';
 
 function init(): void {
-	for (const link of select.all<HTMLAnchorElement>('.js-issue-row a[aria-label*="comment"]')) {
+	for (const link of select.all<HTMLAnchorElement>('.js-issue-row a[aria-label*="comment"], .js-pinned-issue-list-item a[aria-label*="comment"]')) {
 		link.hash = '#partial-timeline';
 	}
 }


### PR DESCRIPTION
Adds jumping to the latest comment on pinned issues