### PR TITLE
Use updated `webext-options-sync` (testing needed)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4442,6 +4442,14 @@
 				}
 			}
 		},
+		"dom-form-serializer": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/dom-form-serializer/-/dom-form-serializer-1.0.7.tgz",
+			"integrity": "sha1-GakPVrTTQgQL+fzHjk84A5bTuqU=",
+			"requires": {
+				"matches-selector": "^1.0.0"
+			}
+		},
 		"dom-loaded": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/dom-loaded/-/dom-loaded-1.2.0.tgz",
@@ -9655,6 +9663,11 @@
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
 			}
+		},
+		"matches-selector": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/matches-selector/-/matches-selector-1.2.0.tgz",
+			"integrity": "sha512-c4vLwYWyl+Ji+U43eU/G5FwxWd4ZH0ePUsFs5y0uwD9HUEFBXUQ1zUUan+78IpRD+y4pUfG0nAzNM292K7ItvA=="
 		},
 		"mathml-tag-names": {
 			"version": "2.1.1",
@@ -16381,24 +16394,12 @@
 			"integrity": "sha512-gaHL3pB/tfsRco7vmhQm96FgmvZP2KnTqfeuIAYERCBWjnjuZhnzdhTmGBAEFy+Xr8XVefd5nQBVr7Wimi0rUA=="
 		},
 		"webext-options-sync": {
-			"version": "0.21.2",
-			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-0.21.2.tgz",
-			"integrity": "sha512-fk5PAcw4zU3KN07lGjhcEe54Q1E219XpYmc6+oX4hApxZwEkeBHPpyvjAmjjgYIqVWXslJgTzd8Rpgtj8mSemA==",
+			"version": "0.22.0-1",
+			"resolved": "https://registry.npmjs.org/webext-options-sync/-/webext-options-sync-0.22.0-1.tgz",
+			"integrity": "sha512-uqT0cyL90MdcbZrMRTKyu+XSXv8tCN1WANa1NK58gZta/Ef2c3iuVDgWW0BA4c482dbFnyanaKOckAWLqFBFHg==",
 			"requires": {
-				"type-fest": "^0.5.2",
-				"webext-detect-page": "^0.9.1"
-			},
-			"dependencies": {
-				"type-fest": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-					"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
-				},
-				"webext-detect-page": {
-					"version": "0.9.1",
-					"resolved": "https://registry.npmjs.org/webext-detect-page/-/webext-detect-page-0.9.1.tgz",
-					"integrity": "sha512-/QoN7CIlobiTqilq721l5cpROBJxbkwCc6UE6KeH+xLZReAgSRyM0Q9r2T0SC+wX8HoNnFKrMDNYGYsq/SgJ4w=="
-				}
+				"dom-form-serializer": "^1.0.7",
+				"webext-detect-page": "^1.0.2"
 			}
 		},
 		"webext-permissions-events-polyfill": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"tiny-version-compare": "^1.0.0",
 		"webext-detect-page": "^1.0.2",
 		"webext-domain-permission-toggle": "^1.0.0-1",
-		"webext-options-sync": "^0.21.1",
+		"webext-options-sync": "^0.22.0-1",
 		"webext-permissions-events-polyfill": "^1.0.1",
 		"webext-storage-cache": "^1.0.2",
 		"webextension-polyfill": "^0.4.0",


### PR DESCRIPTION
I'm looking for testers of this [new version of webext-options-sync](https://github.com/fregante/webext-options-sync/pull/28#issuecomment-515147948)

You can [download a pre-built extension](https://github.com/sindresorhus/refined-github/files/3436334/refined_github-0.0.0.zip) — or fetch, `npm install`, build, and load this PR as usual.

This mainly affects:

- how the options form is saved and restored
- how the options are stored (default values are now excluded, less data is stored to disk)

Things to test:

- new installation: does the extension work correctly without opening the Options page?
- updated of existing installation: does the extension work correctly without opening the Options page? What about after opening it?
- does the Option page show the previous values?
- does the Option page save/restore the changes in all the fields? (excluding an invalid token)