### PR TITLE
Faster `profile-gists-link`

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -1,13 +1,27 @@
 import './profile-gists-link.css';
 import React from 'dom-chef';
-import select from 'select-dom';
+import elementReady from 'element-ready';
+import cache from 'webext-storage-cache';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getCleanPathname} from '../libs/utils';
 import {isEnterprise} from '../libs/page-detect';
 
+const getGistCount = cache.function(async (username: string): Promise<number> => {
+	const {user} = await api.v4(`
+		user(login: "${username}") {
+			gists(first: 0) {
+				totalCount
+			}
+		}
+	`);
+	return user.gists.totalCount;
+}, {
+	cacheKey: ([username]) => 'gist-count:' + username
+});
+
 async function init(): Promise<false | void> {
-	const container = select('body.page-profile .UnderlineNav-body');
+	const container = await elementReady('body.page-profile .UnderlineNav-body');
 
 	if (!container) {
 		return false;
@@ -18,10 +32,11 @@ async function init(): Promise<false | void> {
 	const link = <a href={href} className="UnderlineNav-item" role="tab" aria-selected="false">Gists </a>;
 	container.append(link);
 
-	const userData = await api.v3(`users/${username}`);
-	if (userData.public_gists) {
-		link.append(<span className="Counter hide-lg hide-md hide-sm">{userData.public_gists}</span>);
-	}
+	link.append(
+		<span className="Counter hide-lg hide-md hide-sm">
+			{await getGistCount(username)}
+		</span>
+	);
 }
 
 features.add({
@@ -31,6 +46,6 @@ features.add({
 	include: [
 		features.isUserProfile
 	],
-	load: features.onAjaxedPages,
+	load: features.nowAndOnAjaxedPages,
 	init
 });

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -1,8 +1,8 @@
 import './profile-gists-link.css';
 import React from 'dom-chef';
+import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import elementReady from 'element-ready';
-import cache from 'webext-storage-cache';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getCleanPathname} from '../libs/utils';

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -1,5 +1,6 @@
 import './profile-gists-link.css';
 import React from 'dom-chef';
+import select from 'select-dom';
 import elementReady from 'element-ready';
 import cache from 'webext-storage-cache';
 import * as api from '../libs/api';
@@ -21,16 +22,13 @@ const getGistCount = cache.function(async (username: string): Promise<number> =>
 });
 
 async function init(): Promise<false | void> {
-	const container = await elementReady('body.page-profile .UnderlineNav-body');
-
-	if (!container) {
-		return false;
-	}
+	await elementReady('.UnderlineNav-body + *');
 
 	const username = getCleanPathname();
 	const href = isEnterprise() ? `/gist/${username}` : `https://gist.github.com/${username}`;
 	const link = <a href={href} className="UnderlineNav-item" role="tab" aria-selected="false">Gists </a>;
-	container.append(link);
+
+	select('.UnderlineNav-body')!.append(link);
 
 	link.append(
 		<span className="Counter hide-lg hide-md hide-sm">
@@ -45,6 +43,9 @@ features.add({
 	screenshot: 'https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png',
 	include: [
 		features.isUserProfile
+	],
+	exclude: [
+		features.isOrganizationProfile
 	],
 	load: features.nowAndOnAjaxedPages,
 	init

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -144,8 +144,8 @@ export const _isNotifications = [
 	'https://github.com/notifications?all=1'
 ];
 
-export const isOrganizationProfile = (): boolean => select.exists('.orghead');
-export const _isOrganizationProfile = domBased;
+export const isOrganizationProfile = (): boolean => select.exists('meta[name="hovercard-subject-tag"][content^="organization"]');
+export const _isOrganizationProfile = domBased; // Safe for `nowAndOnAjaxedPages` because this element is in the <head>
 
 export const isOrganizationDiscussion = (): boolean => /^orgs\/[^/]+\/teams\/[^/]+($|\/discussions)/.test(getCleanPathname());
 export const _isOrganizationDiscussion = [


### PR DESCRIPTION
Context: #2671 

- Adds cache
- Switches from API v3 to v4
- Uses `element-ready`

---

Discussion: should the tab be added at all if there are no gists? I don't think so, but this might make the feature "slower" since it would _have to_ wait for the API to respond.

I probably never used this link in the first place, so 🤷‍♂️ . cc @sindresorhus 