### PR TITLE
Add back `mark-merge-commits-in-list` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -254,6 +254,7 @@ Thanks for contributing! 🦋🙌
 - [](# "limit-commit-title-length") [Limits the commit title fields to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 - [](# "expand-all-collapsed-code") [Expands the entire file when you <kbd>alt</kbd> <kbd>click</kbd> on any "Expand code" button in diffs.](https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif)
 - [](# "add-tag-to-commits") [Displays the corresponding tags next to commits.](https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png)
+- [](# "mark-merge-commits-in-list") [Marks merge commits in commit lists.](https://user-images.githubusercontent.com/16872793/75561016-457eb900-5a14-11ea-95e1-a89e81ee7390.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/content.ts
+++ b/source/content.ts
@@ -87,6 +87,7 @@ import './features/recently-pushed-branches-enhancements';
 import './features/create-release-shortcut';
 import './features/patch-diff-links';
 import './features/parse-backticks';
+import './features/mark-merge-commits-in-list';
 import './features/swap-branches-on-compare';
 import './features/reactions-avatars';
 import './features/show-names';

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,7 +1,10 @@
 /* Fade out merge commits from commit list */
 .rgh-merge-commit .commit-title,
 .rgh-merge-commit .commit-meta > div:not(.commit-indicator),
-.rgh-merge-commit .commit-build-statuses > summary {
+.rgh-merge-commit .commit-build-statuses > summary,
+.rgh-merge-commit .signed-commit-badge,
+.rgh-merge-commit .commit-links-group,
+.rgh-merge-commit .tooltipped:not(:hover) {
 	opacity: 0.7;
 }
 

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,0 +1,11 @@
+/* Fade out merge commits from commit list */
+.refined-github-merge-commit .commit-title,
+.refined-github-merge-commit .commit-meta > div:not(.commit-indicator),
+.refined-github-merge-commit .commit-build-statuses > summary {
+	opacity: 0.7;
+}
+
+.refined-github-merge-commit .octicon-git-pull-request {
+	color: #4078c0;
+	width: 20px;
+}

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -5,7 +5,7 @@
 	opacity: 0.7;
 }
 
-.rgh-merge-commit .octicon-git-merge {
+.rgh-merge-commit .octicon-git-pull-request {
 	color: #4078c0;
 	width: 20px;
 }

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -5,7 +5,7 @@
 	opacity: 0.7;
 }
 
-.rgh-merge-commit .octicon-git-pull-request {
+.rgh-merge-commit .octicon-git-merge {
 	color: #4078c0;
 	width: 20px;
 }

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,7 +1,7 @@
 /* Fade out merge commits from commit list */
 .rgh-merge-commit .commit-title,
-.rgh-merge-commit .commit-meta>div:not(.commit-indicator),
-.rgh-merge-commit .commit-build-statuses>summary {
+.rgh-merge-commit .commit-meta > div:not(.commit-indicator),
+.rgh-merge-commit .commit-build-statuses > summary {
 	opacity: 0.7;
 }
 

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,11 +1,11 @@
 /* Fade out merge commits from commit list */
-.refined-github-merge-commit .commit-title,
-.refined-github-merge-commit .commit-meta > div:not(.commit-indicator),
-.refined-github-merge-commit .commit-build-statuses > summary {
+.rgh-merge-commit .commit-title,
+.rgh-merge-commit .commit-meta>div:not(.commit-indicator),
+.rgh-merge-commit .commit-build-statuses>summary {
 	opacity: 0.7;
 }
 
-.refined-github-merge-commit .octicon-git-pull-request {
+.rgh-merge-commit .octicon-git-pull-request {
 	color: #4078c0;
 	width: 20px;
 }

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,9 +1,5 @@
-/* Fade out merge commits from commit list */
-.rgh-merge-commit .commit-title,
-.rgh-merge-commit .commit-meta > div:not(.commit-indicator),
-.rgh-merge-commit .commit-links-group *:not(.tooltipped),
-.rgh-merge-commit .tooltipped:not(:hover) {
-	opacity: 0.7;
+.rgh-merge-commit:not(.navigation-focus) > div > * {
+	opacity: 0.4;
 }
 
 .rgh-merge-commit .octicon-git-pull-request {

--- a/source/features/mark-merge-commits-in-list.css
+++ b/source/features/mark-merge-commits-in-list.css
@@ -1,9 +1,7 @@
 /* Fade out merge commits from commit list */
 .rgh-merge-commit .commit-title,
 .rgh-merge-commit .commit-meta > div:not(.commit-indicator),
-.rgh-merge-commit .commit-build-statuses > summary,
-.rgh-merge-commit .signed-commit-badge,
-.rgh-merge-commit .commit-links-group,
+.rgh-merge-commit .commit-links-group *:not(.tooltipped),
 .rgh-merge-commit .tooltipped:not(:hover) {
 	opacity: 0.7;
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -5,7 +5,7 @@ import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
 
-const getMergeCommits = async (commits: string[]): Promise<string[]> => {
+const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			${commits.map((commit: string) => `
@@ -37,7 +37,7 @@ function getCommitHash(commit: HTMLElement): string {
 
 async function init(): Promise<void | false> {
 	const pageCommits = select.all('li.commit');
-	const mergeCommits = await getMergeCommits(pageCommits.map(getCommitHash));
+	const mergeCommits = await filterMergeCommits(pageCommits.map(getCommitHash));
 	for (const commit of pageCommits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -4,13 +4,13 @@ import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
 
-interface IssueInfo {
+interface CommitInfo {
 	parents: {
 		totalCount: number | string;
 	};
 }
 
-const getCommitParentCount = async (commits: string[]): Promise<Record<string, IssueInfo>> => {
+const getCommitParentCount = async (commits: string[]): Promise<Record<string, CommitInfo>> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			${commits.map((commit: string) => `

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,0 +1,50 @@
+import './mark-merge-commits-in-list.css';
+import select from 'select-dom';
+import * as api from '../libs/api';
+import features from '../libs/features';
+import {getRepoGQL} from '../libs/utils';
+
+const getLastUpdated = async (commits: any): any => {
+	const {repository} = await api.v4(`
+		repository(${getRepoGQL()}) {
+			${commits.map((commit: string) => `
+				${api.escapeKey(commit)}: object(expression: "${commit}") {
+						... on Commit {
+							parents{
+								totalCount
+							}
+						}
+					}
+			`).join('\n')}
+		}
+	`);
+
+	return repository;
+};
+
+function getCommitHash(commit: any): any {
+	return commit.dataset.channel.split(':')[3];
+}
+
+async function init(): Promise<void | false> {
+	const pageCommits = select.all('li.commit');
+	const parentCommitCount = await getLastUpdated(pageCommits.map(getCommitHash));
+	for (const commit of pageCommits) {
+		const commitHash = getCommitHash(commit);
+		const {totalCount} = parentCommitCount[api.escapeKey(commitHash)].parents;
+		if (totalCount === 2) {
+			commit.classList.add('refined-github-merge-commit');
+		}
+	}
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Dims merge commits in commits list.',
+	screenshot: false,
+	include: [
+		features.isCommitList
+	],
+	load: features.onAjaxedPages,
+	init
+});

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -27,7 +27,7 @@ const getCommitParentCount = async (commits: string[]): Promise<Record<string, I
 	return repository;
 };
 
-function getCommitHash(commit: any): any {
+function getCommitHash(commit: any): string {
 	return commit.dataset.channel.split(':')[3];
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -21,9 +21,8 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	`);
 
 	const mergeCommits = [];
-	// @ts-ignore
-	for (const [key, {parents}] of Object.entries(repository)) {
-		if (parents.totalCount === 2) {
+	for (const [key, commit] of Object.entries<AnyObject>(repository)) {
+		if (commit.parents.totalCount === 2) {
 			mergeCommits.push(key.slice(1));
 		}
 	}

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,6 +1,6 @@
 import './mark-merge-commits-in-list.css';
 import select from 'select-dom';
-import gitPullRequest from 'octicon/git-pull-request.svg';
+import pullRequestIcon from 'octicon/git-pull-request.svg';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
@@ -40,7 +40,7 @@ async function init(): Promise<void | false> {
 	for (const commit of pageCommits) {
 		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');
-			select('.commit-title', commit)!.prepend(gitPullRequest());
+			select('.commit-title', commit)!.prepend(pullRequestIcon());
 		}
 	}
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -22,9 +22,9 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 	const mergeCommits = [];
 	// @ts-ignore
-	for (const [commit, {parents}] of Object.entries(repository)) {
+	for (const [key, {parents}] of Object.entries(repository)) {
 		if (parents.totalCount === 2) {
-			mergeCommits.push(commit.slice(1));
+			mergeCommits.push(key.slice(1));
 		}
 	}
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -4,12 +4,17 @@ import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
 
-const getLastUpdated = async (commits: any): any => {
+interface IssueInfo {
+	parents: any;
+	totalCount: any;
+}
+
+const getCommitParentCount = async (commits: string[]): Promise<Record<string, IssueInfo>> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			${commits.map((commit: string) => `
 				${api.escapeKey(commit)}: object(expression: "${commit}") {
-						... on Commit {
+					... on Commit {
 							parents{
 								totalCount
 							}
@@ -28,7 +33,7 @@ function getCommitHash(commit: any): any {
 
 async function init(): Promise<void | false> {
 	const pageCommits = select.all('li.commit');
-	const parentCommitCount = await getLastUpdated(pageCommits.map(getCommitHash));
+	const parentCommitCount = await getCommitParentCount(pageCommits.map(getCommitHash));
 	for (const commit of pageCommits) {
 		const commitHash = getCommitHash(commit);
 		const {totalCount} = parentCommitCount[api.escapeKey(commitHash)].parents;

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -27,8 +27,8 @@ const getCommitParentCount = async (commits: string[]): Promise<Record<string, I
 	return repository;
 };
 
-function getCommitHash(commit: any): string {
-	return commit.dataset.channel.split(':')[3];
+function getCommitHash(commit: HTMLElement): string {
+	return (commit.dataset.channel as string).split(':')[3];
 }
 
 async function init(): Promise<void | false> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -40,11 +40,11 @@ function getCommitHash(commit: HTMLElement): string {
 
 async function init(): Promise<void | false> {
 	const pageCommits = select.all('li.commit');
-	const parentCommitCount = await getMergeCommits(pageCommits.map(getCommitHash));
+	const mergeCommits = await getMergeCommits(pageCommits.map(getCommitHash));
 	for (const commit of pageCommits) {
 		const commitHash = api.escapeKey(getCommitHash(commit));
 
-		if (parentCommitCount.includes(commitHash)) {
+		if (mergeCommits.includes(commitHash)) {
 			commit.classList.add('rgh-merge-commit');
 			select('.commit-title', commit)!.prepend(gitmerge());
 		}

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -47,8 +47,7 @@ async function init(): Promise<void | false> {
 
 features.add({
 	id: __featureName__,
-	description: 'Dims merge commits in commits list.',
-	screenshot: false,
+	description: 'Marks merge commits in commit lists.',
 	include: [
 		features.isCommitList
 	],

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,6 +1,6 @@
 import './mark-merge-commits-in-list.css';
 import select from 'select-dom';
-import gitmerge from 'octicon/git-merge.svg';
+import gitPullRequest from 'octicon/git-pull-request.svg';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
@@ -10,29 +10,26 @@ const getMergeCommits = async (commits: string[]): Promise<string[]> => {
 		repository(${getRepoGQL()}) {
 			${commits.map((commit: string) => `
 				${api.escapeKey(commit)}: object(expression: "${commit}") {
-					... on Commit {
-							parents{
-								totalCount
-							}
+				... on Commit {
+						parents {
+							totalCount
 						}
 					}
+				}
 			`).join('\n')}
 		}
 	`);
 
-	return filterCommits(repository);
-};
-
-function filterCommits(commits: object): string[] {
 	const mergeCommits = [];
-	for (const commit of Object.entries(commits)) {
-		if (commit[1].parents.totalCount === 2) {
-			mergeCommits.push(commit[0]);
+	// @ts-ignore
+	for (const [commit, {parents}] of Object.entries(repository)) {
+		if (parents.totalCount === 2) {
+			mergeCommits.push(commit.slice(1));
 		}
 	}
 
 	return mergeCommits;
-}
+};
 
 function getCommitHash(commit: HTMLElement): string {
 	return (commit.dataset.channel as string).split(':')[3];
@@ -42,11 +39,9 @@ async function init(): Promise<void | false> {
 	const pageCommits = select.all('li.commit');
 	const mergeCommits = await getMergeCommits(pageCommits.map(getCommitHash));
 	for (const commit of pageCommits) {
-		const commitHash = api.escapeKey(getCommitHash(commit));
-
-		if (mergeCommits.includes(commitHash)) {
+		if (mergeCommits.includes(getCommitHash(commit))) {
 			commit.classList.add('rgh-merge-commit');
-			select('.commit-title', commit)!.prepend(gitmerge());
+			select('.commit-title', commit)!.prepend(gitPullRequest());
 		}
 	}
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -44,7 +44,7 @@ async function init(): Promise<void | false> {
 		const commitHash = api.escapeKey(getCommitHash(commit));
 
 		if (parentCommitCount.includes(commitHash)) {
-			commit.classList.add('refined-github-merge-commit');
+			commit.classList.add('rgh-merge-commit');
 		}
 	}
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -1,5 +1,6 @@
 import './mark-merge-commits-in-list.css';
 import select from 'select-dom';
+import gitmerge from 'octicon/git-merge.svg';
 import * as api from '../libs/api';
 import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
@@ -45,6 +46,7 @@ async function init(): Promise<void | false> {
 
 		if (parentCommitCount.includes(commitHash)) {
 			commit.classList.add('rgh-merge-commit');
+			select('.commit-title', commit)!.prepend(gitmerge());
 		}
 	}
 }

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -48,6 +48,7 @@ async function init(): Promise<void | false> {
 features.add({
 	id: __featureName__,
 	description: 'Marks merge commits in commit lists.',
+	screenshot: 'https://user-images.githubusercontent.com/16872793/75561016-457eb900-5a14-11ea-95e1-a89e81ee7390.png',
 	include: [
 		features.isCommitList
 	],

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -5,8 +5,9 @@ import features from '../libs/features';
 import {getRepoGQL} from '../libs/utils';
 
 interface IssueInfo {
-	parents: any;
-	totalCount: any;
+	parents: {
+		totalCount: number | string;
+	};
 }
 
 const getCommitParentCount = async (commits: string[]): Promise<Record<string, IssueInfo>> => {


### PR DESCRIPTION
closes #2827 

I hate typescript

I did not add the icon since typescript would not let me.
~wasted~ used about an hour because if it :confused:

![image](https://user-images.githubusercontent.com/16872793/75483659-51676e00-5975-11ea-9181-90117a8ae3cc.png)
https://github.com/babel/babel/commits/master?after=ddd40bf5c7ad8565fc990f26142f85613958a329+104