### PR TITLE
Improve `forked-to` reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10172,14 +10172,6 @@
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
 			"integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw=="
 		},
-		"p-filter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-			"integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
-			"requires": {
-				"p-map": "^2.0.0"
-			}
-		},
 		"p-finally": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -10207,11 +10199,6 @@
 			"requires": {
 				"p-limit": "^1.1.0"
 			}
-		},
-		"p-map": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
 		"p-reduce": {
 			"version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
 		"linkify-urls": "3.1.0-nolookbehind",
 		"mem": "^6.0.1",
 		"onetime": "^5.1.0",
-		"p-filter": "^2.1.0",
 		"select-dom": "^6.0.0",
 		"shorten-repo-url": "^1.6.0",
 		"strip-indent": "^3.0.0",

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -86,7 +86,11 @@ async function updateUI(forks: string[]): Promise<void> {
 async function init(): Promise<void | false> {
 	const forks = await cache.get<string[]>(getCacheKey());
 	if (forks) {
-		await updateUI(forks);
+		// Don't add button if you're visiting the only fork available
+		if (forks.length > 1 || forks[0] !== getRepoURL()) {
+			await updateUI(forks);
+		}
+
 		await updateCache();
 		return;
 	}

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -2,32 +2,29 @@ import './forked-to.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import pFilter from 'p-filter';
-import onetime from 'onetime';
-import elementReady from 'element-ready';
 import forkIcon from 'octicon/repo-forked.svg';
+import checkIcon from 'octicon/check.svg';
+import elementReady from 'element-ready';
 import linkExternalIcon from 'octicon/link-external.svg';
 import features from '../libs/features';
-import {isRepoWithAccess} from '../libs/page-detect';
+import fetchDom from '../libs/fetch-dom';
 import {getRepoURL, getUsername} from '../libs/utils';
 
-const getCacheKey = onetime((): string => `forked-to:${getUsername()}@${findForkedRepo() ?? getRepoURL()}`);
+const getForkSourceRepo = (): string => findForkedRepo() ?? getRepoURL();
+const getCacheKey = (): string => `forked-to:${getUsername()}@${getForkSourceRepo()}`;
 
-async function save(forks: string[]): Promise<void> {
-	if (forks.length === 0) {
-		return cache.delete(getCacheKey());
-	}
-
-	await cache.set(getCacheKey(), forks, 10);
-}
-
-function saveAllForks(): void {
+const updateCache = cache.function(async (): Promise<string[] | undefined> => {
+	const document = await fetchDom(`/${getForkSourceRepo()}/fork?fragment=1`);
 	const forks = select
-		.all('details-dialog[src*="/fork"] .octicon-repo-forked')
-		.map(({nextSibling}) => nextSibling!.textContent!.trim());
+		.all('.octicon-repo-forked', document)
+		.map(({nextSibling}) => nextSibling!.textContent!.trim().toLowerCase());
 
-	save(forks);
-}
+	return forks.length > 0 ? forks : undefined;
+}, {
+	cacheKey: getCacheKey,
+	maxAge: 1 / 24,
+	staleWhileRevalidate: 5
+});
 
 function findForkedRepo(): string | undefined {
 	const forkSourceElement = select<HTMLAnchorElement>('.fork-flag a');
@@ -38,38 +35,8 @@ function findForkedRepo(): string | undefined {
 	return undefined;
 }
 
-async function validateFork(repo: string): Promise<boolean> {
-	const response = await fetch(location.origin + '/' + repo, {method: 'HEAD'});
-	return response.ok;
-}
-
-async function updateForks(forks: string[]): Promise<void> {
-	// Don't validate current page: it exists; it won't be shown in the list; it will be added later anyway
-	const validForks = await pFilter(forks.filter(fork => fork !== getRepoURL()), validateFork);
-
-	// Add current repo to cache if it's a fork
-	if (isRepoWithAccess() && findForkedRepo()) {
-		save([...validForks, getRepoURL()].sort(undefined));
-	} else {
-		save(validForks);
-	}
-}
-
-async function init(): Promise<void | false> {
-	const fragment = select('details-dialog[src*="/fork"] include-fragment');
-	if (!fragment) {
-		return false;
-	}
-
-	fragment.addEventListener('load', saveAllForks);
-
-	const forks = await cache.get<string[]>(getCacheKey());
-	if (!forks) {
-		return;
-	}
-
+async function updateUI(forks: string[]): Promise<void> {
 	document.body.classList.add('rgh-forked-to');
-
 	const forkCounter = (await elementReady('.social-count[href$="/network/members"]'))!;
 	if (forks.length === 1) {
 		forkCounter.before(
@@ -97,10 +64,12 @@ async function init(): Promise<void | false> {
 					{forks.map(fork => (
 						<a
 							href={`/${fork}`}
-							className="select-menu-item"
+							className={`select-menu-item ${fork === getRepoURL() ? 'selected' : ''}`}
 							title={`Open your fork at ${fork}`}
 						>
-							<span className="select-menu-item-icon">{forkIcon()}</span>
+							<span className="select-menu-item-icon rgh-forked-to-icon">
+								{fork === getRepoURL() ? checkIcon() : forkIcon()}
+							</span>
 							{fork}
 						</a>
 					))}
@@ -108,9 +77,25 @@ async function init(): Promise<void | false> {
 			</details>
 		);
 	}
+}
 
-	// Validate cache after showing links once, to make it faster
-	await updateForks(forks);
+/* This feature only applies to users that have multiple organizations, because that makes a fork picker modal appear on "Fork" click */
+
+/* Only fetch/update forks when we see a fork (on the current page or in the cache).
+   This avoids having to `updateCache` for every single repo they visit. */
+async function init(): Promise<void | false> {
+	const forks = await cache.get<string[]>(getCacheKey());
+	if (forks) {
+		await updateUI(forks);
+		await updateCache();
+		return;
+	}
+
+	if (findForkedRepo()) {
+		await updateCache();
+	} else {
+		return false;
+	}
 }
 
 features.add({

--- a/source/libs/utils.ts
+++ b/source/libs/utils.ts
@@ -74,7 +74,7 @@ export const getCurrentBranch = (): string => {
 
 export const isFirefox = navigator.userAgent.includes('Firefox/');
 
-export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/');
+export const getRepoURL = (): string => location.pathname.slice(1).split('/', 2).join('/').toLowerCase();
 export const getRepoGQL = (): string => {
 	const {ownerName, repoName} = getOwnerAndRepo();
 	return `owner: "${ownerName!}", name: "${repoName!}"`;


### PR DESCRIPTION
Closes #2759 
Closes #2885 

Cases tested:

- User has no organizations (no action taken)
- User has 1 fork (icon shown)
- User has 1 fork and is currently visiting it (no icon shown)
- User has 2 forks (dropdown shown)
- User has 2 forks and is currently visiting 1 (dropdown shown, 1 fork selected)

<img width="326" alt="Screen Shot 2020-03-14 at 18 25 24" src="https://user-images.githubusercontent.com/1402241/76687242-65bc9380-6622-11ea-94dc-1f562f58d9e0.png">


Edge cases that work but aren't strictly supported:

- User has forked a fork (the "source" repo points to the first fork, so the UI might not be exactly what's expected)