### PR TITLE
Fix `releases-tab` when `more-dropdown` is disabled

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -6,6 +6,7 @@ import features from '../libs/features';
 import * as icons from '../libs/icons';
 import {getRepoURL} from '../libs/utils';
 import {isRepoRoot, isReleasesOrTags} from '../libs/page-detect';
+import {appendBefore} from '../libs/dom-utils';
 
 const repoUrl = getRepoURL();
 const repoKey = `releases-count:${repoUrl}`;
@@ -38,11 +39,8 @@ async function init(): Promise<false | void> {
 		</a>
 	);
 
-	if(select('.reponav-dropdown')) {
-		select('.reponav-dropdown')!.before(releasesTab);
-	} else {
-		select.last('.reponav-item')!.after(releasesTab);
-	}
+	const selector = select('.reponav-dropdown') ? '.reponav-dropdown' : '[href$="settings"]';
+	appendBefore('.reponav', selector, releasesTab);
 
 	if (isReleasesOrTags()) {
 		const selected = select('.reponav-item.selected');

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -37,7 +37,12 @@ async function init(): Promise<false | void> {
 			{count === undefined ? '' : <span className="Counter">{count}</span>}
 		</a>
 	);
-	select('.reponav-dropdown')!.before(releasesTab);
+
+	if(select('.reponav-dropdown')) {
+		select('.reponav-dropdown')!.before(releasesTab);
+	} else {
+		select.last('.reponav-item')!.after(releasesTab);
+	}
 
 	if (isReleasesOrTags()) {
 		const selected = select('.reponav-item.selected');


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2361 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
- [x] Repo without admin access
- [x] Repo with admin access