### PR TITLE
Hide the correct editor buttons on the New Issue page

### DIFF
--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -1,7 +1,7 @@
 /* Hide unnecessary comment toolbar items */
 .rgh-clean-rich-text-editor md-mention,
 .rgh-clean-rich-text-editor md-ref,
-.rgh-clean-rich-text-editor #new_issue markdown-toolbar > :nth-last-child(5),
-.rgh-clean-rich-text-editor :not(#new_issue) markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
+.rgh-clean-rich-text-editor form#new_issue markdown-toolbar > :nth-last-child(5),
+.rgh-clean-rich-text-editor form:not(#new_issue) markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
 	display: none !important; /* Has to override `.d-inline-block` */
 }

--- a/source/features/clean-rich-text-editor.css
+++ b/source/features/clean-rich-text-editor.css
@@ -1,6 +1,7 @@
 /* Hide unnecessary comment toolbar items */
 .rgh-clean-rich-text-editor md-mention,
 .rgh-clean-rich-text-editor md-ref,
-.rgh-clean-rich-text-editor markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
+.rgh-clean-rich-text-editor #new_issue markdown-toolbar > :nth-last-child(5),
+.rgh-clean-rich-text-editor :not(#new_issue) markdown-toolbar > :nth-last-child(4) { /* H1, B, I */
 	display: none !important; /* Has to override `.d-inline-block` */
 }


### PR DESCRIPTION
The markup is slightly different between the new issue toolbar and the comments toolbar (some divs are hidden), which was making the selector fail on the new issue page.

<!-- Thanks for contributing! 🍄 -->

Closes #2428 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Go to https://github.com/sindresorhus/refined-github/issues/2428 and scroll down. In the toolbar of the editor, the first block of buttons (Header / Bold / Italic) should be hidden.
- Go to https://github.com/sindresorhus/refined-github/issues/new?labels=bug&template=bug_report.md . In the toolbar of the editor, the first block of buttons (Header / Bold / Italic) should be hidden.