### PR TITLE
Simplify cache usage (as a memoized function)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11020,6 +11020,15 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
+		"p-memoize": {
+			"version": "4.0.0-1",
+			"resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.0-1.tgz",
+			"integrity": "sha512-JRm4SIuLumdi3QVVrNhCaVAEE6x9tBq4MOdkV82d4va744lWHbvn3BIDvgACcY3qGRnIcd7acQnVvxxo+PxLHA==",
+			"requires": {
+				"map-age-cleaner": "^0.1.3",
+				"mimic-fn": "^2.1.0"
+			}
+		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15816,9 +15816,9 @@
 			"integrity": "sha512-dPsU7KtDn+OG+mPy0LLc9UhMXdVeQ8ywD5kK1GFtvceur4IWOnpI5D4uTjMPrKm8+re/8cbHKwVjnviIA9wZ3Q=="
 		},
 		"webext-storage-cache": {
-			"version": "2.0.0-0",
-			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-2.0.0-0.tgz",
-			"integrity": "sha512-zpXclgUgbWVD0MbtXke8CMuH6jhFRL1c1wYQcJNySUjP84OFqjUVuat9OOLo4AgKcQ3iEnfYd2LJ62Zn8mIf1A==",
+			"version": "2.0.0-1",
+			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-2.0.0-1.tgz",
+			"integrity": "sha512-llIu2BxmfXbqcirTpguM6mHODLsSLRxXefloh4qoDD8dDENZ/mHA/7HFCKVYJDh48jUXJ2XGumq1d1q9qDFD5Q==",
 			"requires": {
 				"webext-detect-page": "^1.0.1"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11020,15 +11020,6 @@
 			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
 			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
-		"p-memoize": {
-			"version": "4.0.0-1",
-			"resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.0-1.tgz",
-			"integrity": "sha512-JRm4SIuLumdi3QVVrNhCaVAEE6x9tBq4MOdkV82d4va744lWHbvn3BIDvgACcY3qGRnIcd7acQnVvxxo+PxLHA==",
-			"requires": {
-				"map-age-cleaner": "^0.1.3",
-				"mimic-fn": "^2.1.0"
-			}
-		},
 		"p-try": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -15825,9 +15816,9 @@
 			"integrity": "sha512-dPsU7KtDn+OG+mPy0LLc9UhMXdVeQ8ywD5kK1GFtvceur4IWOnpI5D4uTjMPrKm8+re/8cbHKwVjnviIA9wZ3Q=="
 		},
 		"webext-storage-cache": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-1.0.2.tgz",
-			"integrity": "sha512-0rxXPVHFeD+wvNHBI+jjgyI21Spd45N8tT7w9bbrVkly3Eo3RdbEeMTndJvbCu7jP7k3fqRlUC85xcJ6WdYSsA==",
+			"version": "2.0.0-0",
+			"resolved": "https://registry.npmjs.org/webext-storage-cache/-/webext-storage-cache-2.0.0-0.tgz",
+			"integrity": "sha512-zpXclgUgbWVD0MbtXke8CMuH6jhFRL1c1wYQcJNySUjP84OFqjUVuat9OOLo4AgKcQ3iEnfYd2LJ62Zn8mIf1A==",
 			"requires": {
 				"webext-detect-page": "^1.0.1"
 			}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"webext-dynamic-content-scripts": "^6.0.3",
 		"webext-options-sync": "^1.0.0-8",
 		"webext-permissions-events-polyfill": "^1.0.1",
-		"webext-storage-cache": "^2.0.0-0",
+		"webext-storage-cache": "^2.0.0-1",
 		"webextension-polyfill": "^0.5.0",
 		"zip-text-nodes": "^1.0.0-0"
 	},

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"mem": "^6.0.1",
 		"onetime": "^5.0.0",
 		"p-filter": "^2.1.0",
+		"p-memoize": "^4.0.0-1",
 		"select-dom": "^5.1.0",
 		"shorten-repo-url": "^1.5.3",
 		"tiny-version-compare": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
 		"mem": "^6.0.1",
 		"onetime": "^5.0.0",
 		"p-filter": "^2.1.0",
-		"p-memoize": "^4.0.0-1",
 		"select-dom": "^5.1.0",
 		"shorten-repo-url": "^1.5.3",
 		"tiny-version-compare": "^1.0.0",
@@ -48,7 +47,7 @@
 		"webext-dynamic-content-scripts": "^6.0.3",
 		"webext-options-sync": "^1.0.0-8",
 		"webext-permissions-events-polyfill": "^1.0.1",
-		"webext-storage-cache": "^1.0.2",
+		"webext-storage-cache": "^2.0.0-0",
 		"webextension-polyfill": "^0.5.0",
 		"zip-text-nodes": "^1.0.0-0"
 	},

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -1,47 +1,41 @@
-import select from 'select-dom';
 import cache from 'webext-storage-cache';
+import select from 'select-dom';
+import pMemoize from 'p-memoize';
 import features from '../libs/features';
 import * as api from '../libs/api';
-import {getOwnerAndRepo} from '../libs/utils';
+import {getOwnerAndRepo, getRepoURL, getRepoGQL} from '../libs/utils';
 
