### PR TITLE
Improve spacing in discussion lists and avoid jump

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -105,3 +105,12 @@
 .dropdown-menu-sw {
 	transform-origin: 90% top;
 }
+
+/* Improve spacing in discussion lists meta, made feel crowded by:
+highlight-collaborators-and-own-discussions
+parse-backticks
+pr-branches
+*/
+.js-issue-row .text-small.text-gray {
+	line-height: 1.8;
+}

--- a/source/features/conflict-marker.css
+++ b/source/features/conflict-marker.css
@@ -1,0 +1,4 @@
+.rgh-conflict-marker svg {
+	vertical-align: middle;
+	color: silver;
+}

--- a/source/features/conflict-marker.css
+++ b/source/features/conflict-marker.css
@@ -1,4 +1,4 @@
 .rgh-conflict-marker svg {
 	vertical-align: middle;
-	color: silver;
+	color: #c0c0c0;
 }

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -1,3 +1,4 @@
+import './conflict-marker.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as api from '../libs/api';
@@ -50,7 +51,7 @@ async function init(): Promise<false | void> {
 		if (data[pr.key].pullRequest.mergeable === 'CONFLICTING') {
 			pr.link.after(
 				<a
-					className="tooltipped tooltipped-n m-0 text-gray mr-2"
+					className="rgh-conflict-marker tooltipped tooltipped-n m-0 text-gray mr-1"
 					aria-label="This PR has conflicts that must be resolved"
 					href={`${pr.link.pathname}#partial-pull-merging`}
 				>

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -129,7 +129,7 @@ async function init(): Promise<false | void> {
 		}
 
 		select('.text-small.text-gray', PR)!.append(
-			<span className="mt-1 issue-meta-section d-inline-block">
+			<span className="issue-meta-section d-inline-block">
 				{openPullRequest()}
 				{' '}
 				{branches}


### PR DESCRIPTION
Replaces #2522. The `mt-1` class was causing a jump after being added to the dom.

Improves `conflict-marker` color/spacing as well

# conflict-marker icon

Lighter is new

![](https://user-images.githubusercontent.com/1402241/69935721-55b3f480-1508-11ea-89a6-f549c390a134.gif)

# Spacing before

<img width="294" alt="before" src="https://user-images.githubusercontent.com/1402241/69935741-649aa700-1508-11ea-8241-320f670fe7e7.png">

# Spacing after
<img width="298" alt="after" src="https://user-images.githubusercontent.com/1402241/69935747-66646a80-1508-11ea-89dd-54ddb82ee1b2.png">

