### PR TITLE
Add: `jsdelivr-cdn`

### DIFF
--- a/source/content.ts
+++ b/source/content.ts
@@ -43,6 +43,7 @@ import './features/improve-shortcut-help';
 import './features/deprioritize-marketplace-link';
 import './features/view-markdown-source';
 import './features/copy-file';
+import './features/jsdelivr-cdn';
 import './features/hide-own-stars';
 import './features/infinite-scroll';
 import './features/hide-empty-meta';

--- a/source/features/jsdelivr-cdn.tsx
+++ b/source/features/jsdelivr-cdn.tsx
@@ -1,0 +1,66 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import copyToClipboard from 'copy-text-to-clipboard';
+import delegate from 'delegate-it';
+import features from '../libs/features';
+
+function getURLDetails(url: string): string {
+	return url.replace(/http(s|):\/\/github.com|blob\/\w+\//gi, '');
+}
+
+function handleClick(): void {
+	const baseURL = 'https://cdn.jsdelivr.net/gh';
+
+	// Get "<username>/<repo>/<path-to-file>" removing "blob/<branch>"
+	const path = getURLDetails(window.location.href);
+
+	// https://cdn.jsdelivr.net/gh/sindresorhus/refined-github/contributing.md
+	const cdnURL = baseURL + path;
+
+	copyToClipboard(cdnURL);
+
+	select('main > .Box.mt-3.position-relative')!.prepend(
+		<div className='container flash flash-success my-3 anim-fade-in fast'>
+			<strong>Success!</strong> CDN url copied to clipboard
+		</div>,
+	);
+}
+
+function renderButton(): void {
+	for (const blameButton of select.all('[data-hotkey="b"]')) {
+		blameButton.parentElement!.prepend(
+			<button
+				onClick={handleClick}
+				className='btn btn-sm tooltipped tooltipped-n BtnGroup-item rgh-copy-file'
+				aria-label='Copy CDN url to clipboard'
+				type='button'>
+				CDN Url
+			</button>,
+		);
+	}
+}
+
+function init(): void {
+	console.log('Hey!');
+
+	if (select.exists('.blob.instapaper_body')) {
+		delegate('.rgh-md-source', 'rgh:view-markdown-source', renderButton);
+		delegate('.rgh-md-source', 'rgh:view-markdown-rendered', () => {
+			const button = select('.rgh-copy-file');
+			if (button) {
+				button.remove();
+			}
+		});
+	} else {
+		renderButton();
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Create a CDN link for the current file via https://jsdelivr.com',
+	include: [features.isSingleFile],
+	exclude: [features.isRepoRoot, features.isGist],
+	load: features.onAjaxedPages,
+	init,
+});

--- a/source/features/jsdelivr-cdn.tsx
+++ b/source/features/jsdelivr-cdn.tsx
@@ -18,12 +18,6 @@ function handleClick(): void {
 	const cdnURL = baseURL + path;
 
 	copyToClipboard(cdnURL);
-
-	select('main > .Box.mt-3.position-relative')!.prepend(
-		<div className='container flash flash-success my-3 anim-fade-in fast'>
-			<strong>Success!</strong> CDN url copied to clipboard
-		</div>,
-	);
 }
 
 function renderButton(): void {
@@ -31,18 +25,16 @@ function renderButton(): void {
 		blameButton.parentElement!.prepend(
 			<button
 				onClick={handleClick}
-				className='btn btn-sm tooltipped tooltipped-n BtnGroup-item rgh-copy-file'
-				aria-label='Copy CDN url to clipboard'
-				type='button'>
-				CDN Url
+				className="btn btn-sm tooltipped tooltipped-n BtnGroup-item rgh-copy-file"
+				aria-label="Copy JSDelivr CDN url"
+				type="button">
+				Copy CDN
 			</button>,
 		);
 	}
 }
 
 function init(): void {
-	console.log('Hey!');
-
 	if (select.exists('.blob.instapaper_body')) {
 		delegate('.rgh-md-source', 'rgh:view-markdown-source', renderButton);
 		delegate('.rgh-md-source', 'rgh:view-markdown-rendered', () => {
@@ -58,9 +50,9 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Create a CDN link for the current file via https://jsdelivr.com',
+	description: 'Generate a CDN url for the current file via https://jsdelivr.com',
 	include: [features.isSingleFile],
 	exclude: [features.isRepoRoot, features.isGist],
 	load: features.onAjaxedPages,
-	init,
+	init
 });


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->
# Features
- Adds a new button near the `Copy` button that lets you copy a cdn url from jsdelivr, the pattern for the url is: `https://cdn.jsdelivr.net/gh/<user>/<repo>/<path-to-file>`

# Test
[This one](https://github.com/twbs/bootstrap/blob/master/dist/css/bootstrap.min.css) `https://github.com/twbs/bootstrap/blob/master/dist/css/bootstrap.min.css`

Should generate the [following](https://cdn.jsdelivr.net/gh/twbs/bootstrap/dist/css/bootstrap.min.css)
`https://cdn.jsdelivr.net/gh/twbs/bootstrap/dist/css/bootstrap.min.css`

