### PR TITLE
Restore `filter-comments-by-you` on GHE

### DIFF
--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -5,7 +5,7 @@ import SearchQuery from '../libs/search-query';
 
 function init(): void {
 	// Use an existing dropdown item to preserve its DOM structure (supports old GHE versions)
-	const sourceItem = select([
+	const sourceItem = select<HTMLAnchorElement>([
 		'#filters-select-menu a:last-child', // GHE
 		'.subnav-search-context li:last-child'
 	])!;

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -1,18 +1,22 @@
 import select from 'select-dom';
 import features from '../libs/features';
-import {getUsername, getRepoURL} from '../libs/utils';
-
-const repoUrl = getRepoURL();
+import {getUsername} from '../libs/utils';
+import SearchQuery from '../libs/search-query';
 
 function init(): void {
-	const dropDownElement = select('#filters-select-menu a:last-child, .subnav-search-context li:last-child')!;
-	const newDropDownElement = dropDownElement.cloneNode(true);
-	const href = `/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`;
-	const newDropDownElementLink = newDropDownElement.matches('a') ? newDropDownElement : select('a', newDropDownElement)!;
-	newDropDownElementLink.textContent = 'Everything commented by you';
-	newDropDownElementLink.setAttribute('href', href);
-	newDropDownElementLink.removeAttribute('target');
-	dropDownElement.before(newDropDownElement);
+	// Use an existing dropdown item to preserve its DOM structure (supports old GHE versions)
+	const sourceItem = select([
+		'#filters-select-menu a:last-child', // GHE
+		'.subnav-search-context li:last-child'
+	])!;
+
+	const menuItem = sourceItem.cloneNode(true);
+	const link = select('a', menuItem) ?? menuItem;
+	link.textContent = 'Everything commented by you';
+	link.removeAttribute('target');
+	new SearchQuery(link).set(`is:open commenter:${getUsername()}`);
+
+	sourceItem.before(menuItem);
 }
 
 features.add({

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -1,21 +1,23 @@
-import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
-import {getRepoURL} from '../libs/utils';
+import {getUsername, getRepoURL} from '../libs/utils';
 
 const repoUrl = getRepoURL();
 
 function init(): void {
-	select('.subnav-search-context .SelectMenu-list a:last-child')!
-		.before(
-			<a
-				href={`/${repoUrl}/issues?q=is%3Aopen+commenter:@me`}
-				className="SelectMenu-item"
-				role="menuitem"
-			>
-				Everything commented by you
-			</a>
-		);
+	const dropDownElement = select('#filters-select-menu a:last-child, .subnav-search-context li:last-child');
+	// Exit if not logged in or selector does not match
+	if (!dropDownElement) {
+		return;
+	}
+
+	const newDropDownElement = dropDownElement.cloneNode(true);
+	const href = `/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`;
+	const newDropDownElementLink = newDropDownElement.matches('a') ? newDropDownElement : select('a', newDropDownElement)!;
+	newDropDownElementLink.textContent = 'Everything commented by you';
+	newDropDownElementLink.setAttribute('href', href);
+	newDropDownElementLink.removeAttribute('target');
+	dropDownElement.before(newDropDownElement);
 }
 
 features.add({

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -5,12 +5,7 @@ import {getUsername, getRepoURL} from '../libs/utils';
 const repoUrl = getRepoURL();
 
 function init(): void {
-	const dropDownElement = select('#filters-select-menu a:last-child, .subnav-search-context li:last-child');
-	// Exit if not logged in or selector does not match
-	if (!dropDownElement) {
-		return;
-	}
-
+	const dropDownElement = select('#filters-select-menu a:last-child, .subnav-search-context li:last-child')!;
 	const newDropDownElement = dropDownElement.cloneNode(true);
 	const href = `/${repoUrl}/issues?q=is%3Aopen+commenter:${getUsername()}`;
 	const newDropDownElementLink = newDropDownElement.matches('a') ? newDropDownElement : select('a', newDropDownElement)!;

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -5,13 +5,13 @@ import SearchQuery from '../libs/search-query';
 
 function init(): void {
 	// Use an existing dropdown item to preserve its DOM structure (supports old GHE versions)
-	const sourceItem = select<HTMLAnchorElement>([
+	const sourceItem = select([
 		'#filters-select-menu a:nth-last-child(2)', // GHE
 		'.subnav-search-context li:nth-last-child(2)'
 	])!;
 
 	const menuItem = sourceItem.cloneNode(true);
-	const link = select('a', menuItem) ?? menuItem;
+	const link = select('a', menuItem) ?? menuItem as HTMLAnchorElement;
 	link.textContent = 'Everything commented by you';
 	link.removeAttribute('target');
 	new SearchQuery(link).set(`is:open commenter:${getUsername()}`);

--- a/source/features/filter-comments-by-you.tsx
+++ b/source/features/filter-comments-by-you.tsx
@@ -6,8 +6,8 @@ import SearchQuery from '../libs/search-query';
 function init(): void {
 	// Use an existing dropdown item to preserve its DOM structure (supports old GHE versions)
 	const sourceItem = select<HTMLAnchorElement>([
-		'#filters-select-menu a:last-child', // GHE
-		'.subnav-search-context li:last-child'
+		'#filters-select-menu a:nth-last-child(2)', // GHE
+		'.subnav-search-context li:nth-last-child(2)'
 	])!;
 
 	const menuItem = sourceItem.cloneNode(true);
@@ -16,7 +16,7 @@ function init(): void {
 	link.removeAttribute('target');
 	new SearchQuery(link).set(`is:open commenter:${getUsername()}`);
 
-	sourceItem.before(menuItem);
+	sourceItem.after(menuItem);
 }
 
 features.add({


### PR DESCRIPTION
in github enterprise the old html template is still in use

at least for Enterprise v2.18.8

hint, i am using `getUserName()` instead of `@me`, in enterprise `@me` is not available.