### PR TITLE
Add `expand-all-hidden-comments` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,6 +184,7 @@ Thanks for contributing! 🦋🙌
 - [](# "scrollable-code-and-blockquote") [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
 - [](# "hide-comments-faster") [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
 - [](# "open-issue-to-latest-comment") [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
+- [](# "expand-all-hidden-comments") [On long discussions where GitHub hides comments under a "Load more...", <kbd>alt</kbd> <kbd>click</kbd> will load *all* the comments at once instead of part of them.](https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -157,6 +157,7 @@ import './features/linkify-user-location';
 import './features/repo-age';
 import './features/user-local-time';
 import './features/quick-mention';
+import './features/expand-all-hidden-comments';
 
 // Add global for easier debugging
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -6,7 +6,7 @@ const expanderSelector = '.ajax-pagination-form';
 const expanderButtonSelector = `${expanderSelector} .ajax-pagination-btn`;
 const containerSelector = '#js-progressive-timeline-item-container';
 
-function observe(expanderElement: HTMLElement) {
+function observe(expanderElement: HTMLElement): void {
 	// Waits for the next loaded comments and clicks on any additional "Load more..." buttons it finds
 	const expandingCodeObserver = new MutationObserver(([mutation]) => {
 		const expandButton = select(expanderButtonSelector, mutation.target as Element);

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -2,9 +2,6 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 
-const EXPANDER_SELECTOR = '.ajax-pagination-form';
-const REMAIN_COMMENTS_REGEX = /\s*(\d+) hidden items\s*/;
-
 function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void {
 	if (!event.altKey) {
 		return;
@@ -13,8 +10,8 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 	const form = event.delegateTarget;
 
 	const buttons = select.all('button', form);
-	const remainCommentsButton = buttons.find(button => REMAIN_COMMENTS_REGEX.test(button.textContent!))!;
-	const [remainComments] = REMAIN_COMMENTS_REGEX.exec(remainCommentsButton.textContent!)!;
+	const remainCommentsButton = buttons.find(button => /\s*(\d+) hidden items\s*/.test(button.textContent!))!;
+	const remainComments = remainCommentsButton.textContent!.replace(/\D+g/, '');
 
 	/**
 	As per #2625:
@@ -32,7 +29,7 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 }
 
 function init(): void {
-	delegate(EXPANDER_SELECTOR, 'click', handleAltClick);
+	delegate('.ajax-pagination-form', 'click', handleAltClick);
 }
 
 features.add({

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -1,14 +1,10 @@
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 
-/**
-As per #2625:
-Construct the new URL. This is undocumented, and may break at any time.
-As of 12/08/2019, URLs look like this:
-`/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false`
-The key "variables[first]" in the URL query parameters appears to control how many additional comments are fetched.
-Github appears to always set this to 60, but it can be increased up to the total number of hidden items.
-By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
+/*
+The ajaxed form that loads the new comments points to a URL like:
+/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false
+The parameter `variables[first]` controls how many additional comments are fetched. We change this number from 60 to the total number of hidden items to have it load all of them at once.
 */
 function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	if (!event.altKey) {
@@ -28,7 +24,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'On long discussions where GitHub hides comments under a "Load more...", alt-clicking "Load more..." will load *all* the comments at once instead of part of them.',
+	description: 'On long discussions where GitHub hides comments under a "Load more...", alt-clicking it will load *all* the comments at once instead of part of them.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png',
 	include: [
 		features.isIssue,

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -16,9 +16,9 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): vo
 	}
 
 	const form = event.delegateTarget.form!;
-	const remainComments = form.textContent!.replace(/\D+/g, '');
+	const hiddenItemsCount = form.textContent!.replace(/\D+/g, '');
 	const url = new URL(form.action);
-	url.searchParams.set('variables[first]', remainComments);
+	url.searchParams.set('variables[first]', hiddenItemsCount);
 	form.action = url.href;
 }
 

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -1,0 +1,51 @@
+import select from 'select-dom';
+import delegate, {DelegateEvent} from 'delegate-it';
+import features from '../libs/features';
+
+const expanderSelector = '.ajax-pagination-form .ajax-pagination-btn';
+const containerSelector = '#js-progressive-timeline-item-container';
+
+function observe(expanderElement: HTMLElement) {
+	// Waits for the next loaded comments and clicks on any additional "Load more..." buttons it finds
+	const expandingCodeObserver = new MutationObserver(([mutation]) => {
+		const expandButton = select(expanderSelector, mutation.target as Element);
+
+		if (expandButton) {
+			expandButton.click();
+
+			// Recursively observe the returned list
+			observe(expandButton);
+		}
+
+		expandingCodeObserver.disconnect();
+	});
+
+	expandingCodeObserver.observe(
+		expanderElement.closest(containerSelector)!,
+		{childList: true}
+	);
+}
+
+function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
+	if (!event.altKey) {
+		return;
+	}
+
+	observe(event.delegateTarget);
+}
+
+function init(): void {
+	delegate(expanderSelector, 'click', handleAltClick);
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Expands all the hidden comments when you alt-click on any "Load more..." button in issues.',
+	screenshot: 'https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif',
+	include: [
+		features.isIssue,
+		features.isPRConversation
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -26,7 +26,7 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 	By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
 	 */
 	const actionPath = form.getAttribute('action')!;
-	const url = new URL(actionPath, location.origin);
+	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', remainComments);
 	form.setAttribute('action', url.pathname + url.search);
 }

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -2,41 +2,37 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 
-const expanderSelector = '.ajax-pagination-form';
-const expanderButtonSelector = `${expanderSelector} .ajax-pagination-btn`;
-const containerSelector = '#js-progressive-timeline-item-container';
+const EXPANDER_SELECTOR = '.ajax-pagination-form';
+const REMAIN_COMMENTS_REGEX = /\s*(\d+) hidden items\s*/;
 
-function observe(expanderElement: HTMLElement): void {
-	// Waits for the next loaded comments and clicks on any additional "Load more..." buttons it finds
-	const expandingCodeObserver = new MutationObserver(([mutation]) => {
-		const expandButton = select(expanderButtonSelector, mutation.target as Element);
-
-		if (expandButton) {
-			expandButton.click();
-
-			// Recursively observe the returned list
-			observe(expandButton);
-		}
-
-		expandingCodeObserver.disconnect();
-	});
-
-	expandingCodeObserver.observe(
-		expanderElement.closest(containerSelector)!,
-		{childList: true}
-	);
-}
-
-function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
+function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void {
 	if (!event.altKey) {
 		return;
 	}
 
-	observe(event.delegateTarget);
+	const form = event.delegateTarget;
+
+	const buttons = select.all('button', form);
+	const remainCommentsButton = buttons.find(button => REMAIN_COMMENTS_REGEX.test(button.textContent!))!;
+	const [remainComments] = REMAIN_COMMENTS_REGEX.exec(remainCommentsButton.textContent!)!;
+
+	/**
+	As per #2625:
+	Construct the new URL. This is undocumented, and may break at any time.
+	As of 12/08/2019, URLs look like this:
+	`/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false`
+	The key "variables[first]" in the URL query parameters appears to control how many additional comments are fetched.
+	Github appears to always set this to 60, but it can be increased up to the total number of hidden items.
+	By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
+	 */
+	const actionPath = form.getAttribute('action')!;
+	const url = new URL(actionPath, location.origin);
+	url.searchParams.set('variables[first]', remainComments);
+	form.setAttribute('action', url.pathname + url.search);
 }
 
 function init(): void {
-	delegate(expanderSelector, 'click', handleAltClick);
+	delegate(EXPANDER_SELECTOR, 'click', handleAltClick);
 }
 
 features.add({

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -2,13 +2,14 @@ import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 
-const expanderSelector = '.ajax-pagination-form .ajax-pagination-btn';
+const expanderSelector = '.ajax-pagination-form';
+const expanderButtonSelector = `${expanderSelector} .ajax-pagination-btn`;
 const containerSelector = '#js-progressive-timeline-item-container';
 
 function observe(expanderElement: HTMLElement) {
 	// Waits for the next loaded comments and clicks on any additional "Load more..." buttons it finds
 	const expandingCodeObserver = new MutationObserver(([mutation]) => {
-		const expandButton = select(expanderSelector, mutation.target as Element);
+		const expandButton = select(expanderButtonSelector, mutation.target as Element);
 
 		if (expandButton) {
 			expandButton.click();

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -42,7 +42,7 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Expands all the hidden comments when you alt-click on any "Load more..." button in issues.',
-	screenshot: 'https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif',
+	screenshot: 'https://user-images.githubusercontent.com/7753001/73732470-338f5a80-4775-11ea-8756-070102ba3858.gif',
 	include: [
 		features.isIssue,
 		features.isPRConversation

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -22,7 +22,6 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 	Github appears to always set this to 60, but it can be increased up to the total number of hidden items.
 	By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
 	 */
-	const actionPath = form.getAttribute('action')!;
 	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', remainComments);
 	form.action = url.href;

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -1,34 +1,29 @@
-import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
 import features from '../libs/features';
 
-function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void {
+/**
+As per #2625:
+Construct the new URL. This is undocumented, and may break at any time.
+As of 12/08/2019, URLs look like this:
+`/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false`
+The key "variables[first]" in the URL query parameters appears to control how many additional comments are fetched.
+Github appears to always set this to 60, but it can be increased up to the total number of hidden items.
+By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
+*/
+function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	if (!event.altKey) {
 		return;
 	}
 
-	const form = event.delegateTarget;
-
-	const buttons = select.all('button', form);
-	const remainCommentsButton = buttons.find(button => /\s*\d+ hidden items\s*/.test(button.textContent!))!;
-	const remainComments = remainCommentsButton.textContent!.replace(/\D+/g, '');
-
-	/**
-	As per #2625:
-	Construct the new URL. This is undocumented, and may break at any time.
-	As of 12/08/2019, URLs look like this:
-	`/_render_node/MDExOlB1bGxSZXF1ZXN0MjE2MDA0MzU5/timeline/more_items?variables%5Bafter%5D=Y3Vyc29yOnYyOpPPAAABZemjg2AAqTQyMjE5MTk1MQ%3D%3D&variables%5Bbefore%5D=Y3Vyc29yOnYyOpPPAAABaENrVHAAqTQ1Mzc3MjMzNg%3D%3D&variables%5Bfirst%5D=60&variables%5BhasFocusedReviewComment%5D=false&variables%5BhasFocusedReviewThread%5D=false`
-	The key "variables[first]" in the URL query parameters appears to control how many additional comments are fetched.
-	Github appears to always set this to 60, but it can be increased up to the total number of hidden items.
-	By setting "variables[first]" to total number of hidden items (extracted from the button tex), we can fetch all hidden comments at once.
-	 */
+	const form = event.delegateTarget.form!;
+	const remainComments = form.textContent!.replace(/\D+/g, '');
 	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', remainComments);
 	form.action = url.href;
 }
 
 function init(): void {
-	delegate('.ajax-pagination-form', 'click', handleAltClick);
+	delegate('.ajax-pagination-form button[type="submit"]', 'click', handleAltClick);
 }
 
 features.add({

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -37,8 +37,8 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'Expands all the hidden comments when you alt-click on any "Load more..." button in issues.',
-	screenshot: 'https://user-images.githubusercontent.com/7753001/73830151-1f179480-483f-11ea-97b5-635fd9d3f0bd.gif',
+	description: 'On long discussions where GitHub hides comments under a "Load more...", alt-clicking "Load more..." will load *all* the comments at once instead of part of them.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png',
 	include: [
 		features.isIssue,
 		features.isPRConversation

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -38,7 +38,7 @@ function init(): void {
 features.add({
 	id: __featureName__,
 	description: 'Expands all the hidden comments when you alt-click on any "Load more..." button in issues.',
-	screenshot: 'https://user-images.githubusercontent.com/7753001/73732470-338f5a80-4775-11ea-8756-070102ba3858.gif',
+	screenshot: 'https://user-images.githubusercontent.com/7753001/73830151-1f179480-483f-11ea-97b5-635fd9d3f0bd.gif',
 	include: [
 		features.isIssue,
 		features.isPRConversation

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -28,7 +28,7 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 	const actionPath = form.getAttribute('action')!;
 	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', remainComments);
-	form.setAttribute('action', url.pathname + url.search);
+	form.action = url.href;
 }
 
 function init(): void {

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -10,8 +10,8 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLFormElement>): void
 	const form = event.delegateTarget;
 
 	const buttons = select.all('button', form);
-	const remainCommentsButton = buttons.find(button => /\s*(\d+) hidden items\s*/.test(button.textContent!))!;
-	const remainComments = remainCommentsButton.textContent!.replace(/\D+g/, '');
+	const remainCommentsButton = buttons.find(button => /\s*\d+ hidden items\s*/.test(button.textContent!))!;
+	const remainComments = remainCommentsButton.textContent!.replace(/\D+/g, '');
 
 	/**
 	As per #2625:


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes #1892 
<!--    👆 Does this PR close/fix an existing issue? Put it here. E.g. `Closes #10` -->

Add `expand-all-hidden-comments` feature. Doing a <kbd>Alt</kbd> + <kbd>Click</kbd> on the `Load more` button will load all the hidden comments in the same page. ~Currently we just recursively click on the button over and over again until there is no more button.~ We use an undocumented API from #2625 to load all the comments. Should we add a maximum limit on how many pages a click should load?


# Test
<!-- List some URLs that reviewers can use to test your PR -->

https://github.com/rust-lang/rfcs/pull/2544

GIF: (pay attention to the scroll bar on the right, it takes a long time...)

![Kapture 2020-02-05 at 17 42 43](https://user-images.githubusercontent.com/7753001/73830151-1f179480-483f-11ea-97b5-635fd9d3f0bd.gif)

