### PR TITLE
Tests all URLs in `page-detect` against each other

### DIFF
--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -203,7 +203,12 @@ export const isQuickPRTest = [
 	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1'
 ];
 
-export const isReleasesOrTags = [
+export const isReleasesOrTags = (): boolean => {
+	const parts = (getRepoPath() || '').split('/');
+	return /^(releases|tags)$/.test(parts[0]) && parts[1] !== 'new';
+};
+
+export const isReleasesOrTagsTest = [
 	'https://github.com/sindresorhus/refined-github/releases',
 	'https://github.com/sindresorhus/refined-github/tags',
 	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -5,74 +5,216 @@ import select from 'select-dom';
 import reservedNames from 'github-reserved-names/reserved-names.json';
 import {getUsername, getCleanPathname, getRepoPath, getOwnerAndRepo} from './utils';
 
+const skip = 'skip'; // To be used only to skip tests of combined functions, i.e. isPageA() || isPageB()
+const domBased = 'skip'; // To be used only to skip tests that are DOM-based rather than URL-based
+
 export const is404 = (): boolean => document.title === 'Page not found · GitHub';
+export const is404Test = domBased; // They're specified in page-detect.ts
 
 export const is500 = (): boolean => document.title === 'Server Error · GitHub' || document.title === 'Unicorn! · GitHub';
+export const is500Test = domBased; // They're specified in page-detect.ts
 
 export const isBlame = (): boolean => /^blame\//.test(getRepoPath()!);
+export const isBlameTest = [
+	'https://github.com/sindresorhus/refined-github/blame/master/package.json'
+];
 
 export const isCommit = (): boolean => isSingleCommit() || isPRCommit();
+export const isCommitTest = [
+	'https://github.com/sindresorhus/refined-github/commit/5b614b9035f2035b839f48b4db7bd5c3298d526f',
+	'https://github.com/sindresorhus/refined-github/commit/5b614',
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85',
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196'
+];
 
 export const isCommitList = (): boolean => /^commits\//.test(getRepoPath()!);
+export const isCommitListTest = [
+	'https://github.com/sindresorhus/refined-github/commits/master?page=2',
+	'https://github.com/sindresorhus/refined-github/commits/test-branch',
+	'https://github.com/sindresorhus/refined-github/commits/0.13.0',
+	'https://github.com/sindresorhus/refined-github/commits/230c2',
+	'https://github.com/sindresorhus/refined-github/commits/230c2935fc5aea9a681174ddbeba6255ca040d63'
+];
 
 export const isCompare = (): boolean => /^compare/.test(getRepoPath()!);
+export const isCompareTest = [
+	'https://github.com/sindresorhus/refined-github/compare',
+	'https://github.com/sindresorhus/refined-github/compare/',
+	'https://github.com/sindresorhus/refined-github/compare/master...branch-name',
+	'https://github.com/sindresorhus/refined-github/compare/master...branch-name?quick_pull=1',
+	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?quick_pull=1',
+	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1'
+];
 
 export const isDashboard = (): boolean => !isGist() && /^$|^(orgs[/][^/]+[/])?dashboard([/]|$)/.test(getCleanPathname());
+export const isDashboardTest = [
+	'https://github.com/',
+	'https://github.com',
+	'https://github.com/orgs/test/dashboard',
+	'https://github.com/dashboard/index/2',
+	'https://github.com/dashboard',
+	'https://github.com/orgs/edit/dashboard',
+	'https://github.big-corp.com/',
+	'https://not-github.com/',
+	'https://my-little-hub.com/'
+];
 
 export const isEnterprise = (): boolean => location.hostname !== 'github.com' && location.hostname !== 'gist.github.com';
+export const isEnterpriseTest = [
+	'https://github.big-corp.com/',
+	'https://not-github.com/',
+	'https://my-little-hub.com/',
+	'https://my-little-hub.com/gist'
+];
 
-export const isGist = (): boolean => location.hostname.startsWith('gist.') || location.pathname.startsWith('gist/');
+export const isGist = (): boolean => location.hostname.startsWith('gist.') || location.pathname.split('/', 2)[1] === 'gist';
+export const isGistTest = [
+	'https://gist.github.com',
+	'http://gist.github.com',
+	'https://gist.github.com/sindresorhus/0ea3c2845718a0a0f0beb579ff14f064',
+	'https://my-little-hub.com/gist'
+];
 
 export const isGlobalDiscussionList = (): boolean => ['issues', 'pulls'].includes(location.pathname.split('/', 2)[1]);
+export const isGlobalDiscussionListTest = [
+	'https://github.com/issues',
+	'https://github.com/issues?q=is%3Apr+is%3Aopen',
+	'https://github.com/issues/assigned',
+	'https://github.com/issues/mentioned',
+	'https://github.com/pulls',
+	'https://github.com/pulls?q=issues',
+	'https://github.com/pulls/assigned',
+	'https://github.com/pulls/mentioned',
+	'https://github.com/pulls/review-requested'
+];
 
 export const isGlobalSearchResults = (): boolean => location.pathname === '/search' && new URLSearchParams(location.search).get('q') !== null;
+export const isGlobalSearchResultsTest = [
+	'https://github.com/search?q=refined-github&ref=opensearch'
+];
 
 export const isIssue = (): boolean => /^issues\/\d+/.test(getRepoPath()!);
+export const isIssueTest = [
+	'https://github.com/sindresorhus/refined-github/issues/146'
+];
 
 export const isDiscussionList = (): boolean => isGlobalDiscussionList() || isRepoDiscussionList();
+export const isDiscussionListTest = skip;
 
-export const isLabel = (): boolean => /^labels\/\w+/.test(getRepoPath()!);
-
-export const isLabelList = (): boolean => /^labels\/?(((?=\?).*)|$)/.test(getRepoPath()!);
+export const isLabelList = (): boolean => getRepoPath() === 'labels';
+export const isLabelListTest = [
+	'https://github.com/sindresorhus/refined-github/labels'
+];
 
 export const isMilestone = (): boolean => /^milestone\/\d+/.test(getRepoPath()!);
+export const isMilestoneTest = [
+	'https://github.com/sindresorhus/refined-github/milestone/12'
+];
 
 export const isMilestoneList = (): boolean => getRepoPath() === 'milestones';
+export const isMilestoneListTest = [
+	'https://github.com/sindresorhus/refined-github/milestones'
+];
 
 export const isNewIssue = (): boolean => /^issues\/new/.test(getRepoPath()!);
+export const isNewIssueTest = [
+	'https://github.com/sindresorhus/refined-github/issues/new'
+];
 
 export const isNewRelease = (): boolean => /^releases\/new/.test(getRepoPath()!);
+export const isNewReleaseTest = [
+	'https://github.com/sindresorhus/refined-github/releases/new'
+];
 
 export const isNotifications = (): boolean => /^([^/]+[/][^/]+\/)?notifications/.test(getCleanPathname());
+export const isNotificationsTest = [
+	'https://github.com/notifications',
+	'https://github.com/notifications/participating',
+	'https://github.com/sindresorhus/notifications/notifications',
+	'https://github.com/notifications?all=1'
+];
 
 export const isOrganizationProfile = (): boolean => select.exists('.orghead');
+export const isOrganizationProfileTest = domBased;
 
 export const isOrganizationDiscussion = (): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());
+export const isOrganizationDiscussionTest = [
+	'https://github.com/orgs/refined-github/teams/core-team/discussions?pinned=1',
+	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
+	'https://github.com/orgs/refined-github/teams/core-team'
+];
 
 export const isOwnUserProfile = (): boolean => getCleanPathname() === getUsername();
+export const isOwnUserProfileTest = domBased;
 
 // If there's a Report Abuse link, we're not part of the org
 export const isOwnOrganizationProfile = (): boolean => isOrganizationProfile() && !select.exists('[href*="contact/report-abuse?report="]');
+export const isOwnOrganizationProfileTest = domBased;
 
 export const isProject = (): boolean => /^projects\/\d+/.test(getRepoPath()!);
+export const isProjectTest = [
+	'https://github.com/sindresorhus/refined-github/projects/3'
+];
 
 export const isPR = (): boolean => /^pull\/\d+/.test(getRepoPath()!);
+export const isPRTest = [
+	'https://github.com/sindresorhus/refined-github/pull/148',
+	'https://github.com/sindresorhus/refined-github/pull/148/files',
+	'https://github.com/sindresorhus/refined-github/pull/148/conflicts',
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196',
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85'
+];
 
 export const isConflict = (): boolean => /^pull\/\d+\/conflicts/.test(getRepoPath()!);
+export const isConflictTest = [
+	'https://github.com/sindresorhus/refined-github/pull/148/conflicts'
+];
 
 export const isPRList = (): boolean => location.pathname === '/pulls' || getRepoPath() === 'pulls';
+export const isPRListTest = [
+	'https://github.com/pulls',
+	'https://github.com/pulls?q=issues',
+	'https://github.com/sindresorhus/refined-github/pulls',
+	'https://github.com/sindresorhus/refined-github/pulls/',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Aopen+is%3Apr',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aclosed'
+];
 
 export const isPRCommit = (): boolean => /^pull\/\d+\/commits\/[0-9a-f]{5,40}/.test(getRepoPath()!);
+export const isPRCommitTest = [
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85',
+	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196'
+];
 
 export const isPRConversation = (): boolean => /^pull\/\d+$/.test(getRepoPath()!);
+export const isPRConversationTest = [
+	'https://github.com/sindresorhus/refined-github/pull/148'
+];
 
 export const isPRFiles = (): boolean => /^pull\/\d+\/files/.test(getRepoPath()!);
+export const isPRFilesTest = [
+	'https://github.com/sindresorhus/refined-github/pull/148/files'
+];
 
 export const isQuickPR = (): boolean => isCompare() && /[?&]quick_pull=1(&|$)/.test(location.search);
+export const isQuickPRTest = [
+	'https://github.com/sindresorhus/refined-github/compare/master...branch-name?quick_pull=1',
+	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?quick_pull=1',
+	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1'
+];
 
-export const isReleasesOrTags = (): boolean => /^(releases|tags)/.test(getRepoPath()!);
+export const isReleasesOrTags = [
+	'https://github.com/sindresorhus/refined-github/releases',
+	'https://github.com/sindresorhus/refined-github/tags',
+	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',
+	'https://github.com/sindresorhus/refined-github/releases/tag/0.2.1'
+];
 
 export const isEditingFile = (): boolean => /^edit/.test(getRepoPath()!);
+export const isEditingFileTest = [
+	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
+	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts'
+];
 
 export const isRepo = (): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname()) &&
 	!reservedNames.includes(getOwnerAndRepo().ownerName) &&
