### PR TITLE
Don't show unnecessary `default-branch` after AJAX navigation

### DIFF
--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -52,7 +52,7 @@ export const replaceBranch = (currentBranch: string, newBranch: string): string 
 };
 
 export const getCurrentBranch = (): string => {
-	return select<HTMLLinkElement>('link[rel="alternate"]')!
+	return select.last<HTMLLinkElement>('link[rel="alternate"]')!
 		.href
 		.split('/')
 		.slice(6)


### PR DESCRIPTION
On ajaxed pages, an extra <link> tag is added so we need to get the last one to figure out what the current branch is.

Closes #2799 


1. Visit https://github.com/sindresorhus/refined-github/commit/bf5dce817b31cea8c4d1535759adc81cc194d305
2. Refresh the page
3. Click the "Code" tab
4. Note that there is NO 'left arrow' button next to the branch dropdown, unlike here:
![image](https://user-images.githubusercontent.com/1215056/75387074-11f04180-58e3-11ea-85f3-9247c45ce829.png)
5. Repeat steps 1 to 4 with a single file url, i.e. https://github.com/sindresorhus/refined-github/blob/bf5dce817b31cea8c4d1535759adc81cc194d305/source/features/profile-gists-link.tsx

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
