### PR TITLE
Fix `link-to-file-in-file-history` path detection on page 2+

### DIFF
--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -5,15 +5,14 @@ import features from '../libs/features';
 import {groupSiblings} from '../libs/group-buttons';
 
 function init(): void | false {
-	const repoRootForCurrentBranch = select<HTMLAnchorElement>('.js-repo-root a');
-	if (!repoRootForCurrentBranch) {
+	const breadcrumb = select('.breadcrumb');
+	if (!breadcrumb) {
 		// Probably looking at the base /commits/<branch> page, not a subfolder or file.
 		return false;
 	}
 
-	// Extract the file path. Aware of branche names that contain slashes
-	// /<user>/<repo>/commits/<slashed/branch>/readme.md -> '/readme.md'
-	const path = location.pathname.replace(repoRootForCurrentBranch.pathname, '');
+	// Extract the file path from the breadcrumb. Aware of branch names that contain slashes
+	const path = breadcrumb.textContent!.trim().replace(/^History for [^/]+/, '');
 
 	for (const rootLink of select.all<HTMLAnchorElement>('[aria-label="Browse the repository at this point in the history"]')) {
 		// `rootLink.pathname` points to /tree/ but GitHub automatically redirects to /blob/ when the path is of a file

--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -2,25 +2,24 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import fileIcon from 'octicon/file.svg';
 import features from '../libs/features';
-import {getRepoPath} from '../libs/utils';
 import {groupSiblings} from '../libs/group-buttons';
 
 function init(): void | false {
-	// /user/repo/commits/master/readme.md -> 'readme.md'
-	// /user/repo/commits/master/          -> ''
-	let path = getRepoPath()!.replace(/^commits\/[^/]+\/?/, '');
-	if (!path) {
-		path = select.all('.breadcrumb > .js-path-segment, .breadcrumb > .final-path')?.map(segment => segment.textContent).join('/');
-		if (!path) {
-			return false;
-		}
+	const repoRootForCurrentBranch = select<HTMLAnchorElement>('.js-repo-root a');
+	if (!repoRootForCurrentBranch) {
+		// Probably looking at the base /commits/<branch> page, not a subfolder or file.
+		return false;
 	}
+
+	// Extract the file path. Aware of branche names that contain slashes
+	// /<user>/<repo>/commits/<slashed/branch>/readme.md -> '/readme.md'
+	const path = location.pathname.replace(repoRootForCurrentBranch.pathname, '');
 
 	for (const rootLink of select.all<HTMLAnchorElement>('[aria-label="Browse the repository at this point in the history"]')) {
 		// `rootLink.pathname` points to /tree/ but GitHub automatically redirects to /blob/ when the path is of a file
 		rootLink.before(
 			<a
-				href={rootLink.pathname + '/' + path}
+				href={rootLink.pathname + path}
 				className="btn btn-outline tooltipped tooltipped-sw"
 				aria-label="See object at this point in the history"
 			>

--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -8,9 +8,12 @@ import {groupSiblings} from '../libs/group-buttons';
 function init(): void | false {
 	// /user/repo/commits/master/readme.md -> 'readme.md'
 	// /user/repo/commits/master/          -> ''
-	const path = getRepoPath()!.replace(/^commits\/[^/]+\/?/, '');
+	let path = getRepoPath()!.replace(/^commits\/[^/]+\/?/, '');
 	if (!path) {
-		return false;
+		path = select.all('.breadcrumb > .js-path-segment, .breadcrumb > .final-path')?.map(segment => segment.textContent).join('/');
+		if (!path) {
+			return false;
+		}
 	}
 
 	for (const rootLink of select.all<HTMLAnchorElement>('[aria-label="Browse the repository at this point in the history"]')) {


### PR DESCRIPTION
# Description
Feature `link-to-file-in-file-history` doesn't work on the second page, because the path contains separators.

# Fixes
Fixes #2692.
Fixes #2711.

# Test

## Root 
No link, no errors

* Page 1 https://github.com/typescript-eslint/typescript-eslint/commits/master
* Page 2 https://github.com/typescript-eslint/typescript-eslint/commits/master?after=367b18f0187ee503c4b21444864027f389a0c69a+34

## File
* Page 1 https://github.com/typescript-eslint/typescript-eslint/commits/master/packages/parser/CHANGELOG.md
* Page 2 https://github.com/typescript-eslint/typescript-eslint/commits/master?after=b5730e02feaec3b66b6e6289ad09d4deadb45592+34&path%5B%5D=packages&path%5B%5D=parser&path%5B%5D=CHANGELOG.md

## Branch with slashes
* Root https://github.com/Cog-Creators/Red-DiscordBot/commits/V3/develop
* Folder https://github.com/Cog-Creators/Red-DiscordBot/commits/V3/develop/docs
* File https://github.com/Cog-Creators/Red-DiscordBot/commits/V3/develop/docs/install_linux_mac.rst
* Folder page 2 https://github.com/Cog-Creators/Red-DiscordBot/commits/V3/develop?after=7420df959800173c3909f4c08b874c4aa95d4035+34&path%5B%5D=docs