### PR TITLE
fix: tags-dropdown bugs

### DIFF
--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -17,7 +17,6 @@ function init(): false | void {
 					Select tag&nbsp;
 				</summary>
 				<details-menu
-					preload
 					className="select-menu-modal position-absolute dropdown-menu-sw"
 					src={`/${getRepoURL()}/ref-list/master?source_action=disambiguate&source_controller=files`}
 					role="menu"
@@ -45,7 +44,7 @@ function changeTabToTags(): void {
 
 function updateLinksToTag(): void {
 	// Change links, which point to the content of each tag, to open the tag page instead
-	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown .select-menu-list:last-child [href*="/tree/"]')) {
+	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown .SelectMenu-list:last-child [href*="/tree/"]')) {
 		const pathnameParts = anchorElement.pathname.split('/');
 		pathnameParts[3] = 'releases/tag'; // Replace `tree`
 		anchorElement.pathname = pathnameParts.join('/');

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -40,7 +40,7 @@ function init(): false | void {
 // We're reusing the Branch/Tag selector from the repo's Code tab, so we need to update a few things
 function changeTabToTags(): void {
 	// Change the tab to "Tags"
-	select('.rgh-tags-dropdown .select-menu-tab:last-child button')!.click();
+	select('.rgh-tags-dropdown .SelectMenu-tab:last-child')!.click();
 }
 
 function updateLinksToTag(): void {


### PR DESCRIPTION
<!-- Thanks for contributing! 🍄 -->

Closes https://github.com/sindresorhus/refined-github/issues/2781

Fixes:
- [x] - `Tags` tab not being pre-selected
- [x] - Replacing links to `tags`
- [x] - Removed pre-loading DOM element (`<details-menu>`) that sometimes prevented fetching `tags`

# Test

![Kapture 2020-02-15 at 17 21 05](https://user-images.githubusercontent.com/9092510/74592258-c656b180-501f-11ea-9a30-03711280ee72.gif)

