### PR TITLE
Fix alignment of fork icon in `forked-to`

### DIFF
--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -93,7 +93,7 @@ async function init(): Promise<void> {
 							href={`/${fork}`}
 							className="select-menu-item"
 							title={`Open your fork to ${fork}`}>
-							{forkIcon()}
+							<span className="select-menu-item-icon">{forkIcon()}</span>
 							{fork}
 						</a>
 					)}


### PR DESCRIPTION
# Description
In https://github.com/sindresorhus/refined-github/pull/2610 all icons where moved around. The [fork icon](https://github.com/sindresorhus/refined-github/pull/2610/files#diff-448a2f6bfa96a35ce700134dafedbc76L79) however was using an class inside the [`forked-to` feature](https://github.com/sindresorhus/refined-github/pull/2610/files#diff-ff16301f232100bd87e910eb98614f66L95-R96).

# Screenshots
## Before 
![image](https://user-images.githubusercontent.com/55841/71780765-f9d90180-2fc6-11ea-969c-a62b1f313dd8.png)

## After
![image](https://user-images.githubusercontent.com/55841/71780760-ef1e6c80-2fc6-11ea-85a0-30dbab9e5c90.png)

# Test
1. Fork this repo multiple times.
2. See fork icon being aligned again.
