### PR TITLE
Soften PR review comment requirement

### DIFF
--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -67,10 +67,11 @@ function init(): false | void {
 
 	select('[type="submit"]:not([name])', form)!.remove(); // The selector excludes the "Cancel" button
 
-	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment
+	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment and no other review comments are pending
 	delegate<HTMLButtonElement>(form, 'button', 'click', ({delegateTarget: {value}}) => {
 		const submissionRequiresComment = value === 'reject' || value === 'comment';
-		select('#pull_request_review_body', form)!.toggleAttribute('required', submissionRequiresComment);
+		const reviewRequiresComment = submissionRequiresComment && select.exists('.is-review-pending') === false;
+		select('#pull_request_review_body', form)!.toggleAttribute('required', reviewRequiresComment);
 	});
 
 	// Freeze form to avoid duplicate submissions

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -69,9 +69,8 @@ function init(): false | void {
 
 	// This will prevent submission when clicking "Comment" and "Request changes" without entering a comment and no other review comments are pending
 	delegate<HTMLButtonElement>(form, 'button', 'click', ({delegateTarget: {value}}) => {
-		const submissionRequiresComment = value === 'reject' || value === 'comment';
-		const reviewRequiresComment = submissionRequiresComment && select.exists('.is-review-pending') === false;
-		select('#pull_request_review_body', form)!.toggleAttribute('required', reviewRequiresComment);
+		const submissionRequiresComment = !select.exists('.is-review-pending') && (value === 'reject' || value === 'comment');
+		select('#pull_request_review_body', form)!.toggleAttribute('required', submissionRequiresComment);
 	});
 
 	// Freeze form to avoid duplicate submissions


### PR DESCRIPTION
This fixes reviews always requiring a comment even if other review comments are pending

Closes #2418

Not sure if this is a *"to simple"* solution, but this issue prevented me from reviewing so I wanted a *quick* fix :see_no_evil: