### PR TITLE
`embed-gist-inline` exclude user links

### DIFF
--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -6,7 +6,7 @@ import features from '../libs/features';
 const isGist = (link: HTMLAnchorElement): boolean =>
 	!link.pathname.includes('.') && // Exclude links to embed files
 	(
-		link.hostname.startsWith('gist.') ||
+		(link.hostname.startsWith('gist.') && link.pathname.includes('/', 1)) || // Exclude user links
 		link.pathname.startsWith('gist/')
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Currently it tries to load them and then display `(embed failed)`.

<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

# Test
<!-- List some URLs that reviewers can use to test your PR -->
#### Should match

https://gist.github.com/KomaliVuddanti/f062a78b4fff3ee001529efe2a468375

#### Should not match

https://gist.github.com/defunkt