### PR TITLE
Fix broken Compare icon in `more-dropdown`

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -2,6 +2,7 @@ import './more-dropdown.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import elementReady from 'element-ready';
+import diffIcon from 'octicon/diff.svg';
 import branchIcon from 'octicon/git-branch.svg';
 import historyIcon from 'octicon/history.svg';
 import packageIcon from 'octicon/package.svg';
@@ -43,9 +44,7 @@ async function init(): Promise<void> {
 
 	menu.append(
 		<a href={compareUrl} className="rgh-reponav-more dropdown-item">
-			<svg aria-hidden="true" className="octicon octicon-diff" width="15" height="16" viewBox="0 0 13 16">
-				<path d="M6 7h2v1H6v2H5V8H3V7h2V5h1zm-3 6h5v-1H3zM7.5 2L11 5.5V15c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1zm1-2H3v1h5l4 4v8h1V4.5z" fillRule="evenodd"/>
-			</svg> Compare
+			{diffIcon()} Compare
 		</a>,
 
 		isEnterprise() ? '' : (


### PR DESCRIPTION
## Before

<img width="177" alt="" src="https://user-images.githubusercontent.com/1402241/76001463-2b624080-5f16-11ea-840b-b6cb84b3f794.png">

## After

<img width="174" alt="" src="https://user-images.githubusercontent.com/1402241/76001550-4fbe1d00-5f16-11ea-8ff2-1a6cfc7fd0ac.png">
