### PR TITLE
Fix sidebar issues caused by `sticky-discussion-sidebar`

### DIFF
--- a/source/features/sticky-discussion-sidebar.css
+++ b/source/features/sticky-discussion-sidebar.css
@@ -1,7 +1,6 @@
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 60px !important; /* Matches sticky header's height */
-	z-index: 31 !important;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */

--- a/source/features/sticky-discussion-sidebar.css
+++ b/source/features/sticky-discussion-sidebar.css
@@ -1,3 +1,7 @@
+:root .pagehead ul.pagehead-actions {
+	z-index: initial; /* This affects the social buttons. It seems to have no effect but it constantly causes trouble with other features. */
+}
+
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 60px !important; /* Matches sticky header's height */


### PR DESCRIPTION
Closes #2339

# Test

This feature depends on the viewport size, the sidebar has to be sticky for these issues to appear (or not appear)

1. The Labels dropdown should not overlap the file's header in the review below. [Example](https://github.com/sindresorhus/refined-github/issues/1647)
2. The "Notifications settings" lightbox should appear and work correctly, without the Repo’s social buttons being overlapped. [Example](https://github.com/sindresorhus/refined-github/issues/2189)
3. The "Repo Notifications" dropdown should not overlap the sidebar. [Example](https://github.com/sindresorhus/refined-github/issues/2339)