### PR TITLE
Apply features to Milestone issue lists

### DIFF
--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -257,7 +257,7 @@ export const _isRepoSkipNegatives = true;
 export const isRepoDiscussionList = (): boolean =>
 	isRepoPRList() ||
 	isRepoIssueList() ||
-	/^labels\/.+/.test(getRepoPath()!);
+	/^(labels|milestones)\/.+/.test(getRepoPath()!);
 export const _isRepoDiscussionList = [
 	'http://github.com/sindresorhus/ava/issues',
 	'https://github.com/sindresorhus/refined-github/pulls',
@@ -265,6 +265,7 @@ export const _isRepoDiscussionList = [
 	'https://github.com/sindresorhus/refined-github/pulls/fregante',
 	'https://github.com/sindresorhus/refined-github/issues/fregante',
 	'https://github.com/sindresorhus/refined-github/labels/Priority%3A%20critical',
+	'https://github.com/sindresorhus/refined-github/milestones/1.0',
 	'https://github.com/sindresorhus/refined-github/issues?q=is%3Aclosed+sort%3Aupdated-desc',
 	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Aopen+is%3Apr',
 	'https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aclosed',


### PR DESCRIPTION
Closes #2792 

The `/milestones/xyc` path wasn't detected as a repo discussion list.
Because of that features like `highlight-collaborators-and-own-discussions` didn't work.
*(I only tested if that feature now works and not any other feature that uses `isRepoDiscussionList` or `isDiscussionList`)*

**Test:**
- https://github.com/sindresorhus/got/milestones/v10
- https://github.com/facebook/react/milestones/17.0.0
