### PR TITLE
Adjust filters padding on Security page

### DIFF
--- a/source/content.css
+++ b/source/content.css
@@ -18,24 +18,13 @@
 }
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
-.table-list-filters .table-list-header-toggle .select-menu-button {
-	padding-right: 0;
-	padding-left: 0;
+#js-issues-toolbar .table-list-header-toggle > details {
+	padding: 0 !important;
 }
 
-.table-list-filters .details-reset {
-	padding-right: 8px !important;
-	padding-left: 8px !important;
-}
-
-/* Some filters are wrapped inside a padding-less span */
-.table-list-filters .table-list-header-toggle > .details-reset:last-child {
-	padding-right: 0 !important;
-}
-
-/* For `security` page: increase padding because markup is different than other pages with filters */
-#dependencies + .table-list-header .table-list-filters .table-list-header-toggle > .details-reset:last-child {
-	padding-right: 16px !important;
+#js-issues-toolbar .table-list-header-toggle .rgh-batch-open-issues,
+#js-issues-toolbar .table-list-header-toggle summary {
+	padding: 0 8px !important;
 }
 
 /* Hide empty description of repo */

--- a/source/content.css
+++ b/source/content.css
@@ -22,9 +22,12 @@
 	padding: 0 !important;
 }
 
-#js-issues-toolbar .table-list-header-toggle .rgh-batch-open-issues,
 #js-issues-toolbar .table-list-header-toggle summary {
 	padding: 0 8px !important;
+}
+
+#js-issues-toolbar .table-list-header-toggle :last-child > summary {
+	padding-right: 0 !important;
 }
 
 /* Hide empty description of repo */

--- a/source/content.css
+++ b/source/content.css
@@ -18,7 +18,7 @@
 }
 
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
-#js-issues-toolbar .table-list-header-toggle > details {
+#js-issues-toolbar .table-list-header-toggle details {
 	padding: 0 !important;
 }
 
@@ -26,7 +26,7 @@
 	padding: 0 8px !important;
 }
 
-#js-issues-toolbar .table-list-header-toggle :last-child > summary {
+#js-issues-toolbar .table-list-header-toggle > :last-child > summary {
 	padding-right: 0 !important;
 }
 

--- a/source/content.css
+++ b/source/content.css
@@ -33,6 +33,11 @@
 	padding-right: 0 !important;
 }
 
+/* For `security` page: increase padding because markup is different than other pages with filters */
+#dependencies + .table-list-header .table-list-filters .table-list-header-toggle > .details-reset:last-child {
+	padding-right: 16px !important;
+}
+
 /* Hide empty description of repo */
 .repository-meta.mb-3 > .repository-meta-content > em {
 	display: none !important;

--- a/source/features/batch-open-issues.tsx
+++ b/source/features/batch-open-issues.tsx
@@ -42,7 +42,7 @@ function init(): void | false {
 	select('.table-list-header-toggle:not(.states)')?.prepend(
 		<button
 			type="button"
-			className="btn-link rgh-batch-open-issues"
+			className="btn-link rgh-batch-open-issues px-2"
 		>
 			Open all
 		</button>

--- a/source/features/batch-open-issues.tsx
+++ b/source/features/batch-open-issues.tsx
@@ -42,7 +42,7 @@ function init(): void | false {
 	select('.table-list-header-toggle:not(.states)')?.prepend(
 		<button
 			type="button"
-			className="btn-link rgh-batch-open-issues pr-2"
+			className="btn-link rgh-batch-open-issues"
 		>
 			Open all
 		</button>

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -109,7 +109,7 @@ async function addChecksFilter(): Promise<void> {
 		addDropdownItem(dropdown, status, 'status', status.toLowerCase());
 	}
 
-	reviewsFilter.after(' ', checksFilter);
+	reviewsFilter.after(checksFilter);
 }
 
 function init(): void {


### PR DESCRIPTION
Closes #2888 

- Go to the security page of a repository i.e. https://github.com/sindresorhus/refined-github/network/alerts
Note: you need to have some security alerts for the filter to be displayed
- See that the sort filter on the right-hand side of the bar has some padding-right.

Before:
![Screenshot 2020-03-19 at 10 26 26](https://user-images.githubusercontent.com/1215056/77051975-6fe8e400-69cc-11ea-8c21-e335a78c091a.png)

After:
![Screenshot 2020-03-19 at 10 26 53](https://user-images.githubusercontent.com/1215056/77051995-77a88880-69cc-11ea-811a-499ddc87aaa3.png)

Note: the selector isn't great but the markup is quite different on the security page than the other pages so I didn't want to make it overly complex just to have one selector that matched all the use cases.
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