-type CacheEntry = {
+type Counts = {
 	repoProjectCount: number;
 	orgProjectCount: number;
 	milestoneCount: number;
 };
 
-async function getCount(): Promise<CacheEntry> {
-	const {ownerName, repoName} = getOwnerAndRepo();
-	const cacheKey = `clean-issue-filters:${ownerName}/${repoName}`;
-	const cachedData = await cache.get<CacheEntry>(cacheKey);
-	if (cachedData) {
-		return cachedData;
-	}
-
-	const result = await api.v4(`
-		repository(owner: "${ownerName}", name: "${repoName}") {
+const getCounts = pMemoize(async (): Promise<Counts> => {
+	const {repository, organization} = await api.v4(`
+		repository(${getRepoGQL()}) {
 			projects { totalCount }
 			milestones { totalCount }
 		}
-		organization(login: "${ownerName}") {
+		organization(login: "${getOwnerAndRepo().ownerName}") {
 			projects { totalCount }
 		}
 	`, {
 		allowErrors: true
 	});
 
-	const cacheEntry = {
-		repoProjectCount: result.repository.projects.totalCount,
-		orgProjectCount: result.organization ? result.organization.projects.totalCount : 0,
-		milestoneCount: result.repository.milestones.totalCount
+	return {
+		repoProjectCount: repository.projects.totalCount,
+		orgProjectCount: organization ? organization.projects.totalCount : 0,
+		milestoneCount: repository.milestones.totalCount
 	};
-
-	cache.set(cacheKey, cacheEntry, 1);
-	return cacheEntry;
-}
+}, {
+	cache,
+	cacheKey: () => __featureName__ + ':' + getRepoURL()
+})
 
 async function init(): Promise<void> {
-	const {repoProjectCount, orgProjectCount, milestoneCount} = await getCount();
+	const {repoProjectCount, orgProjectCount, milestoneCount} = await getCounts();
 
 	// If the repo and organization has no projects, its selector will be empty
 	if (repoProjectCount === 0 && orgProjectCount === 0 && select.exists('[data-hotkey="p"')) {

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -1,6 +1,5 @@
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import pMemoize from 'p-memoize';
 import features from '../libs/features';
 import * as api from '../libs/api';
 import {getOwnerAndRepo, getRepoURL, getRepoGQL} from '../libs/utils';
@@ -11,7 +10,7 @@ type Counts = {
 	milestoneCount: number;
 };
 
-const getCounts = pMemoize(async (): Promise<Counts> => {
+const getCounts = cache.function(async (): Promise<Counts> => {
 	const {repository, organization} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			projects { totalCount }
@@ -30,7 +29,7 @@ const getCounts = pMemoize(async (): Promise<Counts> => {
 		milestoneCount: repository.milestones.totalCount
 	};
 }, {
-	cache,
+	expiration: 3,
 	cacheKey: () => __featureName__ + ':' + getRepoURL()
 })
 

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -31,7 +31,7 @@ const getCounts = cache.function(async (): Promise<Counts> => {
 }, {
 	expiration: 3,
 	cacheKey: () => __featureName__ + ':' + getRepoURL()
-})
+});
 
 async function init(): Promise<void> {
 	const {repoProjectCount, orgProjectCount, milestoneCount} = await getCounts();

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -8,7 +8,6 @@ import {isSingleFile} from '../libs/page-detect';
 import getDefaultBranch from '../libs/get-default-branch';
 import {groupSiblings} from '../libs/group-buttons';
 import * as icons from '../libs/icons';
-import pMemoize from 'p-memoize';
 
 async function init(): Promise<void> {
 	// `clipboard-copy` on blob page, `#blob-edit-path` on edit page
@@ -50,7 +49,7 @@ async function init(): Promise<void> {
 /**
 @returns prsByFile {"filename1": [10, 3], "filename2": [2]}
 */
-const getPrsByFile = pMemoize(async (): Promise<Record<string, number[]>> => {
+const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			pullRequests(
@@ -87,7 +86,7 @@ const getPrsByFile = pMemoize(async (): Promise<Record<string, number[]>> => {
 
 	return files;
 }, {
-	cache,
+	expiration: 3,
 	cacheKey: () => `list-prs-for-file:${getRepoURL()}`
 });
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -1,7 +1,6 @@
 import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
-import pMemoize from 'p-memoize';
 import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as api from '../libs/api';
@@ -32,8 +31,8 @@ async function fetchFromApi(): Promise<number | undefined> {
 	return repository.refs.totalCount;
 }
 
-const getReleaseCount = pMemoize(async () => parseCountFromDom() ?? await fetchFromApi(), {
-	cache,
+const getReleaseCount = cache.function(async () => parseCountFromDom() ?? await fetchFromApi(), {
+	expiration: 3,
 	cacheKey: () => cacheKey
 });
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -31,7 +31,7 @@ async function fetchFromApi(): Promise<number | undefined> {
 	return repository.refs.totalCount;
 }
 
-const getReleaseCount = cache.function(async () => parseCountFromDom() ?? await fetchFromApi(), {
+const getReleaseCount = cache.function(async () => parseCountFromDom() ?? fetchFromApi(), {
 	expiration: 3,
 	cacheKey: () => cacheKey
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -10,9 +10,9 @@ import {isRepoRoot, isReleasesOrTags} from '../libs/page-detect';
 const repoUrl = getRepoURL();
 const cacheKey = `releases-count:${repoUrl}`;
 
-async function parseCountFromDom(): Promise<number | void> {
+function parseCountFromDom(): number | void {
 	if (isRepoRoot()) {
-		const releasesCountElement = await elementReady('.numbers-summary a[href$="/releases"] .num');
+		const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
 		return Number(releasesCountElement ? releasesCountElement.textContent!.replace(/,/g, '') : 0);
 	}
 }

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -1,7 +1,6 @@
 import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
-import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as api from '../libs/api';
 import * as icons from '../libs/icons';
@@ -41,12 +40,7 @@ async function init(): Promise<false | void> {
 		await cache.delete(cacheKey);
 	}
 
-	// TODO: currently `elementReady` is useless because `onAjaxedPages` always awaits domReady
-	const [count] = await Promise.all([
-		getReleaseCount(),
-		elementReady('.pagehead + *')
-	]);
-
+	const count = await getReleaseCount();
 	if (count === 0) {
 		return false;
 	}

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -3,7 +3,6 @@
 import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
-import pMemoize from 'p-memoize';
 import features from '../libs/features';
 import * as api from '../libs/api';
 import * as icons from '../libs/icons';
@@ -32,7 +31,7 @@ async function loadCommitPatch(commitUrl: string): Promise<string> {
 	return textContent;
 }
 
-const getLastCommitDate = pMemoize(async (login: string): Promise<string | void> => {
+const getLastCommitDate = cache.function(async (login: string): Promise<string | void> => {
 	for await (const page of api.v3paginated(`users/${login}/events`)) {
 		for (const event of page as any) { // eslint-disable-line @typescript-eslint/no-explicit-any
 			if (event.type !== 'PushEvent') {
@@ -66,7 +65,7 @@ const getLastCommitDate = pMemoize(async (login: string): Promise<string | void>
 		}
 	}
 }, {
-	cache,
+	expiration: 10,
 	cacheKey: login => __featureName__ + ':' + login
 });
 

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -66,7 +66,7 @@ const getLastCommitDate = cache.function(async (login: string): Promise<string |
 	}
 }, {
 	expiration: 10,
-	cacheKey: login => __featureName__ + ':' + login
+	cacheKey: ([login]) => __featureName__ + ':' + login
 });
 
 function parseOffset(date: string): number {
@@ -110,7 +110,6 @@ function init(): void {
 			}
 		}
 
-		debugger;
 		const date = await getLastCommitDate(login);
 		if (!date) {
 			placeholder.textContent = '-';

--- a/source/libs/get-default-branch.ts
+++ b/source/libs/get-default-branch.ts
@@ -31,6 +31,6 @@ async function fetchFromApi(): Promise<string> {
 	return response.default_branch as string;
 }
 
-export default cache.function(async () => parseBranchFromDom() ?? await fetchFromApi(), {
-	cacheKey: repo => 'default-branch:' + repo
+export default cache.function(async () => parseBranchFromDom() ?? fetchFromApi(), {
+	cacheKey: () => 'default-branch:' + getRepoURL()
 });

--- a/source/libs/get-default-branch.ts
+++ b/source/libs/get-default-branch.ts
@@ -1,6 +1,5 @@
 import select from 'select-dom';
 import cache from 'webext-storage-cache';
-import pMemoize from 'p-memoize';
 import * as api from './api';
 import {getRepoURL} from './utils';
 
@@ -32,7 +31,6 @@ async function fetchFromApi(): Promise<string> {
 	return response.default_branch as string;
 }
 
-export default pMemoize(async () => parseBranchFromDom() ?? await fetchFromApi(), {
-	cache,
+export default cache.function(async () => parseBranchFromDom() ?? await fetchFromApi(), {
 	cacheKey: repo => 'default-branch:' + repo
 });


### PR DESCRIPTION
Edit: I replaced `p-memoize` with a new built-in [memoization feature](https://github.com/fregante/webext-storage-cache/pull/5) of [webext-storage-cache](https://github.com/fregante/webext-storage-cache)

Affects (I tested the first 4):

- `clean-issue-filters`
- `list-prs-for-file`
- `releases-tab`
- `user-local-time`
- any additional feature that uses the default branch information
  - `warn-pr-from-master`
  - `branch-buttons`
  - `edit-files-faster`
  - `edit-readme`
  - `useful-not-found-page`
  - `pr-branches`


<details>
<summary>Resolved problems</summary>
Implementation test for https://github.com/sindresorhus/p-memoize/pull/12

- https://github.com/sindresorhus/p-memoize/pull/12#issuecomment-559845913
- I think `releases-count`'s API call is broken
- Currently there's no way to set an expiration, unless `webext-storage-cache` is rewritten with `map-age-cleaner` compatibility

</details>
