### PR TITLE
Allow PR merge-only bots in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -5,8 +5,8 @@ import features from '../libs/features';
 function init(): void {
 	const bots = select.all([
 		/* Commits */
-		'.commit-author[href$="%5Bbot%5D"]',
-		'.commit-author[href$="renovate-bot"]',
+		'.commit-author[href$="%5Bbot%5D"]:first-child',
+		'.commit-author[href$="renovate-bot"]:first-child',
 
 		/* PRs */
 		'.opened-by [href*="author%3Aapp%2F"]'


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2517
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

Thanks @fregante for the simplified selector

# Test
<!-- List some URLs that reviewers can use to test your PR -->

[aws-cdk](https://github.com/aws/aws-cdk/commits/master):
* commits authored by humans but merged by `mergify` shouldn't be dimmed
* as is the case now, commits authored by `dependabot` should be dimmed
