### PR TITLE
Split testing jobs in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: npm ci
-    - run: npm build
+    - run: npm run build
     - uses: actions/upload-artifact@v1
       with:
         name: refined-github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,27 @@ on:
   - pull_request
   - push
 jobs:
-  run:
+
+  AVA:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
     - run: npm ci
-    - run: npm test
+    - run: npx ava
+
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm ci
+    - run: npm run lint
+
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: npm ci
+    - run: npm build
     - uses: actions/upload-artifact@v1
       with:
         name: refined-github


### PR DESCRIPTION
This should have 2 advantages:

- The `npm test` won't be full with hundreds of lines from AVA test results
- It will be easier to see which of the 3 parts of the testing failed at a glance, without loading the Checks tab:

<img width="387" alt="" src="https://user-images.githubusercontent.com/1402241/68495042-015b8300-0282-11ea-88f1-f2d056ee399c.png">


Disadvantage:

- This disconnects it from the `npm test` command, which would have to be kept in sync (or we can add another generic job for this purpose)