### PR TITLE
Fix `highlight-closing-prs-in-open-issues` feature

### DIFF
--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -10,10 +10,10 @@ function add(): void {
 		[aria-label*="will close when"],
 		[aria-label*="will close once"]
 	`)) {
-		const isPR = !infoBubble.getAttribute('aria-label')!.includes('commit');
+		const isCommit = !infoBubble.getAttribute('aria-label')!.includes('commit');
 		let ref;
 		let link;
-		if (isPR) {
+		if (isCommit) {
 			ref = infoBubble
 				.closest('.TimelineItem-body')!
 				.querySelector('a span')!;
@@ -29,8 +29,8 @@ function add(): void {
 					href={link}
 					className="btn btn-outline btn-sm border-blue rgh-closing-pr tooltipped tooltipped-se"
 					aria-label={infoBubble.getAttribute('aria-label')!}>
-					{isPR ? icons.openPullRequest() : icons.commit()}
-					{isPR ? ' ' + ref.textContent! : ''}
+					{isCommit ? icons.openPullRequest() : icons.commit()}
+					{isCommit ? ' ' + ref.textContent! : ''}
 				</a>
 			</div>
 		);

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -17,10 +17,10 @@ function add(): void {
 			ref = infoBubble
 				.closest('.TimelineItem-body')!
 				.querySelector('a span')!;
-			link = ref.closest('a')!.getAttribute('href')!;
+			link = ref.closest('a')!.getAttribute('.href')!;
 		} else {
 			ref = select('.commit-message .issue-keyword a')!;
-			link = ref.getAttribute('href')!;
+			link = ref.getAttribute('.href')!;
 		}
 
 		select('.gh-header-meta .TableObject-item')!.after(

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -12,15 +12,16 @@ function add(): void {
 	`)) {
 		const isPR = !infoBubble.getAttribute('aria-label')!.includes("commit");
 		let ref = null;
+		let link = null;
 		if (isPR) {
 			ref = infoBubble
 				.closest('.TimelineItem-body')!
 				.querySelector("a span")!;
+			link = ref.closest("a")!.getAttribute("href")!;
 		} else {
 			ref = select(".commit-message .issue-keyword a")!;
+			link = ref.getAttribute("href")!;
 		}
-
-		const link = ref.getAttribute("href")!;
 		select('.gh-header-meta .TableObject-item')!.after(
 			<div className="TableObject-item">
 				<a

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -10,20 +10,23 @@ function add(): void {
 		[aria-label*="will close when"],
 		[aria-label*="will close once"]
 	`)) {
-		const ref = infoBubble
-			.closest('.discussion-item')!
-			.querySelector('.issue-num, .commit-id')!;
-		const link = ref.closest('a')!.href;
-		const isIssue = ref.classList.contains('issue-num');
+		const isPR = !infoBubble.getAttribute('aria-label')!.includes("commit");
+		let ref = null;
+		if (isPR) {
+			ref = select(".TableObject-item--primary span a")!;
+		} else {
+			ref = select(".commit-message .issue-keyword a")!;
+		}
 
+		const link = ref.getAttribute("href")!;
 		select('.gh-header-meta .TableObject-item')!.after(
 			<div className="TableObject-item">
 				<a
 					href={link}
 					className="btn btn-outline btn-sm border-blue rgh-closing-pr tooltipped tooltipped-se"
 					aria-label={infoBubble.getAttribute('aria-label')!}>
-					{isIssue ? icons.openPullRequest() : icons.commit()}
-					{isIssue ? ' ' + ref.textContent! : ''}
+					{isPR ? icons.openPullRequest() : icons.commit()}
+					{isPR ? ' ' + ref.textContent! : ''}
 				</a>
 			</div>
 		);

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -17,10 +17,10 @@ function add(): void {
 			ref = infoBubble
 				.closest('.TimelineItem-body')!
 				.querySelector('a span')!;
-			link = ref.closest('a')!.getAttribute('.href')!;
+			link = ref.closest('a')!.href;
 		} else {
-			ref = select('.commit-message .issue-keyword a')!;
-			link = ref.getAttribute('.href')!;
+			ref = select('.commit-message .issue-keyword a')! as HTMLAnchorElement;
+			link = ref.href;
 		}
 
 		select('.gh-header-meta .TableObject-item')!.after(

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -13,7 +13,9 @@ function add(): void {
 		const isPR = !infoBubble.getAttribute('aria-label')!.includes("commit");
 		let ref = null;
 		if (isPR) {
-			ref = select(".TableObject-item--primary span a")!;
+			ref = infoBubble
+				.closest('.TimelineItem-body')!
+				.querySelector("a span")!;
 		} else {
 			ref = select(".commit-message .issue-keyword a")!;
 		}

--- a/source/features/highlight-closing-prs-in-open-issues.tsx
+++ b/source/features/highlight-closing-prs-in-open-issues.tsx
@@ -10,18 +10,19 @@ function add(): void {
 		[aria-label*="will close when"],
 		[aria-label*="will close once"]
 	`)) {
-		const isPR = !infoBubble.getAttribute('aria-label')!.includes("commit");
-		let ref = null;
-		let link = null;
+		const isPR = !infoBubble.getAttribute('aria-label')!.includes('commit');
+		let ref;
+		let link;
 		if (isPR) {
 			ref = infoBubble
 				.closest('.TimelineItem-body')!
-				.querySelector("a span")!;
-			link = ref.closest("a")!.getAttribute("href")!;
+				.querySelector('a span')!;
+			link = ref.closest('a')!.getAttribute('href')!;
 		} else {
-			ref = select(".commit-message .issue-keyword a")!;
-			link = ref.getAttribute("href")!;
+			ref = select('.commit-message .issue-keyword a')!;
+			link = ref.getAttribute('href')!;
 		}
+
 		select('.gh-header-meta .TableObject-item')!.after(
 			<div className="TableObject-item">
 				<a


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2455. The feature was not working because the GitHub HTML has been updated.

<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
To see the PR/commit button beside the issue's status:

- Commit that closes issue:
https://github.com/chelseyong/EPP_Git_Solo_Demo/issues/1

- Pull request that closes issue:
https://github.com/sindresorhus/refined-github/issues/2455

- 2 pull requests that closes issue (no effect):
https://github.com/chelseyong/EPP_Git_Solo_Demo/issues/6

- Pull request that closes another pull request:
https://github.com/chelseyong/EPP_Git_Solo_Demo/pull/2