### PR TITLE
Temporary fix for `widen-search-field`

### DIFF
--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -7,6 +7,7 @@
 	flex-grow: 1;
 	display: flex;
 	font: none !important;
+	align-items: flex-start;
 }
 
 /* Move `New issue` button back to the right */

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -7,7 +7,7 @@
 	font: none !important;
 }
 
-.d-flex[role="search"] {
+.d-flex[role='search'] {
 	flex-grow: 1;
 	margin-bottom: 20px;
 }

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -1,21 +1,18 @@
 /* Expand issue search field width */
+.subnav,
 .subnav-search,
 .subnav-search-input,
+.subnav [role='search'],
 .page-content .subnav > .float-right { /* Global search field container */
 	flex-grow: 1;
 	display: flex;
 	font: none !important;
 }
 
-.d-flex[role='search'] {
-	flex-grow: 1;
-	margin-bottom: 20px;
-}
-
 /* Move `New issue` button back to the right */
-.subnav {
+.subnav .float-right {
 	order: 100;
-	margin-left: 8px;
+	margin-left: 20px;
 }
 
 /*

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -1,18 +1,21 @@
 /* Expand issue search field width */
-.subnav,
 .subnav-search,
 .subnav-search-input,
-.subnav [role='search'],
 .page-content .subnav > .float-right { /* Global search field container */
 	flex-grow: 1;
 	display: flex;
 	font: none !important;
 }
 
+.d-flex[role="search"] {
+	flex-grow: 1;
+	margin-bottom: 20px;
+}
+
 /* Move `New issue` button back to the right */
-.subnav .float-right {
+.subnav {
 	order: 100;
-	margin-left: 20px;
+	margin-left: 8px;
 }
 
 /*


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Technically fixes #2435
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

GitHub made some weird changes to their css regarding `.subnav` selector on Issues and Pull Requests pages. It looks like they are migrating from the old `.float-left/right` model to flexbox, but at the same time they ignore existing "semantic" classes.

You can also see it on the Releases page where they are using the old `.subnav` and `.d-flex.flex-justify-between`.

I would call this PR a temporary workaround until things settle down with GitHub changes. Also, we should probably expect some more broken features soon.

# Test
<!-- List some URLs that reviewers can use to test your PR -->
Open [issues](https://github.com/sindresorhus/refined-github/issues) or [pull request](https://github.com/sindresorhus/refined-github/pulls) page and see.