### PR TITLE
Change icon for `mark-private-orgs`

### DIFF
--- a/source/features/mark-private-orgs.css
+++ b/source/features/mark-private-orgs.css
@@ -11,5 +11,5 @@
 	stroke: #fff;
 	stroke-width: 4px;
 	paint-order: stroke;
-	overflow: visible;
+	overflow: visible !important;
 }

--- a/source/features/mark-private-orgs.css
+++ b/source/features/mark-private-orgs.css
@@ -8,4 +8,8 @@
 	bottom: 2px;
 	right: 2px;
 	fill: #333;
+	stroke: white;
+	stroke-width: 4px;
+	paint-order: stroke;
+	overflow: visible;
 }

--- a/source/features/mark-private-orgs.css
+++ b/source/features/mark-private-orgs.css
@@ -8,7 +8,7 @@
 	bottom: 2px;
 	right: 2px;
 	fill: #333;
-	stroke: white;
+	stroke: #fff;
 	stroke-width: 4px;
 	paint-order: stroke;
 	overflow: visible;

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -1,6 +1,6 @@
 import './mark-private-orgs.css';
 import select from 'select-dom';
-import React from 'dom-chef';
+import eyeClosedIcon from 'octicon/eye-closed-icon.svg';
 import {getUsername} from '../libs/utils';
 import features from '../libs/features';
 import * as api from '../libs/api';
@@ -17,14 +17,7 @@ async function init(): Promise<false | void> {
 	for (const org of orgs) {
 		if (!publicOrgs.includes(org.pathname)) {
 			org.classList.add('rgh-private-org');
-			org.append(
-				<svg className="octicon octicon-lock" width="14" height="16" aria-title="Private organization">
-					<path d="M11.88 5.86h-.3V4.58a4.58 4.58 0 0 0-9.16 0v1.28h-.3A1.66 1.66 0 0 0 .46 7.51v6.83A1.66 1.66 0 0 0 2.12 16h9.76a1.66 1.66 0 0 0 1.66-1.66V7.51a1.66 1.66 0 0 0-1.66-1.65zM5.54 4.58a1.47 1.47 0 0 1 2.94 0v1.28H5.54zm5.66 3.61v5.47H3.78V8.19z" fill="#fff"/>
-					<path d="M11.88 6.54h-1v-2a3.9 3.9 0 0 0-7.8 0v2h-1a1 1 0 0 0-1 1v6.83a1 1 0 0 0 1 1h9.76a1 1 0 0 0 1-1V7.51a1 1 0 0 0-.96-.97zm-7 0v-2a2.15 2.15 0 0 1 4.3 0v2zm7 7.8H3.1V7.51h8.78z"/>
-					<path d="M3.1 7.51h8.78v6.83H3.1z" fill="#eee"/>
-					<path d="M5.05 9.46h-1v-1h1zm0 2.93h-1v1h1zm0-2h-1v1h1z"/>
-				</svg>
-			);
+			org.append(eyeClosedIcon());
 		}
 	}
 }

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -1,6 +1,6 @@
 import './mark-private-orgs.css';
 import select from 'select-dom';
-import eyeClosedIcon from 'octicon/eye-closed-icon.svg';
+import eyeClosedIcon from 'octicon/eye-closed.svg';
 import {getUsername} from '../libs/utils';
 import features from '../libs/features';
 import * as api from '../libs/api';


### PR DESCRIPTION
I think the "invisible" icon makes more sense than the previous "locked"/"secure" icon. Also this lets us drop the custom inlined icon

<img width="220" alt="" src="https://user-images.githubusercontent.com/1402241/74593430-3556f900-5066-11ea-8531-f0c3acacd6da.png">