### PR TITLE
used input type="password" for personalToken

### DIFF
--- a/source/options.html
+++ b/source/options.html
@@ -8,7 +8,7 @@
 		<label>
 			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (<a href="https://github.com/sindresorhus/refined-github/search?q=libs/api" target="_blank">some features</a> use the API)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
-			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" size="40" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
+			<input type="password" name="personalToken" spellcheck="false" autocomplete="off" size="40" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
 		</label>
 	</p>
 


### PR DESCRIPTION
# Test
* Confirmed that `npm build` is successful and tested unpacked extension in browser
* `npm test` is successful

# Screenshots
* Before 
![input-type-text](https://user-images.githubusercontent.com/16024985/61563405-b266b500-aa28-11e9-98f7-3d1ec8f638c4.png)
* After 
![input-type-password](https://user-images.githubusercontent.com/16024985/61563413-b85c9600-aa28-11e9-88e9-8ebf9c938405.png)

