### PR TITLE
Update personal token link based off domain selected

### DIFF
--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -56,12 +56,12 @@ export default getOptions(location.protocol.startsWith('http') ? location.host :
 
 export async function getAllOptions(): Promise<Map<string, OptionsSync<RGHOptions>>> {
 	const optionsByDomain = new Map<string, OptionsSync<RGHOptions>>();
-	optionsByDomain.set('github.com', getOptions('github.com'));
+	optionsByDomain.set('https://github.com', getOptions('github.com'));
 
 	const {origins} = await getAdditionalPermissions();
 	for (const origin of origins) {
-		const {host} = new URL(origin);
-		optionsByDomain.set(host, getOptions(host));
+		const {protocol, host} = new URL(origin);
+		optionsByDomain.set(`${protocol}//${host}`, getOptions(host));
 	}
 
 	return optionsByDomain;

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -56,12 +56,12 @@ export default getOptions(location.protocol.startsWith('http') ? location.host :
 
 export async function getAllOptions(): Promise<Map<string, OptionsSync<RGHOptions>>> {
 	const optionsByDomain = new Map<string, OptionsSync<RGHOptions>>();
-	optionsByDomain.set('https://github.com', getOptions('github.com'));
+	optionsByDomain.set('github.com', getOptions('github.com'));
 
 	const {origins} = await getAdditionalPermissions();
 	for (const origin of origins) {
-		const {protocol, host} = new URL(origin);
-		optionsByDomain.set(`${protocol}//${host}`, getOptions(host));
+		const {host} = new URL(origin);
+		optionsByDomain.set(host, getOptions(host));
 	}
 
 	return optionsByDomain;

--- a/source/options.html
+++ b/source/options.html
@@ -6,7 +6,7 @@
 <form id="options-form" class="detail-view-container">
 	<p>
 		<label>
-			<strong>Personal token</strong>, <a href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (<a href="https://github.com/sindresorhus/refined-github/search?q=libs/api" target="_blank">some features</a> use the API)<br>
+			<strong>Personal token</strong>, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">found here</a> (<a href="https://github.com/sindresorhus/refined-github/search?q=libs/api" target="_blank">some features</a> use the API)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" maxlength="40" pattern="[\da-f]{40}" placeholder=" "></input>
 		</label>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<void> {
 
 	const form = select('form')!;
 	const optionsByDomain = await getAllOptions();
-	await optionsByDomain.get('github.com')!.syncForm(form);
+	await optionsByDomain.get('https://github.com')!.syncForm(form);
 
 	fitTextarea.watch('textarea');
 	indentTextarea.watch('textarea');
@@ -66,7 +66,7 @@ async function init(): Promise<void> {
 			</select>
 		) as unknown as HTMLSelectElement;
 		form.before(<p>Domain selector: {dropdown}</p>, <hr/>);
-		dropdown.addEventListener('change', () => {
+		dropdown.addEventListener('change', (event) => {
 			for (const [domain, options] of optionsByDomain) {
 				if (dropdown.value === domain) {
 					options.syncForm(form);
@@ -74,6 +74,8 @@ async function init(): Promise<void> {
 					options.stopSyncForm();
 				}
 			}
+			const newDomain = (event.target as HTMLInputElement).value;
+			select('#personal-token-link')!.setAttribute('href', `${newDomain}/settings/tokens/new?description=Refined%20GitHub&scopes=repo`);
 		});
 	}
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -66,7 +66,7 @@ async function init(): Promise<void> {
 			</select>
 		) as unknown as HTMLSelectElement;
 		form.before(<p>Domain selector: {dropdown}</p>, <hr/>);
-		dropdown.addEventListener('change', (event) => {
+		dropdown.addEventListener('change', event => {
 			for (const [domain, options] of optionsByDomain) {
 				if (dropdown.value === domain) {
 					options.syncForm(form);
@@ -74,6 +74,7 @@ async function init(): Promise<void> {
 					options.stopSyncForm();
 				}
 			}
+
 			const newHost = (event.target as HTMLInputElement).value;
 			(select('#personal-token-link') as HTMLAnchorElement)!.host = newHost;
 		});

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<void> {
 
 	const form = select('form')!;
 	const optionsByDomain = await getAllOptions();
-	await optionsByDomain.get('https://github.com')!.syncForm(form);
+	await optionsByDomain.get('github.com')!.syncForm(form);
 
 	fitTextarea.watch('textarea');
 	indentTextarea.watch('textarea');
@@ -74,8 +74,8 @@ async function init(): Promise<void> {
 					options.stopSyncForm();
 				}
 			}
-			const newDomain = (event.target as HTMLInputElement).value;
-			select('#personal-token-link')!.setAttribute('href', `${newDomain}/settings/tokens/new?description=Refined%20GitHub&scopes=repo`);
+			const newHost = (event.target as HTMLInputElement).value;
+			(select('#personal-token-link') as HTMLAnchorElement)!.host = newHost;
 		});
 	}
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -76,7 +76,7 @@ async function init(): Promise<void> {
 			}
 
 			const newHost = (event.target as HTMLInputElement).value;
-			(select('#personal-token-link') as HTMLAnchorElement)!.host = newHost;
+			select<HTMLAnchorElement>('#personal-token-link')!.host = newHost;
 		});
 	}
 


### PR DESCRIPTION
This updates the `personal token` link in the settings to use the domain from the dropdown to construct the link. When there is no link, it defaults to GitHub. We now show the protocol in the domain dropdown, otherwise I had to infer it for the link.

![image](https://user-images.githubusercontent.com/857700/66258414-9262aa00-e76a-11e9-92c2-54a640c0dfee.png)


Closes #2408
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
I tested it on GH, a random site I gave permission to, and then a GHE instance (2.17) to confirm the settings URL was the same as GH, it is.