### PR TITLE
Add `bugs-tab` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ Thanks for contributing! 🦋🙌
 - [](# "cycle-lists-with-keyboard-shortcuts") [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 - [](# "toggle-everything-with-alt") [Adds a shortcut to toggle all similar items (minimized comments, deferred diffs, etc) at once: <kbd>alt</kbd> <kbd>click</kbd> on each button or checkbox.](https://user-images.githubusercontent.com/37769974/62208543-dcb75b80-b3b4-11e9-984f-ddb479ea149d.gif)
 - [](# "quick-mention") [Adds a button to `@mention` a user in discussions.](https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif)
-- [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bugs" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
+- [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ Thanks for contributing! 🦋🙌
 - [](# "cycle-lists-with-keyboard-shortcuts") [Allows the <kbd>↑</kbd> and <kbd>↓</kbd> keys to cycle "popover lists" (labels, milestones, etc).](https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif)
 - [](# "toggle-everything-with-alt") [Adds a shortcut to toggle all similar items (minimized comments, deferred diffs, etc) at once: <kbd>alt</kbd> <kbd>click</kbd> on each button or checkbox.](https://user-images.githubusercontent.com/37769974/62208543-dcb75b80-b3b4-11e9-984f-ddb479ea149d.gif)
 - [](# "quick-mention") [Adds a button to `@mention` a user in discussions.](https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif)
+- [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bugs" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -157,6 +157,7 @@ import './features/linkify-user-location';
 import './features/repo-age';
 import './features/user-local-time';
 import './features/quick-mention';
+import './features/bugs-tab';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -37,7 +37,7 @@ async function addBugsTab(isBugsPage: boolean): Promise<HTMLElement | false> {
 
 	// Update Bugs’ link
 	const bugsLink = select('a', bugsTab)!;
-	new SearchQuery(bugsLink).edit(query => `${query} label:bug`);
+	new SearchQuery(bugsLink).add('label:bug');
 
 	// Change the Selected tab if necessary
 	bugsLink.classList.toggle('selected', isBugsPage);

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -58,6 +58,10 @@ async function init(): Promise<void | false> {
 	const bugsLink = select('a', bugsTab)!;
 	new SearchQuery(bugsLink).add('label:bug');
 
+	// Hide bugs from Issues tab
+	const issuesLink = select('a', issuesTab)!;
+	new SearchQuery(issuesLink).add('-label:bug');
+
 	// Change the Selected tab if necessary
 	bugsLink.classList.toggle('selected', isBugsPage);
 	select('.selected', issuesTab)?.classList.toggle('selected', !isBugsPage);
@@ -67,6 +71,8 @@ async function init(): Promise<void | false> {
 	// Update issue counts
 	const bugsCount = await countPromise;
 	select('.Counter', bugsTab)!.textContent = String(bugsCount);
+	// @ts-ignore substraction on string. The alternative is much longer.
+	select('.Counter', issuesTab)!.textContent -= bugsCount;
 }
 
 features.add({

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -78,7 +78,7 @@ async function init(): Promise<void | false> {
 
 features.add({
 	id: __featureName__,
-	description: 'Adds a "Bugs" tab to repos, if there are any open issues with the "bugs" label.',
+	description: 'Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png',
 	include: [
 		features.isRepo

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -4,6 +4,7 @@ import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as api from '../libs/api';
 import {getRepoGQL} from '../libs/utils';
+import SearchQuery from '../libs/search-query';
 
 async function countBugs(): Promise<number> {
 	const {repository} = await api.v4(`
@@ -30,7 +31,7 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const isBugsPage = /[^-]label:bug/.test(new URLSearchParams(location.search).get('q')!);
+	const isBugsPage = new SearchQuery(location).includes('label:bug');
 
 	// Copy Issues tab but update its appearance
 	const bugsTab = issuesTab.cloneNode(true);
@@ -40,7 +41,7 @@ async function init(): Promise<void | false> {
 
 	// Update Bugs’ link
 	const bugsLink = select('a', bugsTab)!;
-	bugsLink.search += '+label%3Abug';
+	new SearchQuery(bugsLink).edit(query => `${query} label:bug`);
 
 	// Change the Selected tab if necessary
 	bugsLink.classList.toggle('selected', isBugsPage);

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -32,18 +32,23 @@ async function init(): Promise<void | false> {
 
 	const isBugsPage = /[^-]label:bug/.test(new URLSearchParams(location.search).get('q')!);
 
+	// Copy Issues tab but update its appearance
 	const bugsTab = issuesTab.cloneNode(true);
 	select('.octicon', bugsTab)!.replaceWith(bugIcon());
 	select('.Counter', bugsTab)!.textContent = String(count);
 	select('[itemprop="name"]', bugsTab)!.textContent = 'Bugs';
 
+	// Update Bugs’ link
 	const bugsLink = select('a', bugsTab)!;
 	bugsLink.search += '+label%3Abug';
+
+	// Change the Selected tab if necessary
 	bugsLink.classList.toggle('selected', isBugsPage);
 	select('.selected', issuesTab)?.classList.toggle('selected', !isBugsPage);
 
 	issuesTab.after(bugsTab);
 
+	// Hide pinned issues on the tab page, they might not belong there
 	if (isBugsPage) {
 		(await elementReady('.js-pinned-issues-reorder-container'))?.remove();
 	}
@@ -52,7 +57,7 @@ async function init(): Promise<void | false> {
 features.add({
 	id: __featureName__,
 	description: 'Adds a "Bugs" tab to repos, if there are any open issues with the "bugs" label.',
-	screenshot: '',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png',
 	include: [
 		features.isRepo
 	],

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -1,0 +1,61 @@
+import select from 'select-dom';
+import bugIcon from '@primer/octicons/build/svg/bug.svg';
+import elementReady from 'element-ready';
+import features from '../libs/features';
+import * as api from '../libs/api';
+import {getRepoGQL} from '../libs/utils';
+
+async function countBugs(): Promise<number> {
+	const {repository} = await api.v4(`
+		repository(${getRepoGQL()}) {
+			bugs: issues(labels: ["bug"], states: [OPEN]) {
+				totalCount
+			}
+		}
+	`);
+
+	return repository.bugs.totalCount;
+}
+
+async function init(): Promise<void | false> {
+	// Query API as early as possible, even if it's not necessary on archived repos
+	const count = await countBugs();
+	if (count === 0) {
+		return false;
+	}
+
+	const issuesTab = (await elementReady('.reponav [data-hotkey="g i"]'))?.parentElement;
+	if (!issuesTab) {
+		// Repo is archived
+		return false;
+	}
+
+	const isBugsPage = /[^-]label:bug/.test(new URLSearchParams(location.search).get('q')!);
+
+	const bugsTab = issuesTab.cloneNode(true);
+	select('.octicon', bugsTab)!.replaceWith(bugIcon());
+	select('.Counter', bugsTab)!.textContent = String(count);
+	select('[itemprop="name"]', bugsTab)!.textContent = 'Bugs';
+
+	const bugsLink = select('a', bugsTab)!;
+	bugsLink.search += '+label%3Abug';
+	bugsLink.classList.toggle('selected', isBugsPage);
+	select('.selected', issuesTab)?.classList.toggle('selected', !isBugsPage);
+
+	issuesTab.after(bugsTab);
+
+	if (isBugsPage) {
+		(await elementReady('.js-pinned-issues-reorder-container'))?.remove();
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Adds a "Bugs" tab to repos, if there are any open issues with the "bugs" label.',
+	screenshot: '',
+	include: [
+		features.isRepo
+	],
+	load: features.nowAndOnAjaxedPages,
+	init
+});


### PR DESCRIPTION
Closes #2749 

<table><td><img width="433" alt="bugs-tab" src="https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png"></table>

Your thoughts needed on the ❓ tasks:

- [x] Basic implementation
- [x] Cache ~~but prefer local count if available~~ (edit: way too convoluted)
- [x] Subtract bugs from Issues tab’s count ❓ 
- [x] Hide bugs from Issues tab ❓ 
- [x] Improve with #2752
- [x] Add some comments and document