### PR TITLE
Avoid adding a duplicate “Update Branch” button

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -57,7 +57,7 @@ function createButton(base: string, head: string): HTMLElement {
 }
 
 async function addButton(): Promise<void> {
-	if (select.exists('.rgh-update-pr-from-master')) {
+	if (select.exists('.rgh-update-pr-from-master, .branch-action-btn > .btn')) {
 		return;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes [#2213](https://github.com/sindresorhus/refined-github/issues/2213)
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

<!-- List some URLs that reviewers can use to test your PR -->
This bug fix avoids the duplicated `update branch` button on pull request pages
- <REPO_OWNER>/<REPO_NAME>/pull/<ID>
