### PR TITLE
Fix `close-out-of-view-modals` conflict with GitHub Actions UI

### DIFF
--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -10,11 +10,9 @@ const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 });
 
 function init(): void {
-	// The `open` attribute is added after this handler is run,
-	// so the selector is inverted
-	delegate('.details-overlay:not([open]) > summary', 'click', event => {
-		// What comes after <summary> is the dropdown
-		observer.observe(select('.dropdown-menu', event.delegateTarget.parentElement!)!);
+	// The `open` attribute is added after this handler is run, so the selector is inverted
+	delegate('.details-overlay:not([open]) > summary', 'click', ({delegateTarget: summary}) => {
+		observer.observe(summary.parentElement!.querySelector('.dropdown-menu')!);
 	});
 }
 

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -1,5 +1,4 @@
 import delegate from 'delegate-it';
-import select from 'select-dom';
 import features from '../libs/features';
 
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -1,4 +1,5 @@
 import delegate from 'delegate-it';
+import select from 'select-dom';
 import features from '../libs/features';
 
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
@@ -13,7 +14,7 @@ function init(): void {
 	// so the selector is inverted
 	delegate('.details-overlay:not([open]) > summary', 'click', event => {
 		// What comes after <summary> is the dropdown
-		observer.observe(event.delegateTarget.nextElementSibling!);
+		observer.observe(select('.dropdown-menu', event.delegateTarget.parentElement!)!);
 	});
 }
 


### PR DESCRIPTION
Fixes #2328.

As mentioned in https://github.com/sindresorhus/refined-github/issues/2328#issuecomment-522060316, the `details` element can contain content after its `summary` element that is not visible to the user. What we actually need is the `.dropdown-menu` item, which is targeted using the change in this PR.

## Test

- Test on user dropdown/create repo dropdown available on every GH page header.
- If you have access to GH Actions, this can be tested on a PR which has one or more failed checks, and you have access to re-run checks.