### PR TITLE
Fix Issues count when `bugs-tab` finds 1000+ issues

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -27,7 +27,7 @@ function setCount(tab: HTMLElement, count: number, add: boolean): void {
 	const counter = select('.Counter', tab)!;
 	const exceedsLimit = add && counter.textContent!.includes('+');
 	if (add) {
-		count = Number(counter.textContent.replace(/\D/g, '')) + count;
+		count = Number(counter.textContent!.replace(/\D/g, '')) + count;
 	}
 
 	counter.textContent = numberFormatter.format(count) + (exceedsLimit ? '+' : '');

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -6,7 +6,7 @@ import features from '../libs/features';
 import * as api from '../libs/api';
 import SearchQuery from '../libs/search-query';
 import {getRepoGQL, getRepoURL} from '../libs/utils';
-/*
+
 const countBugs = cache.function(async (): Promise<number> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
@@ -20,14 +20,14 @@ const countBugs = cache.function(async (): Promise<number> => {
 }, {
 	expiration: 1,
 	cacheKey: (): string => __featureName__ + ':' + getRepoURL()
-});*/
+});
 
 const numberFormatter = new Intl.NumberFormat();
 function setCount(tab: HTMLElement, count: number, add: boolean): void {
 	const counter = select('.Counter', tab)!;
 	const exceedsLimit = add && counter.textContent!.includes('+');
 	if (add) {
-		count = Number(counter.textContent.replace(/\D/g, '') + count;
+		count = Number(counter.textContent.replace(/\D/g, '')) + count;
 	}
 
 	counter.textContent = numberFormatter.format(count) + (exceedsLimit ? '+' : '');

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -6,7 +6,7 @@ import features from '../libs/features';
 import * as api from '../libs/api';
 import SearchQuery from '../libs/search-query';
 import {getRepoGQL, getRepoURL} from '../libs/utils';
-
+/*
 const countBugs = cache.function(async (): Promise<number> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
@@ -20,7 +20,18 @@ const countBugs = cache.function(async (): Promise<number> => {
 }, {
 	expiration: 1,
 	cacheKey: (): string => __featureName__ + ':' + getRepoURL()
-});
+});*/
+
+const numberFormatter = new Intl.NumberFormat();
+function setCount(tab: HTMLElement, count: number, add: boolean): void {
+	const counter = select('.Counter', tab)!;
+	const exceedsLimit = add && counter.textContent!.includes('+');
+	if (add) {
+		count = Number(counter.textContent.replace(/\D/g, '') + count;
+	}
+
+	counter.textContent = numberFormatter.format(count) + (exceedsLimit ? '+' : '');
+}
 
 async function init(): Promise<void | false> {
 	// Query API as early as possible, even if it's not necessary on archived repos
@@ -70,9 +81,8 @@ async function init(): Promise<void | false> {
 
 	// Update issue counts
 	const bugsCount = await countPromise;
-	select('.Counter', bugsTab)!.textContent = String(bugsCount);
-	// @ts-ignore substraction on string. The alternative is much longer.
-	select('.Counter', issuesTab)!.textContent -= bugsCount;
+	setCount(bugsTab, bugsCount, false);
+	setCount(issuesTab, -bugsCount, true);
 }
 
 features.add({


### PR DESCRIPTION
Directly fixes #2780 
Maybe a fuller solution can be implemented in #2805 

# Test

https://github.com/sindresorhus/refined-github/issues (no change)
https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+label%3Abug (no change)
https://github.com/sourcegraph/sourcegraph (1033 issues)
https://github.com/godotengine/godot (5000+ issues)