### PR TITLE
Fix `update-pr-from-base-branch` feature

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -86,16 +86,13 @@ async function addButton(): Promise<void> {
 }
 
 function init(): void | false {
-	const mergeButton = select<HTMLButtonElement>('[data-details-container=".js-merge-pr"]');
-	// Only if user can merge it
-	if (!mergeButton) {
-		return false;
-	}
-
+	// Button exists when the current user can merge the PR.
 	// Button is disabled when:
 	// - There are conflicts (there's already a native "Resolve conflicts" button)
 	// - Draft PR (show the button anyway)
-	if (mergeButton.disabled && !select.exists('[action$="ready_for_review"]')) {
+	const canMerge = select.exists('[data-details-container=".js-merge-pr"]:not(:disabled)');
+	const isDraftPR = select.exists('[action$="ready_for_review"]');
+	if (!canMerge && !isDraftPR) {
 		return false;
 	}
 

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -6,12 +6,12 @@ import features from '../libs/features';
 import {getUsername, getCleanPathname} from '../libs/utils';
 
 async function init(): Promise<void> {
-	const {status} = await api.v3(
+	const {httpStatus} = await api.v3(
 		`users/${getCleanPathname()}/following/${getUsername()}`,
 		{ignoreHTTPStatus: true}
 	);
 
-	if (status === 204) {
+	if (httpStatus === 204) {
 		select('.vcard-names-container:not(.is-placeholder)')!.after(
 			<div className="rgh-follower-badge">Follows you</div>
 		);

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -32,13 +32,15 @@ type JsonError = {
 	message: string;
 };
 
-interface APIResponse {
+interface GraphQLResponse {
 	message?: string;
-}
-
-interface GraphQLResponse extends APIResponse {
 	data?: JsonObject;
 	errors?: JsonError[];
+}
+
+interface RestResponse extends AnyObject {
+	httpStatus: number;
+	ok: boolean;
 }
 
 export const escapeKey = (value: string): string => '_' + value.replace(/[ ./-]/g, '_');
@@ -82,7 +84,7 @@ const v4defaults: GHGraphQLApiOptions = {
 export const v3 = mem(async (
 	query: string,
 	options: GHRestApiOptions = v3defaults
-): Promise<AnyObject> => {
+): Promise<RestResponse> => {
 	const {ignoreHTTPStatus, method, body, headers} = {...v3defaults, ...options};
 	const {personalToken} = await settings;
 
@@ -103,7 +105,7 @@ export const v3 = mem(async (
 
 	if (response.ok || ignoreHTTPStatus) {
 		return Object.assign(apiResponse, {
-			status: response.status,
+			httpStatus: response.status,
 			ok: response.ok
 		});
 	}


### PR DESCRIPTION
This has been broken for months and I'm surprised nobody reported it. It's a super useful feature, especially since now it's supposed to work for cross-repo PRs.

Tested in https://github.com/sindresorhus/refined-github/pull/2513 (see the merge commit https://github.com/sindresorhus/refined-github/pull/2513/commits/9a58274d9442427dafd6d533dd92a84e5c2594fa)

To test it, find any PR:
- you're allowed merge,
- is not up to date, and
- has no conflicts (there's a native button in that case)

It should work whether it's a draft PR or not