### PR TITLE
Fix ci-link's spacing for private repositories

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -8,6 +8,10 @@
 	margin-top: 0 !important;
 }
 
+.Label + .rgh-ci-link {
+	left: 8px; /* Based on Primer’s `mr-2`’s `margin-right` value. */
+}
+
 :root .repohead h1 .commit-build-statuses .octicon {
 	position: static;
 	color: inherit;


### PR DESCRIPTION
**BEFORE:**

![before](https://user-images.githubusercontent.com/11782/72737735-6e539900-3ba0-11ea-9ee1-389fcacbdf61.jpeg)

**AFTER:**

![after](https://user-images.githubusercontent.com/11782/72737744-74e21080-3ba0-11ea-894c-520ed8f8a727.jpeg)

**DOM structure for private repos:**

![image](https://user-images.githubusercontent.com/11782/72737791-8fb48500-3ba0-11ea-809c-c31991b59110.png)
