### PR TITLE
Fix `widen-search-field` caret position

### DIFF
--- a/source/features/widen-search-field.css
+++ b/source/features/widen-search-field.css
@@ -47,6 +47,7 @@ https://github.com/sindresorhus/refined-github/releases/tag/19.9.16
 /* Hide `Filters` text in repo lists */
 .subnav-search-context summary {
 	display: flex;
+	align-items: center;
 	width: 2.4em;
 	text-indent: -10000px;
 }


### PR DESCRIPTION
This was using the default value 'stretch' which meant the caret was not vertically aligned within the button.

<!-- Thanks for contributing! 🍄 -->

Closes #2651 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

Before fix:
<img width="172" alt="Screenshot 2019-12-23 14 29 33" src="https://user-images.githubusercontent.com/1215056/71360580-a8754f00-2590-11ea-91be-c29f8ac865f9.png">

After fix:
<img width="177" alt="Screenshot 2019-12-23 14 28 44" src="https://user-images.githubusercontent.com/1215056/71360551-91cef800-2590-11ea-9525-4e567fa92e6c.png">

# Test
<!-- List some URLs that reviewers can use to test your PR -->
- Go to the PR list page (i.e. https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc)
- See that to the left of the text filed, there is a button with a vertically aligned caret
- Go to the issues list page (i.e. https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
- See that to the left of the text filed, there is a button with a vertically aligned caret