### PR TITLE
Fix PR link spacing issue caused by `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.css
+++ b/source/features/latest-tag-button.css
@@ -3,10 +3,6 @@
 	align-items: flex-start;
 }
 
-.file-navigation .branch-select-menu {
-	margin-right: 0 !important;
-}
-
 .file-navigation .BtnGroup.float-right {
 	order: 100;
 }


### PR DESCRIPTION
Closes #2695.

The removed styling only affects the branch-select-menu button, which only appears in one situation. GitHub's own styling is more appropriate.

# Test
https://github.com/dr4fters/dr4ft/tree/parse_mtgjson_refactor
