### PR TITLE
Fix whitespace selection

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -5,6 +5,7 @@
 }
 
 .rgh-ws-char::before {
+	pointer-events: none;
 	user-select: none;
 	position: absolute;
 	left: 0;


### PR DESCRIPTION
Currently selecting text when `show-whitespace` is on is extremely jerky since `::before`s with whitespace indicators do not have `pointer-events: none`.

# Test
- https://gist.github.com/pipboy96/95708bb962b9855b731ee9ba34f38046
- https://pipboy96.github.io/assets/refined-github/fix-whitespace-selection-before.webm
- https://pipboy96.github.io/assets/refined-github/fix-whitespace-selection-after.webm