### PR TITLE
Fix `edit-files-faster` feature

### DIFF
--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -4,8 +4,9 @@ import select from 'select-dom';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
 import {wrap} from '../libs/dom-utils';
+import getDefaultBranch from '../libs/get-default-branch';
 
-function init(): void {
+async function init(): Promise<void> {
 	for (const fileIcon of select.all('.files :not(a) > .octicon-file')) {
 		const pathnameParts = fileIcon
 			.closest('tr')!
@@ -14,6 +15,11 @@ function init(): void {
 			.split('/');
 
 		pathnameParts[3] = 'edit'; // Replaces `/blob/`
+
+		const isPermalink = /Tag|Tree/.test(select('.branch-select-menu i')!.textContent!);
+		if (isPermalink) {
+			pathnameParts[4] = await getDefaultBranch(); // Replaces /${tag|commit}/
+		}
 
 		wrap(fileIcon, <a href={pathnameParts.join('/')} className="rgh-edit-files-faster" />);
 		fileIcon.after(icons.edit());

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -7,6 +7,7 @@ import {wrap} from '../libs/dom-utils';
 import getDefaultBranch from '../libs/get-default-branch';
 
 async function init(): Promise<void> {
+	const defaultBranch = await getDefaultBranch();
 	for (const fileIcon of select.all('.files :not(a) > .octicon-file')) {
 		const pathnameParts = fileIcon
 			.closest('tr')!
@@ -18,7 +19,7 @@ async function init(): Promise<void> {
 
 		const isPermalink = /Tag|Tree/.test(select('.branch-select-menu i')!.textContent!);
 		if (isPermalink) {
-			pathnameParts[4] = await getDefaultBranch(); // Replaces /${tag|commit}/
+			pathnameParts[4] = defaultBranch; // Replaces /${tag|commit}/
 		}
 
 		wrap(fileIcon, <a href={pathnameParts.join('/')} className="rgh-edit-files-faster" />);


### PR DESCRIPTION

Partially fixes #2261 the same way as #2278 does


# Test

All links should point to `master` except the `release` branch link, that's a valid one.

## Subfolder files

- https://github.com/chartjs/Chart.js/tree/master/docs
- https://github.com/chartjs/Chart.js/tree/release/docs
- https://github.com/chartjs/Chart.js/tree/v2.8.0/docs
- https://github.com/chartjs/Chart.js/tree/6632b8ba8475e020fd0533e2630117376a9cbc73/docs