### PR TITLE
Add support for namespaced branches to`fix-view-file-link-in-pr`

### DIFF
--- a/source/features/fix-view-file-link-in-pr.tsx
+++ b/source/features/fix-view-file-link-in-pr.tsx
@@ -26,7 +26,7 @@ function handleMenuOpening(event: DelegateEvent): void {
 	// - PRs opened from the default branch
 	const headReferenceLink = select<HTMLAnchorElement>('.head-ref a')!;
 	const [, owner, repository] = headReferenceLink.pathname.split('/', 3); // Example pathname: '/kidonng/refined-github/tree/fix-console-error'
- 	const branch = headReferenceLink.title.replace(/^[^:]+:/, ''); // Example title: 'tejanium/refined-github:bra/nch' or just 'local-branch`
+	const branch = headReferenceLink.title.replace(/^[^:]+:/, ''); // Example title: 'tejanium/refined-github:bra/nch' or just 'local-branch`
 
 	const viewFile = select<HTMLAnchorElement>('[data-ga-click^="View file"]', dropdown)!;
 	const filepath = viewFile.pathname.split('/').slice(5).join('/'); // Example pathname: $owner/$repository/blob/$sha/$path_to_file.tsx

--- a/source/features/fix-view-file-link-in-pr.tsx
+++ b/source/features/fix-view-file-link-in-pr.tsx
@@ -24,14 +24,17 @@ function handleMenuOpening(event: DelegateEvent): void {
 	// Looks like `https://github.com/kidonng/refined-github/tree/fix-console-error`
 	const headReferenceLink = select<HTMLAnchorElement>('.head-ref a')!;
 	const branchPathnameParts = headReferenceLink.pathname.split('/');
+	const branchNameParts = headReferenceLink.title.replace(/^[^:]+:/, '').split('/');
 	branchPathnameParts[3] = 'blob'; // This replaces `tree`
-	branchPathnameParts[4] = headReferenceLink.title.replace(/^[^:]+:/, ''); // Ensures that the branch name is attached even when it links to the default branch
+	branchPathnameParts.splice(4, branchNameParts.length, ...branchNameParts); // Ensures that the branch name is attached even when it links to the default branch
 
 	// Looks like `https://github.com/sindresorhus/refined-github/blob/cddac8d7e158c336552aa694a4698d4764754b64/source/features/embed-gist-via-iframe.tsx`
 	const viewFile = select<HTMLAnchorElement>('[data-ga-click^="View file"]', dropdown)!;
 	const viewFilePathnameParts = viewFile.pathname.split('/');
 	viewFilePathnameParts.splice(0, 5, ...branchPathnameParts); // Replaces `user/repo/blob/sha` with `forkuser/repo/blob/branch`
 	viewFile.pathname = viewFilePathnameParts.join('/');
+
+	viewFile.classList.add('rgh-actionable-link'); // Mark this as processed
 }
 
 function init(): void {

--- a/source/features/fix-view-file-link-in-pr.tsx
+++ b/source/features/fix-view-file-link-in-pr.tsx
@@ -21,18 +21,16 @@ function handleMenuOpening(event: DelegateEvent): void {
 		return;
 	}
 
-	// Looks like `https://github.com/kidonng/refined-github/tree/fix-console-error`
+	// This solution accounts for:
+	// - Branches with slashes in it
+	// - PRs opened from the default branch
 	const headReferenceLink = select<HTMLAnchorElement>('.head-ref a')!;
-	const branchPathnameParts = headReferenceLink.pathname.split('/');
-	const branchNameParts = headReferenceLink.title.replace(/^[^:]+:/, '').split('/');
-	branchPathnameParts[3] = 'blob'; // This replaces `tree`
-	branchPathnameParts.splice(4, branchNameParts.length, ...branchNameParts); // Ensures that the branch name is attached even when it links to the default branch
+	const [, owner, repository] = headReferenceLink.pathname.split('/', 3); // Example pathname: '/kidonng/refined-github/tree/fix-console-error'
+ 	const branch = headReferenceLink.title.replace(/^[^:]+:/, ''); // Example title: 'tejanium/refined-github:bra/nch' or just 'local-branch`
 
-	// Looks like `https://github.com/sindresorhus/refined-github/blob/cddac8d7e158c336552aa694a4698d4764754b64/source/features/embed-gist-via-iframe.tsx`
 	const viewFile = select<HTMLAnchorElement>('[data-ga-click^="View file"]', dropdown)!;
-	const viewFilePathnameParts = viewFile.pathname.split('/');
-	viewFilePathnameParts.splice(0, 5, ...branchPathnameParts); // Replaces `user/repo/blob/sha` with `forkuser/repo/blob/branch`
-	viewFile.pathname = viewFilePathnameParts.join('/');
+	const filepath = viewFile.pathname.split('/').slice(5).join('/'); // Example pathname: $owner/$repository/blob/$sha/$path_to_file.tsx
+	viewFile.pathname = '/' + [owner, repository, 'blob', branch, filepath].join('/');
 
 	viewFile.classList.add('rgh-actionable-link'); // Mark this as processed
 }


### PR DESCRIPTION
This PR will fix 404 when clicking "View file" on the PR if branch name is namespaced (example: `namespaced/branch`)

# Test
With the latest build plugin installed, go to this PR's [Files Changed tab](https://github.com/sindresorhus/refined-github/pull/2595/files) >  click on `...` > click "View file" (bonus: click it "View file" multiple time, by closing the dialog and opening it again over and over)
