### PR TITLE
Revert usage of `@me` search keyword to restore GHE support

### DIFF
--- a/source/features/global-discussion-list-filters.tsx
+++ b/source/features/global-discussion-list-filters.tsx
@@ -2,6 +2,7 @@ import './global-discussion-list-filters.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
+import {getUsername} from '../libs/utils';
 import SearchQuery from '../libs/search-query';
 
 function init(): void {
@@ -13,8 +14,8 @@ function init(): void {
 	const typeName = isIssues ? 'Issues' : 'Pull Requests';
 
 	const links = [
-		['Commented', `${typeName} you’ve commented on`, 'commenter:@me'],
-		['Yours', `${typeName} on your repos`, 'user:@me']
+		['Commented', `${typeName} you’ve commented on`, `commenter:${getUsername()}`],
+		['Yours', `${typeName} on your repos`, `user:${getUsername()}`]
 	];
 
 	for (const [label, title, query] of links) {

--- a/source/libs/search-query.ts
+++ b/source/libs/search-query.ts
@@ -1,3 +1,5 @@
+import {getUsername} from './utils';
+
 type Source = HTMLAnchorElement | URL | URLSearchParams | Location;
 
 /**
@@ -44,7 +46,7 @@ export default class SearchQuery {
 			if (this.searchParams.has('user')) { // #1211
 				queries.push(`user:${this.searchParams.get('user')!}`);
 			} else {
-				queries.push('author:@me');
+				queries.push(`author:${getUsername()}`);
 			}
 
 			queries.push('archived:false');


### PR DESCRIPTION
The `@me` filter is not available at enterprise github at least not for v2.18.8

i left out commented-by-you feature as there is #2809 

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
