### PR TITLE
Prevent "Request change" submission without leaving a comment

### DIFF
--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -11,7 +11,6 @@ function init(): false | void {
 		return false;
 	}
 
-	const submitButton = select<HTMLInputElement>('[type="submit"]', form)!;
 	const container = select('.form-actions', form)!;
 
 	// Set the default action for cmd+enter to Comment
@@ -66,7 +65,8 @@ function init(): false | void {
 		radio.closest('.form-checkbox')!.remove();
 	}
 
-	submitButton.remove();
+	select('[type="submit"]:not([name])', form)!.remove(); // The selector excludes the "Cancel" button
+
 	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment
 	delegate<HTMLButtonElement>(form, 'button', 'click', ({delegateTarget: {value}}) => {
 		const submissionRequiresComment = value === 'reject' || value === 'comment';

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import features from '../libs/features';
 
 function init(): false | void {
@@ -66,6 +67,11 @@ function init(): false | void {
 	}
 
 	submitButton.remove();
+	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment
+	delegate<HTMLButtonElement>(form, 'button', 'click', ({delegateTarget: {value}}) => {
+		const submissionRequiresComment = value === 'reject' || value === 'comment';
+		select('#pull_request_review_body', form)!.toggleAttribute('required', submissionRequiresComment);
+	});
 
 	// Freeze form to avoid duplicate submissions
 	form.addEventListener('submit', () => {


### PR DESCRIPTION
Closes #2401

This behavior is already enforced by GitHub, but it only shows up after the form is submitted and the page is reloaded.

This change makes the requirement appear _before_ the form is actually submitted, via client-side validation.

# Test
1. Open a PR you can review
2. Click **Comment** or **Request changes**
3. Expect a "Field required" tooltip on the comment field
4. Click **Approve** or **Cancel review**
5. No tooltip will be shown, no comment is required