### PR TITLE
Fix `dim-bots` styles

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -8,8 +8,9 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 */
 .rgh-dim-bot.commit .commit-title,
 .rgh-dim-bot.commit .commit-meta,
-.rgh-dim-bot.commit .commit-links-cell summary,
-.rgh-dim-bot.commit .commit-links-cell .btn {
+.rgh-dim-bot.commit summary,
+.rgh-dim-bot.commit .commit-links-group,
+.rgh-dim-bot.commit .commit-links-group + .btn {
 	transition: 0.1s 0.3s;
 	transition-property: opacity, margin-bottom;
 }
@@ -20,8 +21,9 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 }
 
 .rgh-dim-bot.commit:not(.navigation-focus) .commit-meta,
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-cell summary, /* `Verified` badge */
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-cell .btn { /* Buttons on the right */
+.rgh-dim-bot.commit:not(.navigation-focus) summary, /* `Verified` badge */
+.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-group, /* Hash and Copy hash buttons */
+.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-group + .btn { /* Browse repository button */
 	opacity: 0;
 	visibility: hidden;
 	margin-bottom: -2em;


### PR DESCRIPTION
I have this strange feeling when I open GitHub today... it seems they have changed their mockup somehow. When I saw commit history page, I knew it was true.

**Chrome**
![image](https://user-images.githubusercontent.com/44045911/76060662-bc8bf280-5fbc-11ea-85f1-143da12a1236.png)

**Firefox**
![image](https://user-images.githubusercontent.com/44045911/76060641-af6f0380-5fbc-11ea-8975-c16b23ea4a59.png)

This PR kindly stops the performance of these gorgeous buttons and fix `dim-bots` up.

## Test URLs

- https://github.com/renovatebot/renovate/commits/master
- https://github.com/kidonng/readhub/commits/master