### PR TITLE
Fix `z-index` bug caused by `sticky-discussion-sidebar`

### DIFF
--- a/source/features/sticky-discussion-sidebar.css
+++ b/source/features/sticky-discussion-sidebar.css
@@ -5,6 +5,7 @@
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 60px !important; /* Matches sticky header's height */
+	z-index: 110; /* Needed so the backdrop of notification modal is over the other elements in the discussion */
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */


### PR DESCRIPTION
Fixes #2576 

This fixes the `z-index` issue with modals opened from the sticky sidebar by increasing the `z-index` of the sidebar.

I set the `z-index` to 110 so the backdrop also overlays the sticky header.
We could also set it to 1 to only overlay the timeline.