### PR TITLE
clean-sidebar: update selectors for GH

### DIFF
--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -58,10 +58,10 @@ function clean(): void {
 	}
 
 	// Projects
-	cleanSection('.sidebar-projects');
+	cleanSection('.sidebar-projects, .sidebar-progress-bar');
 
 	// Milestones
-	const milestones = select('.sidebar-milestone')!;
+	const milestones = select('.sidebar-milestone, .sidebar-progress-bar')!;
 	const milestonesInfo = milestones.lastChild!.lastChild!;
 	if (milestonesInfo.textContent!.trim() === 'No milestone') {
 		if (canEditSidebar) {


### PR DESCRIPTION
GH updated the selectors on the sidebar for Projects/Milestones sections. I left the old selectors to keep GHE working.

Closes #2474


# Test
See URLs in the original issue. Also tested against GHE 2.17.
<!-- List some URLs that reviewers can use to test your PR -->
