### PR TITLE
Restore link to `highest-rated-comment`

### DIFF
--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -82,8 +82,8 @@ function linkBestComment(bestComment: Element): void {
 		link.removeAttribute('data-hovercard-url');
 		link.href = hash;
 
-		// We don't copy the exact timeline item structure,
-		// so we need to align the avatar with the other avatars in the timeline.
+		// We don't copy the exact timeline item structure, so we need to align the avatar with the other avatars in the timeline.
+		// TODO: update DOM to match other comments, instead of applying this CSS
 		avatar.style.left = '-55px';
 
 		bestComment.parentElement!.firstElementChild!.after((

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -77,11 +77,11 @@ function linkBestComment(bestComment: Element): void {
 		const {hash} = select<HTMLAnchorElement>('.js-timestamp', bestComment)!;
 
 		bestComment.parentElement!.firstElementChild!.after((
-			<div className="timeline-comment-wrapper">
+			<div className="timeline-comment-wrapper pl-0 my-0">
 				{avatar}
 
 				<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment bg-gray px-2 d-flex flex-items-center">
-					<span className="btn btn-sm mr-2 pr-1">
+					<span className="btn btn-sm mr-2">
 						{arrowDownIcon()}
 					</span>
 

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -76,6 +76,10 @@ function linkBestComment(bestComment: Element): void {
 		const avatar = select('.TimelineItem-avatar', bestComment)!.cloneNode(true);
 		const {hash} = select<HTMLAnchorElement>('.js-timestamp', bestComment)!;
 
+		// We don't copy the exact timeline item structure,
+		// so we need to align the avatar with the other avatars in the timeline.
+		avatar.style.left = '-55px';
+
 		bestComment.parentElement!.firstElementChild!.after((
 			<div className="timeline-comment-wrapper pl-0 my-0">
 				{avatar}

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -73,8 +73,14 @@ function linkBestComment(bestComment: Element): void {
 	// Only link to it if it doesn't already appear at the top of the conversation
 	if (position >= 3) {
 		const text = select('.comment-body', bestComment)!.textContent!.slice(0, 100);
-		const avatar = select('.TimelineItem-avatar', bestComment)!.cloneNode(true);
 		const {hash} = select<HTMLAnchorElement>('.js-timestamp', bestComment)!;
+
+		// Copy avatar but link it to the comment
+		const avatar = select('.TimelineItem-avatar', bestComment)!.cloneNode(true);
+		const link = select<HTMLAnchorElement>('[data-hovercard-type="user"]', avatar)!;
+		link.removeAttribute('data-hovercard-type');
+		link.removeAttribute('data-hovercard-url');
+		link.href = hash;
 
 		// We don't copy the exact timeline item structure,
 		// so we need to align the avatar with the other avatars in the timeline.

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -73,8 +73,8 @@ function linkBestComment(bestComment: Element): void {
 	// Only link to it if it doesn't already appear at the top of the conversation
 	if (position >= 3) {
 		const text = select('.comment-body', bestComment)!.textContent!.slice(0, 100);
-		const avatar = select('.timeline-comment-avatar', bestComment)!.cloneNode(true);
-		const {hash} = select<HTMLAnchorElement>('.timestamp', bestComment)!;
+		const avatar = select('.TimelineItem-avatar', bestComment)!.cloneNode(true);
+		const {hash} = select<HTMLAnchorElement>('.js-timestamp', bestComment)!;
 
 		bestComment.parentElement!.firstElementChild!.after((
 			<div className="timeline-comment-wrapper">

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -29,7 +29,8 @@ function init(): void | false {
 	}
 
 	// `:first-child` avoids app badges #2630
-	for (const avatar of select.all(`.TimelineItem-avatar > :first-child:not([href="/${getUsername()}"]):not(.rgh-quick-mention)`)) {
+	// The hovercard attribute avoids `highest-rated-comment`
+	for (const avatar of select.all(`.TimelineItem-avatar > [data-hovercard-type="user"]:first-child:not([href="/${getUsername()}"]):not(.rgh-quick-mention)`)) {
 		const userMention = select('img', avatar)!.alt;
 		avatar.classList.add('rgh-quick-mention');
 		avatar.after(


### PR DESCRIPTION
Fixes #2623 

Changed the selectors and adjusted the styling a bit so it fits into the timeline again.

![image](https://user-images.githubusercontent.com/9264728/72709010-3e86a000-3b64-11ea-8a64-de1dd6b147e6.png)
