### PR TITLE
Fix header alignment on Releases and Tags pages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
-source/features/filter-pr-by-build-status.tsx @HardikModha
-source/features/tags-dropdown.tsx @HardikModha
-source/features/tag-changelog-link.tsx @HardikModha
-source/features/link-to-file-in-file-history.tsx @HardikModha
+source/features/filter-pr-by-build-status.tsx @hardikmodha
+source/features/tags-dropdown.tsx @hardikmodha
+source/features/tag-changelog-link.tsx @hardikmodha
+source/features/link-to-file-in-file-history.tsx @hardikmodha
 source/features/default-to-rich-diff.tsx @idasbiste
 source/features/release-download-count.tsx @dotconnor
 source/features/indented-code-wrapping.tsx @notlmn

--- a/source/features/tags-dropdown.css
+++ b/source/features/tags-dropdown.css
@@ -10,3 +10,8 @@
 	min-width: 150px;
 	max-width: 300px;
 }
+
+/* Fix for https://github.com/sindresorhus/refined-github/issues/2325 */
+:root .subnav > :first-child {
+	flex-grow: 1;
+}

--- a/source/features/tags-dropdown.css
+++ b/source/features/tags-dropdown.css
@@ -10,8 +10,3 @@
 	min-width: 150px;
 	max-width: 300px;
 }
-
-/* Fix for https://github.com/sindresorhus/refined-github/issues/2325 */
-:root .subnav > :first-child {
-	flex-grow: 1;
-}

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -15,9 +15,13 @@
 	margin-left: 20px;
 }
 
-/* Move extra buttons to the right on Releases */
-.subnav-links {
-	margin-right: auto;
+/*
+Take full available width for extra buttons on Releases page.
+It excludes anchor tags which are `New Issue` and `New Pull Request` on
+issues and pull-requests tab respectively.
+*/
+.subnav > :first-child:not(a) {
+	flex-grow: 1;
 }
 
 /* Reset width of search field in global lists */


### PR DESCRIPTION
Fixes #2325

# Test

1. Releases tab: https://github.com/sindresorhus/refined-github/releases
![Screen Shot 2019-08-14 at 10 00 20 PM](https://user-images.githubusercontent.com/22439276/63038504-eecde980-bede-11e9-8c2e-19967c42819e.png)


2. Tags page
![Screen Shot 2019-08-14 at 10 00 01 PM](https://user-images.githubusercontent.com/22439276/63038477-e4abeb00-bede-11e9-9518-040624866dbc.png)


3. When "Draft New Release" is present
![Screen Shot 2019-08-14 at 9 59 45 PM](https://user-images.githubusercontent.com/22439276/63038463-db228300-bede-11e9-96e7-d275e21eef2f.png)

4. Unbroken Widen search field on...

**Pull Requests**

![Screen Shot 2019-08-17 at 10 51 56 PM](https://user-images.githubusercontent.com/22439276/63215262-a8c49000-c141-11e9-8e75-703bb4cb9208.png)

**Issues page**

![Screen Shot 2019-08-17 at 10 51 46 PM](https://user-images.githubusercontent.com/22439276/63215268-b37f2500-c141-11e9-947f-77b568225746.png)