### PR TITLE
Change style of `emphasize-draft-pr-label`

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,4 +1,4 @@
 .js-issue-row [aria-label='Open draft pull request'] svg {
 	color: #fff !important;
-	filter: drop-shadow(#6a737d 0 0 0.5px);
+	filter: drop-shadow(#000 0 0 0.7px);
 }

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,4 +1,4 @@
 .js-issue-row [aria-label='Open draft pull request'] svg {
 	color: #fff !important;
-	filter: drop-shadow(#6a737d 0px 0px 0.5px);
+	filter: drop-shadow(#6a737d 0 0 0.5px);
 }

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,15 +1,4 @@
-span[aria-label='Open draft pull request'] {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 1.6em;
-	height: 1.6em;
-	margin-left: -0.4em;
-	margin-right: -0.1em;
-	background: #bbb;
-	border-radius: 50%;
-}
-
-span[aria-label='Open draft pull request'] svg {
+.js-issue-row [aria-label='Open draft pull request'] svg {
 	color: #fff !important;
+	filter: drop-shadow(#6a737d 0px 0px 0.5px);
 }


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/2450

The original problem was that the contrast between green and gray was poor. I think this solution increases the contrast without making Draft PRs look bigger.

## Normally

<img width="539" alt="normal" src="https://user-images.githubusercontent.com/1402241/73355505-e3bf1800-42ca-11ea-97d3-4a681d03f1b7.png">

## Before

<img width="442" alt="before" src="https://user-images.githubusercontent.com/1402241/73355509-e457ae80-42ca-11ea-98d7-17de5cd7f273.png">

## After

<img width="538" alt="after" src="https://user-images.githubusercontent.com/1402241/73355506-e457ae80-42ca-11ea-9080-a301acf1bc51.png">




# Test

https://github.com/sindresorhus/refined-github/pulls
https://github.com/WordPress/gutenberg/pulls
