### PR TITLE
sticky-discussion-sidebar: fixes

### DIFF
--- a/source/features/sticky-discussion-sidebar.tsx
+++ b/source/features/sticky-discussion-sidebar.tsx
@@ -2,9 +2,12 @@ import './sticky-discussion-sidebar.css';
 import select from 'select-dom';
 import debounce from 'debounce-fn';
 import features from '../libs/features';
+import onUpdatableContentUpdate from "../libs/on-updatable-content-update";
+
+const sideBarSelector = '#partial-discussion-sidebar, .discussion-sidebar';
 
 function updateStickiness(): void {
-	const sidebar = select('#partial-discussion-sidebar, .discussion-sidebar')!;
+	const sidebar = select(sideBarSelector)!;
 	const sidebarHeight = sidebar.offsetHeight + 60; // 60 matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebarHeight < window.innerHeight);
 }
@@ -14,6 +17,7 @@ const handler = debounce(updateStickiness, {wait: 100});
 function init(): void {
 	updateStickiness();
 	window.addEventListener('resize', handler);
+	onUpdatableContentUpdate(select(sideBarSelector)!, updateStickiness)
 }
 
 function deinit(): void {

--- a/source/features/sticky-discussion-sidebar.tsx
+++ b/source/features/sticky-discussion-sidebar.tsx
@@ -4,7 +4,7 @@ import debounce from 'debounce-fn';
 import features from '../libs/features';
 
 function updateStickiness(): void {
-	const sidebar = select('#partial-discussion-sidebar')!;
+	const sidebar = select('#partial-discussion-sidebar, .discussion-sidebar')!;
 	const sidebarHeight = sidebar.offsetHeight + 60; // 60 matches sticky header's height
 	sidebar.classList.toggle('rgh-sticky-sidebar', sidebarHeight < window.innerHeight);
 }

--- a/source/features/sticky-discussion-sidebar.tsx
+++ b/source/features/sticky-discussion-sidebar.tsx
@@ -2,7 +2,7 @@ import './sticky-discussion-sidebar.css';
 import select from 'select-dom';
 import debounce from 'debounce-fn';
 import features from '../libs/features';
-import onUpdatableContentUpdate from "../libs/on-updatable-content-update";
+import onUpdatableContentUpdate from '../libs/on-updatable-content-update';
 
 const sideBarSelector = '#partial-discussion-sidebar, .discussion-sidebar';
 
@@ -17,7 +17,7 @@ const handler = debounce(updateStickiness, {wait: 100});
 function init(): void {
 	updateStickiness();
 	window.addEventListener('resize', handler);
-	onUpdatableContentUpdate(select(sideBarSelector)!, updateStickiness)
+	onUpdatableContentUpdate(select(sideBarSelector)!, updateStickiness);
 }
 
 function deinit(): void {

--- a/source/libs/on-updatable-content-update.ts
+++ b/source/libs/on-updatable-content-update.ts
@@ -9,6 +9,10 @@ Limitations:
  * @param callback The function to call after it's replaced
 */
 export default function onUpdatableContentUpdate(updatable: HTMLElement, callback: VoidFunction): void {
+	if (!updatable.classList.contains('js-updatable-content')) {
+		throw new Error('Element is missing js-updateable-content class');
+	}
+
 	new MutationObserver(mutations => {
 		if (updatable.isConnected) {
 			return;


### PR DESCRIPTION
This adds the old selector fix the GHE issue.
It also adds onUpdatableContentUpdate to keep the sidebar sticky after a comment, etc. is posted on the page.

Closes #2409.
Closes #2463.
