### PR TITLE
Improve Options page

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -4,7 +4,6 @@
 <link rel="stylesheet" href="options.css">
 <link rel="stylesheet" href="chrome://global/skin/in-content/common.css">
 <form id="options-form" class="detail-view-container">
-	<h2 class="only-firefox">Options</h2>
 	<p>
 		<label>
 			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (<a href="https://github.com/sindresorhus/refined-github/search?q=libs/api" target="_blank">some features</a> use the API)<br>

--- a/source/options.html
+++ b/source/options.html
@@ -15,12 +15,6 @@
 	<hr>
 
 	<p>
-		Want more features? Check out some <a href="https://github.com/sindresorhus/refined-github#related" target="_blank">related GitHub extensions</a> or <a href="https://github.com/sindresorhus/refined-github/blob/master/contributing.md" target="_blank">contribute</a>!
-	</p>
-
-	<hr>
-
-	<p>
 		If you're a GitHub Enterprise user, visit your Enterprise site, right-click on <a href="https://user-images.githubusercontent.com/1402241/32874388-e0c64150-cacc-11e7-9a50-eae3727fd3c2.png" target="_blank">Refined GitHub's icon in the toolbar</a> and select <strong>Enable Refined GitHub on this domain</strong>.
 	</p>
 
@@ -35,12 +29,18 @@
 
 	<hr>
 
-	<p>
-		<label>
-			<strong>Features</strong><br>
-			<div class="js-features"></div>
-		</label>
-	</p>
+	<div>
+		<strong>Features</strong><br>
+		<p>
+			<em>
+				Want more features? Check out some <a href="https://github.com/sindresorhus/refined-github#related"
+					target="_blank">related GitHub extensions</a> or <a
+					href="https://github.com/sindresorhus/refined-github/blob/master/contributing.md" target="_blank">contribute</a>!
+			</em>
+		</p>
+
+		<div class="js-features"></div>
+	</div>
 
 	<hr>
 


### PR DESCRIPTION
Firefox move the options to its own Tab so the header is no longer needed

# Before 

<img width="683" alt="" src="https://user-images.githubusercontent.com/1402241/61483237-fdec7500-a9ce-11e9-9035-9667642a2a75.png">

# After

<img width="682" alt="" src="https://user-images.githubusercontent.com/1402241/61483243-00e76580-a9cf-11e9-9ed4-e09ed7462602.png">
