### PR TITLE
Add explanatory tooltips to `global-discussion-list-filters`

### DIFF
--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -8,17 +8,19 @@ function init(): void {
 	const defaultQuery = 'is:open archived:false ';
 
 	// Without this, the Issues page also displays PRs, and viceversa
-	const type = location.pathname.split('/', 2)[1] === 'issues' ? 'is:issue ' : 'is:pr ';
+	const type = location.pathname.split('/', 2)[1];
+	const typeQuery = type === 'issues' ? 'is:issue ' : 'is:pr ';
+	const typeText = type === 'issues' ? 'Issues' : 'Pull Requests';
 
 	const links = [
-		['Commented', `commenter:${getUsername()}`],
-		['Yours', `user:${getUsername()}`]
+		['Commented', `${typeText} you've commented on`, `commenter:${getUsername()}`],
+		['Yours', `${typeText} that are owned by you`, `user:${getUsername()}`]
 	];
 
-	for (const [label, query] of links) {
+	for (const [label, title, query] of links) {
 		// Create link
-		const url = new URLSearchParams([['q', type + defaultQuery + query]]);
-		const link = <a href={`${location.pathname}?${url}`} className="subnav-item">{label}</a>;
+		const url = new URLSearchParams([['q', typeQuery + defaultQuery + query]]);
+		const link = <a href={`${location.pathname}?${url}`} title={title} aria-label={title} className="subnav-item">{label}</a>;
 
 		const isCurrentPage = new RegExp(`(^|\\s)${query}(\\s|$)`).test(
 			new URLSearchParams(location.search).get('q')!

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -5,22 +5,23 @@ import features from '../libs/features';
 import {getUsername} from '../libs/utils';
 
 function init(): void {
-	const defaultQuery = 'is:open archived:false ';
+	const defaultQuery = 'is:open archived:false';
 
 	// Without this, the Issues page also displays PRs, and viceversa
-	const type = location.pathname.split('/', 2)[1];
-	const typeQuery = type === 'issues' ? 'is:issue ' : 'is:pr ';
-	const typeText = type === 'issues' ? 'Issues' : 'Pull Requests';
+	const isIssues = location.pathname.startsWith('/issues');
+	const typeQuery = isIssues ? 'is:issue' : 'is:pr';
+	const typeName = isIssues ? 'Issues' : 'Pull Requests';
 
 	const links = [
-		['Commented', `${typeText} you've commented on`, `commenter:${getUsername()}`],
-		['Yours', `${typeText} that are owned by you`, `user:${getUsername()}`]
+		['Commented', `${typeName} you’ve commented on`, `commenter:${getUsername()}`],
+		['Yours', `${typeName} that are owned by you`, `user:${getUsername()}`]
 	];
 
 	for (const [label, title, query] of links) {
 		// Create link
-		const url = new URLSearchParams([['q', typeQuery + defaultQuery + query]]);
-		const link = <a href={`${location.pathname}?${url}`} title={title} aria-label={title} className="subnav-item">{label}</a>;
+		const url = new URL(location.pathname, location.origin);
+		url.searchParams.set('q', `${typeQuery} ${defaultQuery} ${query}`);
+		const link = <a href={url} title={title} className="subnav-item">{label}</a>;
 
 		const isCurrentPage = new RegExp(`(^|\\s)${query}(\\s|$)`).test(
 			new URLSearchParams(location.search).get('q')!

--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -14,14 +14,14 @@ function init(): void {
 
 	const links = [
 		['Commented', `${typeName} you’ve commented on`, `commenter:${getUsername()}`],
-		['Yours', `${typeName} that are owned by you`, `user:${getUsername()}`]
+		['Yours', `${typeName} on your repos`, `user:${getUsername()}`]
 	];
 
 	for (const [label, title, query] of links) {
 		// Create link
 		const url = new URL(location.pathname, location.origin);
 		url.searchParams.set('q', `${typeQuery} ${defaultQuery} ${query}`);
-		const link = <a href={url} title={title} className="subnav-item">{label}</a>;
+		const link = <a href={String(url)} title={title} className="subnav-item">{label}</a>;
 
 		const isCurrentPage = new RegExp(`(^|\\s)${query}(\\s|$)`).test(
 			new URLSearchParams(location.search).get('q')!


### PR DESCRIPTION
This change adds some accessibility to the filter links using the aria-label attribute for the filter link.

Adding the title attribute will show more of an explanation if you mouse hover over (which GitHub has for some of the other filter links).

![01-09-skqpo-4rpi4](https://user-images.githubusercontent.com/574871/68065255-0dcd6200-fcfd-11e9-802a-b739b148ebcc.gif)

# Test

This change adds the extra attributes on the added 'Commented' and 'Yours' filters in the following pages: 

- https://github.com/pulls
- https://github.com/issues
