### PR TITLE
Fix default branch in private repo

### DIFF
--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -45,7 +45,7 @@ export const getCurrentBranch = (): string => {
 		.split('/')
 		.slice(6)
 		.join('/')
-		.replace(/\.atom$/, '');
+		.replace(/\.atom.*/, '');
 };
 
 export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Fixes #2306
In private repo's .atom has a key added.
`master.atom?token=**************************`

<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->



<!-- List some URLs that reviewers can use to test your PR -->
