### PR TITLE
Add `link-to-prior-blame-line` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -296,6 +296,7 @@ Thanks for contributing! 🦋🙌
 - [](# "recently-pushed-branches-enhancements") 🔥 [Moves the "Recently-pushed branches" widget to the header to avoid content jumps. Also adds it to more pages in the repo.](https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif)
 - [](# "deemphasize-unrelated-commit-references") [Makes it easier to tell apart commits added to the current PR versus plain commits that reference the PR.](https://user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif)
 - [](# "embed-gist-via-iframe") [Adds a menu item to embed a gist via `<iframe>`.](https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png)
+- [](# "link-to-prior-blame-line") [Preserves the current line on “View blame prior to this change” links.](https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -143,6 +143,7 @@ import './features/clean-rich-text-editor';
 import './features/highlight-collaborators-and-own-discussions';
 import './features/embed-gist-via-iframe';
 import './features/expand-all-collapsed-code';
+import './features/link-to-prior-blame-line';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -1,0 +1,20 @@
+import select from 'select-dom';
+import features from '../libs/features';
+
+function init(): void {
+	for (const link of select.all<HTMLAnchorElement>('.reblame-link')) {
+		const lineNumber = link.closest('.blame-hunk')!.querySelector('.js-line-number[id]')!.id;
+		link.hash = `#${lineNumber}`;
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Adds the current line to links when visiting a prior change on the blame page.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png',
+	include: [
+		features.isBlame
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -10,7 +10,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Adds the current line to links when visiting a prior change on the blame page.',
+	description: 'Preserves the current line on “View blame prior to this change” links.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png',
 	include: [
 		features.isBlame


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2175
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Go to a blame page (i.e. https://github.com/sindresorhus/refined-github/blame/master/readme.md)
- Click on:
![image](https://user-images.githubusercontent.com/1215056/66275802-8e2ead80-e88c-11e9-8987-e113dce45515.png)
- You're on the line number you clicked on, not at the beginning of the document