### PR TITLE
Restore `pr-filters` and adjust spacing

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -28,7 +28,8 @@
 	padding-left: 8px !important;
 }
 
-.table-list-filters .details-reset:last-child {
+/* Some filters are wrapped inside a padding-less span */
+.table-list-filters .table-list-header-toggle > .details-reset:last-child {
 	padding-right: 0 !important;
 }
 

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -86,7 +86,7 @@ async function addStatusFilter(): Promise<void> {
 	const statusFilter = reviewsFilter.cloneNode(true);
 	statusFilter.id = '';
 
-	select('summary', statusFilter)!.firstChild!.textContent = 'Status '; // Only replace text node, keep caret
+	select('summary', statusFilter)!.firstChild!.textContent = 'Status\u00A0'; // Only replace text node, keep caret
 	select('.SelectMenu-title', statusFilter)!.textContent = 'Filter by build status';
 
 	const dropdown = select('.SelectMenu-list', statusFilter)!;

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -5,8 +5,7 @@ import checkIcon from 'octicon/check.svg';
 import features from '../libs/features';
 import {getIcon as fetchCIStatus} from './ci-link';
 
-// The Reviews dropdown doesn't have a specific class, so we expect this sequence (span contains Projects and Milestones)
-const reviewsFilterSelector = '#label-select-menu + span + details';
+const reviewsFilterSelector = '#reviews-select-menu';
 
 function addDropdownItem(dropdown: HTMLElement, title: string, filterCategory: string, filterValue: string): void {
 	const filterQuery = `${filterCategory}:${filterValue}`;
@@ -25,15 +24,18 @@ function addDropdownItem(dropdown: HTMLElement, title: string, filterCategory: s
 		q: query + (isSelected ? '' : ` ${filterQuery}`)
 	});
 
+	const icon = checkIcon();
+	icon.classList.add('SelectMenu-icon', 'SelectMenu-icon--check');
+
 	dropdown.append(
 		<a
 			href={`?${String(search)}`}
-			className={`select-menu-item ${isSelected ? 'selected' : ''}`}
+			className="SelectMenu-item"
 			aria-checked={isSelected ? 'true' : 'false'}
 			role="menuitemradio"
 		>
-			<span className="select-menu-item-icon">{checkIcon()}</span>
-			<div className="select-menu-item-text">{title}</div>
+			{icon}
+			<span>{title}</span>
 		</a>
 	);
 }
@@ -46,7 +48,7 @@ function addDraftFilter({delegateTarget: reviewsFilter}: DelegateEvent): void {
 
 	hasDraftFilter.add(reviewsFilter);
 
-	const dropdown = select('.select-menu-list', reviewsFilter)!;
+	const dropdown = select('.SelectMenu-list', reviewsFilter)!;
 
 	dropdown.append(
 		<div className="SelectMenu-divider">
@@ -72,10 +74,12 @@ async function addStatusFilter(): Promise<void> {
 
 	// Copy existing element and adapt its content
 	const statusFilter = reviewsFilter.cloneNode(true);
-	const dropdown = select('.select-menu-list', statusFilter)!;
+	statusFilter.id = '';
 
-	select('summary', statusFilter)!.textContent = 'Status\u00A0';
-	select('.select-menu-title', statusFilter)!.textContent = 'Filter by build status';
+	select('summary', statusFilter)!.firstChild!.textContent = 'Status '; // Only replace text node, keep caret
+	select('.SelectMenu-title', statusFilter)!.textContent = 'Filter by build status';
+
+	const dropdown = select('.SelectMenu-list', statusFilter)!;
 	dropdown.textContent = ''; // Drop previous filters
 
 	for (const status of ['Success', 'Failure', 'Pending']) {

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -1,10 +1,8 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import delegate, {DelegateEvent} from 'delegate-it';
-import cache from 'webext-storage-cache';
 import checkIcon from 'octicon/check.svg';
 import features from '../libs/features';
-import {getRepoURL} from '../libs/utils';
 import {getIcon as fetchCIStatus} from './ci-link';
 
 const reviewsFilterSelector = '#reviews-select-menu';
@@ -68,16 +66,8 @@ async function addStatusFilter(): Promise<void> {
 		return;
 	}
 
-	const cachedCIStatus = cache.function(async () => {
-		// TODO: replace this with an API call
-		const statusIcon = await fetchCIStatus();
-		return statusIcon !== undefined;
-	}, {
-		expiration: 3,
-		cacheKey: () => __featureName__ + ':' + getRepoURL()
-	});
-
-	const hasCI = await cachedCIStatus();
+	// TODO: replace this with an API call
+	const hasCI = await fetchCIStatus();
 	if (!hasCI) {
 		return;
 	}

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -86,7 +86,7 @@ async function addStatusFilter(): Promise<void> {
 		addDropdownItem(dropdown, status, 'status', status.toLowerCase());
 	}
 
-	reviewsFilter.after(statusFilter);
+	reviewsFilter.after(' ', statusFilter);
 }
 
 function init(): void {


### PR DESCRIPTION
Currently, the Draft PR filters are not added to the *Reviews* filter, but to the *Assignee* filter in [some repos](https://github.com/OpenLightingProject/open-fixture-library/pulls) and not at all in [others](https://github.com/sindresorhus/refined-github/pulls). The Status filter is not added in either one.

This PR does the following:

* Fix selectors (to show both filters again)
* Use new dropdown syntax (to fix the layout)
* Fix spacing between dropdown buttons
* Cache CI status for faster Status filter (checks another item from #2671)


# Test

* https://github.com/OpenLightingProject/open-fixture-library/pulls
* https://github.com/sindresorhus/refined-github/pulls
* https://github.com/sindresorhus/refined-github/issues (spacing is fixed there, too)