### PR TITLE
Change `highest-rated-comment` color to green instead of orange + fix style

### DIFF
--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -1,9 +1,9 @@
 .rgh-highest-rated-comment {
-	border: 2px solid #ffa500 !important;
+	border: 2px solid #2cbe4e !important;
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::before {
-	border-right-color: #ffa500;
+	border-right-color: #2cbe4e;
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::after {

--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -2,6 +2,16 @@
 	border: 2px solid #ffa500 !important;
 }
 
+.rgh-highest-rated-comment.timeline-comment--caret::before {
+	border-right-color: #ffa500;
+}
+
+.rgh-highest-rated-comment.timeline-comment--caret::after {
+	border-width: 5px;
+	margin-left: 6px;
+	margin-top: 3px;
+}
+
 a.rgh-highest-rated-comment .timeline-comment-header-text {
 	text-overflow: ellipsis;
 	white-space: nowrap;


### PR DESCRIPTION
Also closes #2237

# Description

The `highest-rated-comment` feature adds a border around the highest rated comment. But it bothered me that the caret was not styled. This PR fixes that.

## Before
![image](https://user-images.githubusercontent.com/55841/64129906-4addac80-cdbf-11e9-823c-ad31f86afa2c.png)

## After
![image](https://user-images.githubusercontent.com/55841/64131272-d8bd9580-cdc7-11e9-8a0f-37e0f3864ef4.png)

# Closes 
Closes #2237

# Test
* https://github.com/isaacs/github/issues/50#issuecomment-29907848
