### PR TITLE
Fix branch button alignment

### DIFF
--- a/source/features/branch-buttons.css
+++ b/source/features/branch-buttons.css
@@ -1,0 +1,11 @@
+.rgh-branch-buttons {
+	margin-left: 0.5rem;
+}
+
+.file-navigation .rgh-branch-buttons {
+	margin: 0 3px !important;
+}
+
+.rgh-branch-buttons .BtnGroup {
+	margin: 0 !important;
+}

--- a/source/features/branch-buttons.css
+++ b/source/features/branch-buttons.css
@@ -1,11 +1,20 @@
-.rgh-branch-buttons {
-	margin-left: 0.5rem;
+.file-navigation {
+	display: flex;
 }
 
-.file-navigation .rgh-branch-buttons {
-	margin: 0 3px !important;
+.file-navigation .branch-select-menu {
+	margin-right: 0 !important;
 }
 
-.rgh-branch-buttons .BtnGroup {
-	margin: 0 !important;
+.file-navigation .BtnGroup.float-right {
+	order: 100;
+}
+
+.file-navigation .breadcrumb {
+	flex: 1;
+	margin-left: 8px !important;
+}
+
+.file-navigation .rgh-branch-buttons .BtnGroup {
+	margin: 0;
 }

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -1,3 +1,4 @@
+import './branch-buttons.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import compareVersions from 'tiny-version-compare';
@@ -99,7 +100,7 @@ async function init(): Promise<false | void> {
 	]);
 
 	const wrapper = (
-		<div className="ml-2">
+		<div className="rgh-branch-buttons float-left">
 			{defaultLink}
 			{tagLink}
 		</div>

--- a/source/features/branch-buttons.tsx
+++ b/source/features/branch-buttons.tsx
@@ -100,7 +100,7 @@ async function init(): Promise<false | void> {
 	]);
 
 	const wrapper = (
-		<div className="rgh-branch-buttons float-left">
+		<div className="rgh-branch-buttons ml-2">
 			{defaultLink}
 			{tagLink}
 		</div>


### PR DESCRIPTION
The markup for navigation bar on repo tree is different from that of a single file page. This causes the insertion of a `div` before breadcrumbs whose parent is not a flex container to push breadcrumbs element to the bottom, even when there is enough space, Leading to a slightly broken view on repo tree pages.

## Before view for file and repo tree
![branch-buttons-before](https://user-images.githubusercontent.com/37769974/62715913-fe50bc80-ba1e-11e9-9c88-5551d2d41cf2.gif)

## After view for file and repo tree
![branch-buttons-after](https://user-images.githubusercontent.com/37769974/62716245-74edba00-ba1f-11e9-8ddb-1d63b7bd33a0.gif)

