### PR TITLE
Meta: Add feature option search

### DIFF
--- a/source/options.css
+++ b/source/options.css
@@ -38,11 +38,6 @@ button {
 	border: 1px solid var(--input-border-color);
 }
 
-input:not([type='checkbox']):not(:placeholder-shown):valid {
-	color: var(--github-green) !important;
-	border: 1px solid;
-}
-
 input:not([type='checkbox']):invalid {
 	color: var(--github-red) !important;
 	border: 1px solid;

--- a/source/options.css
+++ b/source/options.css
@@ -110,7 +110,8 @@ h2 ~ h2 {
 	text-decoration: line-through;
 }
 
-.js-features :not(:checked) + .info .extended-options {
+.js-features :not(:checked) + .info .extended-options,
+.feature[hidden] {
 	display: none;
 }
 

--- a/source/options.css
+++ b/source/options.css
@@ -110,8 +110,7 @@ h2 ~ h2 {
 	text-decoration: line-through;
 }
 
-.js-features :not(:checked) + .info .extended-options,
-.feature[hidden] {
+.js-features :not(:checked) + .info .extended-options {
 	display: none;
 }
 

--- a/source/options.css
+++ b/source/options.css
@@ -95,7 +95,7 @@ h2 ~ h2 {
 	margin-top: 2em;
 }
 
-.js-features .feature {
+.js-features .feature:not([hidden]) {
 	display: flex;
 	margin-top: 1em;
 }
@@ -110,8 +110,7 @@ h2 ~ h2 {
 	text-decoration: line-through;
 }
 
-.js-features :not(:checked) + .info .extended-options,
-.feature[hidden] {
+.js-features :not(:checked) + .info .extended-options {
 	display: none;
 }
 

--- a/source/options.html
+++ b/source/options.html
@@ -40,7 +40,7 @@
 		</p>
 		<p>
 			<label>
-				<input name="search-features" type="search" placeholder="Search features (use quotes for a full match)" />
+				<input id="search-features" type="search" placeholder="Search features (use quotes for a full match)" />
 			</label>
 		</p>
 		<div class="js-features"></div>

--- a/source/options.html
+++ b/source/options.html
@@ -40,7 +40,7 @@
 		</p>
 		<p>
 			<label>
-				<input id="filter-features" type="search" placeholder="Filter features" />
+				<input id="filter-features" type="text" placeholder="Filter features" />
 			</label>
 		</p>
 		<div class="js-features"></div>

--- a/source/options.html
+++ b/source/options.html
@@ -40,7 +40,7 @@
 		</p>
 		<p>
 			<label>
-				<input id="search-features" type="search" placeholder="Search features (use quotes for a full match)" />
+				<input id="filter-features" type="search" placeholder="Filter features" />
 			</label>
 		</p>
 		<div class="js-features"></div>

--- a/source/options.html
+++ b/source/options.html
@@ -38,7 +38,11 @@
 					href="https://github.com/sindresorhus/refined-github/blob/master/contributing.md" target="_blank">contribute</a>!
 			</em>
 		</p>
-
+		<p>
+			<label>
+				<input name="search-features" type="search" placeholder="Search features (use quotes for a full match)" />
+			</label>
+		</p>
 		<div class="js-features"></div>
 	</div>
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -73,7 +73,7 @@ function addSearch(): void {
 		const pattern = (event.target as HTMLInputElement).value || '';
 		const patternArray = replaceCharacters(pattern)
 			.split(separators)
-			.filter(s => s); // Remove empty strings
+			.filter(Boolean); // Remove empty strings
 		const hasPattern = pattern !== '';
 		// Use quotes to get an exact match
 		const matchAll = pattern.includes('"');

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -58,8 +58,9 @@ function addSearch(): void {
 
 	const separators = /\s/;
 	const ignoredCharacters = /[,.:;'"’`]/g;
-	const replaceIgnoredCharacters = (string:string): string => (
-		string.toLowerCase().replace(ignoredCharacters, '')
+	const convertToSpace = /[-]/;
+	const replaceCharacters = (string:string): string => (
+		string.toLowerCase().replace(convertToSpace, ' ').replace(ignoredCharacters, '')
 	)
 
 	const plainMatch = (pattern:string[], text:string, matchAll:boolean): boolean => (
@@ -70,7 +71,7 @@ function addSearch(): void {
 
 	const searchHandler = (event: Event): void => {
 		const pattern = (event.target as HTMLInputElement).value || '';
-		const patternArray = replaceIgnoredCharacters(pattern)
+		const patternArray = replaceCharacters(pattern)
 			.split(separators)
 			.filter(s => s); // remove empty strings
 		const hasPattern = pattern !== '';
@@ -86,7 +87,7 @@ function addSearch(): void {
 					// show = fuzzyMath(pattern, patternLength, `${featureObj.name} ${featureObj.description}`);
 					show = plainMatch(
 						patternArray,
-						replaceIgnoredCharacters(`${featureObj.name} ${featureObj.description}`),
+						replaceCharacters(`${featureObj.name} ${featureObj.description}`),
 						matchAll
 					);
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -63,10 +63,13 @@ async function init(): Promise<void> {
 	indentTextarea.watch('textarea');
 
 	// Filter feature options
-	select<HTMLInputElement>('#filter-features')!.addEventListener('input', event => {
-		const keywords = (event.target as HTMLInputElement)!.value.toLowerCase().split(' ').filter((s: string) => s.length);
+	const filterField = select<HTMLInputElement>('#filter-features')!;
+	filterField.addEventListener('input', () => {
+		const keywords = filterField.value.toLowerCase()
+			.split(/\s+/)
+			.filter(Boolean); // Ignore empty strings
 		for (const feature of select.all('.feature')) {
-			feature.hidden = !keywords.every(word => String(feature.dataset.text).includes(word));
+			feature.hidden = !keywords.every(word => feature.dataset.text!.includes(word));
 		}
 	});
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -84,7 +84,6 @@ function addSearch(): void {
 				if (hasPattern) {
 					const index = Number(feature.dataset.index);
 					const featureObj = __featuresInfo__[index]; // minimize DOM interaction
-					// show = fuzzyMath(pattern, patternLength, `${featureObj.name} ${featureObj.description}`);
 					show = plainMatch(
 						patternArray,
 						replaceCharacters(`${featureObj.name} ${featureObj.description}`),

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -67,7 +67,9 @@ async function init(): Promise<void> {
 		const keywords = (event.target as HTMLInputElement)!.value.toLowerCase().split(' ').filter((s: string) => s.length);
 		const hasKeywords = keywords.length > 0;
 		for (const feature of select.all('.feature')) {
-			feature!.hidden = hasKeywords ? !keywords.every((word: string) => String(feature.dataset.text).includes(word)) : false;
+			feature.hidden = hasKeywords ?
+				!keywords.every(word => feature.dataset.text.includes(word)) :
+				false;
 		}
 	});
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -82,7 +82,7 @@ async function init(): Promise<void> {
 			</select>
 		) as unknown as HTMLSelectElement;
 		form.before(<p>Domain selector: {dropdown}</p>, <hr/>);
-		dropdown.addEventListener('change', event => {
+		dropdown.addEventListener('change', () => {
 			for (const [domain, options] of optionsByDomain) {
 				if (dropdown.value === domain) {
 					options.syncForm(form);
@@ -91,8 +91,7 @@ async function init(): Promise<void> {
 				}
 			}
 
-			const newHost = (event.target as HTMLInputElement).value;
-			select<HTMLAnchorElement>('#personal-token-link')!.host = newHost;
+			select<HTMLAnchorElement>('#personal-token-link')!.host = dropdown.value;
 		});
 	}
 

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -33,7 +33,7 @@ function buildFeatureCheckbox({name, description, screenshot, disabled}: Feature
 		false;
 
 	return (
-		<div className="feature" data-text={`${name} ${description}`}>
+		<div className="feature" data-text={`${name} ${description}`.toLowerCase()}>
 			<input type="checkbox" name={key} id={name} disabled={Boolean(disabled)} />
 			<div className="info">
 				<label for={name}>
@@ -66,6 +66,7 @@ async function init(): Promise<void> {
 	const filterField = select<HTMLInputElement>('#filter-features')!;
 	filterField.addEventListener('input', () => {
 		const keywords = filterField.value.toLowerCase()
+			.replace(/\W/g, ' ')
 			.split(/\s+/)
 			.filter(Boolean); // Ignore empty strings
 		for (const feature of select.all('.feature')) {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -4,9 +4,9 @@ import select from 'select-dom';
 import fitTextarea from 'fit-textarea';
 import {applyToLink} from 'shorten-repo-url';
 import indentTextarea from 'indent-textarea';
+import debounce from 'debounce-fn';
 import {getAllOptions} from './options-storage';
 import * as domFormatters from './libs/dom-formatters';
-import debounce from 'debounce-fn';
 
 function parseDescription(description: string): DocumentFragment {
 	const descriptionElement = <span>{description}</span>;
@@ -25,7 +25,7 @@ function parseDescription(description: string): DocumentFragment {
 	return descriptionElement;
 }
 
-function buildFeatureCheckbox({name, description, screenshot, disabled}: FeatureInfo, index: Number): HTMLElement {
+function buildFeatureCheckbox({name, description, screenshot, disabled}: FeatureInfo, index: number): HTMLElement {
 	// `undefined` disconnects it from the options
 	const key = disabled ? undefined : `feature:${name}`;
 
@@ -59,23 +59,23 @@ function addSearch(): void {
 	const separators = /\s/;
 	const ignoredCharacters = /[,.:;'"’`]/g;
 	const convertToSpace = /[-]/;
-	const replaceCharacters = (string:string): string => (
+	const replaceCharacters = (string: string): string => (
 		string.toLowerCase().replace(convertToSpace, ' ').replace(ignoredCharacters, '')
-	)
+	);
 
-	const plainMatch = (pattern:string[], text:string, matchAll:boolean): boolean => (
-		matchAll
-			?	pattern.every((str:string) => text.includes(str))
-			: pattern.some((str:string) => text.includes(str))
+	const plainMatch = (pattern: string[], text: string, matchAll: boolean): boolean => (
+		matchAll ?
+			pattern.every((str: string) => text.includes(str)) :
+			pattern.some((str: string) => text.includes(str))
 	);
 
 	const searchHandler = (event: Event): void => {
 		const pattern = (event.target as HTMLInputElement).value || '';
 		const patternArray = replaceCharacters(pattern)
 			.split(separators)
-			.filter(s => s); // remove empty strings
+			.filter(s => s); // Remove empty strings
 		const hasPattern = pattern !== '';
-		// use quotes to get an exact match
+		// Use quotes to get an exact match
 		const matchAll = pattern.includes('"');
 
 		for (const feature of select.all('.feature')) {
@@ -83,15 +83,14 @@ function addSearch(): void {
 				let show = true;
 				if (hasPattern) {
 					const index = Number(feature.dataset.index);
-					const featureObj = __featuresInfo__[index]; // minimize DOM interaction
+					const featureObj = __featuresInfo__[index]; // Minimize DOM interaction
 					show = plainMatch(
 						patternArray,
 						replaceCharacters(`${featureObj.name} ${featureObj.description}`),
 						matchAll
 					);
-
-					// console.log(index, featureObj.name, show)
 				}
+
 				feature.style.display = show ? '' : 'none';
 			}
 		}
@@ -111,7 +110,7 @@ async function init(): Promise<void> {
 	fitTextarea.watch('textarea');
 	indentTextarea.watch('textarea');
 
-	// search feature options
+	// Search feature options
 	addSearch();
 
 	// GitHub Enterprise domain picker

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -58,7 +58,7 @@ function addSearch(): void {
 
 	const separators = /\s/;
 	const ignoredCharacters = /[,.:;'"’`]/g;
-	const convertToSpace = /[-]/;
+	const convertToSpace = /[-]/g;
 	const replaceCharacters = (string: string): string => (
 		string.toLowerCase().replace(convertToSpace, ' ').replace(ignoredCharacters, '')
 	);

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -62,14 +62,11 @@ async function init(): Promise<void> {
 	fitTextarea.watch('textarea');
 	indentTextarea.watch('textarea');
 
-	// Search feature options
-	select<HTMLInputElement>('#search-features')!.addEventListener('input', event => {
+	// Filter feature options
+	select<HTMLInputElement>('#filter-features')!.addEventListener('input', event => {
 		const keywords = (event.target as HTMLInputElement)!.value.toLowerCase().split(' ').filter((s: string) => s.length);
-		const hasKeywords = keywords.length > 0;
 		for (const feature of select.all('.feature')) {
-			feature.hidden = hasKeywords ?
-				!keywords.every(word => feature.dataset.text.includes(word)) :
-				false;
+			feature.hidden = !keywords.every(word => String(feature.dataset.text).includes(word));
 		}
 	});
 


### PR DESCRIPTION
## Description

This PR adds a feature option search to Refined GitHub's option popup.

Searching for `open batch` will only return one result ("batch-open-issues"); the order of the words doesn't matter. Under the hood, this makes sure that every word in the search pattern matches some part of the feature name and description.

Notes:

- This only searches the feature name & description.
- All matches are case-insensitive.
- The following characters are ignored: <code>,.:;'"’`</code>.
- The following character is replaced with a space: `-`; this allows `"open-batch` to still match "batch-open-issues"

## Screenshots

![search](https://user-images.githubusercontent.com/136959/68098648-78a8a580-fe83-11e9-9f97-bcaa2a830787.gif)

## Closes
Closes #2147

## Test

Open Refined-GitHub's options
