### PR TITLE
Fix `warning-for-disallow-edits`

### DIFF
--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -21,7 +21,7 @@ function init(): void {
 			// Select every time because the sidebar content may be replaced
 			select(`
 				.new-pr-form .timeline-comment,
-				.discussion-sidebar .js-collab-form + .js-dropdown-details
+				#partial-discussion-sidebar .js-collab-form + .js-dropdown-details
 			`)!.after(warning);
 		}
 	};


### PR DESCRIPTION
The warning didn't show after unchecking the checkbox.
`.discussion-sidebar` is no longer available.


**Test**:
On any PR from your fork to an upstream repo, uncheck "Allow edits from maintainers."
The warning should be visible.