### PR TITLE
fix: only add mark unread on PR Conversation view

### DIFF
--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -409,7 +409,7 @@ async function init(): Promise<void> {
 			delegate('.js-delete-notification button', 'click', updateUnreadIndicator),
 			delegate('.js-mark-visible-as-read', 'submit', markVisibleNotificationsRead)
 		);
-	} else if (pageDetect.isPR() || pageDetect.isIssue()) {
+	} else if (pageDetect.isPRConversation() || pageDetect.isIssue()) {
 		await markRead(location.href);
 
 		addMarkUnreadButton();

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -409,7 +409,7 @@ async function init(): Promise<void> {
 			delegate('.js-delete-notification button', 'click', updateUnreadIndicator),
 			delegate('.js-mark-visible-as-read', 'submit', markVisibleNotificationsRead)
 		);
-	} else if (pageDetect.isPRList() || pageDetect.isIssue()) {
+	} else if (pageDetect.isPR() || pageDetect.isIssue()) {
 		await markRead(location.href);
 
 		if (pageDetect.isPRConversation() || pageDetect.isIssue()) {

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -409,11 +409,13 @@ async function init(): Promise<void> {
 			delegate('.js-delete-notification button', 'click', updateUnreadIndicator),
 			delegate('.js-mark-visible-as-read', 'submit', markVisibleNotificationsRead)
 		);
-	} else if (pageDetect.isPRConversation() || pageDetect.isIssue()) {
+	} else if (pageDetect.isPRList() || pageDetect.isIssue()) {
 		await markRead(location.href);
 
-		addMarkUnreadButton();
-		onUpdatableContentUpdate(select('#partial-discussion-sidebar')!, addMarkUnreadButton);
+		if (pageDetect.isPRConversation() || pageDetect.isIssue()) {
+			addMarkUnreadButton();
+			onUpdatableContentUpdate(select('#partial-discussion-sidebar')!, addMarkUnreadButton);
+		}
 	} else if (pageDetect.isDiscussionList()) {
 		for (const discussion of await getNotifications()) {
 			const {pathname} = new URL(discussion.url);


### PR DESCRIPTION
Adding the mark unread button on all pages of the PR, e.g. commits, results in a console error:

```
content.js:2568 TypeError: Cannot read property 'after' of null
    at addMarkUnreadButton (content.js:3769)
    at mark_unread_init (content.js:4011)
    at async features_run (content.js:2562)
```

<!-- Thanks for contributing! 🍄 -->