### PR TITLE
Fix `safer-destructive-actions` on comments

### DIFF
--- a/source/features/safer-destructive-actions.css
+++ b/source/features/safer-destructive-actions.css
@@ -1,8 +1,8 @@
 /* Move "close issue" and "cancel" buttons on authoring comments to the left */
 
 /* ...in issue comment form */
-.form-actions .btn.js-comment-and-button {
-	float: left;
+#partial-new-comment-form-actions > .d-flex {
+	justify-content: space-between !important;
 }
 
 /* ...in comment edit form */

--- a/source/features/safer-destructive-actions.css
+++ b/source/features/safer-destructive-actions.css
@@ -1,6 +1,12 @@
 /* Move "close issue" and "cancel" buttons on authoring comments to the left */
 
 /* ...in issue comment form */
+/* the legacy way (kept for GitHub Enterprise) */
+.form-actions .btn.js-comment-and-button {
+	float: left;
+}
+
+/* the current github.com way */
 #partial-new-comment-form-actions > .d-flex {
 	justify-content: space-between !important;
 }


### PR DESCRIPTION
Re-implements the suggestion from #410 which recently broke since GitHub seems to have changed their markup/CSS a bit.

# Test
Test in any of your own issues, so I can't link any specific one here. 🙂
