### PR TITLE
Fix `clean-sidebar` on sidebar updates

### DIFF
--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -2,7 +2,7 @@ import './clean-sidebar.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
-import observeEl from '../libs/simplified-element-observer';
+import onUpdatableContentUpdate from '../libs/on-updatable-content-update';
 import {isPR} from '../libs/page-detect';
 
 let canEditSidebar = false;
@@ -76,7 +76,7 @@ function clean(): void {
 function init(): void {
 	canEditSidebar = select.exists('.sidebar-labels .octicon-gear');
 	clean();
-	observeEl('.discussion-sidebar', clean);
+	onUpdatableContentUpdate(select('#partial-discussion-sidebar')!, clean);
 }
 
 features.add({


### PR DESCRIPTION
Using the new `onUpdatableContentUpdate` by @fregante.

Closes #2333.

### Test
On a discussion where you have access to assign things on the sidebar (label, milestone, etc.), make a change - after the "partial" content is updated, the sidebar is cleaned.
