### PR TITLE
Add `deemphasize-unrelated-commit-references` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -286,7 +286,7 @@ Thanks for contributing! 🦋🙌
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
-### Fixes for GitHub bugs
+### Fixes for GitHub shortcomings
 
 - [](# "indented-code-wrapping") 🔥 [Indents wrapped code correctly.](https://user-images.githubusercontent.com/37769974/60379474-0ba67e80-9a51-11e9-97f9-077d282e5bdb.png)
 - [](# "focus-confirmation-buttons") [Always focuses confirm buttons in custom modal boxes, like "Mark all as read".](https://user-images.githubusercontent.com/1402241/31700158-1499bdd8-b38d-11e7-9aba-77a0a4b6bf3c.png)
@@ -294,6 +294,7 @@ Thanks for contributing! 🦋🙌
 - [](# "hide-issue-list-autocomplete") [Removes the autocomplete on search fields.](https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png)
 - [](# "hide-obvious-tooltips") Removes tooltips from self-explanatory buttons.
 - [](# "recently-pushed-branches-enhancements") 🔥 [Moves the "Recently-pushed branches" widget to the header to avoid content jumps. Also adds it to more pages in the repo.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
+- [](# "deemphasize-unrelated-commit-references") [Makes it easier to tell apart commits added to the current PR versus plain commits that reference the PR.](https://user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -15,6 +15,7 @@ import './features/hide-readme-header.css';
 import './features/hide-obvious-tooltips.css';
 import './features/clean-discussions.css';
 import './features/sticky-discussion-list-toolbar.css';
+import './features/deemphasize-unrelated-commit-references.css';
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.
 

--- a/source/features/deemphasize-unrelated-commit-references.css
+++ b/source/features/deemphasize-unrelated-commit-references.css
@@ -1,3 +1,7 @@
+/*
+Makes it easier to tell apart commits added to the current PR versus plain commits that reference the PR.
+https: //user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif
+*/
 .TimelineItem:not(.TimelineItem--condensed) ~ .TimelineItem .TimelineItem-badge {
 	visibility: hidden;
 }

--- a/source/features/deemphasize-unrelated-commit-references.css
+++ b/source/features/deemphasize-unrelated-commit-references.css
@@ -1,0 +1,3 @@
+.TimelineItem:not(.TimelineItem--condensed) ~ .TimelineItem .TimelineItem-badge {
+	visibility: hidden;
+}


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes  https://github.com/sindresorhus/refined-github/issues/1579
Follows https://github.com/sindresorhus/refined-github/pull/1794

# Test
- Unrelated commits (commit icon is hidden): https://github.com/sindresorhus/refined-github/issues/226#ref-commit-28fc802
- Commits in the current PR (icon is untouched) https://github.com/sindresorhus/refined-github/pull/2387

![](https://user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif)
