### PR TITLE
Determine `repo-age` with its first commit

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -15,7 +15,10 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 });
 
 const getFirstCommitDate = cache.function(async (): Promise<string | undefined> => {
-	const lastCommitHash = (await elementReady<HTMLAnchorElement>('.commit-tease-sha', {stopOnDomReady: false}))!.href.split('/').pop()!;
+	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>('a.commit-tease-sha, include-fragment.commit-tease');
+	const commitUrl = commitInfo instanceof HTMLAnchorElement ? commitInfo.href : commitInfo!.src;
+	const commitSha = commitUrl.split('/').pop()!;
+
 	const commitsCount = Number(select('li.commits .num')!.textContent!.replace(',', ''));
 
 	// Returning undefined will make sure that it is not cached. It will check again for commits on the next load.
@@ -29,7 +32,7 @@ const getFirstCommitDate = cache.function(async (): Promise<string | undefined> 
 	}
 
 	const relativeTime = await fetchDom(
-		`${getRepoURL()}/commits?after=${lastCommitHash}+${commitsCount - 2}`,
+		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
 		'ol:last-child > li.commits-list-item relative-time'
 	);
 

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -5,8 +5,8 @@ import select from 'select-dom';
 import repoIcon from 'octicon/repo.svg';
 import elementReady from 'element-ready';
 import features from '../libs/features';
-import * as api from '../libs/api';
-import {getRepoGQL, getRepoURL} from '../libs/utils';
+import fetchDom from '../libs/fetch-dom';
+import {getRepoURL} from '../libs/utils';
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	year: 'numeric',
@@ -14,20 +14,36 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	day: 'numeric'
 });
 
-const getRepoCreationDate = cache.function(async (): Promise<string> => {
-	const {repository} = await api.v4(`
-		repository(${getRepoGQL()}) {
-			createdAt
-		}
-	`);
+const getFirstCommitDate = cache.function(async (): Promise<string | undefined> => {
+	const lastCommitHash = (await elementReady<HTMLAnchorElement>('.commit-tease-sha', {stopOnDomReady: false}))!.href.split('/').pop()!;
+	const commitsCount = Number(select('li.commits .num')!.textContent!.replace(',', ''));
 
-	return repository.createdAt;
+	if (commitsCount === 0) {
+		return;
+	}
+
+	if (commitsCount === 1) {
+		return select('.commit-tease-sha + span relative-time')!.getAttribute('datetime')!;
+	}
+
+	const oldestCommit = await fetchDom(
+		`${getRepoURL()}/commits?after=${lastCommitHash}+${commitsCount - 2}`, 'ol:last-child > li.commits-list-item'
+	);
+
+	return select('relative-time', oldestCommit)!.getAttribute('datetime')!;
 }, {
+	isExpired: (cachedValue: string) => !cachedValue,
 	cacheKey: () => __featureName__ + ':' + getRepoURL()
 });
 
 async function init(): Promise<void> {
-	const date = new Date(await getRepoCreationDate());
+	const firstCommitDate = await getFirstCommitDate();
+
+	if (!firstCommitDate) {
+		return;
+	}
+
+	const date = new Date(firstCommitDate);
 
 	// `twas` could also return `an hour ago` or `just now`
 	const [value, unit] = twas(date.getTime())
@@ -36,7 +52,7 @@ async function init(): Promise<void> {
 		.split(' ');
 
 	const element = (
-		<li className="text-gray" title={`Repository created on ${dateFormatter.format(date)}`}>
+		<li className="text-gray" title={`First commit dated ${dateFormatter.format(date)}`}>
 			{repoIcon()} <span className="num text-emphasized">{value}</span> {unit} old
 		</li>
 	);


### PR DESCRIPTION
As discussed on https://github.com/sindresorhus/refined-github/pull/2667#issuecomment-571003482. This merge request change enables the usage of the first commit for the repo-age.

The change is backward compatible so we don't need to worry about existing cached values in user browsers.

Closes https://github.com/sindresorhus/refined-github/issues/2660

## Test
1. https://github.com/sindresorhus/refined-github/tree/ava
2. https://github.com/sindresorhus/refined-github
3. https://github.com/getify/You-Dont-Know-JS
