### PR TITLE
Fix `edit-readme` feature

### DIFF
--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -2,6 +2,7 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
+import getDefaultBranch from '../libs/get-default-branch';
 
 async function init(): Promise<void | false> {
 	const readmeHeader = select('#readme .Box-header h3');
@@ -14,9 +15,14 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
+	const isPermalink = /Tag|Tree/.test(select('.branch-select-menu i')!.textContent!);
+
 	const filename = readmeHeader.textContent!.trim();
 	const pathnameParts = select<HTMLAnchorElement>(`.files [title="${filename}"]`)!.pathname.split('/');
 	pathnameParts[3] = 'edit'; // Replaces /blob/
+	if (isPermalink) {
+		pathnameParts[4] = await getDefaultBranch(); // Replaces /${tag|commit}/
+	}
 
 	readmeHeader.after(
 		<a href={pathnameParts.join('/')}

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -2,7 +2,6 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
-import {getRepoURL, getCurrentBranch} from '../libs/utils';
 
 async function init(): Promise<void | false> {
 	const readmeHeader = select('#readme .Box-header h3');
@@ -15,9 +14,12 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const readmePath = select('.js-tagsearch-popover')!.dataset.tagsearchPath;
+	const filename = readmeHeader.textContent!.trim();
+	const pathnameParts = select<HTMLAnchorElement>(`.files [title="${filename}"]`)!.pathname.split('/');
+	pathnameParts[3] = 'edit'; // Replaces /blob/
+
 	readmeHeader.after(
-		<a href={`/${getRepoURL()}/edit/${getCurrentBranch()}/${readmePath}`}
+		<a href={pathnameParts.join('/')}
 			className="Box-btn-octicon btn-octicon float-right"
 			aria-label="Edit this file">
 			{icons.edit()}

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -35,7 +35,7 @@ async function init(): Promise<void | false> {
 
 features.add({
 	id: __featureName__,
-	description: 'Quickly edit a repository’s README when previewed in a directory',
+	description: 'Adds an Edit button on previewed Readmes in folders, even if you have to make a fork.',
 	include: [
 		features.isRepoTree
 	],


### PR DESCRIPTION
Note: This feature is a bit trippy because GitHub already has it, but **not in repos you you can't push.**

Partial fix to #2261

- The feature was broken everywhere
- The feature was trying to "edit" files on commits and tags: GitHub doesn't allow that.

Since this feature is kind of a "polyfill", we need to match GitHub's behavior: those "Edit readme" links on commits and tags now point to the default branch

# Test

All links should point to `master` except the `release` branch link, that's a valid one.

## Root readme

- https://github.com/chartjs/Chart.js
- https://github.com/chartjs/Chart.js/tree/release
- https://github.com/chartjs/Chart.js/tree/v2.8.0
- https://github.com/chartjs/Chart.js/tree/6632b8ba8475e020fd0533e2630117376a9cbc73

## Subfolder readme

- https://github.com/chartjs/Chart.js/tree/master/docs
- https://github.com/chartjs/Chart.js/tree/release/docs
- https://github.com/chartjs/Chart.js/tree/v2.8.0/docs
- https://github.com/chartjs/Chart.js/tree/6632b8ba8475e020fd0533e2630117376a9cbc73/docs