### PR TITLE
Extract `tab-to-indent` and `one-key-formatting` features

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,13 +157,13 @@ Thanks for contributing! 🦋🙌
 
 ### Writing comments
 
-- [](# "comment-fields-keyboard-shortcuts") 🔥 Enables the <kbd>tab</kbd> key for indentation in comment fields.
+- [](# "tab-to-indent") 🔥 [Enables the <kbd>tab</kbd> key for indentation in comment fields.](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)
 - [](# "submit-review-as-single-comment") [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
 - [](# "collapsible-content-button") [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [](# "edit-comments-faster") [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
 - [](# "comment-fields-keyboard-shortcuts") [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
-- [](# "comment-fields-keyboard-shortcuts") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
+- [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
 - [](# "minimize-upload-bar") [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
 - [](# "clean-rich-text-editor") [Hides unnecessary comment field tooltips and toolbar items](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut.)
 - [](# "monospace-textareas") Use a monospace font for all textareas.

--- a/readme.md
+++ b/readme.md
@@ -163,7 +163,7 @@ Thanks for contributing! 🦋🙌
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [](# "edit-comments-faster") [Moves the `Edit comment` button out of the `...` dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
 - [](# "comment-fields-keyboard-shortcuts") [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
-- [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
+- [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
 - [](# "minimize-upload-bar") [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
 - [](# "clean-rich-text-editor") [Hides unnecessary comment field tooltips and toolbar items](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut.)
 - [](# "monospace-textareas") Use a monospace font for all textareas.

--- a/source/content.ts
+++ b/source/content.ts
@@ -28,6 +28,8 @@ import './features/remove-projects-tab';
 import './features/remove-checks-tab';
 import './features/focus-confirmation-buttons';
 import './features/comment-fields-keyboard-shortcuts';
+import './features/one-key-formatting';
+import './features/tab-to-indent';
 import './features/hide-navigation-hover-highlight';
 import './features/monospace-textareas';
 import './features/selection-in-new-tab';

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -1,22 +1,8 @@
 import select from 'select-dom';
 import delegate, {DelegateEvent, DelegateEventHandler} from 'delegate-it';
 import features from '../libs/features';
+import blurAccessibly from '../libs/blur-field-accessibly';
 
-
-// Element.blur() will reset the tab focus to the start of the document.
-// This places it back next to the blurred field
-export function blurAccessibly(field: HTMLElement): void {
-	field.blur();
-
-	const range = new Range();
-	const selection = getSelection()!;
-	const focusHolder = new Text();
-	field.after(focusHolder);
-	range.selectNodeContents(focusHolder);
-	selection.removeAllRanges();
-	selection.addRange(range);
-	focusHolder.remove();
-}
 export function listenToCommentFields(callback: DelegateEventHandler<KeyboardEvent, HTMLTextAreaElement>) {
 	delegate<HTMLTextAreaElement, KeyboardEvent>('.js-comment-field, #commit-description-textarea', 'keydown', event => {
 		const field = event.delegateTarget;

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -1,11 +1,7 @@
 import select from 'select-dom';
-import delegate from 'delegate-it';
-import indentTextarea from 'indent-textarea';
-import insertText from 'insert-text-textarea';
+import delegate, {DelegateEvent, DelegateEventHandler} from 'delegate-it';
 import features from '../libs/features';
 
-const formattingCharacters = ['`', '\'', '"', '[', '(', '{', '*', '_', '~'];
-const matchingCharacters = ['`', '\'', '"', ']', ')', '}', '*', '_', '~'];
 
 // Element.blur() will reset the tab focus to the start of the document.
 // This places it back next to the blurred field
@@ -21,91 +17,81 @@ export function blurAccessibly(field: HTMLElement): void {
 	selection.addRange(range);
 	focusHolder.remove();
 }
-
-function init(): void {
+export function listenToCommentFields(callback: DelegateEventHandler<KeyboardEvent, HTMLTextAreaElement>) {
 	delegate<HTMLTextAreaElement, KeyboardEvent>('.js-comment-field, #commit-description-textarea', 'keydown', event => {
 		const field = event.delegateTarget;
 
-		// Don't do anything if the suggester box is active
-		if (select.exists('.suggester:not([hidden])', field.form!)) {
+		// Don't do anything if the autocomplete helper is shown or if non-Roman input is being used
+		if (select.exists('.suggester', field.form!) || event.isComposing) {
 			return;
 		}
 
-		if (event.key === 'Tab' && !event.shiftKey) {
-			indentTextarea(field);
-			event.preventDefault();
-		} else if (event.key === 'Escape') {
-			// Cancel buttons have different classes for inline comments and editable comments
-			const cancelButton = select<HTMLButtonElement>(`
+		callback(event);
+	});
+}
+
+function handler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement>): void {
+	const field = event.delegateTarget;
+
+	if (event.key === 'Escape') {
+		// Cancel buttons have different classes for inline comments and editable comments
+		const cancelButton = select<HTMLButtonElement>(`
 				.js-hide-inline-comment-form,
 				.js-comment-cancel-button
 			`, field.form!);
 
-			// Cancel if there is a button, else blur the field
-			if (cancelButton) {
-				cancelButton.click();
-			} else {
-				blurAccessibly(field);
-			}
-
-			event.stopImmediatePropagation();
-			event.preventDefault();
-		} else if (event.key === 'ArrowUp' && field.value === '') {
-			const currentConversationContainer = field.closest([
-				'.js-inline-comments-container', // Current review thread container
-				'.discussion-timeline', // Or just ALL the comments in issues
-				'#all_commit_comments' // Single commit comments at the bottom
-			].join())!;
-			const lastOwnComment = select
-				.all<HTMLDetailsElement>('.js-comment.current-user', currentConversationContainer)
-				.reverse()
-				.find(comment => {
-					const collapsible = comment.closest('details');
-					return !collapsible || collapsible.open;
-				});
-
-			if (lastOwnComment) {
-				select<HTMLButtonElement>('.js-comment-edit-button', lastOwnComment)!.click();
-				const closeCurrentField = field
-					.closest('form')!
-					.querySelector<HTMLButtonElement>('.js-hide-inline-comment-form');
-
-				if (closeCurrentField) {
-					closeCurrentField.click();
-				}
-
-				// Move caret to end of field
-				requestAnimationFrame(() => {
-					select<HTMLTextAreaElement>('.js-comment-field', lastOwnComment)!.selectionStart = Number.MAX_SAFE_INTEGER;
-				});
-			}
-		} else if (formattingCharacters.includes(event.key) && !event.isComposing) {
-			const [start, end] = [field.selectionStart, field.selectionEnd];
-
-			// If `start` and `end` of selection are the same, then no text is selected
-			if (start === end) {
-				return;
-			}
-
-			event.preventDefault();
-
-			const formattingChar = event.key;
-			const selectedText = field.value.slice(start, end);
-			const matchingEndChar = matchingCharacters[formattingCharacters.indexOf(formattingChar)];
-			insertText(field, formattingChar + selectedText + matchingEndChar);
-
-			// Keep the selection as it is, to be able to chain shortcuts
-			field.setSelectionRange(start + 1, end + 1);
+		// Cancel if there is a button, else blur the field
+		if (cancelButton) {
+			cancelButton.click();
+		} else {
+			blurAccessibly(field);
 		}
-	});
+
+		event.stopImmediatePropagation();
+		event.preventDefault();
+	} else if (event.key === 'ArrowUp' && field.value === '') {
+		const currentConversationContainer = field.closest([
+			'.js-inline-comments-container', // Current review thread container
+			'.discussion-timeline', // Or just ALL the comments in issues
+			'#all_commit_comments' // Single commit comments at the bottom
+		].join())!;
+		const lastOwnComment = select
+			.all<HTMLDetailsElement>('.js-comment.current-user', currentConversationContainer)
+			.reverse()
+			.find(comment => {
+				const collapsible = comment.closest('details');
+				return !collapsible || collapsible.open;
+			});
+
+		if (lastOwnComment) {
+			select<HTMLButtonElement>('.js-comment-edit-button', lastOwnComment)!.click();
+			const closeCurrentField = field
+				.closest('form')!
+				.querySelector<HTMLButtonElement>('.js-hide-inline-comment-form');
+
+			if (closeCurrentField) {
+				closeCurrentField.click();
+			}
+
+			// Move caret to end of field
+			requestAnimationFrame(() => {
+				select<HTMLTextAreaElement>('.js-comment-field', lastOwnComment)!.selectionStart = Number.MAX_SAFE_INTEGER;
+			});
+		}
+	}
+}
+
+function init(): void {
+	listenToCommentFields(handler);
 }
 
 features.add({
 	id: __featureName__,
-	description: 'Adds various shortcuts to comment fields: `↑` `tab` `esc` and Markdown formatting shortcuts',
+	description: 'Adds shortcuts to comment fields: `↑` to edit your previous comment; `esc` to blur field or cancel comment.',
 	screenshot: false,
 	shortcuts: {
-		'↑': 'Edit your last comment'
+		'↑': 'Edit your last comment',
+		'esc': 'Unfocuses comment field'
 	},
 	init
 });

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -13,6 +13,9 @@ export function listenToCommentFields(callback: DelegateEventHandler<KeyboardEve
 		}
 
 		callback(event);
+	}, {
+		// Adds support for `esc` key; GitHub seems to use `stopPropagation` on it
+		capture: true
 	});
 }
 

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -3,7 +3,7 @@ import delegate, {DelegateEvent, DelegateEventHandler} from 'delegate-it';
 import features from '../libs/features';
 import blurAccessibly from '../libs/blur-field-accessibly';
 
-export function listenToCommentFields(callback: DelegateEventHandler<KeyboardEvent, HTMLTextAreaElement>) {
+export function listenToCommentFields(callback: DelegateEventHandler<KeyboardEvent, HTMLTextAreaElement>): void {
 	delegate<HTMLTextAreaElement, KeyboardEvent>('.js-comment-field, #commit-description-textarea', 'keydown', event => {
 		const field = event.delegateTarget;
 
@@ -80,7 +80,7 @@ features.add({
 	screenshot: false,
 	shortcuts: {
 		'↑': 'Edit your last comment',
-		'esc': 'Unfocuses comment field'
+		esc: 'Unfocuses comment field'
 	},
 	init
 });

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -1,0 +1,43 @@
+import insertText from 'insert-text-textarea';
+import {DelegateEvent} from 'delegate-it';
+import features from '../libs/features';
+import {listenToCommentFields} from './comment-fields-keyboard-shortcuts';
+
+const formattingCharacters = ['`', '\'', '"', '[', '(', '{', '*', '_', '~'];
+const matchingCharacters = ['`', '\'', '"', ']', ')', '}', '*', '_', '~'];
+
+function handler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement>): void {
+	const field = event.delegateTarget;
+
+	if (!formattingCharacters.includes(event.key)) {
+		return;
+	}
+
+	const [start, end] = [field.selectionStart, field.selectionEnd];
+
+	// If `start` and `end` of selection are the same, then no text is selected
+	if (start === end) {
+		return;
+	}
+
+	event.preventDefault();
+
+	const formattingChar = event.key;
+	const selectedText = field.value.slice(start, end);
+	const matchingEndChar = matchingCharacters[formattingCharacters.indexOf(formattingChar)];
+	insertText(field, formattingChar + selectedText + matchingEndChar);
+
+	// Keep the selection as it is, to be able to chain shortcuts
+	field.setSelectionRange(start + 1, end + 1);
+}
+
+function init(): void {
+	listenToCommentFields(handler);
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Wraps selected text when pressing one of Markdown symbols instead of replacing it: (`[` `’` `"` `(` etc).',
+	screenshot: 'https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif',
+	init
+});

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -38,6 +38,6 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Wraps selected text when pressing one of Markdown symbols instead of replacing it: (`[` `’` `"` `(` etc).',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/59958878-39c51500-94cb-11e9-910a-061bf8ca6575.gif',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif',
 	init
 });

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -1,0 +1,23 @@
+import indentTextarea from 'indent-textarea';
+import {DelegateEvent} from 'delegate-it';
+import features from '../libs/features';
+import {listenToCommentFields} from './comment-fields-keyboard-shortcuts';
+
+function handler(event: DelegateEvent<KeyboardEvent, HTMLTextAreaElement>): void {
+	const field = event.delegateTarget;
+	if (event.key === 'Tab' && !event.shiftKey) {
+		indentTextarea(field);
+		event.preventDefault();
+	}
+}
+
+function init(): void {
+	listenToCommentFields(handler);
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Enables the <kbd>tab</kbd> key for indentation in comment fields.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif',
+	init
+});

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -5,7 +5,7 @@ import delegate from 'delegate-it';
 import features from '../libs/features';
 import fetchDom from '../libs/fetch-dom';
 import * as icons from '../libs/icons';
-import {blurAccessibly} from './comment-fields-keyboard-shortcuts';
+import blurAccessibly from '../libs/blur-field-accessibly';
 
 const btnBodyMap = new WeakMap<Element, Element | Promise<Element>>();
 

--- a/source/libs/blur-field-accessibly.ts
+++ b/source/libs/blur-field-accessibly.ts
@@ -1,0 +1,16 @@
+/**
+Element.blur() will reset the tab focus to the start of the document.
+This places it back next to the blurred field
+*/
+export default function blurAccessibly(field: HTMLElement): void {
+	field.blur();
+
+	const range = new Range();
+	const selection = getSelection()!;
+	const focusHolder = new Text();
+	field.after(focusHolder);
+	range.selectNodeContents(focusHolder);
+	selection.removeAllRanges();
+	selection.addRange(range);
+	focusHolder.remove();
+}


### PR DESCRIPTION
Closes #2414 
Fixes #2413 
Fixes #2148 

### `tab-to-indent`

1. Focus comment field
2. Press `tab`
3. A `tab` character should be entered

### `one-key-formatting`

1. Select word in comment field
2. Press `*` key
3. The word should appear as `*word*`

### `comment-fields-keyboard-shortcuts`: esc

1. Type `@` in comment field
2. Press `tab`
3. The username should be autocompleted without adding any further `tab`s


### `comment-fields-keyboard-shortcuts`: up

1. Visit a discussion where you already posted a comment
2. Focus comment field
3. Press `up` key
4. Your previous comment should now be in `Edit` mode
