### PR TITLE
Fix `warning-for-disallow-edits` on PR page

### DIFF
--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -21,7 +21,7 @@ function init(): void {
 			// Select every time because the sidebar content may be replaced
 			select(`
 				.new-pr-form .timeline-comment,
-				.discussion-sidebar .js-collab-form + .dropdown
+				.discussion-sidebar .js-collab-form + .js-dropdown-details
 			`)!.after(warning);
 		}
 	};


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2244
Still works on the new pull request page.

Snapshot of the current HTML:
![image](https://user-images.githubusercontent.com/10238474/61339078-d36eb080-a844-11e9-931a-3af3d7c9b86a.png)

### Test
Go to a PR of yours, uncheck "Allow edits from maintainers" on the side bar.
