### PR TITLE
Fix wrapping too long PR title on PR files tab

### DIFF
--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -72,6 +72,12 @@ function init(): false | void {
 		)
 	);
 
+	// Trim title
+	const prTitle = select('.pr-toolbar .js-issue-title');
+	if (prTitle && select.exists('.pr-toolbar progress-bar')) { // Only review view has progress-bar
+		prTitle.style.maxWidth = '24em';
+	}
+
 	// Remove previous options UI
 	const singleCommitUI = select('[data-ga-load="Diff, view, Viewed Split Diff"]');
 	if (singleCommitUI) {

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -76,7 +76,7 @@ function init(): false | void {
 	const prTitle = select('.pr-toolbar .js-issue-title');
 	if (prTitle && select.exists('.pr-toolbar progress-bar')) { // Only review view has progress-bar
 		prTitle.style.maxWidth = '24em';
-		prTitle.title = prTitle.textContent;
+		prTitle.title = prTitle.textContent!;
 	}
 
 	// Remove previous options UI

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -76,6 +76,7 @@ function init(): false | void {
 	const prTitle = select('.pr-toolbar .js-issue-title');
 	if (prTitle && select.exists('.pr-toolbar progress-bar')) { // Only review view has progress-bar
 		prTitle.style.maxWidth = '24em';
+		prTitle.title = prTitle.textContent;
 	}
 
 	// Remove previous options UI


### PR DESCRIPTION
# Description
Trim the PR title on the PR files tab.


# Closes 
Fixes #2202.


# Test
* Fixed on: https://github.com/sindresorhus/refined-github/pull/2229/files
* N/A on: https://github.com/sindresorhus/refined-github/pull/2229/commits/b8b9a3394d9aa667ad9c2576ff5fd381147c4960
