### PR TITLE
Disable `linkify-user-location` on own editable profile

### DIFF
--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -1,11 +1,15 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {wrap} from '../libs/dom-utils';
+import {wrap, isEditable} from '../libs/dom-utils';
 import features from '../libs/features';
 
 function addLocation(baseElement: HTMLElement): void {
 	for (const {nextElementSibling, nextSibling} of select.all('.octicon-location', baseElement)) {
 		const location = nextElementSibling || nextSibling!; // `nextSibling` alone might point to an empty TextNode before an element, if there’s an element
+		if (isEditable(location)) {
+			continue;
+		}
+
 		const locationName = location.textContent!.trim();
 		const googleMapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationName)}`;
 


### PR DESCRIPTION
Closes #2581.

I chose slightly different approach: instead of `except: [features.isUserOwnProfile]` it will skip editable nodes by using existing `isEditable` helper. That's because there are two sets of DOM nodes (display and form) on user profile and "Edit profile" button just toggles between those two.

This way displayed location will remain linkified, but editable field will be kept intact.
