### PR TITLE
fix: adjust ci indicator vertical alignment

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -2,6 +2,7 @@
 	position: relative;
 	top: -0.1em;
 	animation: fade-in 0.2s;
+	align-self: stretch !important;
 }
 
 .rgh-ci-link .octicon {

--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -1,8 +1,7 @@
 .rgh-ci-link {
 	position: relative;
-	top: -0.1em;
+	top: -0.3em;
 	animation: fade-in 0.2s;
-	align-self: stretch !important;
 }
 
 .rgh-ci-link .octicon {


### PR DESCRIPTION
Closes #2762 

Example url: https://github.com/sindresorhus/refined-github/

Before:

![Screenshot 2020-02-26 at 09 21 53](https://user-images.githubusercontent.com/1215056/75325857-d9684d80-5879-11ea-997d-5d472519ca19.png)

After:

![Screenshot 2020-02-26 at 09 22 03](https://user-images.githubusercontent.com/1215056/75325872-dec59800-5879-11ea-8c57-1e87e9eb8b6d.png)

(Tested in Firefox 74.0b4 and Chrome 80 on MacOS)

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
