### PR TITLE
Improve compatibility of `show-whitespace` with GitHub Dark

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -10,7 +10,6 @@
 	position: absolute;
 	left: 0;
 	top: 0;
-	color: #000;
 	opacity: 0.25;
 }
 


### PR DESCRIPTION
Closes: https://github.com/StylishThemes/GitHub-Dark/issues/1050

#### Test
https://github.com/sindresorhus/refined-github/blob/master/package.json

#### Before
![image](https://user-images.githubusercontent.com/115237/72218423-e97ed480-353a-11ea-9860-30b3a2dd9a19.png)
![image](https://user-images.githubusercontent.com/115237/72218436-f3a0d300-353a-11ea-8c78-a6dc288f4863.png)


#### After
![image](https://user-images.githubusercontent.com/115237/72218419-d0762380-353a-11ea-8a86-c911ca19ee19.png)
![image](https://user-images.githubusercontent.com/115237/72218454-04514900-353b-11ea-8c44-a47e667b2376.png)

