### PR TITLE
Change `emphasize-draft-pr-label` style

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,4 +1,7 @@
 .js-issue-row [aria-label='Open draft pull request'] svg {
+	stroke: #586069;
+	stroke-width: 1.2px;
 	color: #fff !important;
-	filter: drop-shadow(#000 0 0 0.7px);
+	paint-order: stroke;
+	overflow: visible !important;
 }


### PR DESCRIPTION
Fixes #2755 

Screenshots in Brave 1.3.118 (Chromium 80.0.3987.116) on Ubuntu 18.04.4 LTS

Before:

![image](https://user-images.githubusercontent.com/253237/75658289-f5943200-5c5f-11ea-8bdd-a3e0f4b265a2.png)

After:

![image](https://user-images.githubusercontent.com/253237/75658313-0349b780-5c60-11ea-93f4-365c7921928b.png)