### PR TITLE
Show counts when dropdowns are open in `hide-watch-and-fork-count`

### DIFF
--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,8 +1,18 @@
+/* Hide only when the dropdown is closed */
+
 .rgh-hide-watch-and-fork-count details:not([open]) .btn-with-count[title^='Fork your own'],
 .rgh-hide-watch-and-fork-count [action='/notifications/subscribe'] details:not([open]) .btn-with-count {
 	border-radius: 0.25em; /* Matches GitHub's default */
 }
+
 .rgh-hide-watch-and-fork-count details:not([open]) + .social-count[href$='/network/members'],
 .rgh-hide-watch-and-fork-count details:not([open]) + .social-count[href$='/watchers'] {
 	display: none;
+}
+
+/* Bring the counts above the lightbox, to make them clickable */
+.social-count[href$='/network/members'],
+.social-count[href$='/watchers'] {
+	position: relative;
+	z-index: 100;
 }

--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,8 +1,8 @@
-.rgh-hide-watch-and-fork-count .btn-with-count[title^='Fork your own'],
-.rgh-hide-watch-and-fork-count [action='/notifications/subscribe'] .btn-with-count {
+.rgh-hide-watch-and-fork-count details:not([open]) .btn-with-count[title^='Fork your own'],
+.rgh-hide-watch-and-fork-count [action='/notifications/subscribe'] details:not([open]) .btn-with-count {
 	border-radius: 0.25em; /* Matches GitHub's default */
 }
-.rgh-hide-watch-and-fork-count .social-count[href$='/network/members'],
-.rgh-hide-watch-and-fork-count .social-count[href$='/watchers'] {
+.rgh-hide-watch-and-fork-count details:not([open]) + .social-count[href$='/network/members'],
+.rgh-hide-watch-and-fork-count details:not([open]) + .social-count[href$='/watchers'] {
 	display: none;
 }


### PR DESCRIPTION
I like how clean the buttons area looks now, but I don't deny that sometimes I want to access those links we hide. I think this is a good compromise. #2230 should also allow to click the fork count once merged.

![](https://user-images.githubusercontent.com/1402241/61861532-556e7180-aef6-11e9-9c10-667f556bfe0e.gif)
