### PR TITLE
Fix errors in `open-all-notifications`

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
-import {groupSiblings} from '../libs/group-buttons';
+import {groupButtons} from '../libs/group-buttons';
 
 const confirmationRequiredCount = 10;
 const unreadNotificationsClass = '.unread .js-notification-target';
@@ -70,7 +70,11 @@ function addOpenAllButton(): void {
 		// Create an open button and add it into a button group
 		const button = <button className="btn btn-sm rgh-open-notifications-button">Open all unread in tabs</button>;
 		select('.tabnav .float-right')!.prepend(button);
-		groupSiblings(button);
+
+		// There is no sibling on `/<org>/<repo>/notifications` page
+		if (button.nextElementSibling) {
+			groupButtons([button, button.nextElementSibling]);
+		}
 	}
 }
 

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -70,7 +70,7 @@ function addOpenAllButton(): void {
 		// Create an open button and add it into a button group
 		const button = <button className="btn btn-sm rgh-open-notifications-button">Open all unread in tabs</button>;
 		select('.tabnav .float-right')!.prepend(button);
-		groupButtons([button, button.nextElementSibling!]);
+		groupButtons([button, button.nextElementSibling!].filter(Boolean));
 	}
 }
 

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -4,7 +4,7 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 import * as icons from '../libs/icons';
-import {groupButtons} from '../libs/group-buttons';
+import {groupSiblings} from '../libs/group-buttons';
 
 const confirmationRequiredCount = 10;
 const unreadNotificationsClass = '.unread .js-notification-target';
@@ -70,7 +70,7 @@ function addOpenAllButton(): void {
 		// Create an open button and add it into a button group
 		const button = <button className="btn btn-sm rgh-open-notifications-button">Open all unread in tabs</button>;
 		select('.tabnav .float-right')!.prepend(button);
-		groupButtons([button, button.nextElementSibling!].filter(Boolean));
+		groupSiblings(button);
 	}
 }
 


### PR DESCRIPTION
Fixes #2397

# Test
Follow the instructions in #2397. Happens on all browsers, but with different messages.

The issue occurs, because "Mark all as read" button is missing in repository subpage in Notification, as described in the picture:
![2019-09-05_20-29-06](https://user-images.githubusercontent.com/6443113/64370060-f2f0b100-d01d-11e9-8862-68a80b329328.png)

Here's [`/notifications`](https://github.com/notifications):
![2019-09-05_20-29-11](https://user-images.githubusercontent.com/6443113/64370115-0f8ce900-d01e-11e9-97af-5d3920e974a8.png)

# Other solution
Instead of skipping missing button, we could add the button there. But I think it needs to be treated with caution to prevent bugs like [this one](https://github.com/sindresorhus/refined-github/issues/1634#issuecomment-441174984).
