### PR TITLE
Enable `parse-backticks` on pinned issues

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -14,7 +14,8 @@ function initGeneral(): void {
 		'[aria-label="Issues"][role="group"] .js-navigation-open', // `isDiscussionList`
 		'[id^=ref-issue-]', // Issue references in `isIssue`, `isPRConversation`
 		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
-		'.TimelineItem-body > del, .TimelineItem-body > ins' // Title edits in `isIssue`, `isPRConversation`
+		'.TimelineItem-body > del, .TimelineItem-body > ins', // Title edits in `isIssue`, `isPRConversation`
+		'.js-pinned-issue-list-item > span' // Pinned Issues
 	])) {
 		parseBackticks(title);
 	}


### PR DESCRIPTION
Test on https://github.com/eslint/eslint/issues

![image](https://user-images.githubusercontent.com/16872793/75484265-6e507100-5976-11ea-9308-bd54408d3043.png)
