### PR TITLE
Fix `filter-comments-by-you` link on PR list page

### DIFF
--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -6,16 +6,14 @@ import {getUsername, getRepoURL} from '../libs/utils';
 const repoUrl = getRepoURL();
 
 function init(): void {
-	select('.subnav-search-context li:last-child')!
+	select('.subnav-search-context .SelectMenu-list a:last-child')!
 		.before(
-			<li>
-				<a
-					href={`/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`}
-					className="select-menu-item"
-					role="menuitem">
-						Everything commented by you
-				</a>
-			</li>
+			<a
+				href={`/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`}
+				className="SelectMenu-item"
+				role="menuitem">
+					Everything commented by you
+			</a>
 		);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #2647 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->


# Test
<!-- List some URLs that reviewers can use to test your PR -->
1. Go to the PR list page and click on the caret to the left of the input text (i.e. https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc)
--> See that a link to `Everything commented by you` is added just before the very last link in the list (`View advanced search syntax`)
2. Click on the link `Everything commented by you`
--> See that the url you're redirected to contains `issues?q=is%3Aopen+commenter:YOUR_USERNAME`
3. Repeat steps 1-2 but go to the issues page instead (i.e. https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
