### PR TITLE
Avoid console errors by `pr-branches` on global discussion lists

### DIFF
--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -142,7 +142,7 @@ features.add({
 	description: 'Shows head and base branches in PR lists if they’re significant: The base branch is added when it’s not the repo’s default branch; The head branch is added when it’s from the same repo or the PR is by the current user.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png',
 	include: [
-		features.isDiscussionList
+		features.isRepoDiscussionList
 	],
 	load: features.onAjaxedPages,
 	init


### PR DESCRIPTION
this feature is not working, as there is no single repoOwner and repo in
this list.

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
