### PR TITLE
Add `user-local-time` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -266,6 +266,7 @@ Thanks for contributing! 🦋🙌
 - [](# "show-user-top-repositories") [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
 - [](# "set-default-repositories-type-to-sources") [Hides forks and archived repos from profiles (but they can still be shown.)](https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png)
 - [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.](https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png)
+- [](# "user-local-time") [Shows the user local time in their hovercard (based on their last commit).](https://user-images.githubusercontent.com/1402241/69863648-ef449180-12cf-11ea-8f36-7c92fc487f31.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -152,6 +152,7 @@ import './features/dim-bots';
 import './features/conflict-marker';
 import './features/html-preview-link';
 import './features/linkify-labels-on-dashboard';
+import './features/show-local-user-time';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/content.ts
+++ b/source/content.ts
@@ -154,7 +154,7 @@ import './features/conflict-marker';
 import './features/html-preview-link';
 import './features/linkify-labels-on-dashboard';
 import './features/linkify-user-location';
-import './features/show-local-user-time';
+import './features/user-local-time';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/show-local-user-time.tsx
+++ b/source/features/show-local-user-time.tsx
@@ -79,13 +79,10 @@ function init(): void {
 			return;
 		}
 
-		// NOTE: Adding the time element might changes the height of the hovercard and thuse break the positioning.
-		// So we store the container height and adjust the positioning if needed after adding the placeholder.
+		// Adding the time element might change the height of the hovercard and thus break its positioning
 		const containerHeight = container.offsetHeight;
-		const classNames = ['Popover-message--bottom-right', 'Popover-message--bottom-left'];
-		const needsAdjustment = classNames.some(name => container.classList.contains(name));
 
-		const placeholder = <span>Loading…</span>;
+		const placeholder = <span>Loading timezone…</span>;
 
 		select('div.d-flex.mt-3 > div.overflow-hidden.ml-3', container)!.append(
 			<div className="rgh-local-user-time mt-2 text-gray text-small">
@@ -93,11 +90,11 @@ function init(): void {
 			</div>
 		);
 
-		if (needsAdjustment) {
+		if (container.matches('.Popover-message--bottom-right, .Popover-message--bottom-left')) {
 			const diff = container.offsetHeight - containerHeight;
 			if (diff > 0) {
 				const parent = container.parentElement!;
-				const top = parseInt(parent.style.top ?? '0', 10);
+				const top = parseInt(parent.style.top, 10);
 				parent.style.top = `${top - diff}px`;
 			}
 		}

--- a/source/features/show-local-user-time.tsx
+++ b/source/features/show-local-user-time.tsx
@@ -8,10 +8,13 @@ import {clock} from '../libs/icons';
 interface Commit {
 	url: string;
 }
+
 interface Event {
 	type: string;
 	payload: AnyObject;
-	actor: {id: number};
+	actor: {
+		id: number;
+	};
 }
 
 // NOTE: This is basically copied from api.v3() but we can't use it because
@@ -38,7 +41,7 @@ const api = async (query: string, options: RequestInit = {}): Promise<Response> 
 	});
 };
 
-async function loadLastCommit(url: string): Promise<Commit|null> {
+async function loadLastCommit(url: string): Promise<Commit | null> {
 	const response = await api(url);
 	if (!response.ok) {
 		return null;
@@ -88,9 +91,15 @@ async function loadLastCommit(url: string): Promise<Commit|null> {
 	return loadLastCommit(next);
 }
 
-const getLastCommit = (login: string): Promise<Commit|null> => loadLastCommit(`users/${login}/events`);
+const getLastCommit = (login: string): Promise<Commit | null> => loadLastCommit(`users/${login}/events`);
+
 async function getCommitPatch(commit: Commit): Promise<string> {
-	const response = await api(commit.url, {headers: {Accept: 'application/vnd.github.v3.patch'}});
+	const response = await api(commit.url, {
+		headers: {
+			Accept: 'application/vnd.github.v3.patch'
+		}
+	});
+
 	return response.ok ? response.text() : '';
 }
 
@@ -123,8 +132,10 @@ function getTimezoneOffset(login: string): Promise<number> {
 }
 
 const format = (number: number): string => number.toString().padStart(2, '0');
+
 function init(): void {
 	const container = select('.js-hovercard-content > .Popover-message')!;
+
 	observeEl(container, async () => {
 		if (!container.childElementCount || select.exists('.rgh-local-user-time')) {
 			return;

--- a/source/features/show-local-user-time.tsx
+++ b/source/features/show-local-user-time.tsx
@@ -1,0 +1,184 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+import optionsStorage from '../options-storage';
+import observeEl from '../libs/simplified-element-observer';
+import {clock} from '../libs/icons';
+
+interface Commit {
+	url: string;
+}
+interface Event {
+	type: string;
+	payload: AnyObject;
+	actor: {id: number};
+}
+
+// NOTE: This is basically copied from api.v3() but we can't use it because
+// it always parses the res as json it also can't handle absolute urls yet.
+// TODO: Add this to lib/api somehow
+const settings = optionsStorage.getAll();
+const api3 = location.hostname === 'github.com' ?
+	'https://api.github.com/' :
+	`${location.origin}/api/v3/`;
+const api = async (query: string, options: RequestInit = {}): Promise<Response> => {
+	const {personalToken} = await settings;
+
+	const url = query.startsWith('http') ? query : (api3 + query);
+	const headers = {
+		'User-Agent': 'Refined GitHub',
+		Accept: 'application/vnd.github.v3+json',
+		...options.headers,
+		...(personalToken ? {Authorization: `token ${personalToken}`} : {})
+	};
+
+	return fetch(url, {
+		...options,
+		headers
+	});
+};
+
+async function loadLastCommit(url: string): Promise<Commit|null> {
+	const response = await api(url);
+	if (!response.ok) {
+		return null;
+	}
+
+	// NOTE: We iterate in series here to reduce requests
+	// The first commit should already work in most cases
+	const events = await response.json() as Event[];
+	for (const event of events) {
+		if (event.type !== 'PushEvent') {
+			continue;
+		}
+
+		// NOTE: We want to iterate the commits in reverse to start with the latest commit
+		const commits = event.payload.commits as Commit[];
+		for (let i = commits.length - 1; i >= 0; i--) {
+			const commit = commits[i];
+			// eslint-disable-next-line no-await-in-loop
+			const response = await api(commit.url);
+			if (!response.ok) {
+				// NOTE: Ignore 404 errors and check the next commit
+				if (response.status === 404) {
+					continue;
+				}
+
+				return null;
+			}
+
+			// eslint-disable-next-line no-await-in-loop
+			const {author} = await response.json();
+			// NOTE: Some commits don't have an author when there is no github user for the autor email.
+			if (author && author.id === event.actor.id) {
+				return commit;
+			}
+		}
+	}
+
+	if (!response.headers.has('link')) {
+		return null;
+	}
+
+	const [, next] = (/<([^>]+)>; rel="next"/).exec(response.headers.get('link')!) || [];
+	if (!next) {
+		return null;
+	}
+
+	return loadLastCommit(next);
+}
+
+const getLastCommit = (login: string): Promise<Commit|null> => loadLastCommit(`users/${login}/events`);
+async function getCommitPatch(commit: Commit): Promise<string> {
+	const response = await api(commit.url, {headers: {Accept: 'application/vnd.github.v3.patch'}});
+	return response.ok ? response.text() : '';
+}
+
+// IDEA: We could also return the date from the patch
+// This could help to identify "wrong" offsets e.g. daylight saving
+async function loadTimezoneOffset(login: string): Promise<number> {
+	const commit = await getLastCommit(login);
+	if (!commit) {
+		return NaN;
+	}
+
+	const patch = await getCommitPatch(commit);
+	const match = (/^Date: .*? (\+|-)(\d\d)(\d\d)$/m).exec(patch);
+	if (!match) {
+		return NaN;
+	}
+
+	const [, sign, hours, minutes] = match;
+	const offset = (parseInt(hours, 10) * 60) + parseInt(minutes, 10);
+	return sign === '-' ? -offset : offset;
+}
+
+const cache = new Map<string, Promise<number>>();
+function getTimezoneOffset(login: string): Promise<number> {
+	if (!cache.has(login)) {
+		cache.set(login, loadTimezoneOffset(login));
+	}
+
+	return cache.get(login)!;
+}
+
+const format = (number: number): string => number.toString().padStart(2, '0');
+function init(): void {
+	const container = select('.js-hovercard-content > .Popover-message')!;
+	observeEl(container, async () => {
+		if (!container.childElementCount || select.exists('.rgh-local-user-time')) {
+			return;
+		}
+
+		const profile = select<HTMLAnchorElement>('a[data-octo-dimensions="link_type:profile"', container);
+		if (!profile) {
+			return;
+		}
+
+		const content = select('div.d-flex.mt-3 > div.overflow-hidden.ml-3', container);
+		if (!content) {
+			return;
+		}
+
+		// NOTE: Adding the time element might changes the height of the hovercard and thuse break the positioning.
+		// So we store the container height and adjust the positioning if needed after adding the placeholder.
+		const containerHeight = container.offsetHeight;
+		const classNames = ['Popover-message--bottom-right', 'Popover-message--bottom-left'];
+		const needsAdjustment = classNames.some(name => container.classList.contains(name));
+
+		const placeholder = <span>Loading...</span>;
+		content.append(
+			<div className="rgh-local-user-time mt-2 text-gray text-small">
+				{clock()} {placeholder}
+			</div>
+		);
+
+		if (needsAdjustment) {
+			const diff = container.offsetHeight - containerHeight;
+			if (diff > 0) {
+				const parent = container.parentElement!;
+				const top = parseInt(parent.style.top || '0', 10);
+				parent.style.top = `${top - diff}px`;
+			}
+		}
+
+		const login = profile.pathname.replace(/^\//, '');
+		const offset = await getTimezoneOffset(login);
+		if (Number.isNaN(offset)) {
+			placeholder.textContent = '-';
+			return;
+		}
+
+		const date = new Date();
+		date.setMinutes(offset + date.getTimezoneOffset() + date.getMinutes());
+		placeholder.textContent = `${format(date.getHours())}:${format(date.getMinutes())}`;
+	});
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Show the local time of a user in the hovercard (based on the last commit).',
+	screenshot: false,
+	load: features.onDomReady,
+	init
+});

--- a/source/features/show-local-user-time.tsx
+++ b/source/features/show-local-user-time.tsx
@@ -7,6 +7,7 @@ import features from '../libs/features';
 import observeEl from '../libs/simplified-element-observer';
 import {clock} from '../libs/icons';
 import * as api from '../libs/api';
+import {getUsername} from '../libs/utils';
 
 interface Commit {
 	url: string;
@@ -74,7 +75,7 @@ function init(): void {
 		}
 
 		const login = select<HTMLAnchorElement>('a[data-octo-dimensions="link_type:profile"]', container)?.pathname.slice(1);
-		if (!login) {
+		if (!login || login === getUsername()) {
 			return;
 		}
 

--- a/source/features/show-local-user-time.tsx
+++ b/source/features/show-local-user-time.tsx
@@ -30,6 +30,16 @@ async function loadLastCommit(pathname: string): Promise<Commit | void> {
 			for (const commit of event.payload.commits.reverse()) {
 				const response = await api.v3(commit.url, {ignoreHTTPStatus: true});
 
+				// Commits might not exist anymore even if they are listed in the events
+				// This can happen if the repository was deleted so we can also skip all other commits
+				if (response.httpStatus === 404) {
+					break;
+				}
+
+				if (!response.ok) {
+					throw await api.getError(response);
+				}
+
 				// `response.author` only appears if GitHub can match the email to a GitHub user
 				if (response.author?.id === event.actor.id) {
 					return commit;

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -81,21 +81,18 @@ const loadLastCommitDate = mem(async (login: string): Promise<string | void> => 
 	return date;
 });
 
-async function getLastCommit(login: string): Promise<string | void> {
+const getLastCommit = mem(async (login: string): Promise<string | false> => {
 	const key = `${__featureName__}:${login}`;
 
-	const cached = await cache.get<string>(key);
-	if (cached) {
+	const cached = await cache.get<string | false>(key);
+	if (typeof cached !== 'undefined') {
 		return cached;
 	}
 
-	const date = await loadLastCommitDate(login);
-	if (date) {
-		await cache.set(key, date, 10);
-	}
-
+	const date = await loadLastCommitDate(login) || false;
+	await cache.set(key, date, 10);
 	return date;
-}
+});
 
 function init(): void {
 	const hovercard = select('.js-hovercard-content > .Popover-message')!;

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -137,8 +137,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Show the local time of a user in the hovercard (based on the last commit).',
-	screenshot: false,
+	description: 'Shows the user local time in their hovercard (based on their last commit).',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/69863648-ef449180-12cf-11ea-8f36-7c92fc487f31.gif',
 	load: features.onDomReady,
 	init
 });

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -84,7 +84,7 @@ function init(): void {
 	const hovercard = select('.js-hovercard-content > .Popover-message')!;
 
 	observeEl(hovercard, async () => {
-		if (hovercard.childElementCount === 0 || select.exists('.rgh-local-user-time')) {
+		if (hovercard.childElementCount === 0 || select.exists('.rgh-local-user-time', hovercard)) {
 			return;
 		}
 

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -97,7 +97,7 @@ function init(): void {
 			return;
 		}
 
-		const placeholder = <span>Loading timezone…</span>;
+		const placeholder = <span>Guessing local time…</span>;
 		const container = <div className="rgh-local-user-time mt-2 text-gray text-small">
 			{clock()} {placeholder}
 		</div>;
@@ -118,14 +118,14 @@ function init(): void {
 		const date = await getLastCommit(login);
 		if (!date) {
 			placeholder.textContent = '-';
-			container.title = 'No commit found';
+			container.title = 'Timezone couldn’t be determined from their last commits';
 			return;
 		}
 
 		const now = new Date();
 		now.setMinutes(parseOffset(date) + now.getTimezoneOffset() + now.getMinutes());
 		placeholder.textContent = timeFormatter.format(now);
-		container.title = `Last commit found: ${date}`;
+		container.title = `Timezone guessed from their last commit: ${date}`;
 	});
 }
 

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -10,6 +10,11 @@ import {clock} from '../libs/icons';
 import * as api from '../libs/api';
 import {getUsername} from '../libs/utils';
 
+interface Commit {
+	url: string;
+	sha: string;
+}
+
 const timeFormatter = new Intl.DateTimeFormat('en-US', {
 	hour: 'numeric',
 	minute: 'numeric',
@@ -35,7 +40,7 @@ async function loadLastCommitDate(login: string): Promise<string | void> {
 			}
 
 			// Start from the latest commit, which is the last one in the list
-			for (const commit of event.payload.commits.reverse()) {
+			for (const commit of event.payload.commits.reverse() as Commit[]) {
 				const response = await api.v3(commit.url, {ignoreHTTPStatus: true});
 
 				// Commits might not exist anymore even if they are listed in the events

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -1,13 +1,13 @@
 /* eslint-disable no-await-in-loop */
 
 import mem from 'mem';
+import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
-import cache from 'webext-storage-cache';
 import features from '../libs/features';
-import observeEl from '../libs/simplified-element-observer';
-import {clock} from '../libs/icons';
 import * as api from '../libs/api';
+import * as icons from '../libs/icons';
+import observeEl from '../libs/simplified-element-observer';
 import {getUsername} from '../libs/utils';
 
 interface Commit {
@@ -42,7 +42,6 @@ async function loadLastCommitDate(login: string): Promise<string | void> {
 			// Start from the latest commit, which is the last one in the list
 			for (const commit of event.payload.commits.reverse() as Commit[]) {
 				const response = await api.v3(commit.url, {ignoreHTTPStatus: true});
-
 				// Commits might not exist anymore even if they are listed in the events
 				// This can happen if the repository was deleted so we can also skip all other commits
 				if (response.httpStatus === 404) {
@@ -68,7 +67,7 @@ async function loadLastCommitDate(login: string): Promise<string | void> {
 	}
 }
 
-const parseOffset = (date: string): number => {
+function parseOffset(date: string): number {
 	const [, hourString, minuteString] = (/([-+]\d\d)(\d\d)$/).exec(date) ?? [];
 
 	const hours = parseInt(hourString, 10);
@@ -103,9 +102,11 @@ function init(): void {
 		}
 
 		const placeholder = <span>Guessing local time…</span>;
-		const container = <div className="rgh-local-user-time mt-2 text-gray text-small">
-			{clock()} {placeholder}
-		</div>;
+		const container = (
+			<div className="rgh-local-user-time mt-2 text-gray text-small">
+				{icons.clock()} {placeholder}
+			</div>
+		);
 
 		// Adding the time element might change the height of the hovercard and thus break its positioning
 		const hovercardHeight = hovercard.offsetHeight;

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -1,9 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // TODO: Drop some definitions when their related bugs are resolved
 // TODO: Improve JSX types for event listeners so we can use `MouseEvent` instead of `React.MouseEvent`, which is incompatible with regular `addEventListeners` calls
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyObject = Record<string, any>;
 type AsyncVoidFunction = () => Promise<void>;
+type Unpromise<MaybePromise> = MaybePromise extends Promise<infer Type> ? Type : MaybePromise;
+type AsyncReturnType<T extends (...args: any) => any> = Unpromise<ReturnType<T>>;
 
 interface FeatureInfo {
 	name: string;

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -125,7 +125,7 @@ export const v3 = mem(async (
 
 export const v3paginated = async function * (
 	query: string,
-	options: GHRestApiOptions
+	options?: GHRestApiOptions
 ): AsyncGenerator<AsyncReturnType<typeof v3>> {
 	while (true) {
 		// eslint-disable-next-line no-await-in-loop

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -183,7 +183,7 @@ export const v4 = mem(async (
 	throw await getError(apiResponse as JsonObject);
 });
 
-async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError> {
+export async function getError(apiResponse: JsonObject): Promise<RefinedGitHubAPIError> {
 	const {personalToken} = await settings;
 
 	if ((apiResponse.message as string)?.includes('API rate limit exceeded')) {

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -91,13 +91,13 @@ export const v3 = mem(async (
 	const {ignoreHTTPStatus, method, body, headers, json} = {...v3defaults, ...options};
 	const {personalToken} = await settings;
 
-	// Handle full URLs we might have received from the API itself
-	if (query.startsWith('https://')) {
-		query = new URL(query).pathname.slice(1).replace('api/v3/', '');
+	if (query.startsWith('/')) {
+		throw new TypeError('The query parameter must not start with a slash.');
 	}
 
-	console.log('Will fetch', api3 + query); // TODO: remove temporary logging
-	const response = await fetch(api3 + query, {
+	const url = new URL(query, api3);
+	console.log('Will fetch', url.href); // TODO: remove temporary logging
+	const response = await fetch(url.href, {
 		method,
 		body: body && JSON.stringify(body),
 		headers: {
@@ -110,7 +110,7 @@ export const v3 = mem(async (
 	const textContent = await response.text();
 
 	// The response might just be a 200 or 404, it's the REST equivalent of `boolean`
-	const apiResponse: JsonObject = json ? JSON.parse(textContent.length > 0 ? textContent : '') : {textContent};
+	const apiResponse: JsonObject = (json && textContent.length > 0) ? JSON.parse(textContent) : {textContent};
 
 	if (response.ok || ignoreHTTPStatus) {
 		return Object.assign(apiResponse, {

--- a/source/libs/api.ts
+++ b/source/libs/api.ts
@@ -110,7 +110,7 @@ export const v3 = mem(async (
 	const textContent = await response.text();
 
 	// The response might just be a 200 or 404, it's the REST equivalent of `boolean`
-	const apiResponse: JsonObject = json ? JSON.parse(textContent) : {textContent};
+	const apiResponse: JsonObject = json ? JSON.parse(textContent.length > 0 ? textContent : '') : {textContent};
 
 	if (response.ok || ignoreHTTPStatus) {
 		return Object.assign(apiResponse, {


### PR DESCRIPTION
This is the first implementation of adding the user's time to their hovercard.
This is done through checking their last commit author date.

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/9264728/69049084-5a07ea00-09ff-11ea-92fd-cbf546f147b6.png)
</details>

It is still a bit rough implementation and might not be final.

Todos:
- [x] Should the custom `api` be handled here or extracted out
- [ ] How should errors be handled?
	Right now most of them just result into an empty time (that is also chached).

Closes #1233 