### PR TITLE
Fix `repo-age` selector

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -33,7 +33,7 @@ const getFirstCommitDate = cache.function(async (): Promise<string | undefined> 
 
 	const relativeTime = await fetchDom(
 		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
-		'ol:last-child > li .commit-meta relative-time'
+		'.commit-meta relative-time'
 	);
 
 	return relativeTime!.attributes.datetime.value;

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -33,7 +33,7 @@ const getFirstCommitDate = cache.function(async (): Promise<string | undefined> 
 
 	const relativeTime = await fetchDom(
 		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
-		'ol:last-child > li.commits-list-item relative-time'
+		'ol:last-child > li .commit-meta relative-time'
 	);
 
 	return relativeTime!.attributes.datetime.value;


### PR DESCRIPTION
I am not sure the `.commit-meta` is even needed

see https://github.com/sindresorhus/refined-github/pull/2783#discussion_r388907440
