### PR TITLE
Fix `widen-search-field` feature

### DIFF
--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -17,12 +17,27 @@
 }
 
 /*
-Take full available width for extra buttons on Releases page.
-It excludes anchor tags which are `New Issue` and `New Pull Request` on
-issues and pull-requests tab respectively.
+On Labels page
+search box now on the same side with other buttons
+push `New label` button to the right
+On Releases page
+take full available width for extra buttons
+On Issues and Pull requests page
+push `New issue` and `New pull request` button to the right
 */
 .subnav > :first-child:not(a) {
-	flex-grow: 1;
+	flex-grow: 0;
+	margin-right: auto;
+}
+
+/*
+On Issues and Pull requests page
+remove flex-grow on `New issue` and `New pull request` button
+On Labels page
+remove flex-grow on `New label` button
+*/
+.subnav:nth-last-child(1) {
+    flex-grow: 0;
 }
 
 /* Reset width of search field in global lists */

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -1,5 +1,4 @@
 /* Expand issue search field width */
-.subnav,
 .subnav-search,
 .subnav-search-input,
 .subnav [role='search'],
@@ -10,25 +9,20 @@
 	align-items: flex-start;
 }
 
-/* Move `New issue` button back to the right */
+/* On Releases page, add margin between buttons */
 .subnav .float-right {
 	order: 100;
 	margin-left: 20px;
 }
 
