### PR TITLE
Add `linkify-user-location` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -264,7 +264,7 @@ Thanks for contributing! 🦋🙌
 - [](# "profile-hotkey") Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
 - [](# "show-user-top-repositories") [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
 - [](# "set-default-repositories-type-to-sources") [Hides forks and archived repos from profiles (but they can still be shown.)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
-- [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.]('https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png')
+- [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.](https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -303,7 +303,6 @@ Thanks for contributing! 🦋🙌
 - [](# "embed-gist-via-iframe") [Adds a menu item to embed a gist via `<iframe>`.](https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png)
 - [](# "link-to-prior-blame-line") [Preserves the current line on “View blame prior to this change” links.](https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png)
 - [](# "fix-view-file-link-in-pr") [Points the "View file" in PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.](https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png)
-- [](# "linkify-labels-on-dashboard") [Makes labels clickable in the dashboard’s "Recent activity" box.](https://user-images.githubusercontent.com/9264728/68426593-bb7ebc00-01a8-11ea-9e92-5efdf4ff5f0d.png)
 - [](# "linkify-labels-on-dashboard") [Makes labels clickable in the dashboard’s "Recent activity" box.](https://user-images.githubusercontent.com/1402241/69045444-6ef97300-0a29-11ea-99a3-9a622c395709.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,7 @@ Thanks for contributing! 🦋🙌
 - [](# "profile-hotkey") Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
 - [](# "show-user-top-repositories") [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
 - [](# "set-default-repositories-type-to-sources") [Hides forks and archived repos from profiles (but they can still be shown.)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
+- [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.]('https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png')
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -150,6 +150,7 @@ import './features/link-to-prior-blame-line';
 import './features/dim-bots';
 import './features/conflict-marker';
 import './features/html-preview-link';
+import './features/linkify-user-location';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -4,15 +4,19 @@ import {wrap} from '../libs/dom-utils';
 import features from '../libs/features';
 
 function addLocation(baseElement: HTMLElement): void {
-	const location = select('.octicon-location', baseElement)?.nextSibling;
-	if (!location) {
-		return;
+	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
+		const location = nextElementSibling || nextSibling!;
+		location.textContent = location.textContent!.trim();
+
+		if (!nextElementSibling) {
+			location.before(document.createTextNode(' '));
+		}
+
+		const locationName = location.textContent;
+		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
+
+		wrap(location, <a href={googleMapsLink} />);
 	}
-
-	const locationName = location.textContent!.trim();
-	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
-
-	wrap(location, <a href={googleMapsLink} className="text-gray" />);
 }
 
 const hovercardObserver = new MutationObserver(([mutation]) => {

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -30,7 +30,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Linkifies the user location in their hovercard.',
+	description: 'Linkifies the user location in their hovercard and profile page.',
 	screenshot: 'https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png',
 	load: features.onAjaxedPages,
 	init

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -30,7 +30,7 @@ function init(): void | false {
 
 features.add({
 	id: __featureName__,
-	description: 'Linkifies user location.',
+	description: 'Linkifies the user location in their hovercard.',
 	screenshot: '',
 	load: features.onAjaxedPages,
 	init

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -6,13 +6,12 @@ import features from '../libs/features';
 function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
 		const location = nextElementSibling || nextSibling!;
-		location.textContent = location.textContent!.trim();
 
 		if (!nextElementSibling) {
 			location.before(document.createTextNode(' '));
 		}
 
-		const locationName = location.textContent;
+		const locationName = location.textContent!.trim();
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 
 		wrap(location, <a href={googleMapsLink} />);

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -7,9 +7,7 @@ function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
 		const location = nextElementSibling || nextSibling!;
 
-		if (!nextElementSibling) {
-			location.before(document.createTextNode(' '));
-		}
+		location.before(document.createTextNode(' '));
 
 		const locationName = location.textContent!.trim();
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -6,11 +6,10 @@ import features from '../libs/features';
 function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
 		const location = nextElementSibling || nextSibling!; // `nextSibling` alone might point to an empty TextNode before an element, if there’s an element
-		location.before(' '); // Keeps the link’s underline from extending out to the icon
-
 		const locationName = location.textContent!.trim();
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 
+		location.before(' '); // Keeps the link’s underline from extending out to the icon
 		wrap(location, <a href={googleMapsLink} />);
 	}
 }

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -31,7 +31,7 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Linkifies the user location in their hovercard.',
-	screenshot: '',
+	screenshot: 'https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png',
 	load: features.onAjaxedPages,
 	init
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -5,7 +5,7 @@ import features from '../libs/features';
 
 function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
-		const location = nextElementSibling || nextSibling!;
+		const location = nextElementSibling || nextSibling!; // `nextSibling` alone might point to an empty TextNode before an element, if there’s an element
 		location.before(' '); // Keeps the link’s underline from extending out to the icon
 
 		const locationName = location.textContent!.trim();

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -3,17 +3,16 @@ import select from 'select-dom';
 import {wrap} from '../libs/dom-utils';
 import features from '../libs/features';
 
-function addLocation(baseElement?: HTMLElement): void {
-	const locationIcon = select('.octicon-location', baseElement)!;
-
-	if (!locationIcon) {
+function addLocation(baseElement: HTMLElement): void {
+	const location = select('.octicon-location', baseElement)?.nextSibling;
+	if (!location) {
 		return;
 	}
 
-	const location = locationIcon.parentElement!.textContent!.trim();
-	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
+	const locationName = location.textContent!.trim();
+	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 
-	wrap(locationIcon.nextElementSibling || locationIcon.nextSibling!, <a href={googleMapsLink} />);
+	wrap(location, <a href={googleMapsLink} className="text-gray" />);
 }
 
 const hovercardObserver = new MutationObserver(([mutation]) => {
@@ -21,17 +20,9 @@ const hovercardObserver = new MutationObserver(([mutation]) => {
 });
 
 function init(): void | false {
-	if (features.isUserProfile()) {
-		for (const profileElement of select.all('.js-profile-editable-area')) {
-			addLocation(profileElement);
-		}
-	}
+	addLocation(document.body);
 
-	if (features.isOrganizationProfile()) {
-		addLocation(select('.orghead')!);
-	}
-
-	const hovercardContainer = select('.js-hovercard-content > .Popover-message')!;
+	const hovercardContainer = select('.js-hovercard-content > .Popover-message');
 	if (hovercardContainer) {
 		hovercardObserver.observe(hovercardContainer, {childList: true});
 	}
@@ -41,7 +32,6 @@ features.add({
 	id: __featureName__,
 	description: 'Linkifies user location.',
 	screenshot: '',
-	include: [() => true],
 	load: features.onAjaxedPages,
 	init
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -1,0 +1,49 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import {wrap} from '../libs/dom-utils';
+import features from '../libs/features';
+
+function addLocation(baseElement?: HTMLElement): void {
+	const locationIcon = select('.octicon-location', baseElement)!;
+
+	if (!locationIcon) {
+		return;
+	}
+
+	const location = locationIcon.parentElement!.textContent!.trim();
+	const googleMapsLink = `https://www.google.com/maps/place/${encodeURIComponent(location)}/`;
+
+	wrap(locationIcon.nextElementSibling || locationIcon.nextSibling!, <a href={googleMapsLink} />);
+}
+
+const hovercardObserver = new MutationObserver(([mutation]) => {
+	addLocation(mutation.target as HTMLElement);
+});
+
+function init(): void | false {
+	if (features.isUserProfile()) {
+		for (const profileElement of select.all('.js-profile-editable-area')) {
+			addLocation(profileElement);
+		}
+	}
+
+	if (features.isOrganizationProfile()) {
+		addLocation(select('.orghead')!);
+	}
+
+	const hovercardContainer = select('.js-hovercard-content > .Popover-message')!;
+	if (!hovercardContainer) {
+		return;
+	}
+
+	hovercardObserver.observe(hovercardContainer, {childList: true});
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Linkifies user location.',
+	screenshot: '',
+	include: [() => true],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -19,7 +19,7 @@ const hovercardObserver = new MutationObserver(([mutation]) => {
 	addLocation(mutation.target as HTMLElement);
 });
 
-function init(): void | false {
+function init(): void {
 	addLocation(document.body);
 
 	const hovercardContainer = select('.js-hovercard-content > .Popover-message');

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -11,7 +11,7 @@ function addLocation(baseElement?: HTMLElement): void {
 	}
 
 	const location = locationIcon.parentElement!.textContent!.trim();
-	const googleMapsLink = `https://www.google.com/maps/place/${encodeURIComponent(location)}/`;
+	const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(location)}`;
 
 	wrap(locationIcon.nextElementSibling || locationIcon.nextSibling!, <a href={googleMapsLink} />);
 }

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -6,8 +6,7 @@ import features from '../libs/features';
 function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
 		const location = nextElementSibling || nextSibling!;
-
-		location.before(document.createTextNode(' '));
+		location.before(' '); // Keeps the link’s underline from extending out to the icon
 
 		const locationName = location.textContent!.trim();
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -30,7 +30,7 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Linkifies the user location in their hovercard and profile page.',
-	screenshot: 'https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png',
 	load: features.onAjaxedPages,
 	init
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -32,11 +32,9 @@ function init(): void | false {
 	}
 
 	const hovercardContainer = select('.js-hovercard-content > .Popover-message')!;
-	if (!hovercardContainer) {
-		return;
+	if (hovercardContainer) {
+		hovercardObserver.observe(hovercardContainer, {childList: true});
 	}
-
-	hovercardObserver.observe(hovercardContainer, {childList: true});
 }
 
 features.add({


### PR DESCRIPTION
Closes #2116

![linkifyloc](https://user-images.githubusercontent.com/44227187/68993158-809e1780-087d-11ea-9e22-de82da8aef29.png)

# Test
Hover any user or organization profile or visit a user/organization profile, if location is present, it should be turned into a link to Google Maps.

On user profile pages, resize the browser window, the link should be preserved.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#2116: Hovercard enhancements](https://issuehunt.io/repos/51769689/issues/2116)
---

IssueHunt has been backed by the following sponsors. [Become a sponsor](https://issuehunt.io/membership/members)
</details>
<!-- /Issuehunt content-->