### PR TITLE
Enable `parse-backticks` in more places on discussion pages

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,9 +1,10 @@
+import elementReady from 'element-ready';
 import './parse-backticks.css';
 import select from 'select-dom';
 import features from '../libs/features';
 import {parseBackticks} from '../libs/dom-formatters';
 
-function init(): void {
+function initGeneral(): void {
 	for (const title of select.all([
 		'.commit-title', // `isCommit`
 		'.commit-desc', // `isCommit`, `isCommitList`, `isRepoTree`
@@ -15,6 +16,14 @@ function init(): void {
 		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
 		'.TimelineItem-body' // Title changes in `isIssue`, `isPRConversation`
 	])) {
+		parseBackticks(title);
+	}
+}
+
+// Highlight code in issue/PR titles on Dashboard page ("Recent activity" container)
+async function initDashboard(): Promise<void> {
+	await elementReady('.js-recent-activity-container', {stopOnDomReady: false});
+	for (const title of select.all(['.js-recent-activity-container .text-bold'])) {
 		parseBackticks(title);
 	}
 }
@@ -33,5 +42,15 @@ features.add({
 		features.isSingleFile
 	],
 	load: features.onAjaxedPages,
-	init
+	init: initGeneral
+});
+
+features.add({
+	id: __featureName__,
+	description: '',
+	screenshot: '',
+	include: [
+		features.isDashboard
+	],
+	init: initDashboard
 });

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -7,9 +7,13 @@ function init(): void {
 	for (const title of select.all([
 		'.commit-title', // `isCommit`
 		'.commit-desc', // `isCommit`, `isCommitList`, `isRepoTree`
+		'.commit-message', // Pushed commits in `isPRConversation`
 		'.message', // `isCommitList`, `isRepoTree`
 		'.Box--condensed .link-gray[href*="/commit/"]', // `isSingleFile`
-		'[aria-label="Issues"][role="group"] .js-navigation-open' // `isDiscussionList`
+		'[aria-label="Issues"][role="group"] .js-navigation-open', // `isDiscussionList`
+		'[id^=ref-issue-]', // Issue references in `isIssue`, `isPRConversation`
+		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
+		'.TimelineItem-body' // Title changes in `isIssue`, `isPRConversation`
 	])) {
 		parseBackticks(title);
 	}
@@ -23,6 +27,8 @@ features.add({
 		features.isCommit,
 		features.isCommitList,
 		features.isDiscussionList,
+		features.isIssue,
+		features.isPRConversation,
 		features.isRepoTree,
 		features.isSingleFile
 	],

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -14,7 +14,7 @@ function initGeneral(): void {
 		'[aria-label="Issues"][role="group"] .js-navigation-open', // `isDiscussionList`
 		'[id^=ref-issue-]', // Issue references in `isIssue`, `isPRConversation`
 		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
-		'.TimelineItem-body del, .TimelineItem-body ins' // Title edits in `isIssue`, `isPRConversation`
+		'.TimelineItem-body > del, .TimelineItem-body > ins' // Title edits in `isIssue`, `isPRConversation`
 	])) {
 		parseBackticks(title);
 	}

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -14,7 +14,7 @@ function initGeneral(): void {
 		'[aria-label="Issues"][role="group"] .js-navigation-open', // `isDiscussionList`
 		'[id^=ref-issue-]', // Issue references in `isIssue`, `isPRConversation`
 		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
-		'.TimelineItem-body' // Title changes in `isIssue`, `isPRConversation`
+		'.TimelineItem-body del, .TimelineItem-body ins' // Title edits in `isIssue`, `isPRConversation`
 	])) {
 		parseBackticks(title);
 	}

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -23,7 +23,7 @@ function initGeneral(): void {
 // Highlight code in issue/PR titles on Dashboard page ("Recent activity" container)
 async function initDashboard(): Promise<void> {
 	await elementReady('.js-recent-activity-container', {stopOnDomReady: false});
-	for (const title of select.all(['.js-recent-activity-container .text-bold'])) {
+	for (const title of select.all('.js-recent-activity-container .text-bold')) {
 		parseBackticks(title);
 	}
 }


### PR DESCRIPTION
Follow-up for https://github.com/sindresorhus/refined-github/pull/2653#issuecomment-571549229

**Adds code highlighting in the following places:**

- Issue/PR references:

![image](https://user-images.githubusercontent.com/22477950/72059576-90ad0300-32d2-11ea-905f-5681ecb09d04.png)

- Commmits pushed to a PR:

![image](https://user-images.githubusercontent.com/22477950/72059657-b89c6680-32d2-11ea-98f5-0a1fbd908548.png)

- Issue/PR title changes:

![image](https://user-images.githubusercontent.com/22477950/72059624-a7535a00-32d2-11ea-8f9b-568f3b504165.png)

The last one unfortunately doesn't have a dedicated CSS class. I used `.TimelineItem-body` which targets all timeline items on PRs/issues. It should probably be discussed whether this inclusion is worth it (considering site performance).