### PR TITLE
Improve PR detection in all discussion lists

### DIFF
--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -26,24 +26,25 @@ function buildQuery(prs: PRConfig[]): string {
 	return prs.map(createQueryFragment).join('\n');
 }
 
-function getPRConfig(prLink: HTMLAnchorElement): PRConfig {
-	const [, user, repo, , number] = prLink.pathname.split('/');
+function getPRConfig(prIcon: Element): PRConfig {
+	const link = prIcon.closest('.js-navigation-item')!.querySelector<HTMLAnchorElement>('.js-navigation-open')!;
+	const [, user, repo, , number] = link.pathname.split('/');
 	return {
 		user,
 		repo,
 		number,
+		link,
 		key: api.escapeKey(`${user}_${repo}_${number}`),
-		link: prLink
 	};
 }
 
 async function init(): Promise<false | void> {
-	const prLinks = select.all<HTMLAnchorElement>('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]');
-	if (prLinks.length === 0) {
+	const openPrIcons = select.all('.js-issue-row .octicon-git-pull-request.open');
+	if (openPrIcons.length === 0) {
 		return false;
 	}
 
-	const prs = prLinks.map(getPRConfig);
+	const prs = openPrIcons.map(getPRConfig);
 	const data = await api.v4(buildQuery(prs));
 
 	for (const pr of prs) {

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -38,7 +38,7 @@ function getPRConfig(prLink: HTMLAnchorElement): PRConfig {
 }
 
 async function init(): Promise<false | void> {
-	const prLinks = select.all<HTMLAnchorElement>('.js-issue-row .js-navigation-open');
+	const prLinks = select.all<HTMLAnchorElement>('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]');
 	if (prLinks.length === 0) {
 		return false;
 	}
@@ -67,7 +67,7 @@ features.add({
 	screenshot:
 		'https://user-images.githubusercontent.com/9092510/62777551-2affe500-baae-11e9-8ba4-67f078347913.png',
 	include: [
-		features.isPRList
+		features.isDiscussionList
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -34,7 +34,7 @@ function getPRConfig(prIcon: Element): PRConfig {
 		repo,
 		number,
 		link,
-		key: api.escapeKey(`${user}_${repo}_${number}`),
+		key: api.escapeKey(`${user}_${repo}_${number}`)
 	};
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -8,7 +8,7 @@ function init(): void {
 		'.commit-author[href$="%5Bbot%5D"]:first-child',
 		'.commit-author[href$="renovate-bot"]:first-child',
 
-		/* PRs */
+		/* Issues/PRs */
 		'.opened-by [href*="author%3Aapp%2F"]'
 	].join());
 	for (const bot of bots) {
@@ -22,7 +22,7 @@ features.add({
 	screenshot: 'https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif',
 	include: [
 		features.isCommitList,
-		features.isPRList
+		features.isDiscussionList
 	],
 	load: features.onAjaxedPages,
 	init

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -1,10 +1,10 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import * as api from '../libs/api';
 import features from '../libs/features';
+import * as api from '../libs/api';
+import * as icons from '../libs/icons';
 import getDefaultBranch from '../libs/get-default-branch';
 import {getOwnerAndRepo, getRepoGQL} from '../libs/utils';
-import * as icons from '../libs/icons';
 
 type RepositoryReference = {
 	owner: string;

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -170,6 +170,9 @@ export const _isConflict = [
 	'https://github.com/sindresorhus/refined-github/pull/148/conflicts'
 ];
 
+/**
+ * Do not use this detection if you're looking for PRs, they may appear mixed with issues in search. Use `isDiscussionList`
+ */
 export const isPRList = (): boolean => location.pathname === '/pulls' || getRepoPath() === 'pulls';
 export const _isPRList = [
 	'https://github.com/pulls',


### PR DESCRIPTION
This PR will apply PR-related features to mixed lists of Issues and PRs, not just PR-only lists.

Also fixes https://github.com/sindresorhus/refined-github/issues/2582

## Tests

- `conflict-marker`
  - No icon here: https://github.com/sindresorhus/refined-github/pulls?utf8=%E2%9C%93&q=%22Add+%60Releases%60+tab+to+the+repo+page%22+
  - Icon appears in non-PR-exclusive search: https://github.com/pulls?utf8=%E2%9C%93&q=author%3Afregante+archived%3Afalse+sort%3Aupdated-desc+rewrite+browser+extension+
- `dim-bots` (now includes issues as well to keep the code simple, but I think we originally didn't include them just because we had no examples of bot-opened issues)
  - Bot PRs are hidden in non-PR-exclusive search: https://github.com/issues?utf8=%E2%9C%93&q=user%3Adependabot
- `pr-branches`
  1. Open a repo that has your PRs
  2. Visit the Issues page
  3. Remove the `is:issue` filter
  4. Notice your PRs displaying branches