### PR TITLE
Various fixes for `sync-pr-commit-title`

### DIFF
--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -45,7 +45,7 @@ function needsSubmission(): boolean {
 		return false;
 	}
 
-	// If the commit title was clipped, be more lenient when comparing it to the PR title. 
+	// If the commit title was clipped, be more lenient when comparing it to the PR title.
 	// If the user doesn't change the clipped commit title, the PR doesn't need to change.
 	const commitTitle = createCommitTitle();
 	if (commitTitle.includes('…')) {
@@ -66,7 +66,7 @@ function maybeShowNote(): void {
 		select<HTMLInputElement>('#merge_title_field')!.after(getNote());
 		return;
 	}
-	
+
 	logError(__featureName__, 'Can’t update the PR title');
 }
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -1,6 +1,5 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import debounce from 'debounce-fn';
 import delegate, {DelegateSubscription, DelegateEvent} from 'delegate-it';
 import insertTextTextarea from 'insert-text-textarea';
 import features from '../libs/features';
@@ -11,20 +10,17 @@ const commitTitleLimit = 72;
 const prTitleFieldSelector = '.js-issue-update [name="issue[title]"]';
 const prTitleSubmitSelector = '.js-issue-update [type="submit"]';
 
-const createCommitTitle = debounce<[], string>((): string => {
-	const issueTitle = select('.js-issue-title')!.textContent!.trim();
-	const issueInfo = ` (${getPRNumber()})`;
-	const targetTitleLength = commitTitleLimit - issueInfo.length;
+function createCommitTitle(): string {
+	const prTitle = select('.js-issue-title')!.textContent!.trim();
+	const prInfo = ` (${getPRNumber()})`;
+	const targetTitleLength = commitTitleLimit - prInfo.length;
 
-	if (issueTitle.length > targetTitleLength) {
-		return issueTitle.slice(0, targetTitleLength - 1).trim() + '…' + issueInfo;
+	if (prTitle.length > targetTitleLength) {
+		return prTitle.slice(0, targetTitleLength - 1).trim() + '…' + prInfo;
 	}
 
-	return issueTitle + issueInfo;
-}, {
-	wait: 1000,
-	immediate: true
-});
+	return prTitle + prInfo;
+}
 
 function getNote(): HTMLElement {
 	return select('.note.rgh-sync-pr-commit-title-note') ?? (

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -72,7 +72,7 @@ function updatePRTitle(): void {
 	if (!needsSubmission()) {
 		return;
 	}
-	
+
 	// Remove PR number from commit title
 	const prTitle = getCommitTitleField()!.value
 		.replace(new RegExp(`\\s*\\(${getPRNumber()}\\)$`), '');
@@ -82,7 +82,7 @@ function updatePRTitle(): void {
 	select(prTitleSubmitSelector)!.click(); // `form.submit()` isn't sent via ajax
 }
 
-async function updateCommitTitle(event: Event): Promise<void> {	
+async function updateCommitTitle(event: Event): Promise<void> {
 	const field = getCommitTitleField();
 
 	// Only if the user hasn't already interacted with it in this session
@@ -106,7 +106,7 @@ function init(): void {
 		onPrMergePanelOpen(updateCommitTitle),
 		delegate('#merge_title_field', 'input', updateUI),
 		delegate('form.js-merge-pull-request', 'submit', updatePRTitle),
-		delegate('.rgh-sync-pr-commit-title', 'click', disableSubmission),
+		delegate('.rgh-sync-pr-commit-title', 'click', disableSubmission)
 	];
 }
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -76,9 +76,11 @@ function submitPRTitleUpdate(): void {
 }
 
 function onMergePanelOpen(event: Event): void {
+	const field = select<HTMLTextAreaElement>('.is-squashing #merge_title_field');
+	if (!field) {
+		return;
+	}
 	maybeShowNote();
-
-	const field = select<HTMLTextAreaElement>('#merge_title_field')!;
 
 	// Only if the user hasn't already interacted with it in this session
 	if (field.closest('.is-dirty') || event.type === 'session:resume') {
@@ -110,7 +112,7 @@ function deinit(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Uses the PR’s title and description when merging and updates the PR’s title to the match the commit title, if changed.',
+	description: 'When squashing PRs, it will suggest to have the same PR’s title and merge commit title.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png',
 	include: [
 		features.isPRConversation

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -45,6 +45,13 @@ function needsSubmission(): boolean {
 		return false;
 	}
 
+	// If the commit title was clipped, be more lenient when comparing it to the PR title. 
+	// If the user doesn't change the clipped commit title, the PR doesn't need to change.
+	const commitTitle = createCommitTitle();
+	if (commitTitle.includes('…')) {
+		return !inputField.value.startsWith(commitTitle.replace(/….+/, ''));
+	}
+
 	return createCommitTitle() !== inputField.value;
 }
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -71,13 +71,15 @@ function submitPRTitleUpdate(): void {
 	select(prTitleSubmitSelector)!.click(); // `form.submit()` isn't sent via ajax
 }
 
-function onMergePanelOpen(event: Event): void {
+async function onMergePanelOpen(event: Event): Promise<void> {
 	const field = select<HTMLTextAreaElement>('.is-squashing #merge_title_field');
 	if (!field) {
 		return;
 	}
 	maybeShowNote();
 
+	// Wait for field to be restored first, otherwise it's never dirty
+	await new Promise(resolve => setTimeout(resolve));
 	// Only if the user hasn't already interacted with it in this session
 	if (field.closest('.is-dirty') || event.type === 'session:resume') {
 		return;

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -39,18 +39,24 @@ function handleCancelClick(event: DelegateEvent): void {
 	event.delegateTarget.parentElement!.remove(); // Hide note
 }
 
-function maybeShowNote(): void {
-	const inputField = select<HTMLInputElement>('#merge_title_field')!;
-	const needsSubmission = createCommitTitle() !== inputField.value;
+function needsSubmission(): boolean {
+	const inputField = select<HTMLTextAreaElement>('.is-squashing #merge_title_field');
+	if (!inputField) {
+		return false;
+	}
 
-	if (!needsSubmission) {
+	return createCommitTitle() !== inputField.value;
+}
+
+function maybeShowNote(): void {
+	if (!needsSubmission()) {
 		getNote().remove();
 		return;
 	}
 
 	// Ensure that the required fields are there before adding the note
 	if (select.all([prTitleFieldSelector, prTitleSubmitSelector].join()).length === 2) {
-		inputField.after(getNote());
+		select<HTMLInputElement>('#merge_title_field')!.after(getNote());
 		return;
 	}
 	
@@ -75,6 +81,7 @@ function submitPRTitleUpdate(): void {
 async function onMergePanelOpen(event: Event): Promise<void> {
 	const field = select<HTMLTextAreaElement>('.is-squashing #merge_title_field');
 	if (!field) {
+		maybeShowNote();
 		return;
 	}
 

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -92,11 +92,8 @@ async function onMergePanelOpen(event: Event): Promise<void> {
 		return;
 	}
 
-	// Wait for field to be restored first, otherwise it's never dirty
-	await new Promise(resolve => setTimeout(resolve));
-
 	// Only if the user hasn't already interacted with it in this session
-	if (!field.closest('.is-dirty') && event.type !== 'session:resume') {
+	if (event.type !== 'session:resume') {
 		// Replace default title and fire the correct events
 		field.select();
 		insertTextTextarea(field, createCommitTitle());


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/2713 by avoid renaming merge commits
Fixes https://github.com/sindresorhus/refined-github/issues/1743#issuecomment-530825883 by avoid renaming the PR if the commit title is "the same but clipped"
Fixes: it asks to rename the PR even if it's not necessary, in some cases
Also: slight code cleanup

## Test

Test opening/closing/reopening the merge box on a PR you can merge, also switching between Merge/Squash and changing the title.