-/*
-On Labels page, bring search field to the left, and push `New label` button to the right
-On Releases page, push extra buttons to the right.
-On Issues and Pull requests page, push `New issue` and `New pull request` button to the right
-*/
-.subnav > :first-child:not(a) {
-	flex-grow: 0;
-	margin-right: auto;
+/* On Releases page, use flex to align buttons */
+.subnav {
+	display: flex;
 }
 
-/* On Issues and Pull requests page, remove flex-grow on `New issue` and `New pull request` button */
-.subnav:nth-last-child(1) {
-	flex-grow: 0;
+/* On Releases page, push extra buttons to the right. */
+.subnav > :first-child:not(a) {
+	margin-right: auto;
 }
 
 /* On `Issues` and `Pull Requests` page, expand search field width */

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -33,11 +33,9 @@ push `New issue` and `New pull request` button to the right
 /*
 On Issues and Pull requests page
 remove flex-grow on `New issue` and `New pull request` button
-On Labels page
-remove flex-grow on `New label` button
 */
 .subnav:nth-last-child(1) {
-    flex-grow: 0;
+	flex-grow: 0;
 }
 
 /* Reset width of search field in global lists */

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -42,7 +42,7 @@ remove flex-grow on `New issue` and `New pull request` button
 On `Issues` and `Pull Requests` page
 expand search field width
 */
-.d-flex[role="search"] {
+.d-flex[role='search'] {
 	flex-grow: 1;
 }
 

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -17,39 +17,26 @@
 }
 
 /*
-On Labels page
-search box now on the same side with other buttons
-push `New label` button to the right
-On Releases page
-take full available width for extra buttons
-On Issues and Pull requests page
-push `New issue` and `New pull request` button to the right
+On Labels page, bring search field to the left, and push `New label` button to the right
+On Releases page, push extra buttons to the right.
+On Issues and Pull requests page, push `New issue` and `New pull request` button to the right
 */
 .subnav > :first-child:not(a) {
 	flex-grow: 0;
 	margin-right: auto;
 }
 
-/*
-On Issues and Pull requests page
-remove flex-grow on `New issue` and `New pull request` button
-*/
+/* On Issues and Pull requests page, remove flex-grow on `New issue` and `New pull request` button */
 .subnav:nth-last-child(1) {
 	flex-grow: 0;
 }
 
-/*
-On `Issues` and `Pull Requests` page
-expand search field width
-*/
+/* On `Issues` and `Pull Requests` page, expand search field width */
 .d-flex[role='search'] {
 	flex-grow: 1;
 }
 
-/*
-On `Issues` and `Pull Requests` page
-add margin-left to `New Issue` and `New Pull Request` button
-*/
+/* On `Issues` and `Pull Requests` page, add margin-left to `New Issue` and `New Pull Request` button */
 .subnav > .btn-primary {
 	margin-left: 20px;
 }

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -1,38 +1,44 @@
+/**
+This feature has to work on:
+https: //github.com/issues
+https: //github.com/pulls
+https: //github.com/sindresorhus/refined-github/issues
+https: //github.com/sindresorhus/refined-github/pulls
+https: //github.com/sindresorhus/refined-github/labels
+https: //github.com/sindresorhus/refined-github/milestones
+
 /* Expand issue search field width */
+.repository-content [role='search'], /* Repo issue/PR lists */
+.subnav-links + .float-right, /* Global search pages */
 .subnav-search,
-.subnav-search-input,
-.subnav [role='search'],
-.page-content .subnav > .float-right { /* Global search field container */
+.subnav-search text-expander, /* Labels pages*/
+.subnav-search-input {
 	flex-grow: 1;
 	display: flex;
-	font: none !important;
 	align-items: flex-start;
 }
 
-/* On Releases page, add margin between buttons */
-.subnav .float-right {
-	order: 100;
-	margin-left: 20px;
-}
-
-/* On Releases page, use flex to align buttons */
+/* Global search, labels: enable field expansion */
+/* Releases: place Releases/Tags selector on the same line as `Draft new release` (GitHub bug) */
 .subnav {
 	display: flex;
 }
 
-/* On Releases page, push extra buttons to the right. */
-.subnav > :first-child:not(a) {
-	margin-right: auto;
-}
-
-/* On `Issues` and `Pull Requests` page, expand search field width */
-.d-flex[role='search'] {
-	flex-grow: 1;
-}
-
-/* On `Issues` and `Pull Requests` page, add margin-left to `New Issue` and `New Pull Request` button */
-.subnav > .btn-primary {
+/* Space out buttons */
+.subnav > .float-right, /* On Releases page */
+.subnav > .btn-primary { /* On `Issues` and `Pull Requests` pages */
 	margin-left: 20px;
+}
+
+/* Push nav buttons to the right */
+.subnav .d-flex.flex-md-row.flex-justify-between.flex-md-items-center + div, /* Tags: Draft new release, Edit tag, Delete */
+.subnav > .float-right {  /* Labels, Milestones: "New ****" button */
+	order: 100;
+}
+
+/* Releases: push nav buttons to the right */
+.subnav .d-flex.flex-md-row.flex-justify-between.flex-md-items-center {
+	margin-right: auto;
 }
 
 /* Reset width of search field in global lists */

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -38,6 +38,22 @@ remove flex-grow on `New issue` and `New pull request` button
 	flex-grow: 0;
 }
 
+/*
+On `Issues` and `Pull Requests` page
+expand search field width
+*/
+.d-flex[role="search"] {
+	flex-grow: 1;
+}
+
+/*
+On `Issues` and `Pull Requests` page
+add margin-left to `New Issue` and `New Pull Request` button
+*/
+.subnav > .btn-primary {
+	margin-left: 20px;
+}
+
 /* Reset width of search field in global lists */
 .page-content .subnav-search-input-wide {
 	width: auto;

--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -1,17 +1,22 @@
-/**
+/*
 This feature has to work on:
-https: //github.com/issues
-https: //github.com/pulls
-https: //github.com/sindresorhus/refined-github/issues
-https: //github.com/sindresorhus/refined-github/pulls
-https: //github.com/sindresorhus/refined-github/labels
-https: //github.com/sindresorhus/refined-github/milestones
+https://github.com/issues
+https://github.com/pulls
+https://github.com/sindresorhus/refined-github/issues
+https://github.com/sindresorhus/refined-github/pulls
+
+But not affect these pages, because they also use `.subnav` but don't benefit from a larger field
+https://github.com/sindresorhus/refined-github/releases
+https://github.com/sindresorhus/refined-github/tags
+https://github.com/sindresorhus/refined-github/labels
+https://github.com/sindresorhus/refined-github/milestones
+https://github.com/sindresorhus/refined-github/releases/tag/19.9.16
+*/
 
 /* Expand issue search field width */
 .repository-content [role='search'], /* Repo issue/PR lists */
 .subnav-links + .float-right, /* Global search pages */
 .subnav-search,
-.subnav-search text-expander, /* Labels pages*/
 .subnav-search-input {
 	flex-grow: 1;
 	display: flex;
@@ -19,8 +24,7 @@ https: //github.com/sindresorhus/refined-github/milestones
 }
 
 /* Global search, labels: enable field expansion */
-/* Releases: place Releases/Tags selector on the same line as `Draft new release` (GitHub bug) */
-.subnav {
+.page-content > .subnav:first-child {
 	display: flex;
 }
 
@@ -30,15 +34,9 @@ https: //github.com/sindresorhus/refined-github/milestones
 	margin-left: 20px;
 }
 
-/* Push nav buttons to the right */
-.subnav .d-flex.flex-md-row.flex-justify-between.flex-md-items-center + div, /* Tags: Draft new release, Edit tag, Delete */
-.subnav > .float-right {  /* Labels, Milestones: "New ****" button */
-	order: 100;
-}
-
-/* Releases: push nav buttons to the right */
+/* Releases: place Releases/Tags selector on the same line as `Draft new release` (GitHub bug) */
 .subnav .d-flex.flex-md-row.flex-justify-between.flex-md-items-center {
-	margin-right: auto;
+	float: left;
 }
 
 /* Reset width of search field in global lists */


### PR DESCRIPTION
Follows #2436 
# Test

https://github.com/issues
https://github.com/pulls
https://github.com/sindresorhus/refined-github/issues
https://github.com/sindresorhus/refined-github/pulls

<details>
<summary>Previous content</summary>

### Test link
[Issues](https://github.com/sindresorhus/refined-github/issues)
[Pull Requests](https://github.com/sindresorhus/refined-github/pulls)
[Labels](https://github.com/sindresorhus/refined-github/labels)
[Releases](https://github.com/sindresorhus/refined-github/releases)

## Before
### Issue page
![issue](https://user-images.githubusercontent.com/55282035/64926033-f4db2100-d822-11e9-8a13-07f4ebe1007f.png)

### Pull requests page
![pull](https://user-images.githubusercontent.com/55282035/64926039-fc9ac580-d822-11e9-869b-f61d40b3561b.png)

### Labels page (my repository)
![label](https://user-images.githubusercontent.com/55282035/64926050-1e944800-d823-11e9-83cb-921d0a3cde68.png)

### Labels page
![other-label](https://user-images.githubusercontent.com/55282035/64926062-3370db80-d823-11e9-9be5-72c03d04d65b.png)


## After
### Issue page
![2](https://user-images.githubusercontent.com/55282035/64906609-d259e280-d712-11e9-8db7-4d636ebb3edc.png)

### Pull requests page
![3](https://user-images.githubusercontent.com/55282035/64906616-ddad0e00-d712-11e9-9f84-cbdb9fd67141.png)

### Labels page
![4](https://user-images.githubusercontent.com/55282035/64906618-e30a5880-d712-11e9-8fcd-83288d1f6a1c.png)

### Releases page
![2](https://user-images.githubusercontent.com/55282035/64925211-5eedc900-d817-11e9-91ed-428819ae604d.png)

### Releases page (forked repository)
![releases](https://user-images.githubusercontent.com/55282035/64933587-229a8700-d870-11e9-8373-e18da164b1c5.png)


</details>