### PR TITLE
Add `watch:chrome` NPM script

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -112,6 +112,8 @@ Once built, load it in the browser of your choice:
 				<li>Click on the <strong>Load unpacked extension</strong> button;
 				<li>Select the folder <code>refined-github/distribution</code>.
 			</ol>
+			Or you can use run this command to have Chrome automatically load and reload it through <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run"><code>web-ext run</code></a>:
+			<pre>npm run watch:chrome</pre>
 		</td>
 		<td width="50%" valign="top">
 			<ol>
@@ -119,7 +121,7 @@ Once built, load it in the browser of your choice:
 				<li>Click on the <strong>Load Temporary Add-on</strong> button;
 				<li>Select the file <code>refined-github/distribution/manifest.json</code>.
 			</ol>
-			Or you can use run this command to have Firefox automatically load and reload it through <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run"><code>web-ext run</code></a>:</p>
+			Or you can use run this command to have Firefox automatically load and reload it through <a href="https://developer.mozilla.org/en-US/Add-ons/WebExtensions/web-ext_command_reference#web-ext_run"><code>web-ext run</code></a>:
 			<pre>npm run watch:firefox</pre>
 		</td>
 	</tr>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"test:js": "ava",
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
+		"watch:chrome": "web-ext run --source-dir=distribution --target chromium",
 		"watch:firefox": "web-ext run --source-dir=distribution",
 		"prerelease:version": "dot-json distribution/manifest.json version $VER",
 		"prerelease:source-url": "echo https://github.com/sindresorhus/refined-github/archive/\"${TRAVIS_COMMIT:-$VER}\".zip > distribution/SOURCE_URL",


### PR DESCRIPTION
`web-ext` added support for Chromium browsers in v3.2. This PR adds an NPM script for debugging the extension in Chrome.