### PR TITLE
Fix console error in `show-names`

### DIFF
--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -4,6 +4,7 @@ import select from 'select-dom';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getUsername, compareNames} from '../libs/utils';
+import onNewsfeedLoad from '../libs/on-newsfeed-load';
 
 async function init(): Promise<false | void> {
 	const usernameElements = select.all([
@@ -72,8 +73,8 @@ features.add({
 	include: [
 		features.isDashboard
 	],
-	load: features.onNewsfeedLoad,
-	init
+	load: features.onDomReady,
+	init: async () => onNewsfeedLoad(init)
 });
 
 features.add({

--- a/source/libs/features.tsx
+++ b/source/libs/features.tsx
@@ -4,7 +4,6 @@ import onDomReady from 'dom-loaded';
 import elementReady from 'element-ready';
 import optionsStorage, {RGHOptions} from '../options-storage';
 import onNewComments from './on-new-comments';
-import onNewsfeedLoad from './on-newsfeed-load';
 import onFileListUpdate from './on-file-list-update';
 import * as pageDetect from './page-detect';
 
@@ -188,7 +187,6 @@ export default {
 
 	// Loading mechanisms
 	onDomReady,
-	onNewsfeedLoad,
 	onNewComments,
 	onFileListUpdate,
 	onAjaxedPages,


### PR DESCRIPTION
Fixes #2290

Loading mechanisms are called right away; it's the callback inside that will check the `include` conditions.

The previous setup was calling `onNewsfeedLoad` on every page and failing. This also shows that `onNewComments` should probably receive the same treatment and should be dropped from `features.tsx`’s exports. PR welcome after this is confirmed

# Test

Reload this page, check for console errors