### PR TITLE
Fix spacing on issue/PR list filters

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -26,8 +26,13 @@
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
 .table-list-filters .table-list-header-toggle .select-menu-button {
-	padding-right: 8px;
-	padding-left: 8px;
+	padding-right: 0;
+	padding-left: 0;
+}
+
+.table-list-filters .details-reset {
+	padding-right: 8px !important;
+	padding-left: 8px !important;
 }
 
 /* Hide empty description of repo */

--- a/source/content.css
+++ b/source/content.css
@@ -35,6 +35,10 @@
 	padding-left: 8px !important;
 }
 
+.table-list-filters .details-reset:last-child {
+	padding-right: 0 !important;
+}
+
 /* Hide empty description of repo */
 .repository-meta.mb-3 > .repository-meta-content > em {
 	display: none !important;


### PR DESCRIPTION
Broken following a markup / selector change most likely.

<!-- Thanks for contributing! 🍄 -->

Closes #2631 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

Before fix:
![Screenshot 2019-12-20 at 10 03 48](https://user-images.githubusercontent.com/1215056/71243178-0d6e4200-2310-11ea-9262-cac28cffe7a3.png)

After fix:
![Screenshot 2019-12-20 at 10 02 21](https://user-images.githubusercontent.com/1215056/71243143-f3ccfa80-230f-11ea-8c8d-611d6967b0d5.png)

# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Go to the PR list page https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc and notice that the filters all have a padding of 8px
- Go to the issue list page https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc and notice that the filters all have a padding of 8px