### PR TITLE
Fix showing Refined GitHub's keyboard shortcuts

### DIFF
--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -47,7 +47,7 @@ const observer = new MutationObserver(([{target}]) => {
 function init(): void {
 	document.addEventListener('keypress', ({key}) => {
 		if (key === '?') {
-			observer.observe(select('.kb-shortcut-dialog')!, {childList: true});
+			observer.observe(select('body > details > details-dialog')!, {childList: true});
 		}
 	});
 }


### PR DESCRIPTION
Noticed that the shortcuts added by RG weren't shown anymore due to:
```
Uncaught TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
```

It seems the selector for the shortcut dialog changed, so I changed it. 
Sadly the new classes *(or other attributes)* are really generic so I made the selector very specific.