### PR TITLE
Meta: Restore stylelint on all files, cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"scripts": {
 		"lint": "run-p --silent lint:*",
 		"lint:js": "xo",
-		"lint:css": "stylelint \"source/**/*.css\"",
+		"lint:css": "stylelint 'source/**/*.css'",
 		"lint-fix": "run-p --silent 'lint:* -- --fix'",
 		"test": "run-p --silent test:js lint:* build",
 		"test:js": "ava",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"scripts": {
 		"lint": "run-p --silent lint:*",
 		"lint:js": "xo",
-		"lint:css": "stylelint source/**/*.css",
+		"lint:css": "stylelint \"source/**/*.css\"",
 		"lint-fix": "run-p --silent 'lint:* -- --fix'",
 		"test": "run-p --silent test:js lint:* build",
 		"test:js": "ava",

--- a/source/options.css
+++ b/source/options.css
@@ -95,7 +95,7 @@ h2 ~ h2 {
 	margin-top: 1em;
 }
 
-.js-features input { /* stylelint-disable-line no-descending-specificity */
+.js-features input[type='checkbox'] {
 	flex-shrink: 0;
 	margin-inline-end: 0.6em; /* Spacing for Chrome */
 	margin-top: 4px; /* Alignment for Chrome */

--- a/source/options.css
+++ b/source/options.css
@@ -95,7 +95,7 @@ h2 ~ h2 {
 	margin-top: 1em;
 }
 
-.js-features input {
+.js-features input { /* stylelint-disable-line no-descending-specificity */
 	flex-shrink: 0;
 	margin-inline-end: 0.6em; /* Spacing for Chrome */
 	margin-top: 4px; /* Alignment for Chrome */
@@ -152,7 +152,7 @@ h2 ~ h2 {
 		margin-right: 0;
 	}
 
-	body > :not(hr) {
+	body > :not(hr) { /* stylelint-disable-line no-descending-specificity */
 		margin-left: 6px;
 		margin-right: 6px;
 	}

--- a/source/options.css
+++ b/source/options.css
@@ -140,6 +140,11 @@ h2 ~ h2 {
 }
 
 @-moz-document url-prefix('') {
+	body > :not(hr) {
+		margin-left: 6px;
+		margin-right: 6px;
+	}
+
 	:root {
 		background: none !important;
 	}
@@ -150,11 +155,6 @@ h2 ~ h2 {
 
 	:root hr {
 		margin-right: 0;
-	}
-
-	body > :not(hr) { /* stylelint-disable-line no-descending-specificity */
-		margin-left: 6px;
-		margin-right: 6px;
 	}
 
 	input[type='checkbox'] {


### PR DESCRIPTION
See discussion [here](https://github.com/sindresorhus/refined-github/pull/2678#issuecomment-572209852). Stylelint was not running correctly on any other OS then Windows with the glob value.

This PR fixes:
1. the **glob issue**. See proof here: https://github.com/sindresorhus/refined-github/pull/2687/checks?check_run_id=384780372#step:4:9. I couldn't use single quotes `'`, because that resulted in `Error: No files matching the pattern "'source/**/*.css'" were found.`. Using double quotes fixed that.
2. fixes the **errors from stylelint**.