### PR TITLE
Meta: Use `fregante/setup-git-token` action to enable `git push`

### DIFF
--- a/.github/workflows/no-banned-git-tags.yml
+++ b/.github/workflows/no-banned-git-tags.yml
@@ -8,11 +8,8 @@ jobs:
   delete:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v1
-    - name: Delete extra tag
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        git remote set-url origin "https://sindresorhus:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
-        git push --delete origin hotfix
+    - uses: actions/checkout@v1
+    - uses: fregante/setup-git-token@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - run: git push --delete origin hotfix


### PR DESCRIPTION
Minor change, I just extracted the git credentials setup to its own action so our workflow is shortened:

https://github.com/fregante/setup-git-token