### PR TITLE
Don't apply `shorten-links` on search results

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -2,8 +2,15 @@ import select from 'select-dom';
 import {applyToLink} from 'shorten-repo-url';
 import features from '../libs/features';
 import {linkifiedURLClass} from '../libs/dom-formatters';
+import {isGlobalSearchResults} from '../libs/page-detect'
 
 function init(): void {
+  if (isGlobalSearchResults()) {
+		for (const a of select.all('.repo-list-item p a')) {
+			a.classList.add(linkifiedURLClass)
+		}
+	}
+
 	for (const a of select.all<HTMLAnchorElement>(`a[href]:not(.${linkifiedURLClass})`)) {
 		applyToLink(a, location.href);
 	}

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -2,15 +2,8 @@ import select from 'select-dom';
 import {applyToLink} from 'shorten-repo-url';
 import features from '../libs/features';
 import {linkifiedURLClass} from '../libs/dom-formatters';
-import {isGlobalSearchResults} from '../libs/page-detect'
 
 function init(): void {
-  if (isGlobalSearchResults()) {
-		for (const a of select.all('.repo-list-item p a')) {
-			a.classList.add(linkifiedURLClass)
-		}
-	}
-
 	for (const a of select.all<HTMLAnchorElement>(`a[href]:not(.${linkifiedURLClass})`)) {
 		applyToLink(a, location.href);
 	}
@@ -21,5 +14,9 @@ features.add({
 	description: 'Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png',
 	load: features.onAjaxedPages,
+	exclude: [
+		// Due to GitHub’s bug: #2828
+		features.isGlobalSearchResults
+	],
 	init
 });


### PR DESCRIPTION
I don't know if this is a GitHub bug or to highlight the matched keywords, URLs in repo description on the search page aren't completely linkified, and `shorten-links` makes it even more inaccessible:

![image](https://user-images.githubusercontent.com/44045911/75118087-c99e0d00-56b1-11ea-8ea3-3c0068653923.png)

Sure it will be better if we can fix this up, but it may be difficult to handle various situations. I think this should be implemented by GitHub itself first.

So this PR ~~add `linkifiedURLClass` to these URLs to make `shorten-links` skip them~~ disables `shorten-links` on search page:

![image](https://user-images.githubusercontent.com/44045911/75118086-c7d44980-56b1-11ea-9861-c25131c45cf0.png)

Test URL: https://github.com/search?q=nodejs