### PR TITLE
Make the default branch link smaller in `branch-buttons`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,7 +132,7 @@ Thanks for contributing! 🦋🙌
 - [](# "toggle-files-button") [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
 - [](# "edit-files-faster") [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
 - [](# "edit-readme") [Adds an Edit button on previewed Readmes in folders, even if you have to make a fork.](https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png)
-- [](# "branch-buttons") 🔥 [Adds links to the default branch and to the latest version tag.](https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png)
+- [](# "latest-tag-button") [Adds link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/71885167-63464500-316c-11ea-806c-5abe37281eca.png)
 - [](# "swap-branches-on-compare") [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
 - [](# "linkify-branch-references") [Linkifies branch references in "Quick PR" pages.](https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png)
 - [](# "hide-zero-packages") [Hides the `Packages` tab in repositories if it’s empty.](https://user-images.githubusercontent.com/35382021/62426530-688ef780-b6d5-11e9-93f2-515110aed1eb.jpg)

--- a/readme.md
+++ b/readme.md
@@ -133,6 +133,7 @@ Thanks for contributing! 🦋🙌
 - [](# "edit-files-faster") [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
 - [](# "edit-readme") [Adds an Edit button on previewed Readmes in folders, even if you have to make a fork.](https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png)
 - [](# "latest-tag-button") [Adds link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/71885167-63464500-316c-11ea-806c-5abe37281eca.png)
+- [](# "default-branch-button") 🔥 [Adds link the default branch on directory listings and files.](https://user-images.githubusercontent.com/1402241/71886648-2891dc00-316f-11ea-98d8-c5bf6c24d85c.png)
 - [](# "swap-branches-on-compare") [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
 - [](# "linkify-branch-references") [Linkifies branch references in "Quick PR" pages.](https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png)
 - [](# "hide-zero-packages") [Hides the `Packages` tab in repositories if it’s empty.](https://user-images.githubusercontent.com/35382021/62426530-688ef780-b6d5-11e9-93f2-515110aed1eb.jpg)

--- a/source/content.ts
+++ b/source/content.ts
@@ -65,6 +65,7 @@ import './features/global-discussion-list-filters';
 import './features/filter-comments-by-you';
 import './features/sort-issues-by-update-time'; // Must be after global-discussion-list-filters and filter-comments-by-you
 import './features/latest-tag-button';
+import './features/default-branch-button';
 import './features/faster-pr-diff-options';
 import './features/ci-link';
 import './features/sort-milestones-by-closest-due-date';

--- a/source/content.ts
+++ b/source/content.ts
@@ -64,7 +64,7 @@ import './features/navigate-pages-with-arrow-keys';
 import './features/global-discussion-list-filters';
 import './features/filter-comments-by-you';
 import './features/sort-issues-by-update-time'; // Must be after global-discussion-list-filters and filter-comments-by-you
-import './features/branch-buttons';
+import './features/latest-tag-button';
 import './features/faster-pr-diff-options';
 import './features/ci-link';
 import './features/sort-milestones-by-closest-due-date';

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,3 +1,0 @@
-.file-navigation > .BtnGroup:first-child {
-	margin: 0;
-}

--- a/source/features/default-branch-button.css
+++ b/source/features/default-branch-button.css
@@ -1,0 +1,3 @@
+.file-navigation > .BtnGroup:first-child {
+	margin: 0;
+}

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -1,0 +1,55 @@
+import './default-branch-button.css';
+import React from 'dom-chef';
+import select from 'select-dom';
+import chevronLeftIcon from 'octicon/chevron-left.svg';
+import features from '../libs/features';
+import {isRepoRoot} from '../libs/page-detect';
+import getDefaultBranch from '../libs/get-default-branch';
+import {getRepoURL, getCurrentBranch, replaceBranch} from '../libs/utils';
+import {groupButtons} from '../libs/group-buttons';
+
+async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
+	const defaultBranch = await getDefaultBranch();
+	const currentBranch = getCurrentBranch();
+
+	// Don't show the button if we’re already on the default branch
+	if (defaultBranch === currentBranch) {
+		return;
+	}
+
+	let url;
+	if (isRepoRoot()) {
+		url = `/${getRepoURL()}`;
+	} else {
+		url = replaceBranch(currentBranch, defaultBranch);
+	}
+
+	return (
+		<a
+			className="btn btn-sm tooltipped tooltipped-ne"
+			href={url}
+			aria-label="See this view on the default branch">
+			{chevronLeftIcon()}
+		</a>
+	);
+}
+
+async function init(): Promise<false | void> {
+	const defaultLink = await getDefaultBranchLink();
+	if (defaultLink) {
+		select('#branch-select-menu')!.before(defaultLink);
+		groupButtons([defaultLink, defaultLink.nextElementSibling!]);
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Adds link the default branch on directory listings and files.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/71886648-2891dc00-316f-11ea-98d8-c5bf6c24d85c.png',
+	include: [
+		features.isRepoTree,
+		features.isSingleFile
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -8,13 +8,13 @@ import getDefaultBranch from '../libs/get-default-branch';
 import {getRepoURL, getCurrentBranch, replaceBranch} from '../libs/utils';
 import {groupButtons} from '../libs/group-buttons';
 
-async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
+async function init(): Promise<false | void> {
 	const defaultBranch = await getDefaultBranch();
 	const currentBranch = getCurrentBranch();
 
 	// Don't show the button if we’re already on the default branch
 	if (defaultBranch === currentBranch) {
-		return;
+		return false;
 	}
 
 	let url;
@@ -24,7 +24,8 @@ async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 		url = replaceBranch(currentBranch, defaultBranch);
 	}
 
-	return (
+	const branchSelector = select('#branch-select-menu')!;
+	const defaultLink = (
 		<a
 			className="btn btn-sm tooltipped tooltipped-ne"
 			href={url}
@@ -32,14 +33,9 @@ async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
 			{chevronLeftIcon()}
 		</a>
 	);
-}
 
-async function init(): Promise<false | void> {
-	const defaultLink = await getDefaultBranchLink();
-	if (defaultLink) {
-		select('#branch-select-menu')!.before(defaultLink);
-		groupButtons([defaultLink, defaultLink.nextElementSibling!]);
-	}
+	branchSelector.before(defaultLink);
+	groupButtons([defaultLink, branchSelector]);
 }
 
 features.add({

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -1,4 +1,3 @@
-import './default-branch-button.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import chevronLeftIcon from 'octicon/chevron-left.svg';
@@ -35,7 +34,9 @@ async function init(): Promise<false | void> {
 	);
 
 	branchSelector.before(defaultLink);
-	groupButtons([defaultLink, branchSelector]);
+
+	const group = groupButtons([defaultLink, branchSelector]);
+	group.classList.add('m-0');
 }
 
 features.add({

--- a/source/features/latest-tag-button.css
+++ b/source/features/latest-tag-button.css
@@ -14,7 +14,3 @@
 	flex: 1;
 	margin-left: 8px !important;
 }
-
-.file-navigation .rgh-branch-buttons .BtnGroup {
-	margin: 0;
-}

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -1,14 +1,11 @@
-import './branch-buttons.css';
+import './latest-tag-button.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import tagIcon from 'octicon/tag.svg';
-import branchIcon from 'octicon/git-branch.svg';
 import compareVersions from 'tiny-version-compare';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {isRepoRoot} from '../libs/page-detect';
-import {groupSiblings} from '../libs/group-buttons';
-import getDefaultBranch from '../libs/get-default-branch';
 import {getRepoURL, getCurrentBranch, replaceBranch, getRepoGQL} from '../libs/utils';
 
 async function getTagLink(): Promise<'' | HTMLAnchorElement> {
@@ -39,7 +36,7 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 		latestRelease = tags[0];
 	}
 
-	const link = <a className="btn btn-sm btn-outline tooltipped tooltipped-ne">{tagIcon()}</a> as unknown as HTMLAnchorElement;
+	const link = <a className="btn btn-sm btn-outline tooltipped tooltipped-ne ml-2">{tagIcon()}</a> as unknown as HTMLAnchorElement;
 
 	const currentBranch = getCurrentBranch();
 
@@ -60,65 +57,22 @@ async function getTagLink(): Promise<'' | HTMLAnchorElement> {
 	return link;
 }
 
-async function getDefaultBranchLink(): Promise<HTMLElement | undefined> {
-	const defaultBranch = await getDefaultBranch();
-	const currentBranch = getCurrentBranch();
-
-	// Don't show the button if we’re already on the default branch
-	if (defaultBranch === currentBranch) {
-		return;
-	}
-
-	let url;
-	if (isRepoRoot()) {
-		url = `/${getRepoURL()}`;
-	} else {
-		url = replaceBranch(currentBranch, defaultBranch);
-	}
-
-	return (
-		<a
-			className="btn btn-sm btn-outline tooltipped tooltipped-ne"
-			href={url}
-			aria-label="Visit the default branch">
-			{branchIcon()}
-			{' '}
-			{defaultBranch}
-		</a>
-	);
-}
-
 async function init(): Promise<false | void> {
 	const breadcrumbs = select('.breadcrumb');
 	if (!breadcrumbs) {
 		return false;
 	}
 
-	const [defaultLink = '', tagLink = ''] = await Promise.all([
-		getDefaultBranchLink(),
-		getTagLink()
-	]);
-
-	const wrapper = (
-		<div className="rgh-branch-buttons ml-2">
-			{defaultLink}
-			{tagLink}
-		</div>
-	);
-
-	if (wrapper.children.length > 0) {
-		breadcrumbs.before(wrapper);
-	}
-
-	if (wrapper.children.length > 1) {
-		groupSiblings(wrapper.firstElementChild!);
+	const tagLink = await getTagLink();
+	if (tagLink) {
+		breadcrumbs.before(tagLink);
 	}
 }
 
 features.add({
 	id: __featureName__,
-	description: 'Adds links to the default branch and to the latest version tag.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/38107328-ccb3fb46-33bb-11e8-9654-23a6410943cc.png',
+	description: 'Adds link to the latest version tag on directory listings and files.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/71885167-63464500-316c-11ea-806c-5abe37281eca.png',
 	include: [
 		features.isRepoTree,
 		features.isSingleFile

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -21,9 +21,7 @@ const defaults = Object.assign({
 }, __featuresOptionDefaults__); // This variable is replaced at build time
 
 const migrations = [
-	featureWasRenamed('filter-pr-by-build-status', 'pr-filters'), // Merged on November 1st
-	featureWasRenamed('linkify-branch-refs', 'linkify-branch-references'), // Merged on November 10th
-	featureWasRenamed('prev-next-commit-buttons', 'previous-next-commit-buttons'), // Merged on November 10th
+	featureWasRenamed('branch-buttons', 'latest-tag-button'), // Merged on January 10th
 
 	// Removed features will be automatically removed from the options as well
 	OptionsSync.migrations.removeUnused


### PR DESCRIPTION
<img width="402" alt="Screenshot 2020-01-07 at 17 03 13" src="https://user-images.githubusercontent.com/1402241/71886925-9d651600-316f-11ea-80a9-7cd80c04eb12.png">

Closes https://github.com/sindresorhus/refined-github/issues/2635
Partial solution to https://github.com/sindresorhus/refined-github/issues/2624

# Test

On default branch: https://github.com/sindresorhus/refined-github
On non-default branch: https://github.com/sindresorhus/refined-github/tree/incremental-tag-changelog-link
On non-default branch (file): https://github.com/sindresorhus/refined-github/blob/incremental-tag-changelog-link/contributing.md
On latest tag (at the moment): https://github.com/sindresorhus/refined-github/tree/20.1.6