### PR TITLE
Fix always expanded "More" dropdown menu

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -14,11 +14,9 @@ function createDropdown(): void {
 	// Markup copied from native GHE dropdown
 	appendBefore('.reponav', '[href$="settings"]',
 		<details className="reponav-dropdown details-overlay details-reset">
-			<summary>
-				<span className="btn-link reponav-item">
-					{'More '}
-					<span className="dropdown-caret"/>
-				</span>
+			<summary className="btn-link reponav-item">
+				{'More '}
+				<span className="dropdown-caret"/>
 			</summary>
 			<details-menu className="dropdown-menu dropdown-menu-se"/>
 		</details>

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -13,15 +13,15 @@ const repoUrl = getRepoURL();
 function createDropdown(): void {
 	// Markup copied from native GHE dropdown
 	appendBefore('.reponav', '[href$="settings"]',
-		<div className="reponav-dropdown js-menu-container">
-			<button type="button" className="btn-link reponav-item js-menu-target" aria-expanded="false" aria-haspopup="true">
-				{'More '}
-				<span className="dropdown-caret"/>
-			</button>
-			<div className="dropdown-menu-content js-menu-content">
-				<div className="dropdown-menu dropdown-menu-se"/>
-			</div>
-		</div>
+		<details className="reponav-dropdown details-overlay details-reset">
+			<summary>
+				<span className="btn-link reponav-item">
+					{'More '}
+					<span className="dropdown-caret"/>
+				</span>
+			</summary>
+			<details-menu className="dropdown-menu dropdown-menu-se"/>
+		</details>
 	);
 }
 

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -78,7 +78,7 @@ declare namespace JSX {
 		'has-rgh': {};
 		'label': LabelIntrinsicElement & {for?: string};
 		'include-fragment': BaseIntrinsicElement & {src?: string};
-		'details-menu': BaseIntrinsicElement & {src: string; preload: boolean};
+		'details-menu': BaseIntrinsicElement & {src?: string; preload?: boolean};
 		'relative-time': BaseIntrinsicElement & {datetime: string; title: string};
 		'details-dialog': BaseIntrinsicElement & {tabindex: string};
 	}


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2357
Closes #2358

For some reason using `<button>` won't open the dropdown, I have read GitHub's code for some time but can't figure out why, so changed it to `<span>` and everything looks fine.
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
This repo