### PR TITLE
Cleanup `html-preview-link` feature page detection

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -1,7 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
-import {isSingleHTMLFile} from '../libs/utils';
 
 function init(): void {
 	const rawButton = select<HTMLAnchorElement>('#raw-url')!;
@@ -24,7 +23,7 @@ features.add({
 	description: 'Adds a link to preview HTML files.',
 	screenshot: 'https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png',
 	include: [
-		isSingleHTMLFile
+		features.isSingleHTMLFile
 	],
 	exclude: [
 		features.isEnterprise

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -2,6 +2,8 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 
+const isSingleHTMLFile = (): boolean => features.isSingleFile() && (location.pathname.endsWith('.html') || location.pathname.endsWith('.htm'));
+
 function init(): void {
 	const rawButton = select<HTMLAnchorElement>('#raw-url')!;
 	const link = rawButton.pathname.split('/');
@@ -23,7 +25,7 @@ features.add({
 	description: 'Adds a link to preview HTML files.',
 	screenshot: 'https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png',
 	include: [
-		features.isSingleHTMLFile
+		isSingleHTMLFile
 	],
 	exclude: [
 		features.isEnterprise

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -323,7 +323,13 @@ export const isSingleFile = (): boolean => /^blob\//.test(getRepoPath()!);
 export const isSingleFileTest = [
 	'https://github.com/sindresorhus/refined-github/blob/master/.gitattributes',
 	'https://github.com/sindresorhus/refined-github/blob/fix-narrow-diff/distribution/content.css',
-	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt'
+	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt',
+	'https://github.com/sindresorhus/refined-github/blob/master/source/options.html'
+];
+
+export const isSingleHTMLFile = (): boolean => isSingleFile() && (location.pathname.endsWith('.html') || location.pathname.endsWith('.htm'));
+export const isSingleHTMLFileTest = [
+	'https://github.com/sindresorhus/refined-github/blob/master/source/options.html'
 ];
 
 export const isTrending = (): boolean => location.pathname === '/trending' || location.pathname.startsWith('/trending/');

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -323,13 +323,7 @@ export const isSingleFile = (): boolean => /^blob\//.test(getRepoPath()!);
 export const isSingleFileTest = [
 	'https://github.com/sindresorhus/refined-github/blob/master/.gitattributes',
 	'https://github.com/sindresorhus/refined-github/blob/fix-narrow-diff/distribution/content.css',
-	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt',
-	'https://github.com/sindresorhus/refined-github/blob/master/source/options.html'
-];
-
-export const isSingleHTMLFile = (): boolean => isSingleFile() && (location.pathname.endsWith('.html') || location.pathname.endsWith('.htm'));
-export const isSingleHTMLFileTest = [
-	'https://github.com/sindresorhus/refined-github/blob/master/source/options.html'
+	'https://github.com/sindresorhus/refined-github/blob/master/edit.txt'
 ];
 
 export const isTrending = (): boolean => location.pathname === '/trending' || location.pathname.startsWith('/trending/');

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -138,5 +138,3 @@ export function reportBug(featureName: string, bugName: string): void {
 	console.log('Find existing issues:\n' + String(issuesUrl));
 	console.log('Open new issue:\n' + String(newIssueUrl));
 }
-
-export const isSingleHTMLFile = (): boolean => /\.html?$/.test(location.pathname);


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

- Move `isSingleHTMLFile` function to `html-preview-link` ~~(despite https://github.com/sindresorhus/refined-github/pull/2505#discussion_r339354154)~~
- Handle edge cases (e.g. `https://github.com/<user>/<name>.html`)
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
https://github.com/sindresorhus/refined-github/blob/master/source/options.html (is this fine?)
Sorry I didn't actually find some repo ending with `.html`😅