### PR TITLE
Pull Request details spacing fix

### DIFF
--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -129,7 +129,7 @@ async function init(): Promise<false | void> {
 		}
 
 		select('.text-small.text-gray', PR)!.append(
-			<span className="issue-meta-section d-inline-block">
+			<span className="mt-1 issue-meta-section d-inline-block">
 				{openPullRequest()}
 				{' '}
 				{branches}


### PR DESCRIPTION
# Issue
Small design glitch where the PR details from Refined-Github overflow the PR informations (see screenshots below)

# Fix
Using Github CSS class `mt-1`, it adds a tiny spacing above the PR details injected by Refined Github

# Screenshots
## Before
![Screenshot 2019-11-06 at 15 02 24](https://user-images.githubusercontent.com/6444106/68307390-732da400-00ab-11ea-9c37-5ebdf7fae7e5.png)

## After
![Screenshot 2019-11-06 at 15 03 04](https://user-images.githubusercontent.com/6444106/68307398-758ffe00-00ab-11ea-9074-12f51e2ed6f3.png)

### Please let me know if this PR needs any other material or changes from my part
