### PR TITLE
Fix `releases-tab` position on repo with "settings" in their name

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -15,7 +15,7 @@ const repoUrl = getRepoURL();
 
 function createDropdown(): void {
 	// Markup copied from native GHE dropdown
-	appendBefore('.reponav', '[href$="settings"]',
+	appendBefore('.reponav', '[data-selected-links^="repo_settings"]',
 		<details className="reponav-dropdown details-overlay details-reset">
 			<summary className="btn-link reponav-item">
 				{'More '}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -59,7 +59,7 @@ async function init(): Promise<false | void> {
 	);
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
-	appendBefore('.reponav', '.reponav-dropdown, [href$="settings"]', releasesTab);
+	appendBefore('.reponav', '.reponav-dropdown, [data-selected-links^="repo_settings"]', releasesTab);
 
 	// Update "selected" tab mark
 	if (isReleasesOrTags()) {

--- a/source/libs/dom-utils.ts
+++ b/source/libs/dom-utils.ts
@@ -28,10 +28,8 @@ export const appendBefore = (parent: string|Element, before: string, child: Elem
 		parent = select(parent)!;
 	}
 
-	const scopedBefore = getScopedSelector(before);
-
 	// Select direct children only
-	const beforeElement = select(scopedBefore, parent);
+	const beforeElement = select(getScopedSelector(before), parent);
 	if (beforeElement) {
 		beforeElement.before(child);
 	} else {

--- a/source/libs/dom-utils.ts
+++ b/source/libs/dom-utils.ts
@@ -1,5 +1,5 @@
 import select from 'select-dom';
-import { getScopedSelector } from './utils';
+import {getScopedSelector} from './utils';
 
 /**
  * Append to an element, but before a element that might not exist.

--- a/source/libs/dom-utils.ts
+++ b/source/libs/dom-utils.ts
@@ -1,4 +1,5 @@
 import select from 'select-dom';
+import { getScopedSelector } from './utils';
 
 /**
  * Append to an element, but before a element that might not exist.
@@ -27,8 +28,10 @@ export const appendBefore = (parent: string|Element, before: string, child: Elem
 		parent = select(parent)!;
 	}
 
+	const scopedBefore = getScopedSelector(before);
+
 	// Select direct children only
-	const beforeElement = select(`:scope > ${before}`, parent);
+	const beforeElement = select(scopedBefore, parent);
 	if (beforeElement) {
 		beforeElement.before(child);
 	} else {

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -149,3 +149,11 @@ export function reportBug(featureName: string, bugName: string): void {
 	console.log('Find existing issues:\n' + String(issuesUrl));
 	console.log('Open new issue:\n' + String(newIssueUrl));
 }
+
+/**
+ * Prepend `:scope >` to a single or group of css selectors.
+ * @param {string} selector A css selector.
+ */
+export const getScopedSelector = (selector: string): string => {
+	return selector.split(',').map(sub => `:scope > ${sub.trim()}`).join(',');
+}

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -155,5 +155,5 @@ export function reportBug(featureName: string, bugName: string): void {
  * @param {string} selector A css selector.
  */
 export function getScopedSelector(selector: string): string {
-	return selector.split().map(sub => `:scope > ${sub.trim()}`).join();
+	return selector.split(',').map(sub => `:scope > ${sub.trim()}`).join(',');
 }

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -156,4 +156,4 @@ export function reportBug(featureName: string, bugName: string): void {
  */
 export const getScopedSelector = (selector: string): string => {
 	return selector.split(',').map(sub => `:scope > ${sub.trim()}`).join(',');
-}
+};

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -154,6 +154,6 @@ export function reportBug(featureName: string, bugName: string): void {
  * Prepend `:scope >` to a single or group of css selectors.
  * @param {string} selector A css selector.
  */
-export const getScopedSelector = (selector: string): string => {
-	return selector.split(',').map(sub => `:scope > ${sub.trim()}`).join(',');
-};
+export function getScopedSelector(selector: string): string {
+	return selector.split().map(sub => `:scope > ${sub.trim()}`).join();
+}

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,7 +10,8 @@ import {
 	getRepoPath,
 	getReference,
 	parseTag,
-	compareNames
+	compareNames,
+	getScopedSelector,
 } from '../source/libs/utils';
 
 test('getDiscussionNumber', t => {
@@ -207,4 +208,25 @@ test('compareNames', t => {
 	t.true(compareNames('nicolo', 'Nicolò'));
 	t.false(compareNames('dotconnor', 'Connor Love'));
 	t.false(compareNames('fregante ', 'Federico Brigante'));
+});
+
+test('getScopedSelector', t => {
+	const pairs = new Map<string, string>([
+		[
+			'[href$="settings"]',
+			':scope > [href$="settings"]'
+		],
+		[
+			'.reponav-dropdown,[href$="settings"]',
+			':scope > .reponav-dropdown,:scope > [href$="settings"]'
+		],
+		[
+			'.reponav-dropdown, [href$="settings"]',
+			':scope > .reponav-dropdown,:scope > [href$="settings"]'
+		],
+	]);
+
+	for (const [selector, result] of pairs) {
+		t.is(result, getScopedSelector(selector));
+	}
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,7 @@ import {
 	getReference,
 	parseTag,
 	compareNames,
-	getScopedSelector,
+	getScopedSelector
 } from '../source/libs/utils';
 
 test('getDiscussionNumber', t => {
@@ -223,7 +223,7 @@ test('getScopedSelector', t => {
 		[
 			'.reponav-dropdown, [href$="settings"]',
 			':scope > .reponav-dropdown,:scope > [href$="settings"]'
-		],
+		]
 	]);
 
 	for (const [selector, result] of pairs) {


### PR DESCRIPTION
Closes #2763 

- Go to https://github.com/sindresorhus/refined-github/
- Go to https://github.com/atom-community/sync-settings
- Go to https://github.com/aritchie/settings
--> The `releases` tab should be right before the `More` tab

![Screenshot 2020-03-06 at 15 27 58](https://user-images.githubusercontent.com/1215056/76092085-168db780-5fbf-11ea-98d9-da9d238ad0ec.png)

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
