### PR TITLE
Make `quick-mention` button ever-so-slightly more visible

### DIFF
--- a/source/features/quick-mention.css
+++ b/source/features/quick-mention.css
@@ -5,7 +5,7 @@ button.rgh-quick-mention {
 
 /* Show button when the avatar or the button itself are hovered/focused */
 :not(:hover):not(:focus) + button.rgh-quick-mention:not(:hover):not(:focus) {
-	opacity: 0; /* As opposed to display:none, this makes it appear when the user hovers it even when hidden, so you don't have to hover the avatar first */
+	opacity: 0.1;
 }
 
 /* Show icon in black if it's not hovered/focused, instead of the blue color caused by .btn-link */


### PR DESCRIPTION
In #2556 I made the button invisible to avoid clutter, but I think it can still look clean if we make it slightly visible. This is not super _accessible_ but it's still more visible than _invisible_

<img width="98" alt="" src="https://user-images.githubusercontent.com/1402241/70628431-b8b93000-1c5a-11ea-97cd-1864266fbf0c.png">
