### PR TITLE
Restore "Delete branch" button in responsive branch list

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -105,23 +105,3 @@
 .dropdown-menu-sw {
 	transform-origin: 90% top;
 }
-
-/* Restore "Delete branch" button in responsive branch list */
-@media (max-width: 1011px) {
-	.js-branch-row .Details-content--shown {
-		display: block !important;
-	}
-	form.js-branch-destroy {
-		display: block !important;
-	}
-}
-
-@media (max-width: 767px) {
-	.js-branch-row .col-12 {
-		width: auto;
-		flex-grow: 1;
-	}
-	:root .js-branch-row .col-12 .css-truncate-target {
-		white-space: initial;
-	}
-}

--- a/source/content.css
+++ b/source/content.css
@@ -111,10 +111,17 @@
 	.js-branch-row .Details-content--shown {
 		display: block !important;
 	}
-	.js-branch-row .col-12 {
-		width: 91.667%;
-	}
 	form.js-branch-destroy {
 		display: block !important;
+	}
+}
+
+@media (max-width: 767px) {
+	.js-branch-row .col-12 {
+		width: auto;
+		flex-grow: 1;
+	}
+	:root .js-branch-row .col-12 .css-truncate-target {
+		white-space: initial;
 	}
 }

--- a/source/content.css
+++ b/source/content.css
@@ -107,8 +107,11 @@
 }
 
 /* Restore "Delete branch" button in responsive branch list */
-@media (min-width: 768px) {
-	.js-branch-destroy.d-lg-inline-block {
-		display: inline-block !important;
+@media (max-width: 1011px) {
+	.js-branch-row .Details-content--shown {
+		display: flex !important;
+	}
+	form.js-branch-destroy {
+		display: block !important;
 	}
 }

--- a/source/content.css
+++ b/source/content.css
@@ -109,7 +109,10 @@
 /* Restore "Delete branch" button in responsive branch list */
 @media (max-width: 1011px) {
 	.js-branch-row .Details-content--shown {
-		display: flex !important;
+		display: block !important;
+	}
+	.js-branch-row .col-12 {
+		width: 91.667%;
 	}
 	form.js-branch-destroy {
 		display: block !important;

--- a/source/content.css
+++ b/source/content.css
@@ -105,3 +105,10 @@
 .dropdown-menu-sw {
 	transform-origin: 90% top;
 }
+
+/* Restore "Delete branch" button in responsive branch list */
+@media (min-width: 768px) {
+	.js-branch-destroy.d-lg-inline-block {
+		display: inline-block !important;
+	}
+}

--- a/source/content.ts
+++ b/source/content.ts
@@ -16,6 +16,7 @@ import './features/hide-obvious-tooltips.css';
 import './features/clean-discussions.css';
 import './features/sticky-discussion-list-toolbar.css';
 import './features/deemphasize-unrelated-commit-references.css';
+import './features/always-show-branch-delete-buttons.css';
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.
 

--- a/source/features/always-show-branch-delete-buttons.css
+++ b/source/features/always-show-branch-delete-buttons.css
@@ -1,0 +1,16 @@
+/* Restore "Delete branch" button in responsive branch list */
+@media (max-width: 1011px) {
+	.js-branch-row .Details-content--shown, form.js-branch-destroy {
+		display: block !important;
+	}
+}
+
+@media (max-width: 767px) {
+	.js-branch-row .col-12 {
+		width: auto;
+		flex-grow: 1;
+	}
+	:root .js-branch-row .col-12 .css-truncate-target {
+		white-space: initial;
+	}
+}

--- a/source/features/always-show-branch-delete-buttons.css
+++ b/source/features/always-show-branch-delete-buttons.css
@@ -1,6 +1,7 @@
 /* Restore "Delete branch" button in responsive branch list */
 @media (max-width: 1011px) {
-	.js-branch-row .Details-content--shown, form.js-branch-destroy {
+	.js-branch-row .Details-content--shown,
+	form.js-branch-destroy {
 		display: block !important;
 	}
 }

--- a/source/features/always-show-branch-delete-buttons.css
+++ b/source/features/always-show-branch-delete-buttons.css
@@ -11,6 +11,7 @@
 		width: auto;
 		flex-grow: 1;
 	}
+
 	:root .js-branch-row .col-12 .css-truncate-target {
 		white-space: initial;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2452 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

(Assuming we don't want to show the delete branch button after it hits the 768px width, if we do, I'll change it accordingly)