@@ -80,42 +222,135 @@ export const isRepo = (): boolean => /^[^/]+\/[^/]+/.test(getCleanPathname()) &&
 	!isDashboard() &&
 	!isGist() &&
 	!isRepoSearch();
+export const isRepoTest = [
+	'https://github.com/sindresorhus/refined-github/blame/master/package.json',
+	'https://github.com/sindresorhus/refined-github/issues/146',
+	'https://github.com/sindresorhus/notifications/',
+	'https://github.com/sindresorhus/refined-github/pull/148'
+];
+export const isRepoTestSkipNegatives = true;
 
 export const isRepoDiscussionList = (): boolean =>
-	/^(issues|pulls)($|\/$|\/(?!\d+|new))/.test(getRepoPath()!) || // `issues/fregante` is a list but `issues/1` isn't
+	isRepoPRList() ||
+	isRepoIssueList() ||
 	/^labels\/.+/.test(getRepoPath()!);
+export const isRepoDiscussionListTest = [
+	'http://github.com/sindresorhus/ava/issues',
+	'https://github.com/sindresorhus/refined-github/pulls',
+	'https://github.com/sindresorhus/refined-github/pulls/',
+	'https://github.com/sindresorhus/refined-github/pulls/fregante',
+	'https://github.com/sindresorhus/refined-github/issues/fregante',
+	'https://github.com/sindresorhus/refined-github/labels/Priority%3A%20critical',
+	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Aopen+is%3Apr',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aclosed',
+	'https://github.com/sindresorhus/refined-github/issues'
+];
+
+export const isRepoPRList = (): boolean => (getRepoPath() || '').startsWith('pulls');
+export const isRepoPRListTest = [
+	'https://github.com/sindresorhus/refined-github/pulls',
+	'https://github.com/sindresorhus/refined-github/pulls/',
+	'https://github.com/sindresorhus/refined-github/pulls/fregante',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Aopen+is%3Apr',
+	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aclosed'
+];
+
+export const isRepoIssueList = (): boolean => {
+	const parts = (getRepoPath() || '').split('/');
+	return parts[0] === 'issues' && parts[1] !== 'new' && !/\d/.test(parts[1]); // `issues/fregante` is a list but `issues/1` isn't
+};
+
+export const isRepoIssueListTest = [
+	'http://github.com/sindresorhus/ava/issues',
+	'https://github.com/sindresorhus/refined-github/issues',
+	'https://github.com/sindresorhus/refined-github/issues/fregante',
+	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc'
+];
 
 export const isRepoRoot = (): boolean => /^(tree[/][^/]+)?$/.test(getRepoPath()!);
