### PR TITLE
fix: marketplace is opt-in for Enterprise, handle it being turned off

### DIFF
--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -5,7 +5,7 @@ import domLoaded from 'dom-loaded';
 import features from '../libs/features';
 
 async function init(): Promise<void> {
-	const marketPlaceLink = (await elementReady('.Header-link[href="/marketplace"]'))!;
+	const marketPlaceLink = (await elementReady('.Header-link[href="/marketplace"]'));
 	if (marketPlaceLink) {
 		// The Marketplace link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
 		marketPlaceLink.closest('.border-top, .mr-3')!.remove();

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -5,9 +5,11 @@ import domLoaded from 'dom-loaded';
 import features from '../libs/features';
 
 async function init(): Promise<void> {
-	(await elementReady('.Header-link[href="/marketplace"]'))!
+	const marketPlaceLink = (await elementReady('.Header-link[href="/marketplace"]'))!;
+	if (marketPlaceLink) {
 		// The Marketplace link seems to have an additional wrapper that other links don't have https://i.imgur.com/KV9rtSq.png
-		.closest('.border-top, .mr-3')!.remove();
+		marketPlaceLink.closest('.border-top, .mr-3')!.remove();
+	}
 
 	await domLoaded;
 


### PR DESCRIPTION
Marketplace is an opt-in feature for GHE, if you're on an instance where it's not enabled, `marketPlaceLink` will be undefined and return an error in the console when `.closest` is invoked.
