### PR TITLE
Avoid FOUC on some features

### DIFF
--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -4,11 +4,11 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import pFilter from 'p-filter';
 import onetime from 'onetime';
+import elementReady from 'element-ready';
 import features from '../libs/features';
 import {isRepoWithAccess} from '../libs/page-detect';
 import {getRepoURL, getUsername} from '../libs/utils';
 import * as icons from '../libs/icons';
-import elementReady from 'element-ready';
 
 const getCacheKey = onetime((): string => `forked-to:${getUsername()}@${findForkedRepo() || getRepoURL()}`);
 

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -8,6 +8,7 @@ import features from '../libs/features';
 import {isRepoWithAccess} from '../libs/page-detect';
 import {getRepoURL, getUsername} from '../libs/utils';
 import * as icons from '../libs/icons';
+import elementReady from 'element-ready';
 
 const getCacheKey = onetime((): string => `forked-to:${getUsername()}@${findForkedRepo() || getRepoURL()}`);
 
@@ -65,7 +66,7 @@ async function init(): Promise<void> {
 
 	document.body.classList.add('rgh-forked-to');
 
-	const forkCounter = select('.social-count[href$="/network/members"]')!;
+	const forkCounter = (await elementReady('.social-count[href$="/network/members"]'))!;
 	if (forks.length === 1) {
 		forkCounter.before(
 			<a href={`/${forks[0]}`}
@@ -111,6 +112,6 @@ features.add({
 	include: [
 		features.isRepo
 	],
-	load: features.onAjaxedPages,
+	load: features.nowAndOnAjaxedPages,
 	init
 });

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -1,6 +1,7 @@
 import './mark-unread.css';
 import React from 'dom-chef';
 import select from 'select-dom';
+import onDomReady from 'dom-loaded';
 import elementReady from 'element-ready';
 import delegate, {DelegateSubscription, DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
@@ -392,6 +393,7 @@ function destroy(): void {
 
 async function init(): Promise<void> {
 	destroy();
+	await onDomReady;
 
 	if (pageDetect.isNotifications()) {
 		const notifications = await getNotifications();

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -79,6 +79,6 @@ features.add({
 	include: [
 		features.isRepo
 	],
-	load: features.onAjaxedPages,
+	load: features.nowAndOnAjaxedPages,
 	init
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -56,7 +56,7 @@ async function init(): Promise<false | void> {
 	);
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
-	appendBefore('.reponav', '.reponav-dropdown, [href$="settings"]', releasesTab)
+	appendBefore('.reponav', '.reponav-dropdown, [href$="settings"]', releasesTab);
 
 	// Update "selected" tab mark
 	if (isReleasesOrTags()) {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -1,9 +1,11 @@
 import cache from 'webext-storage-cache';
 import React from 'dom-chef';
 import select from 'select-dom';
+import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as api from '../libs/api';
 import * as icons from '../libs/icons';
+import {appendBefore} from '../libs/dom-utils';
 import {getRepoURL, getRepoGQL} from '../libs/utils';
 import {isRepoRoot, isReleasesOrTags} from '../libs/page-detect';
 
@@ -52,7 +54,9 @@ async function init(): Promise<false | void> {
 			{count === undefined ? '' : <span className="Counter">{count}</span>}
 		</a>
 	);
-	select('.reponav-dropdown')!.before(releasesTab);
+
+	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
+	appendBefore('.reponav', '.reponav-dropdown, [href$="settings"]', releasesTab)
 
 	// Update "selected" tab mark
 	if (isReleasesOrTags()) {
@@ -73,7 +77,7 @@ features.add({
 	include: [
 		features.isRepo
 	],
-	load: features.onAjaxedPages,
+	load: features.nowAndOnAjaxedPages,
 	shortcuts: {
 		'g r': 'Go to Releases'
 	},

--- a/source/features/sticky-discussion-sidebar.tsx
+++ b/source/features/sticky-discussion-sidebar.tsx
@@ -1,6 +1,7 @@
 import './sticky-discussion-sidebar.css';
 import select from 'select-dom';
 import debounce from 'debounce-fn';
+import onDomReady from 'dom-loaded';
 import features from '../libs/features';
 import onUpdatableContentUpdate from '../libs/on-updatable-content-update';
 
@@ -14,7 +15,8 @@ function updateStickiness(): void {
 
 const handler = debounce(updateStickiness, {wait: 100});
 
-function init(): void {
+async function init(): Promise<void> {
+	await onDomReady;
 	updateStickiness();
 	window.addEventListener('resize', handler);
 	onUpdatableContentUpdate(select(sideBarSelector)!, updateStickiness);

--- a/source/libs/features.tsx
+++ b/source/libs/features.tsx
@@ -43,13 +43,22 @@ export interface FeatureDetails {
  * Alternatively, use `onAjaxedPagesRaw` if your callback needs to be called at every page
  * change (e.g. to "unmount" a feature / listener) regardless of *newness* of the page.
  */
-async function onAjaxedPagesRaw(callback: () => void): Promise<void> {
-	await onDomReady;
+function onAjaxedPagesRaw(callback: () => void): void {
 	document.addEventListener('pjax:end', callback);
 	callback();
 }
 
 function onAjaxedPages(callback: () => void): void {
+	onAjaxedPagesRaw(async () => {
+		await onDomReady;
+		if (!select.exists('has-rgh')) {
+			callback();
+		}
+	});
+}
+
+// Like onAjaxedPages but doesn't wait for `dom-ready`
+function nowAndOnAjaxedPages(callback: () => void): void {
 	onAjaxedPagesRaw(() => {
 		if (!select.exists('has-rgh')) {
 			callback();
@@ -64,10 +73,7 @@ onAjaxedPages(async () => {
 	await globalReady; // Match `add()`
 	await Promise.resolve(); // Kicks it to the next tick, after the other features have `run()`
 
-	const ajaxContainer = select('#js-repo-pjax-container,#js-pjax-container');
-	if (ajaxContainer) {
-		ajaxContainer.append(<has-rgh/>);
-	}
+	select('#js-repo-pjax-container,#js-pjax-container')?.append(<has-rgh/>);
 });
 
 let log: typeof console.log;
@@ -189,6 +195,7 @@ export default {
 	onNewComments,
 	onFileListUpdate,
 	onAjaxedPages,
+	nowAndOnAjaxedPages,
 	onAjaxedPagesRaw,
 
 	// Loading filters

--- a/source/libs/features.tsx
+++ b/source/libs/features.tsx
@@ -73,7 +73,10 @@ onAjaxedPages(async () => {
 	await globalReady; // Match `add()`
 	await Promise.resolve(); // Kicks it to the next tick, after the other features have `run()`
 
-	select('#js-repo-pjax-container,#js-pjax-container')?.append(<has-rgh/>);
+	const ajaxContainer = select('#js-repo-pjax-container,#js-pjax-container');
+	if (ajaxContainer) {
+		ajaxContainer.append(<has-rgh/>);
+	}
 });
 
 let log: typeof console.log;


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/2604

Naming suggestions welcome. Perhaps `features.onAjaxedPagesInstant` (like the existing `features.onAjaxedPagesRaw`)

# Before

This shows a page refresh. Notice how `releases-tab`, `more-dropdown` and `forked-to` are not there for a moment before `dom-ready` happens.

> ![before](https://user-images.githubusercontent.com/1402241/70370051-25e46280-18f5-11ea-8563-a7d78e6db7c8.gif)

# After

Notice how `parse-backticks` still has a FUOC (Flash Of Unstyled Content) but it no longer happens for the 3 features above.

> ![after](https://user-images.githubusercontent.com/1402241/70370062-47dde500-18f5-11ea-9b0c-3479e26644b6.gif)