+export const isRepoRootTest = [
+	// Some tests are here only as "gotchas" for other tests that may misidentify their pages
+	'https://github.com/sindresorhus/edit',
+	'https://github.com/sindresorhus/search',
+	'https://github.com/sindresorhus/refined-github',
+	'https://github.com/sindresorhus/refined-github/',
+	'https://github.com/sindresorhus/notifications/',
+	'https://github.com/sindresorhus/refined-github/tree/native-copy-buttons',
+	'https://github.com/sindresorhus/refined-github/tree/native-copy-buttons/',
+	'https://github.com/sindresorhus/refined-github/tree/03fa6b8b4d6e68dea9dc9bee1d197ef5d992fbd6',
+	'https://github.com/sindresorhus/refined-github/tree/03fa6b8b4d6e68dea9dc9bee1d197ef5d992fbd6/',
+	'https://github.com/sindresorhus/refined-github/tree/57bf4',
+	'https://github.com/sindresorhus/refined-github?files=1',
+	'https://github.com/sindresorhus/refined-github/tree/master?files=1'
+];
 
 export const isRepoSearch = (): boolean => location.pathname.slice(1).split('/')[2] === 'search';
+export const isRepoSearchTest = [
+	'https://github.com/sindresorhus/refined-github/search?q=diff',
+	'https://github.com/sindresorhus/refined-github/search?q=diff&unscoped_q=diff&type=Issues',
+	'https://github.com/sindresorhus/refined-github/search'
+];
 
 export const isRepoSettings = (): boolean => /^settings/.test(getRepoPath()!);
