### PR TITLE
Fix issue links in options

### DIFF
--- a/source/libs/dom-formatters.ts
+++ b/source/libs/dom-formatters.ts
@@ -13,15 +13,17 @@ export const linkifiedURLClass = 'rgh-linkified-code';
 // https://github.com/sindresorhus/refined-github/issues/1305
 const currentRepo = getOwnerAndRepo();
 
-export function linkifyIssues(element: Element): void {
+export function linkifyIssues(element: Element, options: Partial<linkifyIssuesCore.TypeDomOptions> = {}): void {
 	const linkified = linkifyIssuesCore(element.textContent!, {
 		user: currentRepo.ownerName || '/',
 		repository: currentRepo.repoName || '/',
 		type: 'dom',
 		baseUrl: '',
+		...options,
 		attributes: {
 			rel: 'noreferrer noopener',
-			class: linkifiedURLClass // Necessary to avoid also shortening the links
+			class: linkifiedURLClass, // Necessary to avoid also shortening the links
+			...options.attributes
 		}
 	});
 	if (linkified.children.length === 0) { // Children are <a>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -9,7 +9,11 @@ import * as domFormatters from './libs/dom-formatters';
 
 function parseDescription(description: string): DocumentFragment {
 	const descriptionElement = <span>{description}</span>;
-	domFormatters.linkifyIssues(descriptionElement);
+	domFormatters.linkifyIssues(descriptionElement, {
+		baseUrl: 'https://github.com',
+		user: 'sindresorhus',
+		repository: 'refined-github'
+	});
 	domFormatters.linkifyURLs(descriptionElement);
 	domFormatters.parseBackticks(descriptionElement);
 


### PR DESCRIPTION
Fixes #2460

I decided that the easiest way to fix this was by allowing overwriting the options for `linkify-issues`.