### PR TITLE
Improve `show-whitespace` performance on large files

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -14,6 +14,6 @@
 	opacity: 0.25;
 }
 
-[data-rgh-whitespace^='→'] {
+[data-rgh-whitespace^='→']::before {
 	letter-spacing: calc((var(--tab-size, 4) * 1ch) - 1ch);
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,10 +1,11 @@
-.rgh-ws-char {
+[data-rgh-whitespace] {
 	position: relative;
 	line-height: 1em;
 	text-indent: 0; /* Reset any indentation added by `indented-code-wrapping` feature */
 }
 
-.rgh-ws-char::before {
+[data-rgh-whitespace]::before {
+	content: attr(data-rgh-whitespace);
 	pointer-events: none;
 	user-select: none;
 	position: absolute;
@@ -13,11 +14,6 @@
 	opacity: 0.25;
 }
 
-.rgh-tab-char::before {
-	content: attr(data-rgh-tabs);
+[data-rgh-whitespace^='→'] {
 	letter-spacing: calc((var(--tab-size, 4) * 1ch) - 1ch);
-}
-
-.rgh-space-char::before {
-	content: attr(data-rgh-spaces);
 }

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -49,9 +49,14 @@ function showWhiteSpacesOn(line: Element): void {
 }
 
 async function run(): Promise<void> {
+	let timeKeeper = Date.now();
 	for (const line of select.all('.blob-code-inner')) {
 		line.classList.add('rgh-showing-whitespace');
 		showWhiteSpacesOn(line);
+		if (timeKeeper + 100 < Date.now()) {
+			await new Promise(resolve => setTimeout(resolve, 50));
+			timeKeeper = Date.now();
+		}
 	}
 }
 

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -6,11 +6,17 @@ import onPrFileLoad from '../libs/on-pr-file-load';
 import onNewComments from '../libs/on-new-comments';
 import getTextNodes from '../libs/get-text-nodes';
 
+// `splitText` is used before and after each whitespace group so a new whitespace-only text node is created. This new node is then wrapped in a <span>
 function showWhiteSpacesOn(line: Element): void {
 	for (const textNode of getTextNodes(line)) {
+		// `textContent` reads must be cached #2737
 		let text = textNode.textContent!;
+
+		// Loop goes in reverse otherwise `splitText`'s `index` parameter needs to keep track of the previous split
 		for (let i = text.length - 1; i >= 0; i--) {
 			const thisCharacter = text[i];
+
+			// Exclude irrelevant characters
 			if (thisCharacter !== ' ' && thisCharacter !== '\t') {
 				continue;
 			}
@@ -19,11 +25,14 @@ function showWhiteSpacesOn(line: Element): void {
 				textNode.splitText(i + 1);
 			}
 
+			// Find the same character so they can be wrapped together
 			while (text[i - 1] === thisCharacter) {
 				i--;
 			}
 
 			textNode.splitText(i);
+
+			// Update cached variable here because it just changed
 			text = textNode.textContent!;
 
 			const whitespace = textNode.nextSibling!.textContent!

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -8,7 +8,6 @@ import getTextNodes from '../libs/get-text-nodes';
 
 // `splitText` is used before and after each whitespace group so a new whitespace-only text node is created. This new node is then wrapped in a <span>
 function showWhiteSpacesOn(line: Element): void {
-	const range = new Range();
 	for (const textNode of getTextNodes(line)) {
 		// `textContent` reads must be cached #2737
 		let text = textNode.textContent!;
@@ -22,23 +21,29 @@ function showWhiteSpacesOn(line: Element): void {
 				continue;
 			}
 
-			range.setEnd(textNode, i + 1);
+			if (i < text.length - 1) {
+				textNode.splitText(i + 1);
+			}
 
 			// Find the same character so they can be wrapped together
 			while (text[i - 1] === thisCharacter) {
 				i--;
 			}
 
-			range.setStart(textNode, i);
-
-			const whitespace = range.toString()
-				.replace(/ /g, '·')
-				.replace(/\t/g, '→');
-
-			range.surroundContents(<span data-rgh-whitespace={whitespace}/>);
+			textNode.splitText(i);
 
 			// Update cached variable here because it just changed
 			text = textNode.textContent!;
+
+			const whitespace = textNode.nextSibling!.textContent!
+				.replace(/ /g, '·')
+				.replace(/\t/g, '→');
+
+			textNode.after(
+				<span data-rgh-whitespace={whitespace}>
+					{textNode.nextSibling}
+				</span>
+			);
 		}
 	}
 }

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -8,6 +8,7 @@ import getTextNodes from '../libs/get-text-nodes';
 
 // `splitText` is used before and after each whitespace group so a new whitespace-only text node is created. This new node is then wrapped in a <span>
 function showWhiteSpacesOn(line: Element): void {
+	const range = new Range();
 	for (const textNode of getTextNodes(line)) {
 		// `textContent` reads must be cached #2737
 		let text = textNode.textContent!;
@@ -21,29 +22,23 @@ function showWhiteSpacesOn(line: Element): void {
 				continue;
 			}
 
-			if (i < text.length - 1) {
-				textNode.splitText(i + 1);
-			}
+			range.setEnd(textNode, i + 1);
 
 			// Find the same character so they can be wrapped together
 			while (text[i - 1] === thisCharacter) {
 				i--;
 			}
 
-			textNode.splitText(i);
+			range.setStart(textNode, i);
 
-			// Update cached variable here because it just changed
-			text = textNode.textContent!;
-
-			const whitespace = textNode.nextSibling!.textContent!
+			const whitespace = range.toString()
 				.replace(/ /g, '·')
 				.replace(/\t/g, '→');
 
-			textNode.after(
-				<span data-rgh-whitespace={whitespace}>
-					{textNode.nextSibling}
-				</span>
-			);
+			range.surroundContents(<span data-rgh-whitespace={whitespace}/>);
+
+			// Update cached variable here because it just changed
+			text = textNode.textContent!;
 		}
 	}
 }

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -15,17 +15,16 @@ function showWhiteSpacesOn(line: Element): void {
 				continue;
 			}
 
-			let l = i;
-			while (text[l - 1] === text[i]) {
-				l--;
-			}
-
 			if (i < text.length - 1) {
 				textNode.splitText(i + 1);
 			}
 
-			textNode.splitText(l);
-			text = textNode.textContent!; // Update cached variable here because it just changed
+			while (text[i - 1] === thisCharacter) {
+				i--;
+			}
+
+			textNode.splitText(i);
+			text = textNode.textContent!;
 
 			const whitespace = textNode.nextSibling!.textContent!
 				.replace(/ /g, '·')

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -48,15 +48,19 @@ function showWhiteSpacesOn(line: Element): void {
 	}
 }
 
-async function run(): Promise<void> {
-	let timeKeeper = Date.now();
-	for (const line of select.all('.blob-code-inner')) {
-		line.classList.add('rgh-showing-whitespace');
-		showWhiteSpacesOn(line);
-		if (timeKeeper + 100 < Date.now()) {
-			await new Promise(resolve => setTimeout(resolve, 50));
-			timeKeeper = Date.now();
+const viewportObserver = new IntersectionObserver(changes => {
+	for (const change of changes) {
+		if (change.isIntersecting) {
+			showWhiteSpacesOn(change.target);
+			viewportObserver.unobserve(change.target);
 		}
+	}
+});
+
+async function run(): Promise<void> {
+	for (const line of select.all('.blob-code-inner:not(.rgh-observing-whitespace)')) {
+		line.classList.add('rgh-observing-whitespace');
+		viewportObserver.observe(line);
 	}
 }
 

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -20,7 +20,7 @@ function showWhiteSpacesOn(line: Element): void {
 				l--;
 			}
 
-			if (i < text.length - 2) {
+			if (i < text.length - 1) {
 				textNode.splitText(i + 1);
 			}
 

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -11,7 +11,14 @@ function showWhiteSpacesOn(line: Element): void {
 
 	for (const textNode of textNodes) {
 		const textContent = textNode.textContent!;
-		if (textContent.length === 0 || !(textContent.includes(' ') || textContent.includes('\t'))) {
+		if (
+			textContent.length === 0 ||
+			textContent.length > 1000 || // #2732
+			!(
+				textContent.includes(' ') || 
+				textContent.includes('\t')
+			)
+		) {
 			continue;
 		}
 

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -49,13 +49,7 @@ function showWhiteSpacesOn(line: Element): void {
 }
 
 async function run(): Promise<void> {
-	const lines = select.all([
-		'table.js-file-line-container .blob-code-inner', // Single blob file, and gist
-		'.file table.diff-table .blob-code-inner', // Split and unified diffs
-		'.file table.d-table .blob-code-inner' // "Suggested changes" in PRs
-	]);
-
-	for (const line of lines) {
+	for (const line of select.all('.blob-code-inner')) {
 		line.classList.add('rgh-showing-whitespace');
 		showWhiteSpacesOn(line);
 	}


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/2732

I rewrote the feature to limit DOM manipulation. The previous one created a new DocumentFragment for each character, whether it was whitespace or not.

Even this version was slow until I cached `textNode.textContent`; Firefox really doesn't like reading that many times in a loop. Now it's only read once per replacement, which makes the test URL instant. A related bug was opened here but closed as `worksforme`: https://bugzilla.mozilla.org/show_bug.cgi?id=1330475

~~I wonder if manipulation could be further improved with [`Range.surroundContents`](https://developer.mozilla.org/en-US/docs/Web/API/range/surroundContents) but the current solution seems fast enough.~~ Edit: tried, 5x slower: https://github.com/sindresorhus/refined-github/pull/2737/commits/066402aa8a083228d6f875cb9d255bbca65d05b3

Current bugs: 
- [x] for some reason it's also trying to replace other characters like [`=` and `{`](https://user-images.githubusercontent.com/1402241/73139102-fd7b1800-409c-11ea-89f7-1a2620702b3f.png)
- [x] alignment seems off

<img width="245" alt="" src="https://user-images.githubusercontent.com/1402241/73149324-537aaa80-40f3-11ea-882f-091db6a808b2.png">


# Test
Careful, this URL will freeze your Firefox window if you open it with the `master` version of Refined GitHub: https://github.com/teropa/to-sting/blob/master/index.js