+export const isRepoSettingsTest = [
+	'https://github.com/sindresorhus/refined-github/settings',
+	'https://github.com/sindresorhus/refined-github/settings/branches'
+];
 
 export const isRepoTree = (): boolean => isRepoRoot() || /^tree\//.test(getRepoPath()!);
+export const isRepoTreeTest = [
+	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
+	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution',
+	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution'
+].concat(isRepoRootTest);
 
 export const isRepoWithAccess = (): boolean => isRepo() && select.exists('.reponav-item[href$="/settings"]');
+export const isRepoWithAccessTest = domBased;
 
 export const isSingleCommit = (): boolean => /^commit\/[0-9a-f]{5,40}/.test(getRepoPath()!);
+export const isSingleCommitTest = [
+	'https://github.com/sindresorhus/refined-github/commit/5b614b9035f2035b839f48b4db7bd5c3298d526f',
+	'https://github.com/sindresorhus/refined-github/commit/5b614'
+];
 
 export const isSingleFile = (): boolean => /^blob\//.test(getRepoPath()!);
+export const isSingleFileTest = [
+	'https://github.com/sindresorhus/refined-github/blob/master/.gitattributes',
+	'https://github.com/sindresorhus/refined-github/blob/fix-narrow-diff/distribution/content.css',
+	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt'
+];
 
 export const isTrending = (): boolean => location.pathname === '/trending' || location.pathname.startsWith('/trending/');
+export const isTrendingTest = [
+	'https://github.com/trending',
+	'https://github.com/trending/developers',
+	'https://github.com/trending/unknown'
+];
 
 export const isUserProfile = (): boolean => select.exists('.user-profile-nav');
+export const isUserProfileTest = domBased;
 
 export const isSingleTagPage = (): boolean => /^(releases\/tag)/.test(getRepoPath()!);
+export const isSingleTagPageTest = [
+	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',
+	'https://github.com/sindresorhus/refined-github/releases/tag/0.2.1'
+];
 
+export const hasCommentsTest = skip;
 export const hasComments = (): boolean =>
 	isPR() ||
 	isIssue() ||
 	isCommit() ||
 	isOrganizationDiscussion();
 
+export const hasRichTextEditorTest = skip;
 export const hasRichTextEditor = (): boolean =>
 	hasComments() ||
 	isNewIssue() ||
 	isCompare();
 
+export const hasCodeTest = skip;
 export const hasCode = (): boolean => // Static code, not the editor
 	hasComments() ||
 	isRepoTree() || // Readme files

--- a/test/page-detect.ts
+++ b/test/page-detect.ts
@@ -1,21 +1,53 @@
-import test, {ExecutionContext} from 'ava';
+import test from 'ava';
 import './fixtures/globals';
 import * as pageDetect from '../source/libs/page-detect';
 
