### PR TITLE
Add `fix-view-file-link-in-pr` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -301,6 +301,7 @@ Thanks for contributing! 🦋🙌
 - [](# "deemphasize-unrelated-commit-references") [Makes it easier to tell apart commits added to the current PR versus plain commits that reference the PR.](https://user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif)
 - [](# "embed-gist-via-iframe") [Adds a menu item to embed a gist via `<iframe>`.](https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png)
 - [](# "link-to-prior-blame-line") [Preserves the current line on “View blame prior to this change” links.](https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png)
+- [](# "fix-view-file-link-in-pr") [Points the "View file" in PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.](https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -110,6 +110,7 @@ import './features/hide-watch-and-fork-count';
 import './features/resolve-conflicts';
 import './features/follow-file-renames';
 import './features/default-to-rich-diff';
+import './features/fix-view-file-link-in-pr'; // Must be before raw-file-link
 import './features/raw-file-link';
 import './features/tags-dropdown';
 import './features/pr-filters';

--- a/source/features/fix-view-file-link-in-pr.tsx
+++ b/source/features/fix-view-file-link-in-pr.tsx
@@ -10,8 +10,8 @@ function handleMenuOpening(event: DelegateEvent): void {
 		return;
 	}
 
-	// Only enabled on Open PRs. Editing files doesn't make sense after a PR is closed/merged.
-	if (!select.exists('.gh-header-meta .State--green')) {
+	// Only enabled on Open/Draft PRs. Editing files doesn't make sense after a PR is closed/merged.
+	if (!select.exists('.gh-header-meta [title$="Open"], .gh-header-meta [title$="Draft"]')) {
 		return;
 	}
 

--- a/source/features/fix-view-file-link-in-pr.tsx
+++ b/source/features/fix-view-file-link-in-pr.tsx
@@ -1,0 +1,46 @@
+import select from 'select-dom';
+import delegate, {DelegateEvent} from 'delegate-it';
+import features from '../libs/features';
+
+function handleMenuOpening(event: DelegateEvent): void {
+	const dropdown = event.delegateTarget.nextElementSibling!;
+
+	// Only if it's not already there
+	if (select.exists('.rgh-actionable-link', dropdown)) {
+		return;
+	}
+
+	// Only enabled on Open PRs. Editing files doesn't make sense after a PR is closed/merged.
+	if (!select.exists('.gh-header-meta .State--green')) {
+		return;
+	}
+
+	// If you're viewing changes from partial commits, ensure you're on the latest one.
+	const isPartialCommits = select.exists('.js-commits-filtered');
+	if (isPartialCommits && !select.exists('[aria-label="You are viewing the latest commit"]')) {
+		return;
+	}
+
+	const branch = select('.head-ref + span clipboard-copy')!.getAttribute('value')!;
+
+	const viewFile = select<HTMLAnchorElement>('[data-ga-click^="View file"]', dropdown)!;
+	const pathnameParts = viewFile.pathname.split('/');
+	pathnameParts[4] = branch;
+	viewFile.pathname = pathnameParts.join('/');
+}
+
+function init(): void {
+	delegate('#files', '.js-file-header-dropdown > summary', 'click', handleMenuOpening);
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Points the "View file" in PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.',
+	screenshot: '',
+	include: [
+		features.isPRFiles,
+		features.isPRCommit
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/raw-file-link.tsx
+++ b/source/features/raw-file-link.tsx
@@ -1,29 +1,29 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
-import onPrFileLoad from '../libs/on-pr-file-load';
 
-function createRawUrl(pathname: string): string {
-	const url = pathname.split('/');
-	url[3] = 'raw'; // Replaces 'blob'
-	return url.join('/');
-}
+function handleMenuOpening(event: DelegateEvent): void {
+	const dropdown = event.delegateTarget.nextElementSibling!;
 
-function addRawButtons(): void {
-	const links = select.all<HTMLAnchorElement>('.js-file-header-dropdown [data-ga-click^="View file"]:not(.rgh-has-raw-file-link)');
-	for (const fileLink of links) {
-		fileLink.classList.add('rgh-has-raw-file-link');
-		fileLink.after(
-			<a href={createRawUrl(fileLink.pathname)} className="pl-5 dropdown-item btn-link" role="menuitem">
-				View raw
-			</a>
-		);
+	// Only if it's not already there
+	if (select.exists('.rgh-raw-file-link', dropdown)) {
+		return;
 	}
+
+	const viewFile = select<HTMLAnchorElement>('[data-ga-click^="View file"]', dropdown)!;
+	const url = viewFile.pathname.split('/');
+	url[3] = 'raw'; // Replaces 'blob'
+
+	viewFile.after(
+		<a href={url.join('/')} className="pl-5 dropdown-item btn-link rgh-raw-file-link" role="menuitem">
+			View raw
+		</a>
+	);
 }
 
 function init(): void {
-	addRawButtons();
-	onPrFileLoad(addRawButtons);
+	delegate('#files', '.js-file-header-dropdown > summary', 'click', handleMenuOpening);
 }
 
 features.add({


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/2260

# Test

This feature only works on open PRs.

### The "View file" (and "Raw file") links should point to the branch, not the commit

- Files tab: https://github.com/sindresorhus/refined-github/pull/2529/files
- Latest commit: [#2529/commits/d6ca2e2](https://github.com/sindresorhus/refined-github/pull/2529/commits/d6ca2e2528c237912eb1be0bbd204e3993bf8327)


### The "View file" (and "Raw file") links should NOT point to the branch, but to the commit, as usual

- _Not_ the latest commit [#2529/commits/3c91c2](https://github.com/sindresorhus/refined-github/pull/2529/commits/3c91c2e0bbd030e98995dc47a529a63e6d9adf09)
- Files tab of a merged PR: https://github.com/sindresorhus/refined-github/pull/2259/files
- Files tab of a closed PR: https://github.com/sindresorhus/refined-github/pull/2472/files