### PR TITLE
Fix style of deep-linked `highest-rated-comment`

### DIFF
--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -3,7 +3,7 @@
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::before {
-	border-right-color: #2cbe4e;
+	border-right-color: #2cbe4e !important;
 }
 
 .rgh-highest-rated-comment.timeline-comment--caret::after {


### PR DESCRIPTION
**tl;dr:**

<img src="https://user-images.githubusercontent.com/1922624/73610910-c8ab1b80-45dc-11ea-9fbf-1a0b36b15b9f.png" alt="Comparison of a targeted highest rated comment before and after the PR" width="283" height="510">

---

This PR fixes a minor visual bug I didn't bother to open an issue for: The green border of a highest rated comment carries an `!important` marker only on the main box, not on the triangle on the upper left. This leads to the triangle being incorrectly colored when the comment is focused via a URL anchor (because then there's a `:target` pseudo class in GitHub's CSS which overrules our selector's specificity).