### PR TITLE
Fix `profile-hotkey`

### DIFF
--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -3,7 +3,7 @@ import features from '../libs/features';
 import {getUsername} from '../libs/utils';
 
 function init(): false | void {
-	const menuItem = select(`#user-links a.dropdown-item[href="/${getUsername()}"]`);
+	const menuItem = select(`a[href="/${getUsername()}"]`);
 
 	if (menuItem) {
 		menuItem.setAttribute('data-hotkey', 'g m');


### PR DESCRIPTION
Closes #2400 

# Test
any page and press `g m` to go to profile.
