### PR TITLE
Show `00:mm` instead of `24:mm` in `user-local-time`

### DIFF
--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -14,7 +14,7 @@ interface Commit {
 	sha: string;
 }
 
-const timeFormatter = new Intl.DateTimeFormat(['default', 'en-US'], {
+const timeFormatter = new Intl.DateTimeFormat(['en-GB'], {
 	hour: 'numeric',
 	minute: 'numeric',
 	hour12: false

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -14,7 +14,7 @@ interface Commit {
 	sha: string;
 }
 
-const timeFormatter = new Intl.DateTimeFormat('en-US', {
+const timeFormatter = new Intl.DateTimeFormat('default', {
 	hour: 'numeric',
 	minute: 'numeric',
 	hour12: false

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -14,7 +14,7 @@ interface Commit {
 	sha: string;
 }
 
-const timeFormatter = new Intl.DateTimeFormat('default', {
+const timeFormatter = new Intl.DateTimeFormat(['default', 'en-US'], {
 	hour: 'numeric',
 	minute: 'numeric',
 	hour12: false

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -14,7 +14,7 @@ interface Commit {
 	sha: string;
 }
 
-const timeFormatter = new Intl.DateTimeFormat(['en-GB'], {
+const timeFormatter = new Intl.DateTimeFormat('en-GB', {
 	hour: 'numeric',
 	minute: 'numeric',
 	hour12: false


### PR DESCRIPTION
<!-- 
Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
-->

# Before

When hovering over usernames, sometimes it showed a local time in the hour after midnight:

![image](https://user-images.githubusercontent.com/1324225/75794954-3da77780-5d7a-11ea-81dd-51862208cee6.png)

That looks strange to me, normally I see those times beginning "00:xx", not "24:xx". I guess I'm not used the US locale.

# After

Use the browser's default locale, with fallback to `en-US`:

![image](https://user-images.githubusercontent.com/1324225/75795017-59ab1900-5d7a-11ea-930c-e2998d6e5a99.png)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat#Examples