-function urlMatcherMacro(
-	t: ExecutionContext,
-	detectFn: (url: string) => boolean,
-	shouldMatch: string[] = [],
-	shouldNotMatch: string[] = []
-): void {
-	for (const url of shouldMatch) {
-		location.href = url;
-		t.true(detectFn(url));
+const allUrls = new Set<string>();
+for (const imported of Object.values(pageDetect)) {
+	if (Array.isArray(imported)) {
+		for (const url of imported) {
+			allUrls.add(url);
+		}
+	}
+}
+
+for (const [key, detect] of Object.entries(pageDetect)) {
+	if (key.endsWith('Test') || typeof detect !== 'function') {
+		continue;
 	}
 
-	for (const url of shouldNotMatch) {
-		location.href = url;
-		t.false(detectFn(url));
+	const testsKey = key + 'Test';
+	// @ts-ignore `import-all` has no index signature https://github.com/Microsoft/TypeScript/issues/16248
+	const validURLs = pageDetect[testsKey] as string[] | string;
+
+	if (validURLs === 'skip') {
+		continue;
+	}
+
+	test(key, t => {
+		t.true(Array.isArray(validURLs), `The function \`${key}\` doesn’t have any tests. Export an array of valid URLs as \`${testsKey}\``);
+	});
+
+	let i = 0;
+	for (const url of validURLs) {
+		test(`${key} ${++i}`, t => {
+			location.href = url;
+			t.true(detect(), `\n${url}\nisn’t matched by ${key}() but it’s in its tests array.`);
+		});
+	}
+
+	// @ts-ignore `import-all` has no index signature https://github.com/Microsoft/TypeScript/issues/16248
+	if (pageDetect[key + 'TestSkipNegatives']) {
+		continue;
+	}
+
+	for (const url of allUrls) {
+		if (!validURLs.includes(url)) {
+			test(`${key} ${++i}`, t => {
+				location.href = url;
+				t.false(detect(), `\n${url}\nis matched by ${key.replace(/^is/, '')}, but it isn’t specified in its tests array. Add it or fix the test.`);
+			});
+		}
 	}
 }
 
@@ -52,369 +84,3 @@ test('is500', t => {
 	document.title = 'Server Error · Issue #266 · sintaxi/surge · GitHub';
 	t.false(pageDetect.is500());
 });
-
-test('isBlame', urlMatcherMacro, pageDetect.isBlame, [
-	'https://github.com/sindresorhus/refined-github/blame/master/package.json'
-], [
-	'https://github.com/sindresorhus/refined-github/blob/master/package.json'
-]);
-
-test('isCommit', urlMatcherMacro, pageDetect.isCommit, [
-	'https://github.com/sindresorhus/refined-github/commit/5b614b9035f2035b839f48b4db7bd5c3298d526f',
-	'https://github.com/sindresorhus/refined-github/commit/5b614',
-	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85',
-	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148/commits',
-	'https://github.com/sindresorhus/refined-github/branches',
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'https://github.com/sindresorhus/refined-github/pull/commits',
-	'https://github.com/sindresorhus/refined-github/pulls'
-]);
-
-test('isCommitList', urlMatcherMacro, pageDetect.isCommitList, [
-	'https://github.com/sindresorhus/refined-github/commits/master?page=2',
-	'https://github.com/sindresorhus/refined-github/commits/test-branch',
-	'https://github.com/sindresorhus/refined-github/commits/0.13.0',
-	'https://github.com/sindresorhus/refined-github/commits/230c2',
-	'https://github.com/sindresorhus/refined-github/commits/230c2935fc5aea9a681174ddbeba6255ca040d63'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'https://github.com/sindresorhus/refined-github/pull/commits',
-	'https://github.com/sindresorhus/refined-github/branches'
-]);
-
-test('isCompare', urlMatcherMacro, pageDetect.isCompare, [
-	'https://github.com/sindresorhus/refined-github/compare',
-	'https://github.com/sindresorhus/refined-github/compare/'
-], [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/graphs'
-]);
-
-test('isDashboard', urlMatcherMacro, pageDetect.isDashboard, [
-	'https://github.com/',
-	'https://github.com',
-	'https://github.com/orgs/test/dashboard',
-	'https://github.com/dashboard/index/2',
-	'https://github.com/dashboard'
-], [
-	'https://github.com/sindresorhus/refined-github/tree/master/dashboard/index/2',
-	'https://github.com/sindresorhus/dashboard',
-	'https://github.com/sindresorhus'
-]);
-
-test('isOrganizationDiscussion', urlMatcherMacro, pageDetect.isOrganizationDiscussion, [
-	'https://github.com/orgs/refined-github/teams/core-team/discussions?pinned=1',
-	'https://github.com/orgs/refined-github/teams/core-team/discussions/1',
-	'https://github.com/orgs/refined-github/teams/core-team'
-], [
-	'https://github.com/orgs/refined-github/teams/core-team/members',
-	'https://github.com/sindresorhus/teams/tree/discussions',
-	'https://github.com/sindresorhus/orgs/tree/teams/core-team'
-]);
-
-test('isEnterprise', urlMatcherMacro, pageDetect.isEnterprise, [
-	'https://github.big-corp.com/',
-	'https://not-github.com/',
-	'https://my-little-hub.com/'
-], [
-	'https://github.com/',
-	'https://gist.github.com/'
-]);
-
-test('isGist', urlMatcherMacro, pageDetect.isGist, [
-	'https://gist.github.com',
-	'http://gist.github.com',
-	'https://gist.github.com/sindresorhus/0ea3c2845718a0a0f0beb579ff14f064'
-], [
-	'https://github.com',
-	'https://help.github.com/'
-]);
-
-test('isGlobalSearchResults', urlMatcherMacro, pageDetect.isGlobalSearchResults, [
-	'https://github.com/search?q=refined-github&ref=opensearch'
-], [
-	'https://github.com/search', // The dom is different
-	'https://github.com/searcher',
-	'https://github.com/sindresorhus/search',
-	'https://github.com/sindresorhus/refined-github/tree/search',
-	'https://github.com/sindresorhus/refined-github/tree/master/search'
-]);
-
-test('isIssue', urlMatcherMacro, pageDetect.isIssue, [
-	'https://github.com/sindresorhus/refined-github/issues/146'
-], [
-	'http://github.com/sindresorhus/ava',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/issues'
-]);
-
-test('isRepoDiscussionList', urlMatcherMacro, pageDetect.isRepoDiscussionList, [
-	'http://github.com/sindresorhus/ava/issues',
-	'https://github.com/sindresorhus/refined-github/pulls',
-	'https://github.com/sindresorhus/refined-github/pulls/',
-	'https://github.com/sindresorhus/refined-github/pulls/fregante',
-	'https://github.com/sindresorhus/refined-github/issues/fregante',
-	'https://github.com/sindresorhus/refined-github/labels/Priority%3A%20critical',
-	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc'
-], [
-	'http://github.com/sindresorhus/ava',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/issues/new',
-	'https://github.com/sindresorhus/refined-github/issues/170',
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'http://github.com/sindresorhus/issues',
-	'https://github.com/sindresorhus/refined-github/labels',
-	'https://github.com/sindresorhus/refined-github/labels/'
-]);
-
-test('isGlobalDiscussionList', urlMatcherMacro, pageDetect.isGlobalDiscussionList, [
-	'https://github.com/issues',
-	'https://github.com/issues?q=is%3Apr+is%3Aopen',
-	'https://github.com/issues/assigned',
-	'https://github.com/issues/mentioned',
-	'https://github.com/pulls',
-	'https://github.com/pulls?q=issues',
-	'https://github.com/pulls/assigned',
-	'https://github.com/pulls/mentioned',
-	'https://github.com/pulls/review-requested'
-], [
-	'https://github.com/issuesorter',
-	'https://github.com/sindresorhus/refined-github/issues',
-	'https://github.com/sindresorhus/refined-github/issues/170',
-	'https://github.com/pullsup',
-	'https://github.com/sindresorhus/refined-github/pulls',
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'http://github.com/sindresorhus/ava/issues',
-	'https://github.com/sindresorhus/refined-github/pulls',
-	'https://github.com/sindresorhus/refined-github/labels/Priority%3A%20critical',
-	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc'
-]);
-
-test('isMilestone', urlMatcherMacro, pageDetect.isMilestone, [
-	'https://github.com/sindresorhus/refined-github/milestone/12'
-], [
-	'http://github.com/sindresorhus/ava',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/milestones'
-]);
-
-test('isNewIssue', urlMatcherMacro, pageDetect.isNewIssue, [
-	'https://github.com/sindresorhus/refined-github/issues/new'
-], [
-	'http://github.com/issues/new',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/issues',
-	'https://github.com/sindresorhus/refined-github/blob/issues/new'
-]);
-
-test('isNewRelease', urlMatcherMacro, pageDetect.isNewRelease, [
-	'https://github.com/sindresorhus/refined-github/releases/new'
-], [
-	'http://github.com/releases/new',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/releases',
-	'https://github.com/sindresorhus/refined-github/blob/releases/new'
-]);
-
-test('isNotifications', urlMatcherMacro, pageDetect.isNotifications, [
-	'https://github.com/notifications',
-	'https://github.com/notifications/participating',
-	'http://github.com/sindresorhus/refined-github/notifications',
-	'https://github.com/sindresorhus/notifications/notifications',
-	'https://github.com/notifications?all=1'
-], [
-	'https://github.com/settings/notifications',
-	'https://github.com/watching',
-	'https://github.com/sindresorhus/notifications/',
-	'https://github.com/jaredhanson/node-notifications/tree/master/lib/notifications'
-]);
-
-test('isProject', urlMatcherMacro, pageDetect.isProject, [
-	'https://github.com/sindresorhus/refined-github/projects/3'
-], [
-	'https://github.com/sindresorhus/refined-github/projects/project',
-	'https://github.com/sindresorhus/refined-github/project/3',
-	'http://github.com/sindresorhus/projects/3',
-	'https://github.com/projects/3'
-]);
-
-test('isPRList', urlMatcherMacro, pageDetect.isPRList, [
-	'https://github.com/sindresorhus/refined-github/pulls',
-	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Aopen+is%3Apr',
-	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aclosed'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/1641',
-	'https://github.com/sindresorhus/refined-github/issues'
-]);
-
-test('isPR', urlMatcherMacro, pageDetect.isPR, [
-	'https://github.com/sindresorhus/refined-github/pull/148'
-], [
-	'http://github.com/sindresorhus/ava',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/pulls'
-]);
-
-test('isPRConversation', urlMatcherMacro, pageDetect.isPRConversation, [
-	'https://github.com/sindresorhus/refined-github/pull/148'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148/commits',
-	'https://github.com/sindresorhus/refined-github/pull/148/files',
-	'http://github.com/sindresorhus/ava',
-	'https://github.com',
-	'https://github.com/sindresorhus/refined-github/pulls'
-]);
-
-test('isPRCommit', urlMatcherMacro, pageDetect.isPRCommit, [
-	'https://github.com/sindresorhus/refined-github/pull/148/commits/0019603b83bd97c2f7ef240969f49e6126c5ec85',
-	'https://github.com/sindresorhus/refined-github/pull/148/commits/00196'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'https://github.com/sindresorhus/refined-github/pull/commits',
-	'https://github.com/sindresorhus/refined-github/pulls'
-]);
-
-test('isPRFiles', urlMatcherMacro, pageDetect.isPRFiles, [
-	'https://github.com/sindresorhus/refined-github/pull/148/files'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148',
-	'https://github.com/sindresorhus/refined-github/pull/commits',
-	'https://github.com/sindresorhus/refined-github/pulls'
-]);
-
-test('isQuickPR', urlMatcherMacro, pageDetect.isQuickPR, [
-	'https://github.com/sindresorhus/refined-github/compare/master...branch-name?quick_pull=1',
-	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?quick_pull=1',
-	'https://github.com/sindresorhus/refined-github/compare/test-branch?quick_pull=1'
-], [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/compare',
-	'https://github.com/sindresorhus/refined-github/compare/',
-	'https://github.com/sindresorhus/refined-github/compare/test-branch',
-	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2',
-	'https://github.com/sindresorhus/refined-github/compare/branch-1...branch-2?expand=1'
-]);
-
-test('isReleasesOrTags', urlMatcherMacro, pageDetect.isReleasesOrTags, [
-	'https://github.com/sindresorhus/refined-github/releases',
-	'https://github.com/sindresorhus/refined-github/tags',
-	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',
-	'https://github.com/sindresorhus/refined-github/releases/tag/0.2.1'
-], [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/graphs'
-]);
-
-test('isRepo', urlMatcherMacro, pageDetect.isRepo, [
-	'http://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/issues/146',
-	'https://github.com/sindresorhus/notifications/',
-	'https://github.com/sindresorhus/refined-github/pull/145'
-], [
-	'https://github.com/sindresorhus',
-	'https://github.com',
-	'https://github.com/stars',
-	'http://github.com/sindresorhus/refined-github/notifications',
-	'https://github.com/sindresorhus/notifications/notifications',
-	'https://github.com/orgs/test/dashboard',
-	'https://github.com/settings/profile',
-	'https://github.com/trending/developers',
-	'https://github.com/sindresorhus/refined-github/search?q=diff'
-]);
-
-test('isRepoRoot', urlMatcherMacro, pageDetect.isRepoRoot, [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/',
-	'https://github.com/sindresorhus/refined-github/tree/native-copy-buttons',
-	'https://github.com/sindresorhus/refined-github/tree/native-copy-buttons/',
-	'https://github.com/sindresorhus/refined-github/tree/03fa6b8b4d6e68dea9dc9bee1d197ef5d992fbd6',
-	'https://github.com/sindresorhus/refined-github/tree/03fa6b8b4d6e68dea9dc9bee1d197ef5d992fbd6/'
-], [
-	'https://github.com/',
-	'https://github.com/tree/master/issues',
-	'https://github.com/sindresorhus/refined-github/issues',
-	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/master/tree/master'
-]);
-
-test('isRepoSettings', urlMatcherMacro, pageDetect.isRepoSettings, [
-	'https://github.com/sindresorhus/refined-github/settings',
-	'https://github.com/sindresorhus/refined-github/settings/branches'
-], [
-	'https://github.com/sindresorhus/refined-github/releases'
-]);
-
-test('isRepoTree', urlMatcherMacro, pageDetect.isRepoTree, [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/tree/master/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/0.13.0/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/57bf435ee12d14b482df0bbd88013a2814c7512e/distribution',
-	'https://github.com/sindresorhus/refined-github/tree/57bf4',
-	'https://github.com/sindresorhus/refined-github?files=1',
-	'https://github.com/sindresorhus/refined-github/tree/master?files=1'
-], [
-	'https://github.com/sindresorhus/refined-github/issues',
-	'https://github.com/sindresorhus/refined-github/issues?files=1',
-	'https://github.com/sindresorhus/refined-github/blob/tree/master/distribution'
-]);
-
-test('isSingleCommit', urlMatcherMacro, pageDetect.isSingleCommit, [
-	'https://github.com/sindresorhus/refined-github/commit/5b614b9035f2035b839f48b4db7bd5c3298d526f',
-	'https://github.com/sindresorhus/refined-github/commit/5b614'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/148/commits',
-	'https://github.com/sindresorhus/refined-github/branches'
-]);
-
-test('isSingleFile', urlMatcherMacro, pageDetect.isSingleFile, [
-	'https://github.com/sindresorhus/refined-github/blob/master/.gitattributes',
-	'https://github.com/sindresorhus/refined-github/blob/fix-narrow-diff/distribution/content.css'
-], [
-	'https://github.com/sindresorhus/refined-github/pull/164/files',
-	'https://github.com/sindresorhus/refined-github/commit/57bf4'
-]);
-
-test('isTrending', urlMatcherMacro, pageDetect.isTrending, [
-	'https://github.com/trending',
-	'https://github.com/trending/developers',
-	'https://github.com/trending/unknown'
-], [
-	'https://github.com/trendinguser',
-	'https://github.com/settings/trending',
-	'https://github.com/watching',
-	'https://github.com/jaredhanson/node-trending/tree/master/lib/trending'
-]);
-
-test('isRepoSearch', urlMatcherMacro, pageDetect.isRepoSearch, [
-	'https://github.com/sindresorhus/refined-github/search?q=diff',
-	'https://github.com/sindresorhus/refined-github/search?q=diff&unscoped_q=diff&type=Issues',
-	'https://github.com/sindresorhus/refined-github/search'
-], [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/search',
-	'https://github.com/search'
-]);
-
-test('isSingleTagPage', urlMatcherMacro, pageDetect.isSingleTagPage, [
-	'https://github.com/sindresorhus/refined-github/releases/tag/v1.0.0-beta.4',
-	'https://github.com/sindresorhus/refined-github/releases/tag/0.2.1'
-], [
-	'https://github.com/sindresorhus/refined-github/tags',
-	'https://github.com/sindresorhus/refined-github/releases',
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/graphs'
-]);
-
-test('isEditingFile', urlMatcherMacro, pageDetect.isEditingFile, [
-	'https://github.com/sindresorhus/refined-github/edit/master/readme.md',
-	'https://github.com/sindresorhus/refined-github/edit/ghe-injection/source/background.ts'
-], [
-	'https://github.com/sindresorhus/refined-github',
-	'https://github.com/sindresorhus/refined-github/pulls',
-	'https://github.com/edit',
-	'https://github.com/orgs/edit/dashboard',
-	'https://github.com/sindresorhus/edit',
-	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt'
-]);


### PR DESCRIPTION
- Enforces tests on all new page detections
- Keeps expected URLs near the function, as examples
- Tests each function with ALL the available URLs in the file, so any new URL added is an automatic _new test_ for all the rest.

They'll be tree-shaken by webpack.