### PR TITLE
Fix `sync-pr-commit-title` with new issue option

### DIFF
--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -8,7 +8,7 @@ import features from '../libs/features';
 import onPrMergePanelOpen from '../libs/on-pr-merge-panel-open';
 
 const commitTitleLimit = 72;
-const prTitleFieldSelector = '[name="issue[title]"]';
+const prTitleFieldSelector = '.js-issue-update [name="issue[title]"]';
 const prTitleSubmitSelector = '.js-issue-update [type="submit"]';
 
 const createCommitTitle = debounce<[], string>((): string => {


### PR DESCRIPTION
GitHub added a **Reference in new issue** option to comments that also
contain a `[name="issue[title]"]` element.

```html
<dl class="form-group">
	<dt><label for="convert-to-issue-title==">Title</label></dt>
	<dd><input id="convert-to-issue-title==" class="form-control" type="text" name="issue[title]" value="Example issue title" aria-label="Issue title" autofocus="" required=""></dd>
</dl>
```

![Reference in new issue dialog](https://user-images.githubusercontent.com/240770/64286109-d889db00-cf2a-11e9-8847-450150e959e5.png)

Resulting in this error:

```js
content.js:5341 Uncaught Error: Refined GitHub: `sync-pr-commit-title` can’t update the PR title
    at maybeShowNote (content.js:5341)
    at onMergePanelOpen (content.js:5358)
    at HTMLDivElement.<anonymous> (content.js:5293)
    at HTMLDivElement.listenerFn (content.js:364)
```

Because `maybeShowNote()` only expects two elements:

https://github.com/sindresorhus/refined-github/blob/84d0df7ef8a38afa0ab0011c1b674a8db45f0a8d/source/features/sync-pr-commit-title.tsx#L47-L50

# Test
The **Reference in new issue** option is available for comments in **Issues** & **Pull requests** in repos where you are an author or collaborator.