### PR TITLE
Fix `comments-time-machine-links` feature for pending review comments

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -57,7 +57,7 @@ function init(): void {
 	// PR reviews' main content has nested `.timeline-comment`, but the deepest one doesn't have `relative-time`. These are filtered out with `:not([id^="pullrequestreview"])`
 	const comments = select.all(`
 		:not(.js-new-comment-form):not([id^="pullrequestreview"]) > .timeline-comment:not(.rgh-time-machine-links),
-		.review-comment:not(.rgh-time-machine-links)
+		.review-comment:not(.rgh-time-machine-links) > .previewable-edit:not(.is-pending)
 	`);
 
 	for (const comment of comments) {

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -61,15 +61,11 @@ function init(): void {
 	`);
 
 	for (const comment of comments) {
-		const timestampEl = select('relative-time', comment)!;
+		const timestamp = select('relative-time', comment)!.attributes.datetime.value;
 
-		if (timestampEl) {
-			const timestamp = timestampEl.attributes.datetime.value;
-
-			addDropdownLink(comment, timestamp);
-			addInlineLinks(comment, timestamp);
-			comment.classList.add('rgh-time-machine-links');
-		}
+		addDropdownLink(comment, timestamp);
+		addInlineLinks(comment, timestamp);
+		comment.classList.add('rgh-time-machine-links');
 	}
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -61,11 +61,15 @@ function init(): void {
 	`);
 
 	for (const comment of comments) {
-		const timestamp = select('relative-time', comment)!.attributes.datetime.value;
+		const timestampEl = select('relative-time', comment)!;
 
-		addDropdownLink(comment, timestamp);
-		addInlineLinks(comment, timestamp);
-		comment.classList.add('rgh-time-machine-links');
+		if (timestampEl) {
+			const timestamp = timestampEl.attributes.datetime.value;
+
+			addDropdownLink(comment, timestamp);
+			addInlineLinks(comment, timestamp);
+			comment.classList.add('rgh-time-machine-links');
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2187 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Start a review on a PR by adding a comment (--> it's now "pending")
- Reload the `Files changed` page of the PR
- On the comment that was just added, open the dropdown menu (... button)
--> It shouldn't be broken anymore (unlike in that screenshot, below)

![image](https://user-images.githubusercontent.com/1215056/66160904-6a206180-e62b-11e9-8e84-8a6fde0d20a0.png)

- Go to the `Conversation` tab of the PR and see the pending comment here as well.
- Again, open the dropdown menu (... button)
--> It shouldn't be broken anymore (unlike in that screenshot, above)

Note: I'm not 100% sure where the `View repo at this time` link is meant to be (or if there's some extra condition to see it) as I couldn't see it myself but I could see the error in my console and my fix seems to be solving that... So, please feel free to edit the test scenario with something a bit more accurate if needs be.