### PR TITLE
Cache improvements for `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -74,7 +74,8 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 		isUpToDate: latestTag.commit === repository.defaultBranchRef.target.oid
 	};
 }, {
-	maxAge: 1,
+	maxAge: 1 / 24, // One hour
+	staleWhileRevalidate: 2,
 	shouldRevalidate: value => typeof value === 'string',
 	cacheKey: () => __featureName__ + ':' + getRepoURL()
 });
@@ -84,9 +85,9 @@ const getAheadByCount = cache.function(async (latestTag: string): Promise<string
 	// This text is "4 commits to master since this tag"
 	return select('.release-header relative-time + a[href*="/compare/"]', tagPage)!.textContent!.replace(/\D/g, '');
 }, {
-	maxAge: 1,
+	maxAge: 1 / 24, // One hour
 	staleWhileRevalidate: 2,
-	cacheKey: () => __featureName__ + ':aheadBy:' + getRepoURL()
+	cacheKey: ([latestTag]) => `tag-head-by:${getRepoURL()}/${latestTag}`
 });
 
 async function init(): Promise<false | void> {

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -87,7 +87,7 @@ const getAheadByCount = cache.function(async (latestTag: string): Promise<string
 }, {
 	maxAge: 1 / 24, // One hour
 	staleWhileRevalidate: 2,
-	cacheKey: ([latestTag]) => `tag-head-by:${getRepoURL()}/${latestTag}`
+	cacheKey: ([latestTag]) => `tag-ahead-by:${getRepoURL()}/${latestTag}`
 });
 
 async function init(): Promise<false | void> {


### PR DESCRIPTION
- Retry earlier
- `aheadBy`'s cache key should include the tag itself, otherwise it might return the information for a previous tag

<!-- 

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
