### PR TITLE
Sort features in Readme by area instead of by type

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,18 +113,6 @@ Thanks for contributing! 🦋🙌
 
 -->
 
-### Profiles
-
-- [Shows the followers you have in common.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
-- [Tells you whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
-- [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
-- [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
-- Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
-- [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
-- [Hides forks and archived repos from profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
-
-<!-- Refer to style guide above. Keep this message between sections. -->
-
 ### Repositories
 
 - 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
@@ -245,6 +233,18 @@ Thanks for contributing! 🦋🙌
 - [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 - [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded.)
 - [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
+
+### Profiles
+
+- [Shows the followers you have in common.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
+- [Tells you whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
+- [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
+- [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
+- Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
+- [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
+- [Hides forks and archived repos from profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ GitHub Enterprise is also supported. More info in the options.
 			Linkifies issue/PR references and URLs in code
 		</th>
 		<th width="50%">
-			Links to an issue's closing commit or pull request
+			Add link to an issue’s closing commit or pull request
 		</th>
 	</tr>
 	<tr><!-- Prevent zebra stripes --></tr>
@@ -115,168 +115,177 @@ Thanks for contributing! 🦋🙌
 
 ### Repositories
 
-- 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
-- [Adds a download count next to release assets.](https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png)
-- Removes the file hover effect in the repo file browser.
-- Hides the `Projects` tab from repositories and profiles when it’s empty.
+- <!-- ci-link --> 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
+- <!--release-download-count --> [Adds a download count next to release assets.](https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png)
+- <!-- hide-navigation-hover-highlight --> Removes the file hover effect in the repo file browser.
+- <!-- hide-empty-meta --> Hides the placeholder text in repos without a description.
+- <!-- remove-projects-tab --> Hides the `Projects` tab from repositories and profiles when it’s empty.
     * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
-- [Hides forks and watchers counters.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
-- Changes the default sort order of milestones `Closest due date`.
-- [Adds a `Releases` tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
-- Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
-- [Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.](https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png)
-- Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
-- [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
-- 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
-- [Adds a button to a download button entire folders.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *Uses [download-directory.github.io](https://download-directory.github.io)*
-- [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
-- [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
-- 🔥 [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
-- [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
+- <!-- hide-watch-and-fork-count --> [Hides forks and watchers counters.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
+- <!-- sort-milestones-by-closest-due-date --> Changes the default sort order of milestones `Closest due date`.
+- <!-- releases-tab --> [Adds a `Releases` tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
+- <!-- create-release-shortcut --> Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
+- <!-- more-dropdown --> [Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.](https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png)
+- <!-- star-repo-hotkey --> Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
+- <!-- tags-dropdown --> [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
+- <!-- tag-changelog-link --> 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
+- <!-- download-folder-button --> [Adds a button to a download button entire folders.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *Uses [download-directory.github.io](https://download-directory.github.io)*
+- <!-- toggle-files-button --> [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
+- <!-- edit-files-faster --> [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
+- <!-- edit-readme --> [Adds an Edit button on previewed Readmes in folders, even if you have to make a fork.](https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png)
+- <!-- branch-buttons --> 🔥 [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
+- <!-- swap-branches-on-compare --> [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
+- <!-- linkify-branch-refs --> [Linkifies branch references in "Quick PR" pages.](https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Code
 
-- Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
-- [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
-- [Adds a button to copy a file’s content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
-- [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
-- [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
-- 🔥 [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
-- [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
-- [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
+- <!-- copy-on-y --> Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
+- <!-- view-markdown-source --> [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
+- <!-- copy-file --> [Adds a button to copy a file’s content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
+- <!-- linkify-symbolic-links --> [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
+- <!-- list-prs-for-file --> [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
+- <!-- show-whitespace --> 🔥 [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
+- <!-- content --> [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
+- <!-- esc-to-deselect-line --> [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Writing comments
 
-- 🔥 Enables the <kbd>tab</kbd> key for indentation in comment fields.
-- [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
-- [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
-- 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
-- [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
-- [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
-- [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
-- [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
-- [Hides unnecessary buttons in the comment box toolbar](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
+- <!-- comment-fields-keyboard-shortcuts --> 🔥 Enables the <kbd>tab</kbd> key for indentation in comment fields.
+- <!-- submit-review-as-single-comment --> [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
+- <!-- collapsible-content-button --> [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
+- <!-- fit-textareas --> 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
+- <!-- edit-comments-faster --> [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
+- <!-- comment-fields-keyboard-shortcuts --> [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
+- <!-- comment-fields-keyboard-shortcuts --> [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
+- <!-- minimize-upload-bar --> [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
+- <!-- clean-rich-text-editor --> [Hides unnecessary buttons in the comment box toolbar](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
+- <!-- monospace-textareas --> Use a monospace font for all textareas.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Reading comments
 
-- [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
-- Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
-- [Adds the real name of users next to their usernames.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
-- [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
-- 🔥 [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
-- 🔥 [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
-- [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers’) [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
-- [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
-- [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
-- [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+- <!-- embed-gist-inline --> [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- <!-- comments-time-machine-links --> Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
+- <!-- show-names --> [Adds the real name of users next to their usernames.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
+- <!-- shorten-links --> [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
+- <!-- preview-hidden-comments --> 🔥 [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
+- <!-- highest-rated-comment --> 🔥 [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
+- <!-- hide-useless-comments --> [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers’) [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
+- <!-- scrollable-code-and-blockquote --> [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
+- <!-- hide-comments-faster --> [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
+- <!-- open-issue-to-latest-comment --> [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Discussions
 
-- 🔥 [Adds a button to open multiple discussions at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
-- [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
-- [Makes the discussion filters bar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
-- [Highlights discussions opened by you.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
-- [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
-- 🔥 Changes the default sort order of discussions to `Recently updated`.
-- [Widens the discussion search box.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
-- [Adds a `Everything commented by you` filter in the search box dropdown.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
-- [Adds filters for discussions _in your repos_ and _commented on by you_ in the global discussion search.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
-- 🔥 [Hides empty sections in the discussion sidebar.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
-- [Hides `Projects` and `Milestones` filters in discussion lists if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
-- [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
+- <!-- batch-open-issues --> 🔥 [Adds a button to open multiple discussions at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- <!-- split-issue-pr-search-results --> [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
+- <!-- make-discussion-sidebar-sticky --> [Makes the discussion filters bar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
+- <!-- highlight-own-issues-and-prs --> [Highlights discussions opened by you.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
+- <!-- align-issue-labels --> [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
+- <!-- sort-issues-by-update-time --> 🔥 Changes the default sort order of discussions to `Recently updated`.
+- <!-- widen-search-field --> [Widens the discussion search box.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
+- <!-- filter-comments-by-you --> [Adds a `Everything commented by you` filter in the search box dropdown.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
+- <!-- global-discussion-list-filters --> [Adds filters for discussions _in your repos_ and _commented on by you_ in the global discussion search.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
+- <!-- clean-sidebar --> 🔥 [Hides empty sections (or just their "empty" label) in the discussion sidebar.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
+- <!-- clean-issue-filters --> [Hides `Projects` and `Milestones` filters in discussion lists if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
+- <!-- cycle-lists-with-keyboard-shortcuts --> [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Viewing pull requests
 
-- [Adds link to non-PR commit when visiting a PR commit.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
-- [Adds a `Build status` dropdown filter in PR lists.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
-- [Shows color-coded review counts in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
-- [Shows head and base branches in PR lists if they’re significant.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
-- Hides the `Checks` tab if it’s empty.
-- [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
-- [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+- <!-- linkify-commit-sha --> [Adds link to non-PR commit when visiting a PR commit.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
+- <!-- filter-pr-by-build-status --> [Adds a `Build status` dropdown filter in PR lists.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
+- <!-- pr-approvals-count --> [Shows color-coded review counts in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
+- <!-- pr-branches --> [Shows head and base branches in PR lists if they’re significant.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
+- <!-- remove-checks-tab --> Hides the `Checks` tab if it’s empty, unless you’re the owner.
+- <!-- hide-inactive-deployments --> [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
+- <!-- prev-next-commit-buttons --> [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+- <!-- preserve-whitespace-option-in-nav --> Preserves the "ignore whitespace" setting when navigating with Next/Previous in PR review mode.
+- <!-- bypass-checks --> [Bypasses the "Checks" interstitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
+- <!-- open-ci-details-in-new-tab --> Opens the Checks "details" link in a new tab.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Editing pull requests
 
-- 🔥 [Uses the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
-- [Adds `co-authored-by` to the commit when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
-- [Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
-- [Simplifies the PR review form.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
-- [Warns you when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
-- [Warns you when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
-- Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
-- [Bypasses the "Checks" interstitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
-- [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+- <!-- sync-pr-commit-title --> 🔥 [Uses the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
+- <!-- add-co-authored-by --> [Adds `co-authored-by` to the commit when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
+- <!-- update-pr-from-base-branch --> [Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
+- <!-- quick-review-buttons --> [Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
+- <!-- warn-pr-from-master --> [Warns you when creating a pull request from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
+- <!-- warning-for-disallow-edits --> [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
+- <!-- pull-request-hotkey --> Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
+- <!-- mark-files-as-viewed --> [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+- <!-- pr-branch-auto-delete --> Automatically deletes the branch right after merging a PR, if possible.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Commits
 
-- Adds a keyboard shortcut to ignore whitespace in diffs: <kbd>d</kbd> <kbd>w</kbd>.
-- [Adds links to `.patch` and `.diff` files in commits.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
-- [Renders the rich diff by default in SVG files diffs.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
-- [Adds link to view the raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
-- [Adds one-click buttons to change diff style and to ignore the whitespace.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
-- 🔥 [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
-- [Adds link to file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
-- [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
-- [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded.)
-- [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
+- <!-- faster-pr-diff-options --> Adds a keyboard shortcut to ignore the whitespace in diffs: <kbd>d</kbd> <kbd>w</kbd>.
+- <!-- patch-diff-links --> [Adds links to `.patch` and `.diff` files in commits.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
+- <!-- default-to-rich-diff --> [Renders the rich diff by default in SVG files’ diffs.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
+- <!-- raw-file-link --> [Adds link to view the raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
+- <!-- faster-pr-diff-options --> [Adds one-click buttons to change diff style and to ignore the whitespace.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
+- <!-- follow-file-renames --> 🔥 [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
+- <!-- link-to-file-in-file-history --> [Adds links to the file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
+- <!-- extend-diff-expander --> [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
+- <!-- remove-diff-signs --> [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded already.)
+- <!-- limit-commit-title-length --> [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Profiles
 
-- [Shows the followers you have in common.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
-- [Tells you whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
-- [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
-- [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
-- Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
-- [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
-- [Hides forks and archived repos from profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
+- <!--  --> [Shows the followers you have in common.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
+- <!-- user-profile-follower-badge --> [Tells you whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
+- <!-- profile-gists-link --> [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
+- <!-- mark-private-orgs --> [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
+- <!-- profile-hotkey --> Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
+- <!-- show-user-top-repositories --> [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
+- <!-- set-default-repositories-type-to-sources --> [Hides forks and archived repos from profiles (but they can still be shown.)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Newsfeed
 
-- 🔥 [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
-- Hides "starred" events for your own repos
-- Hides other inutile events (commits, forks, new followers).
-- Automagically expands the newsfeed when you scroll down.
+- <!-- clean-dashboard --> 🔥 [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
+- <!-- hide-own-stars --> Hides "starred" events for your own repos.
+- <!-- hide-useless-newsfeed-events --> Hides other inutile events (commits, forks, new followers).
+- <!-- infinite-scroll --> Automagically expands the newsfeed when you scroll down.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Global
 
-- 🔥 [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
-- [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
-- [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
-- [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
-- Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
-- Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
-- [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
-- [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
+- <!-- useful-not-found-page --> 🔥 [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
+- <!-- selection-in-new-tab --> [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
+- <!-- close-out-of-view-modals --> [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
+- <!-- deprioritize-marketplace-link --> Moves the "Marketplace" link from the black header bar to the profile dropdown.
+- <!-- parse-backticks --> [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- <!-- trending-menu-item --> Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
+- <!-- navigate-pages-with-arrow-keys --> Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
+- <!-- open-all-notifications --> [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
+- <!-- improve-shortcut-help --> [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png) *(<kbd>?</kbd> hotkey)*
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Fixes for GitHub bugs
 
-- 🔥 [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
-- [Hides the milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
-- [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
-- Removes tooltips from self-explanatory buttons.
-- 🔥 [Moves the "Recently-pushed branches" widget to the header to avoid content jumps.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
+- <!-- indented-code-wrapping --> 🔥 [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
+- <!-- focus-confirmation-buttons --> [Always focuses confirm buttons in custom modal boxes, like "Mark all as read".](https://user-images.githubusercontent.com/1402241/31700158-1499bdd8-b38d-11e7-9aba-77a0a4b6bf3c.png)
+- <!-- hide-disabled-milestone-sorter --> [Hides the milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
+- <!-- hide-issue-list-autocomplete --> [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
+- <!-- hide-obvious-tooltips --> Removes tooltips from self-explanatory buttons.
+- <!-- recently-pushed-branches-enhancements --> 🔥 [Moves the "Recently-pushed branches" widget to the header to avoid content jumps. Also adds it to more pages in the repo.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ GitHub Enterprise is also supported. More info in the options.
 - **Opera** extension: Use [this Opera extension](https://addons.opera.com/en/extensions/details/download-chrome-extension-9/) to install the Chrome version.
 
 
-## Highlights
+## Highlights 🔥
 
 <table>
 	<tr>
@@ -127,7 +127,7 @@ Thanks for contributing! 🦋🙌
 
 ### Repositories
 
-- [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
+- 🔥 [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
 - [Adds a download count next to release assets.](https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png)
 - Removes the file hover effect in the repo file browser.
 - Hides the `Projects` tab from repositories and profiles when it’s empty.
@@ -139,23 +139,23 @@ Thanks for contributing! 🦋🙌
 - [Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.](https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png)
 - Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
 - [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
-- [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
+- 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [Adds a button to a download button entire folders.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *Uses [download-directory.github.io](https://download-directory.github.io)*
 - [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
 - [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
-- [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
+- 🔥 [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
 - [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
-### Files
+### Code
 
 - Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
 - [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
 - [Adds a button to copy a file’s content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
 - [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
 - [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
-- [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
+- 🔥 [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
 - [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
 - [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 
@@ -163,10 +163,10 @@ Thanks for contributing! 🦋🙌
 
 ### Writing comments
 
-- Enables the <kbd>tab</kbd> key for indentation in comment fields.
+- 🔥 Enables the <kbd>tab</kbd> key for indentation in comment fields.
 - [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
 - [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
-- [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
+- 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
 - [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
 - [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
@@ -181,8 +181,8 @@ Thanks for contributing! 🦋🙌
 - Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
 - [Adds the real name of users next to their usernames.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
 - [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
-- [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
-- [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
+- 🔥 [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
+- 🔥 [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
 - [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers’) [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
 - [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
 - [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
@@ -192,16 +192,16 @@ Thanks for contributing! 🦋🙌
 
 ### Discussions
 
-- [Adds a button to open multiple discussions at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- 🔥 [Adds a button to open multiple discussions at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
 - [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
 - [Makes the discussion filters bar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
 - [Highlights discussions opened by you.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
 - [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
-- Changes the default sort order of discussions to `Recently updated`.
+- 🔥 Changes the default sort order of discussions to `Recently updated`.
 - [Widens the discussion search box.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
 - [Adds a `Everything commented by you` filter in the search box dropdown.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
 - [Adds filters for discussions _in your repos_ and _commented on by you_ in the global discussion search.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
-- [Hides empty sections in the discussion sidebar.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
+- 🔥 [Hides empty sections in the discussion sidebar.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
 - [Hides `Projects` and `Milestones` filters in discussion lists if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
 - [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 
@@ -221,7 +221,7 @@ Thanks for contributing! 🦋🙌
 
 ### Editing pull requests
 
-- [Uses the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
+- 🔥 [Uses the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
 - [Adds `co-authored-by` to the commit when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
 - [Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
 - [Simplifies the PR review form.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
@@ -240,7 +240,7 @@ Thanks for contributing! 🦋🙌
 - [Renders the rich diff by default in SVG files diffs.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
 - [Adds link to view the raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
 - [Adds one-click buttons to change diff style and to ignore the whitespace.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
-- [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
+- 🔥 [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
 - [Adds link to file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
 - [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
 - [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded.)
@@ -250,7 +250,7 @@ Thanks for contributing! 🦋🙌
 
 ### Newsfeed
 
-- [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
+- 🔥 [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
 - Hides "starred" events for your own repos
 - Hides other inutile events (commits, forks, new followers).
 - Automagically expands the newsfeed when you scroll down.
@@ -259,7 +259,7 @@ Thanks for contributing! 🦋🙌
 
 ### Global
 
-- [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
+- 🔥 [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
 - [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
 - [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
 - [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
@@ -272,11 +272,11 @@ Thanks for contributing! 🦋🙌
 
 ### Fixes for GitHub bugs
 
-- [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
+- 🔥 [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
 - [Hides the milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
 - [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - Removes tooltips from self-explanatory buttons.
-- [Moves the "Recently-pushed branches" widget to the header to avoid content jumps.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
+- 🔥 [Moves the "Recently-pushed branches" widget to the header to avoid content jumps.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -94,134 +94,144 @@ GitHub Enterprise is also supported. More info in the options.
 	</tr>
 </table>
 
-### Added features
 
-- Copy the canonical link of a file with [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/).
-- Indent text with <kbd>tab</kbd> inside comment fields (<kbd>shift</kbd> <kbd>tab</kbd> for original behavior).
-- [Use the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [update the PR’s title to the merge commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
-- [View linked gists inline in comments.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
-- [Access related pages on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
-- [Add co-authors when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
-- [Search for issues and PRs separately in the top search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
-- [View the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
-- [Update a PR from the base branch to ensure it build correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png)
-- [Submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
 
-### More actions
+### Profiles
 
-- [Click on branch references in pull requests.](https://github.com/sindresorhus/refined-github/issues/1)
-- [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
-- [Open selection in new tab with <kbd>shift</kbd> <kbd>o</kbd> when navigating via <kbd>j</kbd> and <kbd>k</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
+- [Shows the followers you have in common.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
+- [Tells you whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
+- [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
+- [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
+- Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
+- [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
+- [Hides forks and archived repos from profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
+
+### Repositories
+
+- [Adds a build/CI status icon next to the repo’s name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
+- [Adds a download count next to release assets.](https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png)
+- Removes the file hover effect in the repo file browser.
+- Hides the `Projects` tab from repositories and profiles when it’s empty.
+    * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
+- [Hides forks and watchers counters.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
+- Changes the default sort order of milestones `Closest due date`.
+- [Adds a `Releases` tab and a keyboard shortcut: <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
+- Adds a keyboard shortcut to create a new release while on the Releases page: <kbd>c</kbd>.
+- [Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.](https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png)
+- Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
+- [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
+- [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
+
+### Files
+
+- Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
+- [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
 - [Copy a file's content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
-- [Quickly access a commit's `.patch` and `.diff` files.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
-- [Navigate from PR commit to raw commit by clicking the commit hash.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
-- [Browse a repository at the time of each comment,](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) including [each link.](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png)
-- [Visit a user's public gists from their profile.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
 - [Download entire folders from repositories using the `Download folder` button.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *(Uses [download-directory.github.io](https://download-directory.github.io).)*
 - [Collapse or expand a repository's browser file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
 - [Quickly visit a repository's default branch and latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
-- [Open multiple issues at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
-- [Swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
-- [Insert collapsible content when writing comments (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
-- [Filter pull requests by their build status.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
-- [View raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
-
-### More info at a glance
-
-- [Full names of comment authors are shown next to their username.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
-- [Issue listing header is always visible.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
-- [Merge commits are dimmed in commits list.](https://user-images.githubusercontent.com/1402241/36772362-8ddf8138-1c87-11e8-9f34-1f6b76e5499f.png)
-- [Repo URLs are shortened to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
-- [The current repository's build/CI status is always visible next to its name.](https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png)
-- [Review counts are shown and colored in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
-- [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
-- [Followers you know are shown on profile pages.](https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png)
-- [Private organizations are marked when viewing your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
-- [Badge on user's profile if they follow you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
-- [Significant head and base branches are added to the PR list.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
-- [Hidden comments are previewed inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
-- [Your issues and PRs are highlighted.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
-- [SVG files in a PR default to rich-diff view.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
-- [Download count next to release assets.](https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png)
-- [The most useful comment in issues is highlighted.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
+- [Visit symbolic links with a click.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
 - [List PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
-- [Your repo forks are shown under the repo title.](https://user-images.githubusercontent.com/55841/60543588-f5c9df80-9d16-11e9-8667-52ff16b2cb16.png)
 - [Whitespace characters are displayed.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
+- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
+- [Diff signs are hidden.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
+- [Tabs in code are shown as 4 spaces instead of 8 spaces.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
+- [Wrapped code in diff views is aligned at the indented level of original line.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
+- [Press <kbd>esc</kbd> to deselect the current line when viewing files.](https://github.com/sindresorhus/refined-github/issues/1590)
+- [Edit files straight from a repo’s list by clicking their icon.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
 
-### Declutter
+### Comments
+
+- Indent text with <kbd>tab</kbd> inside comment fields (<kbd>shift</kbd> <kbd>tab</kbd> for original behavior).
+- [View linked gists inline in comments.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- [Submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
+- [Browse a repository at the time of each comment,](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) including [each link.](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png)
+- [Insert collapsible content when writing comments (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
+- [Full names of comment authors are shown next to their username.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
+- [Repo URLs are shortened to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
+- [Hidden comments are previewed inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
+- [The most useful comment in issues is highlighted.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
+- [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
+- [Tall code blocks and quotes are limited in height.](https://github.com/sindresorhus/refined-github/issues/1123)
+- [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
+- [Edit comments in one click.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
+- [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
+- [Hide comments in fewer clicks.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
+- [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+- [Format selected text with a key press when writing comments.](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif)
+- [The upload bar on commits is reduced to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
+
+### Issues
+
+- [Open multiple issues at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- [Search for issues and PRs separately in the top search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
+- [Issue listing header is always visible.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
+- [Your issues and PRs are highlighted.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
+- [Labels are moved to the left of issue and pull request lists.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
+- The default sort order of issues and pull requests is changed to `Recently updated`.
+- [The PR/issues search box is wider.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
+- [Search for issues and PRs with the `Everything commented by you` filter.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
+- [See just the issues and PRs _on your repos_ or _commented on by you_ in the global `Issues`/`Pull Requests` pages.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
+- [Empty sections in the issue/PRs sidebar are hidden.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
+- [Projects and Milestones filters are dropped if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
+- [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
+
+
+### Pull requests
+
+- [Use the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [update the PR’s title to the merge commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
+- [Add co-authors when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
+- [Update a PR from the base branch to ensure it build correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png)
+- [Navigate from PR commit to raw commit by clicking the commit hash.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
+- [Swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
+- [Filter pull requests by their build status.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
+- [Review counts are shown and colored in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
+- [Significant head and base branches are added to the PR list.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
+- The `Checks` tab is hidden from PRs when there are no checks.
+- [Approve or reject reviews faster with one-click review type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
+- [Inactive deployments in PR timelines are hidden.](https://github.com/sindresorhus/refined-github/issues/1144)
+- [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
+- [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
+- [Limit the number of characters that can be used as a commit title while editing files or merging PRs.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
+- Cycle through PR tabs by pressing <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
+- [Go to the next or previous commit from the bottom of the commit page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+- [Bypass the "Checks" page and go directly to build results when clicking the "Details" links on a PR](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
+- [Mark all files as viewed when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+
+### Commits
+
+- Toggle whitespace visibility in diffs by pressing <kbd>d</kbd> <kbd>w</kbd>.
+- [Quickly access a commit's `.patch` and `.diff` files.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
+- [SVG files diffs default to rich-diff view.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
+- [View raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
+- [Change diff style and whitespace visibility in one click.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
+- [Follow file renames in commits lists.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
+- [Link to file itself in the history pages](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
+- [The `Expand diff` button is widened.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
+
+### Fixes for GitHub bugs
+
+- [Hide milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
+- [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
+- Obvious tooltips are removed.
+- Recently-pushed branches no longer cause the content to jump down ([they are moved to the header](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)).
+
+### Global
+
+- [404 pages show possible related pages and alternatives.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
+- [Open selection in new tab with <kbd>shift</kbd> <kbd>o</kbd> when navigating via <kbd>j</kbd> and <kbd>k</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
+- [Dropdown menus are automatically closed when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
+- [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- Access trending repositories using the `Trending` link in the global navbar or by pressing <kbd>g</kbd> <kbd>t</kbd>.
+- Use <kbd>←</kbd> and <kbd>→</kbd> to navigate through pages with pagination.
+- [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
+- [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
+
+### Newsfeed
 
 - [Newsfeed events take up less space and "User starred X repos" groups are now always expanded.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
 - Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
-- The file hover effect in the repo file browser is removed.
-- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
-- Obvious tooltips are removed.
-- The `Checks` tab is hidden from PRs when there are no checks.
-- The `Projects` tab is hidden from repositories and profiles when there are no projects.
-    * New projects can still be created via the [`Create new…` menu](https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png).
-- [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
-- [Forks and archived repos are hidden on profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
-- [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
-- [Tall code blocks and quotes are limited in height.](https://github.com/sindresorhus/refined-github/issues/1123)
-- [Forks and watchers counters are hidden.](https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png)
-- [Diff signs are hidden.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
-- [Hide milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
-- [Empty sections in the issue/PRs sidebar are hidden.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
-- [Projects and Milestones filters are dropped if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
-- [Add upload button to the comment toolbar and remove the upload message.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
-
-
-### UI improvements
-
-- [Tabs in code are shown as 4 spaces instead of 8 spaces.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
-- [Labels are moved to the left of issue and pull request lists.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
-- [Approve or reject reviews faster with one-click review type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
 - The news feeds automagically expands when you scroll down.
-- The default sort order of milestones is changed to `Closest due date`.
-- The default sort order of issues and pull requests is changed to `Recently updated`.
-- Recently-pushed branches no longer cause the content to jump down ([they are moved to the header](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)).
-- [The `Expand diff` button is widened.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
-- [Dropdown menus are automatically closed when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
-- [Inactive deployments in PR timelines are hidden.](https://github.com/sindresorhus/refined-github/issues/1144)
-- [The PR/issues search box is wider.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
-- [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
-- [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
-- [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
-- [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
-- [Wrapped code in diff views is aligned at the indented level of original line.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
-- [Limit the number of characters that can be used as a commit title while editing files or merging PRs.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
-
-### More shortcuts
-
-- [Access a repository's releases using the `Releases` tab or by pressing <kbd>g</kbd> <kbd>r</kbd>.](https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png)
-- Create a new release on the Releases tab by pressing <kbd>c</kbd>.
-- [Access `Commits`, `Branches`, `Dependencies`, and `Compare` pages from anywhere in a repository.](https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png)
-- [Search for issues and PRs with the `Everything commented by you` filter.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
-- [See just the issues and PRs _on your repos_ or _commented on by you_ in the global `Issues`/`Pull Requests` pages.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
-- Access trending repositories using the `Trending` link in the global navbar or by pressing <kbd>g</kbd> <kbd>t</kbd>.
-- [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
-- Visit your profile by pressing <kbd>g</kbd> <kbd>m</kbd>.
-- Cycle through PR tabs by pressing <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
-- [Go to the next or previous commit from the bottom of the commit page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
-- [Hide comments in fewer clicks.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
-- Use <kbd>←</kbd> and <kbd>→</kbd> to navigate through pages with pagination.
-- [Find a user’s most starred repositories in their profile.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
-- [Bypass the "Checks" page and go directly to build results when clicking the "Details" links on a PR](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
-- Star/unstar a repository by pressing <kbd>g</kbd> <kbd>s</kbd>.
-- [Delete a forked repo in one click after its PR has been merged.](https://user-images.githubusercontent.com/1402241/54188399-94bd9800-44ea-11e9-8d37-85170309bbef.png)
-- Toggle whitespace visibility in diffs by pressing <kbd>d</kbd> <kbd>w</kbd>.
-- [Change diff style and whitespace visibility in one click.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
-- [Press <kbd>esc</kbd> to deselect the current line when viewing files.](https://github.com/sindresorhus/refined-github/issues/1590)
-- [Edit comments in one click.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
-- [Follow file renames in commits lists.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
-- [Edit files straight from a repo’s list by clicking their icon.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
-- [Search or select tags from a dropdown in the `Releases` page.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
-- [Link to file itself in the history pages](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
-- [See an automatic changelog for each tag or release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
-- [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
-- [Format selected text with a key press when writing comments.](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif)
-- [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
-- [Mark all files as viewed when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
-- [Visit symbolic links with a click.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
 
 ### Previously part of Refined GitHub
 

--- a/readme.md
+++ b/readme.md
@@ -35,11 +35,11 @@ GitHub Enterprise is also supported. More info in the options.
 <table>
 	<tr>
 		<th width="50%">
-			Mark issues and pull requests as unread<br>
+			Adds button to mark issues and PRs as unread<br>
 			<em>(They will reappear in Notifications)</em>
 		</th>
 		<th width="50%">
-			Fix merge conflicts in a click
+			Adds one-click merge conflict fixers
 		</th>
 	</tr>
 	<tr><!-- Prevent zebra stripes --></tr>
@@ -56,10 +56,10 @@ GitHub Enterprise is also supported. More info in the options.
 <table>
 	<tr>
 		<th width="50%">
-			Reaction avatars showing <i>who</i> reacted to a comment
+			Adds reaction avatars showing <i>who</i> reacted to a comment
 		</th>
 		<th width="50%">
-			The option to wait for checks when merging a PR
+			Adds the option to wait for checks when merging a PR
 		</th>
 	</tr>
 	<tr><!-- Prevent zebra stripes --></tr>
@@ -76,7 +76,7 @@ GitHub Enterprise is also supported. More info in the options.
 <table>
 	<tr>
 		<th width="50%">
-			Clickable references to issues and pull requests
+			Linkifies issue/PR references and URLs in code
 		</th>
 		<th width="50%">
 			Links to an issue's closing commit or pull request
@@ -121,141 +121,153 @@ GitHub Enterprise is also supported. More info in the options.
 - Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
 - [Adds a tags dropdown/search on tag/release pages.](https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png)
 - [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
+- [Adds a button to a download button entire folders.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *Uses [download-directory.github.io](https://download-directory.github.io)*
+- [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
+- [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
+- [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
+- [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
 
 ### Files
 
 - Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
 - [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
-- [Copy a file's content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
-- [Download entire folders from repositories using the `Download folder` button.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *(Uses [download-directory.github.io](https://download-directory.github.io).)*
-- [Collapse or expand a repository's browser file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
-- [Quickly visit a repository's default branch and latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
-- [Visit symbolic links with a click.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
-- [List PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
-- [Whitespace characters are displayed.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
-- [Unnecessary buttons in the comment box toolbar are hidden](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
-- [Diff signs are hidden.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
-- [Tabs in code are shown as 4 spaces instead of 8 spaces.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
-- [Wrapped code in diff views is aligned at the indented level of original line.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
-- [Press <kbd>esc</kbd> to deselect the current line when viewing files.](https://github.com/sindresorhus/refined-github/issues/1590)
-- [Edit files straight from a repo’s list by clicking their icon.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
+- [Adds a button to copy a file's content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
+- [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
+- [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
+- [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
+- [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
+- [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 
-### Comments
+### Writing comments
 
-- Indent text with <kbd>tab</kbd> inside comment fields (<kbd>shift</kbd> <kbd>tab</kbd> for original behavior).
-- [View linked gists inline in comments.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
-- [Submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
-- [Browse a repository at the time of each comment,](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) including [each link.](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png)
-- [Insert collapsible content when writing comments (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
-- [Full names of comment authors are shown next to their username.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
-- [Repo URLs are shortened to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
-- [Hidden comments are previewed inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
-- [The most useful comment in issues is highlighted.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
-- [Reaction comments ("+1", "👍", …) are hidden](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
-- [Tall code blocks and quotes are limited in height.](https://github.com/sindresorhus/refined-github/issues/1123)
-- [Comment boxes expand with their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
-- [Edit comments in one click.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
-- [Quickly edit your last comment using the <kbd>↑</kbd> shortcut.](https://github.com/sindresorhus/refined-github/pull/961)
-- [Hide comments in fewer clicks.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
-- [Open issues to the latest comment by clicking the comments icon.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
-- [Format selected text with a key press when writing comments.](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif)
-- [The upload bar on commits is reduced to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
+- Enables the <kbd>tab</kbd> key for indentation in comment fields.
+######## - [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
+- [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
+- [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
+- [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
+- [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
+- [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
+- [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
+- [Hides unnecessary buttons in the comment box toolbar](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
 
-### Issues
+### Reading comments
 
-- [Open multiple issues at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
-- [Search for issues and PRs separately in the top search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
-- [Issue listing header is always visible.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
-- [Your issues and PRs are highlighted.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
-- [Labels are moved to the left of issue and pull request lists.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
-- The default sort order of issues and pull requests is changed to `Recently updated`.
-- [The PR/issues search box is wider.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
-- [Search for issues and PRs with the `Everything commented by you` filter.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
-- [See just the issues and PRs _on your repos_ or _commented on by you_ in the global `Issues`/`Pull Requests` pages.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
-- [Empty sections in the issue/PRs sidebar are hidden.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
-- [Projects and Milestones filters are dropped if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
-- [Cycle "popover lists" (labels, milestones, etc) when selecting them with the <kbd>↑</kbd> and <kbd>↓</kbd> keys.](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
+- [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
+- [Adds the real name of users next to their usernames.](https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png)
+- [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
+- [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
+- [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
+- [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
+- [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
+- [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
+- [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+
+### Discussions
+
+- [Adds a button to open multiple discussions at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
+- [Makes the discussion filters bar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
+- [Highlights discussions opened by you.](https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png)
+- [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
+- Changes the default sort order of discussions to `Recently updated`.
+- [Widens the discussion search box.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
+- [Adds a `Everything commented by you` filter in the search box dropdown.](https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png)
+- [Adds filters for discussions _in your repos_ and _commented on by you_ in the global discussion search.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
+- [Hides empty sections in the discussion sidebar.](https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png)
+- [Hides `Projects` and `Milestones` filters in discussion lists if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
+- [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 
 
-### Pull requests
+### Viewing pull requests
 
-- [Use the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [update the PR’s title to the merge commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
-- [Add co-authors when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
-- [Update a PR from the base branch to ensure it build correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png)
-- [Navigate from PR commit to raw commit by clicking the commit hash.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
-- [Swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
-- [Filter pull requests by their build status.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
-- [Review counts are shown and colored in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
-- [Significant head and base branches are added to the PR list.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
-- The `Checks` tab is hidden from PRs when there are no checks.
-- [Approve or reject reviews faster with one-click review type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
-- [Inactive deployments in PR timelines are hidden.](https://github.com/sindresorhus/refined-github/issues/1144)
-- [A warning appears when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
-- [A warning appears when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
-- [Limit the number of characters that can be used as a commit title while editing files or merging PRs.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
-- Cycle through PR tabs by pressing <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
-- [Go to the next or previous commit from the bottom of the commit page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
-- [Bypass the "Checks" page and go directly to build results when clicking the "Details" links on a PR](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
-- [Mark all files as viewed when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+- [Adds link to non-PR commit when visiting a PR commit.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
+- [Adds a `Build status` dropdown filter in PR lists.](https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png)
+- [Shows color-coded review counts in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
+- [Shows head and base branches in PR lists if they’re significant.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
+- Hides the `Checks` tab if it’s empty.
+- [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
+- [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+
+### Editing pull requests
+
+- [Uses the PR’s title and description when merging](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
+- [Adds `co-authored-by` to the commit when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
+- [Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
+- [Simplifies the PR review form.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
+- [Warns you when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
+- [Warns you when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
+- Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
+- [Bypasses the "Checks" intersitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
+- [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 
 ### Commits
 
-- Toggle whitespace visibility in diffs by pressing <kbd>d</kbd> <kbd>w</kbd>.
-- [Quickly access a commit's `.patch` and `.diff` files.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
-- [SVG files diffs default to rich-diff view.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
-- [View raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
-- [Change diff style and whitespace visibility in one click.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
-- [Follow file renames in commits lists.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
-- [Link to file itself in the history pages](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
-- [The `Expand diff` button is widened.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
-
-### Fixes for GitHub bugs
-
-- [Hide milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
-- [The autocomplete on the issue search field is removed.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
-- Obvious tooltips are removed.
-- Recently-pushed branches no longer cause the content to jump down ([they are moved to the header](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)).
-
-### Global
-
-- [404 pages show possible related pages and alternatives.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
-- [Open selection in new tab with <kbd>shift</kbd> <kbd>o</kbd> when navigating via <kbd>j</kbd> and <kbd>k</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
-- [Dropdown menus are automatically closed when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
-- [Text wrapped in backticks in issue titles and commit titles is highlighted.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
-- Access trending repositories using the `Trending` link in the global navbar or by pressing <kbd>g</kbd> <kbd>t</kbd>.
-- Use <kbd>←</kbd> and <kbd>→</kbd> to navigate through pages with pagination.
-- [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
-- [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
+- Adds a keyboard shortcut to ignore whitespace in diffs: <kbd>d</kbd> <kbd>w</kbd>.
+- [Adds links to `.patch` and `.diff` files in commits.](https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png)
+- [Renders the rich diff by default in SVG files diffs.](https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png)
+- [Adds link to view the raw version of files in PRs and commits.](https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png)
+- [Adds one-click buttons to change diff style and to ignore the whitespace.](https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png)
+- [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
+- [Adds link to file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
+- [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
+- [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded.)
+- [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 
 ### Newsfeed
 
-- [Newsfeed events take up less space and "User starred X repos" groups are now always expanded.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
-- Stars on your repos and some other useless events (commits, forks, new followers) are hidden.
-- The news feeds automagically expands when you scroll down.
+- [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
+- Hides "starred" events for your own repos
+- Hides other inutile events (commits, forks, new followers).
+- Automagically expands the newsfeed when you scroll down.
+
+### Global
+
+- [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)
+- [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
+- [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
+- [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
+- Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
+- [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
+- [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
+
+### Fixes for GitHub bugs
+
+- [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
+- [Hides the milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
+- [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
+- Removes tooltips from self-explanatory buttons.
+- [Moves the "Recently-pushed branches" widget to the header to avoid content jumps.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
 
 ### Previously part of Refined GitHub
 
-- [Implemented by GitHub](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view): [Blame parent commits in blame view.](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)
-- [Implemented by GitHub](https://cloud.githubusercontent.com/assets/170270/25772137/6a6b678e-3296-11e7-97c7-02e31ef17743.png): [Collapse/expand files in a PR diff.](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
-- [Implemented by GitHub](https://user-images.githubusercontent.com/1402241/31265633-779ad0fe-aa35-11e7-8c42-a3b375f8f32c.png): [Preview a issue/PR reference's title in comments.](https://user-images.githubusercontent.com/170270/30729486-2816df06-9f8a-11e7-8069-8999302e9ddd.png)
-- [Implemented by GitHub](https://github.com/sindresorhus/refined-github/pull/1330): The dashboard organization switcher is moved to the right column.
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-24-button-to-edit-a-repositorys-readme-from-the-repository-root/): [Quickly edit a repository's README from the repository root.](https://user-images.githubusercontent.com/170270/27501200-31a1fa20-586c-11e7-9a3f-ce270014bf0a.png)
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-25-access-your-repositories-straight-from-the-profile-dropdown/): [Access `Your repositories` from the profile dropdown.](https://user-images.githubusercontent.com/4201088/34920280-479e2454-f996-11e7-8e24-ad69793b9d9b.png)
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-26-highlighting-of-permalinked-comments/): [Permalinked comments are highlighted.](https://user-images.githubusercontent.com/1402241/37349492-226bd37a-2709-11e8-8087-d9686b330240.png)
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-24-keyboard-shortcut-to-leave-a-single-comment-in-pull-requests-reviews/): Leave a single comment in pull request diffs instead of starting a review by pressing <kbd>shift</kbd> <kbd>enter</kbd>.
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-31-removing-files-from-a-pull-request/): [Quickly delete a file from pull requests.](https://user-images.githubusercontent.com/1402241/42529637-578587e4-847f-11e8-9705-57384a1edd24.png)
-- [Implemented by GitHub](https://github.com/sindresorhus/refined-github/issues/1521): Pressing `Cancel` on an inline comment opens a prompt to prevent accidental cancelling.
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-07-31-unselectable-diff-markers/): The `+` and `-` signs in diffs are made unselectable for easier copy-pasting.
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-08-17-collapse-all-diffs-in-a-pull-request-at-once/): Toggle all [outdated PR comments](https://user-images.githubusercontent.com/25818354/33240033-3e271588-d2af-11e7-93af-13b6e325f65d.gif) or [PR/commit files](https://user-images.githubusercontent.com/1402241/35192652-6f79dc42-fec9-11e7-89ad-2b4a9c5f4f52.gif) with <kbd>alt</kbd> <kbd>click</kbd>.
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-11-05-related-issues/): [Avoid opening duplicate issues thanks to the list of possibly-related issues.](https://user-images.githubusercontent.com/29176678/37566899-85953e6e-2abf-11e8-9f0e-52d18c87bbe3.gif)
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-11-16-copy-file-paths-in-diffs/): [Copy the path of a PR file.](https://cloud.githubusercontent.com/assets/4201088/26023064/18c9c77c-37d2-11e7-8926-b0a05a2706ae.png)
-- [Implemented by GitHub](https://blog.github.com/changelog/2018-11-26-searching-by-user-from-a-profile-page/): [Search a user profile page when visiting it.](https://user-images.githubusercontent.com/1402241/35185441-24ad4b1e-fe37-11e7-9e1b-0dc09fc1ada2.png)
-- [Implemented by GitHub](https://user-images.githubusercontent.com/36004334/52573199-ea365480-2e19-11e9-8ebf-3ea6a7a640f8.png): [Access the `Labels` `Milestones` navigation from individual milestone pages.](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
-- [Implemented by GitHub](https://github.blog/changelog/2019-02-13-comment-author-label/): [The comments of who opened an issue/PR are marked with `Original Poster` label.](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
-- [Implemented by GitHub](https://github.blog/changelog/2019-02-14-prompt-to-clean-up-merged-forks): [Quickly delete a forked repo after its pull request has been merged.](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
-- [Implemented by GitHub](https://github.blog/changelog/2019-03-05-exclude-labels-from-search/): [Exclude PR/issue filters from their list](https://user-images.githubusercontent.com/1402241/48470535-493cfb00-e824-11e8-863a-964f52b62553.png) with <kbd>alt/option</kbd>-<kbd>click</kbd>.
-- [Implemented by GitHub](https://github.blog/changelog/2019-03-18-sticky-file-headers-in-pull-requests/): [File headers are always visible.](https://user-images.githubusercontent.com/81981/28682784-78bac340-72fe-11e7-9386-bdbab7703693.gif)
+GitHub implemented 20 features that used to be part of Refined GitHub 🎉
 
+<details><summary>See list</summary>
+
+- [Blog post](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view): [Blame parent commits in blame view.](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)
+- [Blog post](https://cloud.githubusercontent.com/assets/170270/25772137/6a6b678e-3296-11e7-97c7-02e31ef17743.png): [Collapse/expand files in a PR diff.](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
+- [Blog post](https://user-images.githubusercontent.com/1402241/31265633-779ad0fe-aa35-11e7-8c42-a3b375f8f32c.png): [Preview a issue/PR reference's title in comments.](https://user-images.githubusercontent.com/170270/30729486-2816df06-9f8a-11e7-8069-8999302e9ddd.png)
+- [Blog post](https://github.com/sindresorhus/refined-github/pull/1330): The dashboard organization switcher is moved to the right column.
+- [Blog post](https://blog.github.com/changelog/2018-07-24-button-to-edit-a-repositorys-readme-from-the-repository-root/): [Quickly edit a repository's README from the repository root.](https://user-images.githubusercontent.com/170270/27501200-31a1fa20-586c-11e7-9a3f-ce270014bf0a.png)
+- [Blog post](https://blog.github.com/changelog/2018-07-25-access-your-repositories-straight-from-the-profile-dropdown/): [Access `Your repositories` from the profile dropdown.](https://user-images.githubusercontent.com/4201088/34920280-479e2454-f996-11e7-8e24-ad69793b9d9b.png)
+- [Blog post](https://blog.github.com/changelog/2018-07-26-highlighting-of-permalinked-comments/): [Permalinked comments are highlighted.](https://user-images.githubusercontent.com/1402241/37349492-226bd37a-2709-11e8-8087-d9686b330240.png)
+- [Blog post](https://blog.github.com/changelog/2018-07-24-keyboard-shortcut-to-leave-a-single-comment-in-pull-requests-reviews/): Leave a single comment in pull request diffs instead of starting a review by pressing <kbd>shift</kbd> <kbd>enter</kbd>.
+- [Blog post](https://blog.github.com/changelog/2018-07-31-removing-files-from-a-pull-request/): [Quickly delete a file from pull requests.](https://user-images.githubusercontent.com/1402241/42529637-578587e4-847f-11e8-9705-57384a1edd24.png)
+- [Blog post](https://github.com/sindresorhus/refined-github/issues/1521): Pressing `Cancel` on an inline comment opens a prompt to prevent accidental cancelling.
+- [Blog post](https://blog.github.com/changelog/2018-07-31-unselectable-diff-markers/): The `+` and `-` signs in diffs are made unselectable for easier copy-pasting.
+- [Blog post](https://blog.github.com/changelog/2018-08-17-collapse-all-diffs-in-a-pull-request-at-once/): Toggle all [outdated PR comments](https://user-images.githubusercontent.com/25818354/33240033-3e271588-d2af-11e7-93af-13b6e325f65d.gif) or [PR/commit files](https://user-images.githubusercontent.com/1402241/35192652-6f79dc42-fec9-11e7-89ad-2b4a9c5f4f52.gif) with <kbd>alt</kbd> <kbd>click</kbd>.
+- [Blog post](https://blog.github.com/changelog/2018-11-05-related-issues/): [Avoid opening duplicate issues thanks to the list of possibly-related issues.](https://user-images.githubusercontent.com/29176678/37566899-85953e6e-2abf-11e8-9f0e-52d18c87bbe3.gif)
+- [Blog post](https://blog.github.com/changelog/2018-11-16-copy-file-paths-in-diffs/): [Copy the path of a PR file.](https://cloud.githubusercontent.com/assets/4201088/26023064/18c9c77c-37d2-11e7-8926-b0a05a2706ae.png)
+- [Blog post](https://blog.github.com/changelog/2018-11-26-searching-by-user-from-a-profile-page/): [Search a user profile page when visiting it.](https://user-images.githubusercontent.com/1402241/35185441-24ad4b1e-fe37-11e7-9e1b-0dc09fc1ada2.png)
+- [Blog post](https://user-images.githubusercontent.com/36004334/52573199-ea365480-2e19-11e9-8ebf-3ea6a7a640f8.png): [Access the `Labels` `Milestones` navigation from individual milestone pages.](https://cloud.githubusercontent.com/assets/170270/25217211/37b67aea-25d0-11e7-8482-bead2b04ee74.png)
+- [Blog post](https://github.blog/changelog/2019-02-13-comment-author-label/): [The comments of who opened an issue/PR are marked with `Original Poster` label.](https://cloud.githubusercontent.com/assets/4331946/25075520/d62fbbd0-2316-11e7-921f-ab736dc3522e.png)
+- [Blog post](https://github.blog/changelog/2019-02-14-prompt-to-clean-up-merged-forks): [Quickly delete a forked repo after its pull request has been merged.](https://cloud.githubusercontent.com/assets/170270/13520281/b2c9335c-e211-11e5-9e36-b0f325166356.png)
+- [Blog post](https://github.blog/changelog/2019-03-05-exclude-labels-from-search/): [Exclude PR/issue filters from their list](https://user-images.githubusercontent.com/1402241/48470535-493cfb00-e824-11e8-863a-964f52b62553.png) with <kbd>alt/option</kbd>-<kbd>click</kbd>.
+- [Blog post](https://github.blog/changelog/2019-03-18-sticky-file-headers-in-pull-requests/): [File headers are always visible.](https://user-images.githubusercontent.com/81981/28682784-78bac340-72fe-11e7-9386-bdbab7703693.gif)
+
+</details>
 
 ## Customization
 

--- a/readme.md
+++ b/readme.md
@@ -164,7 +164,7 @@ Thanks for contributing! 🦋🙌
 ### Writing comments
 
 - Enables the <kbd>tab</kbd> key for indentation in comment fields.
-######## - [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
+- [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
 - [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
 - [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
@@ -228,7 +228,7 @@ Thanks for contributing! 🦋🙌
 - [Warns you when trying to create a PR from the default branch.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [Warns you when unchecking `Allow edits from maintainers`.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
 - Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
-- [Bypasses the "Checks" intersitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
+- [Bypasses the "Checks" interstitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
 - [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,24 @@ GitHub Enterprise is also supported. More info in the options.
 	</tr>
 </table>
 
+<!--
 
+############################
+  Descriptions style guide
+############################
+
+- Starts with: "(Refined GitHub) <verb in third person> ..."
+- Ends with period (inside link or parens, if present, like this.)
+- Keyboard shortcuts must follow:
+	- "Adds a keyboard shortcut to ...: <kbd>key1</kbd> <kbd>key2</kbd>"
+	- "Adds keyboard shortcuts to ...: <kbd>a</kbd> and <kbd>alt</kbd> <kbd>a</kbd>"
+- You should try to use the same description and screenshot in the feature’s file (inside `features.add`)
+- Use smart apostrophes: ’ instead of '
+- Keep it concise.
+
+Thanks for contributing! 🦋🙌
+
+-->
 
 ### Profiles
 
@@ -105,6 +122,8 @@ GitHub Enterprise is also supported. More info in the options.
 - Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
 - [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
 - [Hides forks and archived repos from profiles (but they can still be shown)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Repositories
 
@@ -127,16 +146,20 @@ GitHub Enterprise is also supported. More info in the options.
 - [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
 - [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
 
+<!-- Refer to style guide above. Keep this message between sections. -->
+
 ### Files
 
 - Enhances [the <kbd>y</kbd> hotkey](https://help.github.com/articles/getting-permanent-links-to-files/) to also copy the permalink.
 - [Adds a button to view the source of Markdown files.](https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png)
-- [Adds a button to copy a file's content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
+- [Adds a button to copy a file’s content.](https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png)
 - [Linkifies symbolic links files.](https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png)
 - [Shows PRs that touch the current file.](https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png)
 - [Shows whitespace characters.](https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png)
 - [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
 - [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Writing comments
 
@@ -150,6 +173,8 @@ GitHub Enterprise is also supported. More info in the options.
 - [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
 - [Hides unnecessary buttons in the comment box toolbar](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut).
 
+<!-- Refer to style guide above. Keep this message between sections. -->
+
 ### Reading comments
 
 - [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
@@ -158,10 +183,12 @@ GitHub Enterprise is also supported. More info in the options.
 - [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
 - [Previews hidden comments inline.](https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png)
 - [Highlights the most useful comment in issues.](https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png)
-- [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers') [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
+- [Hides reaction comments ("+1", "👍", …)](https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png) (except the maintainers’) [but they can still be shown.](https://user-images.githubusercontent.com/1402241/45543720-d628ff80-b847-11e8-9fb6-758a3102e3a9.png)
 - [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
 - [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
 - [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Discussions
 
@@ -178,6 +205,7 @@ GitHub Enterprise is also supported. More info in the options.
 - [Hides `Projects` and `Milestones` filters in discussion lists if they are empty.](https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png)
 - [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Viewing pull requests
 
@@ -188,6 +216,8 @@ GitHub Enterprise is also supported. More info in the options.
 - Hides the `Checks` tab if it’s empty.
 - [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
 - [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Editing pull requests
 
@@ -200,6 +230,8 @@ GitHub Enterprise is also supported. More info in the options.
 - Adds keyboard shortcuts to cycle through PR tabs: <kbd>g</kbd> <kbd>←</kbd> and <kbd>g</kbd> <kbd>→</kbd>, or <kbd>g</kbd> <kbd>1</kbd>, <kbd>g</kbd> <kbd>2</kbd>, <kbd>g</kbd> <kbd>3</kbd> and <kbd>g</kbd> <kbd>4</kbd>.
 - [Bypasses the "Checks" intersitial when clicking the "Details" links on a PR.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
 - [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Commits
 
@@ -214,12 +246,16 @@ GitHub Enterprise is also supported. More info in the options.
 - [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded.)
 - [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 
+<!-- Refer to style guide above. Keep this message between sections. -->
+
 ### Newsfeed
 
 - [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
 - Hides "starred" events for your own repos
 - Hides other inutile events (commits, forks, new followers).
 - Automagically expands the newsfeed when you scroll down.
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Global
 
@@ -232,6 +268,8 @@ GitHub Enterprise is also supported. More info in the options.
 - [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
 - [All available keyboard shortcuts are shown in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)  *(<kbd>?</kbd> hotkey)*
 
+<!-- Refer to style guide above. Keep this message between sections. -->
+
 ### Fixes for GitHub bugs
 
 - [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
@@ -239,6 +277,8 @@ GitHub Enterprise is also supported. More info in the options.
 - [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - Removes tooltips from self-explanatory buttons.
 - [Moves the "Recently-pushed branches" widget to the header to avoid content jumps.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
 
 ### Previously part of Refined GitHub
 
@@ -248,9 +288,9 @@ GitHub implemented 20 features that used to be part of Refined GitHub 🎉
 
 - [Blog post](https://github.com/blog/2304-navigate-file-history-faster-with-improved-blame-view): [Blame parent commits in blame view.](https://github.com/sindresorhus/refined-github/issues/2#issuecomment-189141373)
 - [Blog post](https://cloud.githubusercontent.com/assets/170270/25772137/6a6b678e-3296-11e7-97c7-02e31ef17743.png): [Collapse/expand files in a PR diff.](https://cloud.githubusercontent.com/assets/170270/13954167/40caa604-f072-11e5-89ba-3145217c4e28.png)
-- [Blog post](https://user-images.githubusercontent.com/1402241/31265633-779ad0fe-aa35-11e7-8c42-a3b375f8f32c.png): [Preview a issue/PR reference's title in comments.](https://user-images.githubusercontent.com/170270/30729486-2816df06-9f8a-11e7-8069-8999302e9ddd.png)
+- [Blog post](https://user-images.githubusercontent.com/1402241/31265633-779ad0fe-aa35-11e7-8c42-a3b375f8f32c.png): [Preview a issue/PR reference’s title in comments.](https://user-images.githubusercontent.com/170270/30729486-2816df06-9f8a-11e7-8069-8999302e9ddd.png)
 - [Blog post](https://github.com/sindresorhus/refined-github/pull/1330): The dashboard organization switcher is moved to the right column.
-- [Blog post](https://blog.github.com/changelog/2018-07-24-button-to-edit-a-repositorys-readme-from-the-repository-root/): [Quickly edit a repository's README from the repository root.](https://user-images.githubusercontent.com/170270/27501200-31a1fa20-586c-11e7-9a3f-ce270014bf0a.png)
+- [Blog post](https://blog.github.com/changelog/2018-07-24-button-to-edit-a-repositorys-readme-from-the-repository-root/): [Quickly edit a repository’s README from the repository root.](https://user-images.githubusercontent.com/170270/27501200-31a1fa20-586c-11e7-9a3f-ce270014bf0a.png)
 - [Blog post](https://blog.github.com/changelog/2018-07-25-access-your-repositories-straight-from-the-profile-dropdown/): [Access `Your repositories` from the profile dropdown.](https://user-images.githubusercontent.com/4201088/34920280-479e2454-f996-11e7-8e24-ad69793b9d9b.png)
 - [Blog post](https://blog.github.com/changelog/2018-07-26-highlighting-of-permalinked-comments/): [Permalinked comments are highlighted.](https://user-images.githubusercontent.com/1402241/37349492-226bd37a-2709-11e8-8087-d9686b330240.png)
 - [Blog post](https://blog.github.com/changelog/2018-07-24-keyboard-shortcut-to-leave-a-single-comment-in-pull-requests-reviews/): Leave a single comment in pull request diffs instead of starting a review by pressing <kbd>shift</kbd> <kbd>enter</kbd>.

--- a/source/features/add-co-authored-by.tsx
+++ b/source/features/add-co-authored-by.tsx
@@ -76,7 +76,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Add co-authors when merging pull requests with multiple committers',
+	description: 'Adds `co-authored-by` to the commit when merging PRs with multiple committers.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png',
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/batch-open-issues.tsx
+++ b/source/features/batch-open-issues.tsx
@@ -64,7 +64,8 @@ function init(): void | false {
 
 features.add({
 	id: __featureName__,
-	description: 'Open multiple issues in your repo at once',
+	description: 'Adds a button to open multiple discussions at once in your repos.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif',
 	include: [
 		features.isDiscussionList
 	],

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -116,7 +116,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Quickly visit a repository’s default branch and latest version tag',
+	description: 'Adds links to the default branch and to the latest version tag.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png',
 	include: [
 		features.isRepoTree,
 		features.isSingleFile

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -15,7 +15,8 @@ async function bypass(check: HTMLElement): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Bypass the `Checks` page and go directly to build results when clicking the `Details` links on a pull request',
+	description: 'Bypasses the "Checks" interstitial when clicking the "Details" links on a PR.',
+	screenshot: 'https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png',
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -33,7 +33,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Add build status and link to CI after the repo’s title',
+	description: 'Add build status and link to CI after the repo’s title.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png',
 	include: [
 		features.isRepo
 	],

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -58,11 +58,11 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide empty issue/PR filters in lists',
+	description: 'Hides `Projects` and `Milestones` filters in discussion lists if they are empty.',
 	screenshot: 'https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png',
-	init,
 	load: features.onAjaxedPages,
 	include: [
 		features.isRepoDiscussionList
-	]
+	],
+	init
 });

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -81,7 +81,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide all empty sections (or just their "empty" label) in the discussion sidebar',
+	description: 'Hides empty sections (or just their "empty" label) in the discussion sidebar.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png',
 	include: [
 		features.isIssue,
 		features.isPRConversation

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -19,6 +19,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Automatically close modals when they’re no longer visible',
+	description: 'Automatically closes dropdown menus when they’re no longer visible.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif',
 	init
 });

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -64,7 +64,7 @@ function addContentToDetails(event: DelegateEvent<MouseEvent, HTMLButtonElement>
 
 features.add({
 	id: __featureName__,
-	description: 'Insert collapsible content when writing comments (via `<summary>`)',
+	description: 'Adds a button to insert collapsible content (via `<details>`).',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png',
 	include: [
 		features.hasRichTextEditor

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -102,7 +102,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Quickly edit your last comment using the `↑` keyboard shortcut',
+	description: 'Adds various shortcuts to comment fields: `↑` `tab` `esc` and Markdown formatting shortcuts',
+	screenshot: false,
 	shortcuts: {
 		'↑': 'Edit your last comment'
 	},

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -71,7 +71,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Browse a repository at the time of each comment',
+	description: 'Adds links to browse the repository and linked files at the time of each comment.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png',
 	include: [
 		features.hasComments
 	],

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -44,7 +44,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Copy a file’s content',
+	description: 'Adds a button to copy a file’s content.',
+	screenshot: 'https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png',
 	include: [
 		features.isSingleFile,
 		features.isGist

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -19,7 +19,8 @@ function deinit(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Add keyboard shortcut to copy the permalink of a file to the clipboard',
+	description: 'Enhances the `y` hotkey to also copy the permalink.',
+	screenshot: false,
 	include: [
 		features.isSingleFile
 	],

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -10,7 +10,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Add keyboard shortcut to quickly create a new release',
+	description: 'Adds a keyboard shortcut to create a new release while on the Releases page: `c`.',
+	screenshot: false,
 	include: [
 		features.isReleasesOrTags
 	],

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -56,13 +56,13 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Cycle "popover lists" (labels, milestones, etc) when selecting them with the `↑` and `↓` keys.',
+	description: 'Allows the `↑` and `↓` keys to cycle "popover lists" (labels, milestones, etc).',
 	screenshot: 'https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif',
-	init,
 	load: features.onAjaxedPages,
 	include: [
 		features.isPRConversation,
 		features.isIssue,
 		features.isCompare
-	]
+	],
+	init
 });

--- a/source/features/default-to-rich-diff.tsx
+++ b/source/features/default-to-rich-diff.tsx
@@ -38,7 +38,8 @@ function init(): void {
 features.add({
 	disabled: '#2041',
 	id: __featureName__,
-	description: 'Some of the files in pull requests can be reviewed using a rich-diff mode, for example, Markdown and SVG. This feature sets the rich-diff view as default in pull requests for files with a rich diff.',
+	description: 'Renders the rich diff by default in SVG files’ diffs.',
+	screenshot: 'https://user-images.githubusercontent.com/5243867/57125552-c08a2b00-6d81-11e9-9b84-cdb535baa98e.png',
 	include: [
 		features.isCommit,
 		features.isPRFiles

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -19,7 +19,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Move the "Marketplace" link from the black header bar to the profile dropdown',
+	description: 'Moves the "Marketplace" link from the black header bar to the profile dropdown.',
+	screenshot: false,
 	exclude: [
 		features.isGist
 	],

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -17,7 +17,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Download entire folders from repositories using the `Download folder` button, via https://download-directory.github.io',
+	description: 'Adds a button to a download button entire folders, via https://download-directory.github.io',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png',
 	include: [
 		features.isRepoTree
 	],

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -34,7 +34,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Edit comments in one click',
+	description: 'Moves the `Edit comment` button out of the `...` dropdown.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png',
 	include: [
 		features.hasComments
 	],

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -29,7 +29,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Edit files straight from a repo’s file list by clicking their file icon',
+	description: 'Adds a button to edit files from the repo file list.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png',
 	include: [
 		features.isRepoTree
 	],

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -36,6 +36,7 @@ async function init(): Promise<void | false> {
 features.add({
 	id: __featureName__,
 	description: 'Adds an Edit button on previewed Readmes in folders, even if you have to make a fork.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png',
 	include: [
 		features.isRepoTree
 	],

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -50,7 +50,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'View linked gists inline in comments',
+	description: 'Embeds linked gists.',
+	screenshot: 'https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.',
 	include: [
 		features.hasComments
 	],

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -26,6 +26,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Press the `esc` key to deselect the current line when viewing files',
+	description: 'Adds a keyboard shortcut to deselect the current line: `esc`.',
+	screenshot: false,
 	init
 });

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -16,7 +16,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Widen the `Expand diff` button',
+	description: 'Widens the `Expand diff` button to be clickable across the screen.',
+	screenshot: 'https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG',
 	include: [
 		features.isPRFiles,
 		features.isCommit

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -97,7 +97,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Change diff style and whitespace visibility in one click',
+	description: 'Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: `d` `w`.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png',
 	include: [
 		features.isPRFiles,
 		features.isCommit

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -21,7 +21,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Search for issues and pull requests with the "Everything commented by you filter"',
+	description: 'Adds a `Everything commented by you` filter in the search box dropdown.',
+	screenshot: 'https://user-images.githubusercontent.com/170270/27501170-f394a304-586b-11e7-92d8-d92d6922356b.png',
 	include: [
 		features.isRepoDiscussionList
 	],

--- a/source/features/filter-pr-by-build-status.tsx
+++ b/source/features/filter-pr-by-build-status.tsx
@@ -60,7 +60,8 @@ async function init(): Promise<void | false> {
 
 features.add({
 	id: __featureName__,
-	description: 'Filter pull requests by their build status (success, failure, and pending)',
+	description: 'Adds a `Build status` dropdown filter in PR lists.',
+	screenshot: 'https://user-images.githubusercontent.com/22439276/56372372-7733ca80-621c-11e9-8b60-a0b95aa4cd4f.png',
 	include: [
 		features.isPRList
 	],

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -28,14 +28,15 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Automatically expand textareas to fit all of their content, rather than have a height limit like GitHub’s native "fit to content" behavior',
+	description: 'Auto-resizes comment fields to fit their content and no longer show scroll bars, rather than have a height limit like GitHub’s native "fit to content" behavior.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif',
 	init
 });
 
 features.add({
 	id: __featureName__,
-	description: '',
+	description: false,
+	screenshot: false,
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/focus-confirmation-buttons.tsx
+++ b/source/features/focus-confirmation-buttons.tsx
@@ -9,6 +9,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Ensure that confirm buttons, like "Mark all as read", are always in focus',
+	description: 'Always focuses confirm buttons in custom modal boxes, like "Mark all as read".',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/31700158-1499bdd8-b38d-11e7-9aba-77a0a4b6bf3c.png',
 	init
 });

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -61,7 +61,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Enable Newer/Older buttons in commit lists to follow file renames',
+	description: 'Enhances files’ commit lists navigation to follow file renames.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png',
 	include: [
 		features.isCommitList
 	],

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -42,7 +42,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'See just the issues and PRs on your repos or commented on by you in the global Issues/Pull Requests pages',
+	description: 'Adds filters for discussions _in your repos_ and _commented on by you_ in the global discussion search.',
+	screenshot: 'https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png',
 	include: [
 		features.isGlobalDiscussionList
 	],

--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -61,7 +61,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide comments in fewer clicks',
+	description: 'Simplifies the UI to hide comments.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif',
 	include: [
 		features.hasComments
 	],

--- a/source/features/hide-disabled-milestone-sorter.tsx
+++ b/source/features/hide-disabled-milestone-sorter.tsx
@@ -14,7 +14,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide the milestone drag icon when you don’t have permission to sort the milestones',
+	description: 'Hides the milestone sorter UI if you don’t have permission to use it.',
+	screenshot: 'https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png',
 	include: [
 		features.isMilestone
 	],

--- a/source/features/hide-empty-meta.tsx
+++ b/source/features/hide-empty-meta.tsx
@@ -10,7 +10,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide the placeholder text for when there’s no repo description',
+	description: 'Hides the placeholder text in repos without a description.',
+	screenshot: false,
 	include: [
 		features.isRepoRoot
 	],

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -14,7 +14,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide inactive deployments in pull requests',
+	description: 'Hides inactive deployments in PRs.',
+	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1144',
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/hide-issue-list-autocomplete.tsx
+++ b/source/features/hide-issue-list-autocomplete.tsx
@@ -7,7 +7,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'The autocomplete on the issue search field is removed',
+	description: 'Removes the autocomplete on search fields.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png',
 	include: [
 		features.isDiscussionList
 	],

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -12,6 +12,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Some lists like notifications, file lists, and issue lists, are highlighted as you move the mouse over them. This highlight is useful when navigating via the keyboard (j/k), but annoying when just moving the mouse around.\n\nThis feature will hide the highlight until the first keyboard navigation, then it will be displayed until the next full reload.',
+	description: 'Removes the file hover effect in the repo file browser. Some lists like notifications, file lists, and issue lists, are highlighted as you move the mouse over them. This highlight is useful when navigating via the keyboard (j/k), but annoying when just moving the mouse around.',
+	screenshot: false,
 	init
 });

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -25,7 +25,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide other users starring/forking your repos in the dashboard',
+	description: 'Hides "starred" events for your own repos on the newsfeed.',
+	screenshot: false,
 	include: [
 		features.isDashboard
 	],

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -57,7 +57,8 @@ function unhide(event: React.MouseEvent<HTMLButtonElement>): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide useless comments like "+1"',
+	description: 'Hides reaction comments ("+1", "👍", …).',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png',
 	include: [
 		features.isIssue
 	],

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -7,7 +7,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide useless news feed events like "User started following X"',
+	description: 'Hides inutile newsfeed events (commits, forks, new followers).',
+	screenshot: false,
 	include: [
 		features.isDashboard
 	],

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -7,7 +7,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide watch and fork count from repo pages',
+	description: 'Hides forks and watchers counters.',
+	screenshot: 'https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png',
 	include: [
 		features.isRepo
 	],

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -65,7 +65,7 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'The most useful comment in issues is highlighted.',
+	description: 'Highlights the most useful comment in issues.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png',
 	include: [
 		features.isIssue

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -37,7 +37,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Link to pull requests that will close the current issue when merged',
+	description: 'Add link to an issue’s closing commit or pull request.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/37037746-8b8eac8a-2185-11e8-94f6-4d50a9c8a152.png',
 	include: [
 		features.isPRConversation,
 		features.isIssue

--- a/source/features/highlight-own-issues-and-prs.tsx
+++ b/source/features/highlight-own-issues-and-prs.tsx
@@ -11,7 +11,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Highlight your own issues and pull requests in the issue list',
+	description: 'Highlights discussions opened by you.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/53065281-01560000-3506-11e9-9a51-0bdf69e20b4a.png',
 	include: [
 		features.isDiscussionList
 	],

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -55,5 +55,6 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Show Refined GitHub’s keyboard shortcuts in the help modal (`?` hotkey)',
+	screenshot: 'https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png',
 	init
 });

--- a/source/features/indented-code-wrapping.tsx
+++ b/source/features/indented-code-wrapping.tsx
@@ -66,7 +66,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Wrap code inside all code blocks to match indentation',
+	description: 'Indents wrapped code correctly.',
+	screenshot: 'https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png',
 	include: [
 		features.isPRFiles,
 		features.isCommit,

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -57,7 +57,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Add infinite scrolling to the dashboard news feed',
+	description: 'Automagically expands the newsfeed when you scroll down.',
+	screenshot: false,
 	include: [
 		features.isDashboard
 	],

--- a/source/features/limit-commit-title-length.tsx
+++ b/source/features/limit-commit-title-length.tsx
@@ -26,12 +26,13 @@ function init(): void {
 }
 
 features.add({
-	id: 'limit-commit-title-length',
-	description: 'Limits the length of commit fields to 72 characters',
-	init,
+	id: __featureName__,
+	description: 'Limits the commit title fields to 72 characters.',
+	screenshot: 'https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif',
 	load: features.onAjaxedPages,
 	include: [
 		features.isPRConversation,
 		features.isEditingFile
-	]
+	],
+	init
 });

--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -34,7 +34,8 @@ function init(): void | false {
 
 features.add({
 	id: __featureName__,
-	description: 'Link to current file when viewing the history of a file',
+	description: 'Adds links to the file itself in a file’s commit list.',
+	screenshot: 'https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png',
 	include: [
 		features.isCommitList
 	],

--- a/source/features/linkify-branch-refs.tsx
+++ b/source/features/linkify-branch-refs.tsx
@@ -66,7 +66,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Click on branch references in pull requests',
+	description: 'Linkifies branch references in "Quick PR" pages.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png',
 	include: [
 		features.isPR,
 		features.isQuickPR

--- a/source/features/linkify-commit-sha.tsx
+++ b/source/features/linkify-commit-sha.tsx
@@ -12,7 +12,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Open the regular commit from PR-related commits by clicking the commit hash',
+	description: 'Adds link to non-PR commit when visiting a PR commit.',
+	screenshot: 'https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png',
 	include: [
 		features.isPRCommit
 	],

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -13,7 +13,7 @@ function init(): void | false {
 
 features.add({
 	id: __featureName__,
-	description: 'Linkify symbolic link files',
+	description: 'Linkifies symbolic links files.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png',
 	include: [
 		features.isSingleFile

--- a/source/features/linkify-urls-in-code.tsx
+++ b/source/features/linkify-urls-in-code.tsx
@@ -82,7 +82,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Make URLs in code clickable',
+	description: 'Linkifies URLs in code.',
+	screenshot: 'https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png',
 	include: [
 		features.hasCode
 	],

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -99,7 +99,7 @@ async function getPrsByFile(): Promise<Record<string, number[]>> {
 
 features.add({
 	id: __featureName__,
-	description: 'Lists PRs that touch the current file',
+	description: 'Shows PRs that touch the current file.',
 	screenshot: 'https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png',
 	include: [
 		features.isEditingFile,

--- a/source/features/make-discussion-sidebar-sticky.tsx
+++ b/source/features/make-discussion-sidebar-sticky.tsx
@@ -22,7 +22,8 @@ function deinit(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Make the discussion sidebar sticky',
+	description: 'Makes the discussion filters bar sticky.',
+	screenshot: 'https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif',
 	include: [
 		features.isIssue,
 		features.isPRConversation

--- a/source/features/mark-files-as-viewed.tsx
+++ b/source/features/mark-files-as-viewed.tsx
@@ -15,7 +15,8 @@ function init(): void {
 features.add({
 	disabled: '#2252',
 	id: __featureName__,
-	description: 'Mark all files as viewed when approving a PR',
+	description: 'Marks all files as "viewed" when approving a PR.',
+	screenshot: 'https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif',
 	include: [
 		features.isPR
 	],

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -15,7 +15,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Merge commits are dimmed in the commit list',
+	description: 'Dims merge commits in commits list.',
+	screenshot: false,
 	include: [
 		features.isCommitList
 	],

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -24,7 +24,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Mark private organizations on your own profile',
+	description: 'Marks private organizations on your own profile.',
+	screenshot: 'https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png',
 	include: [
 		features.isOwnUserProfile
 	],

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -430,7 +430,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Mark any issues and pull requests as unread',
+	description: 'Adds button to mark issues and PRs as unread. They will reappear in Notifications.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/27847663-963b7d7c-6171-11e7-9470-6e86d8463771.png',
 	load: features.onAjaxedPagesRaw,
 	init
 });

--- a/source/features/minimize-upload-bar.tsx
+++ b/source/features/minimize-upload-bar.tsx
@@ -30,7 +30,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Add upload button to the comment toolbar and remove the upload message',
+	description: 'Reduces the upload bar to a small button.',
 	screenshot: 'https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png',
 	include: [
 		features.hasRichTextEditor

--- a/source/features/monospace-textareas.tsx
+++ b/source/features/monospace-textareas.tsx
@@ -7,6 +7,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Limit the width of the commit title and description inputs to 50/80 characters and use a monospace font',
+	description: 'Use a monospace font for all textareas.',
+	screenshot: false,
 	init
 });

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -76,7 +76,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Access the `Commits`, `Branches`, `Dependencies`, and `Compare` pages from anywhere in a repository',
+	description: 'Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png',
 	include: [
 		features.isRepo
 	],

--- a/source/features/navigate-pages-with-arrow-keys.tsx
+++ b/source/features/navigate-pages-with-arrow-keys.tsx
@@ -15,7 +15,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Use the `←` and `→` keys to navigate through pages with pagination',
+	description: 'Adds shortcuts to navigate through pages with pagination: `←` and `→`.',
+	screenshot: false,
 	load: features.onAjaxedPages,
 	shortcuts: {
 		'→': 'Go to the next page',

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -92,7 +92,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Open all your notifications in one click',
+	description: 'Open all your notifications at once.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png',
 	include: [
 		features.isNotifications
 	],

--- a/source/features/open-ci-details-in-new-tab.tsx
+++ b/source/features/open-ci-details-in-new-tab.tsx
@@ -11,7 +11,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Open CI details in a new tab',
+	description: 'Opens the Checks "details" link in a new tab.',
+	screenshot: false,
 	include: [
 		features.isPR
 	],

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -9,7 +9,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Clicking the comments icon in issue lists will take you to latest comment.',
+	description: 'Links the comments icon to the latest comment.',
+	screenshot: 'https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png',
 	include: [
 		features.isDiscussionList
 	],

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -21,7 +21,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Parse `code in backticks` that appear in issue titles as Markdown',
+	description: 'Renders text in `backticks` in issue titles and commit titles.',
 	screenshot: 'https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png',
 	include: [
 		features.isDiscussionList,

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -22,7 +22,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Quickly access a commit’s `.patch` and `.diff` files',
+	description: 'Adds links to `.patch` and `.diff` files in commits.',
+	screenshot: 'https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png',
 	include: [
 		features.isCommit
 	],

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -20,7 +20,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Automatically deletes the branch right after merging a PR, if possible',
+	description: 'Automatically deletes the branch right after merging a PR, if possible.',
+	screenshot: false,
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -142,7 +142,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Some head and base branches are shown on the PR list: The base branch is added when it’s not the repo’s default branch; The head branch is added when it’s from the same repo or the PR is by the current user.',
+	description: 'Shows head and base branches in PR lists if they’re significant: The base branch is added when it’s not the repo’s default branch; The head branch is added when it’s from the same repo or the PR is by the current user.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png',
 	include: [
 		features.isPRList
 	],

--- a/source/features/preserve-whitespace-option-in-nav.tsx
+++ b/source/features/preserve-whitespace-option-in-nav.tsx
@@ -15,7 +15,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Preserve the whitespace setting when navigating with Next/Previous in pull request review mode',
+	description: 'Preserves the "ignore whitespace" setting when navigating with Next/Previous in PR review mode.',
+	screenshot: false,
 	include: [
 		features.isRepo
 	],

--- a/source/features/prev-next-commit-buttons.tsx
+++ b/source/features/prev-next-commit-buttons.tsx
@@ -15,7 +15,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Navigate PR commits with Previous/Next buttons at the bottom of the page',
+	description: 'Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.',
+	screenshot: 'https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png',
 	include: [
 		features.isPRFiles,
 		features.isPRCommit

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -35,7 +35,8 @@ const init = (): void => {
 
 features.add({
 	id: __featureName__,
-	description: 'Preview hidden comments inline',
+	description: 'Preview hidden comments inline.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png',
 	include: [
 		features.hasComments
 	],

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -26,7 +26,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Visit a user’s public gists from their profile',
+	description: 'Adds a link to the user’s public gists.',
+	screenshot: 'https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png',
 	include: [
 		features.isUserProfile
 	],

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -14,7 +14,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Go to your profile by pressing `g` `m`',
+	description: 'Adds a keyboard shortcut to visit your own profile: `g` `m`.',
+	screenshot: false,
 	load: features.onDomReady,
 	shortcuts: {
 		'g m': 'Go to Profile'

--- a/source/features/pull-request-hotkey.tsx
+++ b/source/features/pull-request-hotkey.tsx
@@ -20,7 +20,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Cycle through pull request tabs by pressing `g` `←` and `g` `→`, or `g` `1`, `g` `2`, `g` `3` and `g` `4`',
+	description: 'Adds keyboard shortcuts to cycle through PR tabs: `g` `←` and `g` `→`, or `g` `1`, `g` `2`, `g` `3` and `g` `4`',
+	screenshot: false,
 	include: [
 		features.isPR
 	],

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -80,7 +80,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Approve or reject reviews faster with one-click review-type buttons',
+	description: 'Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png',
 	include: [
 		features.isPR
 	],

--- a/source/features/raw-file-link.tsx
+++ b/source/features/raw-file-link.tsx
@@ -28,7 +28,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Link to raw files in pull requests and commits',
+	description: 'Adds link to view the raw version of files in PRs and commits.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png',
 	include: [
 		features.isCommit,

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -95,7 +95,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'See the avatar of who reacted to a comment',
+	description: 'Adds reaction avatars showing *who* reacted to a comment',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png',
 	include: [
 		features.hasComments
 	],

--- a/source/features/recently-pushed-branches-enhancements.tsx
+++ b/source/features/recently-pushed-branches-enhancements.tsx
@@ -52,7 +52,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'GitHub shows a widget to create a new Pull Request from a recently-pushed branch, but only on the repo root and on the PR list pages. This feature also adds this widget to the Issues List, Issue page, and Pull Request page.',
+	description: 'Moves the "Recently-pushed branches" widget to the header to avoid content jumps. Also adds it to more pages in the repo.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif',
 	include: [
 		features.isRepo
 	],
@@ -62,7 +63,8 @@ features.add({
 
 features.add({
 	id: __featureName__,
-	description: '',
+	description: false,
+	screenshot: false,
 	include: [
 		features.isRepo
 	],

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -52,7 +52,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Access a repository’s releases using the "Releases" tab or by pressing `g` `r`',
+	description: 'Adds a `Releases` tab and a keyboard shortcut: `g` `r`.',
+	screenshot: 'https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png',
 	include: [
 		features.isRepo
 	],
@@ -65,7 +66,8 @@ features.add({
 
 features.add({
 	id: __featureName__,
-	description: '',
+	description: false,
+	screenshot: false,
 	include: [
 		features.isRepo
 	],

--- a/source/features/remove-checks-tab.tsx
+++ b/source/features/remove-checks-tab.tsx
@@ -25,7 +25,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Remove the "Checks" tab in pull requests unless you’re the owner',
+	description: 'Hides the `Checks` tab if it’s empty, unless you’re the owner.',
+	screenshot: false,
 	include: [
 		features.isPR
 	],

--- a/source/features/remove-diff-signs.tsx
+++ b/source/features/remove-diff-signs.tsx
@@ -7,6 +7,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide diff signs (+-)',
+	description: 'Hides diff signs (+-) since diffs are color coded already.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png',
 	init
 });

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -68,7 +68,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Hide the "Projects" tab from repositories and profiles when there are no projects',
+	description: 'Hides the `Projects` tab from repositories and profiles when it’s empty. New projects can still be created via the `Create new…` menu.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png',
 	include: [
 		features.isRepo,
 		features.isUserProfile,

--- a/source/features/remove-upload-files-button.tsx
+++ b/source/features/remove-upload-files-button.tsx
@@ -14,6 +14,7 @@ function init(): false | void {
 features.add({
 	id: __featureName__,
 	description: 'Remove the "Upload files" button',
+	screenshot: false,
 	include: [
 		features.isRepoTree
 	],

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -14,6 +14,7 @@ async function init(): Promise<void> {
 features.add({
 	id: __featureName__,
 	description: 'Fix merge conflicts in a click',
+	screenshot: false,
 	include: [
 		features.isConflict
 	],

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -18,7 +18,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Open selection in new tab with `Shift` `o` when navigating via `j` and `k`',
+	description: 'Adds a keyboard shortcut to open selection in new tab when navigating via  `j` and `k`: `Shift` `o`.',
+	screenshot: false,
 	shortcuts: {
 		'shift o': 'Open selection in new tab'
 	},

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -18,7 +18,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Forks and archived repos are hidden on profiles',
+	description: 'Hides forks and archived repos from profiles (but they can still be shown.)',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png',
 	load: features.onAjaxedPages,
 	init
 });

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -11,7 +11,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Repository URLs are shortened to readable references like `user/repo/.file@d71718d`',
+	description: 'Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png',
 	load: features.onAjaxedPages,
 	init
 });

--- a/source/features/show-followers-you-know.tsx
+++ b/source/features/show-followers-you-know.tsx
@@ -51,6 +51,7 @@ async function init(): Promise<false | void> {
 features.add({
 	id: __featureName__,
 	description: 'Followers you know are shown on profile pages',
+	screenshot: false,
 	include: [
 		features.isUserProfile
 	],

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -62,7 +62,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'The full name of users is shown next to their username',
+	description: 'Adds the real name of users next to their usernames.',
+	screenshot: 'https://cloud.githubusercontent.com/assets/170270/16172068/0a67b98c-3580-11e6-92f0-6fc930ee17d1.png',
 	include: [
 		features.isDashboard
 	],
@@ -72,7 +73,8 @@ features.add({
 
 features.add({
 	id: __featureName__,
-	description: '',
+	description: false,
+	screenshot: false,
 	include: [
 		features.hasComments
 	],

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -26,7 +26,7 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Find a user’s most starred repositories in their profile',
+	description: 'Adds a link to the user’s most starred repositories.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png',
 	include: [
 		features.isUserProfile

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -91,7 +91,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Renders whitespace characters in code',
+	description: 'Shows whitespace characters.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png',
 	include: [
 		features.hasCode

--- a/source/features/sort-issues-by-update-time.tsx
+++ b/source/features/sort-issues-by-update-time.tsx
@@ -56,14 +56,16 @@ async function cleanBar(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Change the default sort order of issues and pull requests to "Recently updated"',
+	description: 'Changes the default sort order of discussions to `Recently updated`.',
+	screenshot: false,
 	load: features.onAjaxedPages,
 	init
 });
 
 features.add({
 	id: __featureName__,
-	description: '',
+	description: false,
+	screenshot: false,
 	include: [
 		features.isGlobalDiscussionList
 	],

--- a/source/features/sort-milestones-by-closest-due-date.tsx
+++ b/source/features/sort-milestones-by-closest-due-date.tsx
@@ -15,7 +15,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Change the default sort order of milestones to "Closest due date"',
+	description: 'Changes the default sort order of milestones `Closest due date`.',
+	screenshot: false,
 	include: [
 		features.isRepo
 	],

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -70,7 +70,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Search for issues and pull request separately in the global search',
+	description: 'Separates issues from PRs in the global search.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png',
 	include: [
 		features.isRepoSearch,
 		features.isGlobalSearchResults

--- a/source/features/star-repo-hotkey.tsx
+++ b/source/features/star-repo-hotkey.tsx
@@ -10,7 +10,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Star/unstar a repository by pressing `g` `s`',
+	description: 'Adds a keyboard shortcut to star/unstar the current repo: `g` `s`.',
+	screenshot: false,
 	include: [
 		features.isRepo
 	],

--- a/source/features/submit-review-as-single-comment.tsx
+++ b/source/features/submit-review-as-single-comment.tsx
@@ -108,7 +108,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Submit a single PR comment if you mistakenly started a new review',
+	description: 'Adds a button to submit a single PR comment if you mistakenly started a new review.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif',
 	include: [
 		features.isPRFiles

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -22,7 +22,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Swap head and base branches in the branch compare view',
+	description: 'Adds link to swap branches in the branch compare view.',
+	screenshot: 'https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png',
 	include: [
 		features.isCompare
 	],

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -103,7 +103,7 @@ function deinit(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Use the same title for the PR and its merging commit',
+	description: 'Uses the PR’s title and description when merging and updates the PR’s title to the match the commit title, if changed.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png',
 	include: [
 		features.isPRConversation

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -117,7 +117,8 @@ const getPreviousTag = (current: number, allTags: TagDetails[]): string | undefi
 
 features.add({
 	id: __featureName__,
-	description: 'See an automatic changelog for each tag or release.',
+	description: 'Adds a link to an automatic changelog for each tag/release.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png',
 	include: [
 		features.isReleasesOrTags
 	],

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -49,7 +49,8 @@ function onFragmentLoaded(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Search or select tags from a dropdown in the Releases page',
+	description: 'Adds a tags dropdown/search on tag/release pages.',
+	screenshot: 'https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png',
 	include: [
 		features.isReleasesOrTags
 	],

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -33,7 +33,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Add a "Toggle all files" button to file lists in repositories',
+	description: 'Adds a button to toggle the repo file list.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif',
 	include: [
 		features.isRepoTree
 	],

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -15,7 +15,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Access trending repositories using the "Trending" link in the global navigation bar or by pressing `g` ` t`',
+	description: 'Adds a `Trending` link to the global navbar and a keyboard shortcut: `g` ` t`',
+	screenshot: false,
 	exclude: [
 		features.isGist
 	],

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -105,7 +105,8 @@ function init(): void | false {
 
 features.add({
 	id: __featureName__,
-	description: 'Button to update a PR from the base branch to ensure it build correctly before merging the PR itself.',
+	description: 'Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png',
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -108,7 +108,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Suggest alternative links on 404 Not Found pages',
+	description: 'Adds possible related pages and alternatives on 404 pages.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png',
 	include: [
 		features.is404
 	],

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -20,7 +20,8 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __featureName__,
-	description: 'See whether a user follows you on their profile',
+	description: 'Tells you whether the user follows you.',
+	screenshot: 'https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif',
 	include: [
 		features.isUserProfile
 	],

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -105,7 +105,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'See the source of Markdown files instead of just their rendered version',
+	description: 'Adds a button to view the source of Markdown files.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png',
 	include: [
 		features.isSingleFile
 	],

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -111,7 +111,8 @@ function init(): false | void {
 
 features.add({
 	id: __featureName__,
-	description: 'Wait for CI Checks to be finished and successful before merging a PR',
+	description: 'Adds the option to wait for checks when merging a PR.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif',
 	include: [
 		features.isPRConversation
 	],

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -19,7 +19,8 @@ async function init(): Promise<false | void> {
 
 features.add({
 	id: __featureName__,
-	description: 'Warns you when creating a pull request from the default branch, as it’s an anti-pattern',
+	description: 'Warns you when creating a pull request from the default branch, as it’s an anti-pattern.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png',
 	include: [
 		features.isCompare
 	],

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -32,7 +32,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Shows a warning when unchecking "Allow edits from maintainers" when creating pull request',
+	description: 'Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif',
 	include: [
 		features.isCompare,
 		features.isPRConversation

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -9,7 +9,7 @@ interface FeatureInfo {
 
 declare const __featuresList__: string[];
 declare const __featuresInfo__: FeatureInfo[];
-declare const __featureName__: 'webpack will replace this string';
+declare const __featureName__: 'use the __featureName__ variable';
 
 interface Window {
 	collectFeatures: Map<string, FeatureDetails>;

--- a/source/libs/features.tsx
+++ b/source/libs/features.tsx
@@ -25,9 +25,9 @@ export interface FeatureDetails {
 	@example '#123'
 	*/
 	disabled?: string;
-	id: string;
-	description: string;
-	screenshot?: string;
+	id: typeof __featureName__;
+	description: string | false;
+	screenshot: string | false;
 	include?: BooleanFunction[];
 	exclude?: BooleanFunction[];
 	init: () => false | void | Promise<false | void>;
@@ -135,6 +135,7 @@ const add = async (definition: FeatureDetails): Promise<void> => {
 	const {
 		id,
 		description,
+		screenshot,
 		include = [() => true], // Default: every page
 		exclude = [], // Default: nothing
 		load = (fn: VoidFunction) => fn(), // Run it right away
@@ -163,7 +164,7 @@ const add = async (definition: FeatureDetails): Promise<void> => {
 	}
 
 	// Initialize the feature using the specified loading mechanism
-	const details: FeatureDetails = {id, description, include, exclude, init, deinit};
+	const details: FeatureDetails = {id, description, screenshot, include, exclude, init, deinit};
 	if (load === onNewComments) {
 		details.init = async () => {
 			const result = await init();


### PR DESCRIPTION
It's easier to keep track of what features applies where.

Also I'm rewriting the descriptions to follow the style "Refined Github <verb>" instead of "Refined GitHub allows you to <verb>" which often results in awkward phrasing.