### PR TITLE
Load all hidden comments on page load

### DIFF
--- a/source/content.ts
+++ b/source/content.ts
@@ -160,6 +160,7 @@ import './features/linkify-user-location';
 import './features/repo-age';
 import './features/user-local-time';
 import './features/quick-mention';
+import './features/load-hidden-comments';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/load-hidden-comments.tsx
+++ b/source/features/load-hidden-comments.tsx
@@ -1,0 +1,50 @@
+import select from 'select-dom';
+import features from '../libs/features';
+
+function init(): void {
+	// Retrieve the form associated with the "X Hidden Items\nLoad More" button
+	const form = select('form.ajax-pagination-form');
+	if (form) {
+		// The first button, which has the text "X hidden items".
+		const button = select('button', form);
+		if (button) {
+			// Extract the number of hidden items from the button text
+			const numberString = button.textContent?.trim()?.split(' ')[0];
+			if (numberString) {
+				// Construct the new URL. This is undocumented, and may break at any time.
+				// As of 12/08/2019, URLS look like this:
+				// "/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false"
+				// The key "variables[first]" in the URL query parameters appears to control
+				// how many additional comments are fetched.
+				// Github appears to always set this to 60, but it can be increased up to the
+				// total number of hidden items.
+				// By setting "variables[first]" to total number of hidden items (extracted from the button tex),
+				// we can fetch all hidden comments at once
+				const url = new URL('https://github.com' + (form.getAttribute('action')?.toString() || ''));
+				url.searchParams.set('variables[first]', numberString);
+				form.setAttribute('action', url.toString());
+
+				// Trigger a button click, causing the page to fetch and display
+				// the hidden comments.
+				// For some reason, trying to do this immediately (without setTimeout)
+				// causes the browser to navigate to the actual URL (e.g. https://github.com//_render_node/...)
+				// instead of triggering the proper Github event handler.
+				// It seems likely that the event handler isn't yet registered when this function runs.
+				// Delaying the button clock with setTimeout() appears to cause the event
+				// handler to be consistently triggered, resulting in the desired behavior
+				setTimeout(() => button.click(), 0);
+			}
+		}
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Simplify the GitHub interface and adds useful features',
+	screenshot: false,
+	include: [
+		features.hasComments
+	],
+	load: features.onAjaxedPages,
+	init
+});


### PR DESCRIPTION
Fixes #1892

Github has a "feature" that hides a large fraction of the comments in
long issue/PR threads, requiring the user to click a "Show hidden
button" to see them.

Not only can this cut off important parts of a
discussion, clicking the button only reveals *some* of the hidden
comments. To show the entire thread, a user must:

1. Search on the page for "show hidden"
2. Click the button
3. Wait several seconds for an AJAX request to complete and the page to
update
4. Go back to step 1 if there are more hidden comments

This must be done every time the user nagivates to an issue/PR page.

This PR adds a new feature called 'load-hidden-comments', which performs
this process automatically on page load. It dramatically speeds up the
process by modifiying the undocumented API request (github.com/_render_node/...)
used by the "Show hidden button". By increasing the "variables[first]"
query parameter from "60" to the total number of hidden requests, we can
load all hidden comments with a single HTTP request.

Since the URL being modified is undocumented, this trick could break at
any time. However, the alternative is to repeatedly click the (newly
generated) button after each partial comment fetch completes. This
takes *significantly* longer, and results in janky scrollbar behavior
due to comments being added one chunk at a time.

<!-- Thanks for contributing! 🍄 -->

Closes 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
1. Go to a PR with hidden comments (e.g. https://github.com/rust-lang/rfcs/pull/2544)
2. Note the "X hidden items" button when this PR is not in use
3. With this PR enabled, note that the "X hidden items" button disappears shortly after page load, and that all comments are shown on the page.
