### PR TITLE
Add `line-through` on deleted branches in PRs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -230,7 +230,7 @@ Thanks for contributing! 🦋🙌
 - [](# "mark-files-as-viewed") [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "revert-file") 🔥 [Adds button to revert all the changes to a file in a PR.](https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif)
-- [](# "cross-deleted-pr-branches") [Adds a line-through to the deleted branches.](URL)
+- [](# "cross-deleted-pr-branches") [Adds a line-through to the deleted branches.](https://user-images.githubusercontent.com/30543444/63117366-480a4b80-bfb9-11e9-949f-f624c8f0485c.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -230,6 +230,7 @@ Thanks for contributing! 🦋🙌
 - [](# "mark-files-as-viewed") [Marks all files as "viewed" when approving a PR.](https://user-images.githubusercontent.com/11782/60969312-8740df00-a31f-11e9-8e34-d1f0c1a871aa.gif)
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "revert-file") 🔥 [Adds button to revert all the changes to a file in a PR.](https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif)
+- [](# "cross-deleted-pr-branches") [Adds a line-through to the deleted branches.](URL)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -137,6 +137,7 @@ import './features/linkify-symbolic-links';
 import './features/hide-zero-packages';
 import './features/revert-file';
 import './features/hidden-review-comments-indicator';
+import './features/cross-deleted-pr-branches';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -1,0 +1,61 @@
+import select from 'select-dom';
+import features from '../libs/features';
+import * as pageDetect from '../libs/page-detect';
+
+function inPR(): void {
+    let deletedBranch: string | undefined;
+    const lastBranchAction = select.all(`
+		.discussion-item-head_ref_deleted .commit-ref,
+		.discussion-item-head_ref_restored .commit-ref
+    `).pop();
+
+    if (lastBranchAction && lastBranchAction.closest('.discussion-item-head_ref_deleted')) {
+		deletedBranch = lastBranchAction.textContent!.trim();
+    }
+
+	// Making deleted branch link to the default fork
+	for (const el of select.all('.commit-ref[title].head-ref[title]')) {
+        const [repo] = el.title.split(':', 1);
+		const branchName = el.textContent!.trim();
+		if (branchName !== 'unknown repository') {
+			if (branchName === deletedBranch) {
+				el.children[0].setAttribute('href', `${branchName}/${repo}`);
+			}
+		}
+	}
+
+	// Adding a linethrough to the branch name
+	for (const el of select.all('.commit-ref')) {
+		const branchName = el.textContent!.trim();
+
+		if (branchName !== 'unknown repository') {
+			if (branchName === deletedBranch) {
+				if ( el.classList.contains('head-ref')) {
+					let deletedBranchElement = el.children[0].children;
+					for (let item of deletedBranchElement) {
+						item.setAttribute('style', 'text-decoration: line-through;');
+					}
+				}
+				el.title = 'Deleted';
+				el.style.textDecoration = 'line-through';
+			}
+		}
+	}
+}
+
+function init(): void {
+    if (pageDetect.isPR()) {
+        inPR();
+    }
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Adds a line-through to the deleted branches',
+	screenshot: 'URL-HERE',
+	include: [
+		features.isPR
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -2,57 +2,55 @@ import select from 'select-dom';
 import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 
-function inPR(): void {
+function init(): void {
+	if (!pageDetect.isPR()) {
+		return;
+	}
+
 	let deletedBranch: string | undefined;
-	const lastBranchAction = select.all(`
+	const lastBranchAction = select.last(`
 		.discussion-item-head_ref_deleted .commit-ref,
 		.discussion-item-head_ref_restored .commit-ref
-    `).pop();
+    `);
 
 	if (lastBranchAction && lastBranchAction.closest('.discussion-item-head_ref_deleted')) {
 		deletedBranch = lastBranchAction.textContent!.trim();
 	}
 
-	// Making deleted branch link to the default fork
-	for (const el of select.all('.commit-ref[title].head-ref[title]')) {
-		const [repo] = el.title.split(':', 1);
-		const branchName = el.textContent!.trim();
-		if (branchName !== 'unknown repository') {
-			if (branchName === deletedBranch) {
-				el.children[0].setAttribute('href', `${branchName}/${repo}`);
-			}
+	// Point the deleted branch link to the default branch
+	for (const element of select.all('.commit-ref[title].head-ref[title]')) {
+		const [repo] = element.title.split(':', 1);
+		const branchName = element.textContent!.trim();
+		if (branchName !== 'unknown repository' && branchName === deletedBranch) {
+			const deletedBranchHTMLElement = element.children[0] as HTMLLinkElement;
+			deletedBranchHTMLElement.href = `${branchName}/${repo}`;
 		}
 	}
 
 	// Adding a linethrough to the branch name
-	for (const el of select.all('.commit-ref')) {
-		const branchName = el.textContent!.trim();
+	for (const element of select.all('.commit-ref')) {
+		const branchName = element.textContent!.trim();
 
 		if (branchName !== 'unknown repository') {
 			if (branchName === deletedBranch) {
-				if (el.classList.contains('head-ref')) {
-					const deletedBranchElement = el.children[0].children;
+				if (element.classList.contains('head-ref')) {
+					const deletedBranchElement = element.children[0].children;
 					for (const item of deletedBranchElement) {
-						item.setAttribute('style', 'text-decoration: line-through;');
+						const itemHTMLElement = item as HTMLElement;
+						itemHTMLElement.style.textDecoration = 'line-through';
 					}
 				}
 
-				el.title = 'Deleted';
-				el.style.textDecoration = 'line-through';
+				element.title = 'Deleted';
+				element.style.textDecoration = 'line-through';
 			}
 		}
-	}
-}
-
-function init(): void {
-	if (pageDetect.isPR()) {
-		inPR();
 	}
 }
 
 features.add({
 	id: __featureName__,
-	description: 'Adds a line-through to the deleted branches',
+	description: 'Adds a line-through to the deleted branches in PRs',
 	screenshot: 'https://user-images.githubusercontent.com/30543444/63117366-480a4b80-bfb9-11e9-949f-f624c8f0485c.png',
 	include: [
 		features.isPR

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -3,19 +3,19 @@ import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 
 function inPR(): void {
-    let deletedBranch: string | undefined;
-    const lastBranchAction = select.all(`
+	let deletedBranch: string | undefined;
+	const lastBranchAction = select.all(`
 		.discussion-item-head_ref_deleted .commit-ref,
 		.discussion-item-head_ref_restored .commit-ref
     `).pop();
 
-    if (lastBranchAction && lastBranchAction.closest('.discussion-item-head_ref_deleted')) {
+	if (lastBranchAction && lastBranchAction.closest('.discussion-item-head_ref_deleted')) {
 		deletedBranch = lastBranchAction.textContent!.trim();
-    }
+	}
 
 	// Making deleted branch link to the default fork
 	for (const el of select.all('.commit-ref[title].head-ref[title]')) {
-        const [repo] = el.title.split(':', 1);
+		const [repo] = el.title.split(':', 1);
 		const branchName = el.textContent!.trim();
 		if (branchName !== 'unknown repository') {
 			if (branchName === deletedBranch) {
@@ -30,12 +30,13 @@ function inPR(): void {
 
 		if (branchName !== 'unknown repository') {
 			if (branchName === deletedBranch) {
-				if ( el.classList.contains('head-ref')) {
-					let deletedBranchElement = el.children[0].children;
-					for (let item of deletedBranchElement) {
+				if (el.classList.contains('head-ref')) {
+					const deletedBranchElement = el.children[0].children;
+					for (const item of deletedBranchElement) {
 						item.setAttribute('style', 'text-decoration: line-through;');
 					}
 				}
+
 				el.title = 'Deleted';
 				el.style.textDecoration = 'line-through';
 			}
@@ -44,9 +45,9 @@ function inPR(): void {
 }
 
 function init(): void {
-    if (pageDetect.isPR()) {
-        inPR();
-    }
+	if (pageDetect.isPR()) {
+		inPR();
+	}
 }
 
 features.add({

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -52,7 +52,7 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Adds a line-through to the deleted branches',
-	screenshot: 'URL-HERE',
+	screenshot: 'https://user-images.githubusercontent.com/30543444/63117366-480a4b80-bfb9-11e9-949f-f624c8f0485c.png',
 	include: [
 		features.isPR
 	],


### PR DESCRIPTION
Closes #2274 

For deleted branches, it links to PR owner's repo.

![Screenshot from 2019-08-15 23-42-10](https://user-images.githubusercontent.com/30543444/63117366-480a4b80-bfb9-11e9-949f-f624c8f0485c.png)
