### PR TITLE
Stricter usage of `any`

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
 				"rules": {
 					"@typescript-eslint/no-misused-promises": "off",
 					"@typescript-eslint/promise-function-async": "off",
-					"@typescript-eslint/no-explicit-any": "off",
 					"@typescript-eslint/no-unused-vars": [
 						"error",
 						{

--- a/source/content.ts
+++ b/source/content.ts
@@ -143,5 +143,5 @@ import './features/clean-rich-text-editor';
 import './features/highlight-collaborators-in-lists';
 
 // Add global for easier debugging
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 (window as any).select = select;

--- a/source/content.ts
+++ b/source/content.ts
@@ -143,4 +143,5 @@ import './features/clean-rich-text-editor';
 import './features/highlight-collaborators-in-lists';
 
 // Add global for easier debugging
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 (window as any).select = select;

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -31,7 +31,7 @@ async function getAssetsForTag(tags: string[]): Promise<Tag> {
 
 	const assets: Tag = {};
 	for (const [tag, release] of Object.entries(repository)) {
-		assets[tag] = (release as any).releaseAssets.nodes;
+		assets[tag] = (release as AnyObject).releaseAssets.nodes;
 	}
 
 	return assets;

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -1,15 +1,15 @@
 import delay from 'delay';
-import delegate from 'delegate-it';
+import delegate, {DelegateEvent} from 'delegate-it';
 import loadImage from 'image-promise';
 import features from '../libs/features';
 
-async function handleErroredImage({target}: any): Promise<void> {
+async function handleErroredImage({delegateTarget}: DelegateEvent<ErrorEvent, HTMLImageElement>): Promise<void> {
 	await delay(5000);
 	try {
 		// A clone image retries downloading
 		// `loadImage` awaits it
 		// If successfully loaded, the failed image will be replaced.
-		target.replaceWith(await loadImage(target.cloneNode() as HTMLImageElement));
+		delegateTarget.replaceWith(await loadImage(delegateTarget.cloneNode() as HTMLImageElement));
 	} catch {}
 }
 

--- a/source/features/revert-file.tsx
+++ b/source/features/revert-file.tsx
@@ -75,8 +75,7 @@ async function commitFileContent(menuItem: Element, content: string): Promise<vo
 async function handleRevertFileClick(event: React.MouseEvent<HTMLButtonElement>): Promise<void> {
 	const menuItem = event.currentTarget;
 	// Allow only one click
-	// TODO: change JSX event types to be plain browser events
-	menuItem.removeEventListener('click', handleRevertFileClick as any);
+	menuItem.removeEventListener('click', handleRevertFileClick as unknown as EventListener);
 	menuItem.textContent = 'Reverting…';
 	event.preventDefault();
 	event.stopPropagation();

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -1,5 +1,7 @@
 // TODO: Drop some definitions when their related bugs are resolved
+// TODO: Improve JSX types for event listeners so we can use `MouseEvent` instead of `React.MouseEvent`, which is incompatible with regular `addEventListeners` calls
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 type AnyObject = Record<string, any>;
 type AsyncVoidFunction = () => Promise<void>;
 

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -1,7 +1,7 @@
 // TODO: Drop some definitions when their related bugs are resolved
 // TODO: Improve JSX types for event listeners so we can use `MouseEvent` instead of `React.MouseEvent`, which is incompatible with regular `addEventListeners` calls
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = Record<string, any>;
 type AsyncVoidFunction = () => Promise<void>;
 

--- a/source/resolve-conflicts.ts
+++ b/source/resolve-conflicts.ts
@@ -9,7 +9,7 @@ declare namespace CodeMirror {
 	}
 }
 
-const editor: CodeMirrorInstance = document.querySelector<any>('.CodeMirror').CodeMirror;
+const editor = document.querySelector<Element & {CodeMirror: CodeMirrorInstance}>('.CodeMirror')!.CodeMirror;
 
 // Event fired when each file is loaded
 editor.on('swapDoc', () => setTimeout(addWidget, 1));

--- a/test/fixtures/globals.ts
+++ b/test/fixtures/globals.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {JSDOM} from 'jsdom';
 
 const {window} = new JSDOM('...');


### PR DESCRIPTION
Follow-up to #2391 

Perhaps we can just disable `any` for these exceptions. In some cases it can be replaced with `AnyObject` for a cheap workaround. I don't want to risk passing what was in `reload-failed-proxied-images` anymore