### PR TITLE
Improve `list-prs-for-file`'s display

### DIFF
--- a/source/features/list-prs-for-file.css
+++ b/source/features/list-prs-for-file.css
@@ -1,5 +1,0 @@
-/* Vertical alignment */
-.form-warning .rgh-list-prs-for-file {
-	margin-top: -0.8em;
-	margin-bottom: -0.5em;
-}

--- a/source/features/list-prs-for-file.css
+++ b/source/features/list-prs-for-file.css
@@ -1,0 +1,5 @@
+/* Vertical alignment */
+.form-warning .rgh-list-prs-for-file {
+	margin-top: -0.8em;
+	margin-bottom: -0.5em;
+}

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -23,7 +23,7 @@ function getDropdown(prs: number[]): HTMLElement {
 
 			<ul className="dropdown-menu dropdown-menu-se">
 				<div className="dropdown-header">
-					File touched by
+					File touched by PRs
 				</div>
 				{prs.map(prNumber => (
 					<li>


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/2624

- Groups multiple PRs under a dropdown in `isSingleFile`
- Improves "single PR" wording and style in `isEditingFile`
- Drops tooltips everywhere except "single PR" `isSingleFile` (everywhere else, links have context)

## Test

https://github.com/sindresorhus/refined-github/blob/master/source/content.ts 
<img width="588" alt="view multiple" src="https://user-images.githubusercontent.com/1402241/76112196-cc262e00-5ff2-11ea-8476-250a9deb9dd7.png">



https://github.com/sindresorhus/refined-github/edit/master/source/content.ts

<img width="664" alt="edit multiple" src="https://user-images.githubusercontent.com/1402241/76112003-6b96f100-5ff2-11ea-98a9-4a2ec1b0e4ce.png">

https://github.com/sindresorhus/refined-github/blob/master/source/features/releases-tab.tsx
![](https://user-images.githubusercontent.com/1402241/76112242-e233ee80-5ff2-11ea-9969-677558a18d30.png)


https://github.com/sindresorhus/refined-github/edit/master/source/features/releases-tab.tsx

<img width="365" alt="edit single" src="https://user-images.githubusercontent.com/1402241/76112078-908b6400-5ff2-11ea-9290-8d68c430bef7.png">
