### PR TITLE
Move testing to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
-name: Run tests
+name: Test
 on: push
 jobs:
-  test:
+  run:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/setup-node@v1
     - run: npm ci
     - run: npm test
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v1
       with:
-        name: refined-github
+        name: refined-github.zip
         path: distribution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,3 +8,7 @@ jobs:
     - uses: actions/setup-node@v1
     - run: npm ci
     - run: npm test
+    - uses: actions/upload-artifact@master
+      with:
+        name: refined-github
+        path: distribution

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,5 @@ jobs:
     - run: npm test
     - uses: actions/upload-artifact@v1
       with:
-        name: refined-github.zip
+        name: refined-github
         path: distribution

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,5 +6,5 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
-    - run: npm install
+    - run: npm ci
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,10 @@
 name: Run tests
-on: [push]
+on: push
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
     - run: npm install
     - run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,12 @@
+name: Run tests
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - run: npm install
+    - run: npm test


### PR DESCRIPTION
I think GitHub Actions can replace Travis for testing. Configuration is verbose but it's only done once and the speed increase seems worth it.

Deployment can stay there until https://github.com/notlmn/browser-extension-template/issues/19, it should be unaffected by this PR because Travis still runs the daily cronjob.

PR and branch testing can later be disabled on https://travis-ci.org/sindresorhus/refined-github/settings
<img width="313" alt="Screenshot 2019-09-16 at 03 58 02" src="https://user-images.githubusercontent.com/1402241/64927532-31644800-d836-11e9-84f7-2839cf71f14a.png">
