### PR TITLE
Avoid duplicate `comments-time-machine-links` in comment dropdown

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -59,7 +59,7 @@ function init(): void {
 	// PR reviews' main content has nested `.timeline-comment`, but the deepest one doesn't have `relative-time`. These are filtered out with `:not([id^="pullrequestreview"])`
 	const comments = select.all(`
 		:not(.js-new-comment-form):not([id^="pullrequestreview"]) > .timeline-comment:not(.rgh-time-machine-links),
-		.review-comment:not(.rgh-time-machine-links) > .previewable-edit:not(.is-pending)
+		.review-comment > .previewable-edit:not(.is-pending):not(.rgh-time-machine-links)
 	`);
 
 	for (const comment of comments) {


### PR DESCRIPTION
Closes #2637  

# Test

Reproduceable steps:
1. Add a comment (to any PR/issue)
2. Hide the comment
3. Add a second comment
4. Check the hidden comment - there should be only one 'View repo at this time' link

# Underlying issue
The feature marks comments with a special class to indicate whether the button is there.  
Everytime you add a new comment it will select comments that do not have that class, but the select was looking for that class in the wrong place
