### PR TITLE
Avoid duplicate view switcher in `faster-pr-diff-options`

### DIFF
--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -80,7 +80,7 @@ function init(): false | void {
 	}
 
 	// Remove previous options UI
-	const singleCommitUI = select('[data-ga-load="Diff, view, Viewed Split Diff"],[data-ga-load="Diff, view, Viewed Unified Diff"]');
+	const singleCommitUI = select('[data-ga-load^="Diff, view"]');
 
 	if (singleCommitUI) {
 		singleCommitUI.remove();

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -80,7 +80,8 @@ function init(): false | void {
 	}
 
 	// Remove previous options UI
-	const singleCommitUI = select('[data-ga-load="Diff, view, Viewed Split Diff"]');
+	const singleCommitUI = select('[data-ga-load="Diff, view, Viewed Split Diff"],[data-ga-load="Diff, view, Viewed Unified Diff"]');
+
 	if (singleCommitUI) {
 		singleCommitUI.remove();
 		return;


### PR DESCRIPTION
The text for data-ga-load is actually slightly different on the two buttons so we need a selector that covers both values

<!-- Thanks for contributing! 🍄 -->

Closes #2217
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Go to a single commit view (default) (https://github.com/sindresorhus/refined-github/commit/75624f2acf21abf14fa75ea512cfcab42eeb6a2c)
--> the original split/unified buttons should be hidden and the 'icon-only' buttons should be displayed
- Go to a single commit view (split) (https://github.com/sindresorhus/refined-github/commit/75624f2acf21abf14fa75ea512cfcab42eeb6a2c?diff=split)
--> the original split/unified buttons should be hidden and the 'icon-only' buttons should be displayed
- Go to a single commit view (unified) (https://github.com/sindresorhus/refined-github/commit/75624f2acf21abf14fa75ea512cfcab42eeb6a2c?diff=unified)
--> the original split/unified buttons should be hidden and the 'icon-only' buttons should be displayed