### PR TITLE
Fix `mark-unread` button injection

### DIFF
--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -1,13 +1,12 @@
-import './mark-unread.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 import delegate, {DelegateSubscription, DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
-import observeEl from '../libs/simplified-element-observer';
 import * as icons from '../libs/icons';
 import * as pageDetect from '../libs/page-detect';
 import {getUsername, getRepoURL} from '../libs/utils';
+import onUpdatableContentUpdate from '../libs/on-updatable-content-update';
 
 type NotificationType = 'pull-request' | 'issue';
 type NotificationState = 'open' | 'merged' | 'closed' | 'draft';
@@ -412,10 +411,8 @@ async function init(): Promise<void> {
 	} else if (pageDetect.isPR() || pageDetect.isIssue()) {
 		await markRead(location.href);
 
-		// The sidebar changes when new comments are added or the issue status changes
-		// This selector targets the sidebar column, because the sidebar content can be updated after page load.
-		// See: https://user-images.githubusercontent.com/10238474/62722516-41a72d00-ba17-11e9-96fc-432df4688204.png
-		observeEl('#discussion_bucket > :last-child', addMarkUnreadButton);
+		addMarkUnreadButton();
+		onUpdatableContentUpdate(select('#partial-discussion-sidebar')!, addMarkUnreadButton);
 	} else if (pageDetect.isDiscussionList()) {
 		for (const discussion of await getNotifications()) {
 			const {pathname} = new URL(discussion.url);

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -413,7 +413,9 @@ async function init(): Promise<void> {
 		await markRead(location.href);
 
 		// The sidebar changes when new comments are added or the issue status changes
-		observeEl('#partial-discussion-sidebar', addMarkUnreadButton);
+		// This selector targets the sidebar column, because the sidebar content can be updated after page load.
+		// See: https://user-images.githubusercontent.com/10238474/62722516-41a72d00-ba17-11e9-96fc-432df4688204.png
+		observeEl('#discussion_bucket > :last-child', addMarkUnreadButton);
 	} else if (pageDetect.isDiscussionList()) {
 		for (const discussion of await getNotifications()) {
 			const {pathname} = new URL(discussion.url);

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -63,7 +63,7 @@ function stripHash(url: string): string {
 function addMarkUnreadButton(): void {
 	if (!select.exists('.rgh-btn-mark-unread')) {
 		select('.thread-subscription-status')!.after(
-			<button className="btn btn-sm rgh-btn-mark-unread" onClick={markUnread}>
+			<button className="btn btn-sm btn-block mt-2 rgh-btn-mark-unread" onClick={markUnread}>
 				Mark as unread
 			</button>
 		);

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -413,7 +413,7 @@ async function init(): Promise<void> {
 		await markRead(location.href);
 
 		// The sidebar changes when new comments are added or the issue status changes
-		observeEl('.discussion-sidebar', addMarkUnreadButton);
+		observeEl('#partial-discussion-sidebar', addMarkUnreadButton);
 	} else if (pageDetect.isDiscussionList()) {
 		for (const discussion of await getNotifications()) {
 			const {pathname} = new URL(discussion.url);

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -1,3 +1,4 @@
+import './mark-unread.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import elementReady from 'element-ready';

--- a/source/libs/on-updatable-content-update.ts
+++ b/source/libs/on-updatable-content-update.ts
@@ -8,7 +8,7 @@ Limitations:
  * @param updatable The `.js-updatable-content` element to watch
  * @param callback The function to call after it's replaced
 */
-export default function onUpdatableContentUpdate(updatable: HTMLElement, callback: VoidFunction) {
+export default function onUpdatableContentUpdate(updatable: HTMLElement, callback: VoidFunction): void {
 	new MutationObserver(mutations => {
 		if (updatable.isConnected) {
 			return;

--- a/source/libs/on-updatable-content-update.ts
+++ b/source/libs/on-updatable-content-update.ts
@@ -1,0 +1,31 @@
+/**
+This will call the callback when the supplied `.js-updatable-content` element is replaced.
+
+Limitations:
+- only tested in the discussion sidebar
+- won't detect removals of ancestors (it could recursively look for `.js-updatable-content`)
+
+ * @param updatable The `.js-updatable-content` element to watch
+ * @param callback The function to call after it's replaced
+*/
+export default function onUpdatableContentUpdate(updatable: HTMLElement, callback: VoidFunction) {
+	new MutationObserver(mutations => {
+		if (updatable.isConnected) {
+			return;
+		}
+
+		for (const mutation of mutations) {
+			const replacedElement = [...mutation.addedNodes].find(newNode =>
+				newNode instanceof HTMLElement && newNode.dataset.url === updatable.dataset.url
+			);
+
+			if (replacedElement) {
+				callback();
+
+				// Listen to future updates
+				updatable = replacedElement as HTMLElement;
+				return;
+			}
+		}
+	}).observe(updatable.parentElement!, {childList: true});
+}


### PR DESCRIPTION
Fixes #2335

`.discussion-sidebar` is no longer available.

**Test**:
Open any discussion, look for the "Mark as unread" button
