### PR TITLE
Shorten personal token field in options for privacy

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -36,7 +36,7 @@ input[type='checkbox'] {
 }
 
 [name='personalToken'] {
-	width: 40% !important; /* https://github.com/sindresorhus/refined-github/issues/1374#issuecomment-397906701 */
+	width: 20em !important; /* https://github.com/sindresorhus/refined-github/issues/1374#issuecomment-397906701 */
 }
 
 .small {

--- a/source/options.css
+++ b/source/options.css
@@ -36,7 +36,7 @@ input[type='checkbox'] {
 }
 
 [name='personalToken'] {
-	width: 50% !important; /* https://github.com/sindresorhus/refined-github/issues/1374#issuecomment-397906701 */
+	width: 40% !important; /* https://github.com/sindresorhus/refined-github/issues/1374#issuecomment-397906701 */
 }
 
 .small {

--- a/source/options.html
+++ b/source/options.html
@@ -8,7 +8,7 @@
 		<label>
 			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (<a href="https://github.com/sindresorhus/refined-github/search?q=libs/api" target="_blank">some features</a> use the API)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
-			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" size="40" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
+			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
 		</label>
 	</p>
 


### PR DESCRIPTION
Do to layout changes the box was made wider so 50% is still too big

<!-- Thanks for contributing! 🍄 -->

Closes #2257
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->



<!-- List some URLs that reviewers can use to test your PR -->
