### PR TITLE
Wrap reaction avatars to avoid "CSS IS AWESØME"

### DIFF
--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -20,7 +20,7 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	height: 2em;
 	border-radius: 3px;
 	margin-top: -0.3em;
-	margin-left: -0.2em;
+	margin-left: -0.5em;
 	vertical-align: middle;
 	background: #efefef; /* Placeholder before the images load */
 	box-shadow: 0 0 0 2px var(--background, #fff);

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -3,9 +3,14 @@
 	padding-left: 0.7em !important;
 }
 button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
-	border-bottom: 1px solid #e1e4e8;
-	margin-bottom: -1px;
+	border-top: 1px solid #e1e4e8; /* Required when the second line is longer than the first line */
+	border-bottom: 1px solid #e1e4e8; /* Required when the first line is longer than the second line */
+	margin-bottom: -1px; /* Makes up for `order-bottom` */
 }
+.comment-reactions .js-pick-reaction {
+	margin-top: -1px; /* Makes up for `.reaction-summary-item {border-top}` */
+}
+
 .reaction-summary-item.user-has-reacted {
 	--background: #f2f8fa;
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -2,6 +2,10 @@
 	padding-right: 0.7em !important;
 	padding-left: 0.7em !important;
 }
+button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
+	border-bottom: 1px solid #e1e4e8;
+	margin-bottom: -1px;
+}
 .reaction-summary-item.user-has-reacted {
 	--background: #f2f8fa;
 }
@@ -16,7 +20,6 @@
 	background: #efefef; /* Placeholder before the images load */
 	box-shadow: 0 0 0 2px var(--background, #fff);
 	font-size: 10px; /* Base sizer */
-	transition: margin-left 0.2s;
 }
 .reaction-summary-item a:first-of-type {
 	margin-left: 0.5em;
@@ -33,17 +36,4 @@
 	max-width: 100%;
 	border-radius: inherit;
 	background-color: var(--background);
-}
-
-/* Overlap reaction avatars when there are 5+ types of reactions */
-.rgh-reactions-near-limit .reaction-summary-item:not(:hover) a:not(:first-of-type) {
-	margin-left: -12px;
-}
-/* Avoid wrapping */
-.has-reactions,
-.rgh-reactions-near-limit {
-	display: flex;
-}
-.rgh-reactions-near-limit {
-	background: #fff;
 }

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -65,11 +65,6 @@ function init(): void {
 
 		list.classList.add('rgh-reactions');
 
-		// Overlap reaction avatars when near the avatarLimit
-		if (flatParticipants.length > avatarLimit * 0.9) {
-			list.classList.add('rgh-reactions-near-limit');
-		}
-
 		onUpdatableContentUpdate(list.closest<HTMLElement>('.js-updatable-content')!, init);
 	}
 }


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/1402241/77155645-236dd900-6a9e-11ea-9fe5-3c23e5bdece0.jpg)


Fixes https://github.com/sindresorhus/refined-github/issues/1744

- Issues are now responsive, we can't use previous JS solutions that only run on load
- CSS Grid doesn't allow automatic wrap
- CSS `flex-grow` can't be used because if there's a 1-avatar reaction on the second line, it will be stretched along the whole line, making it huge

## Demos from https://github.com/facebook/react/issues/13525

Some aren't great, but that's just how it is 🤷‍♂️ 

<img width="512" alt="Screen Shot 2020-03-20 at 11 37 12" src="https://user-images.githubusercontent.com/1402241/77156293-63818b80-6a9f-11ea-80b0-71f9c8129d9f.png">

<img width="509" alt="Screen Shot 2020-03-20 at 11 37 40" src="https://user-images.githubusercontent.com/1402241/77156295-654b4f00-6a9f-11ea-848b-00517830035b.png">
<img width="510" alt="Screen Shot 2020-03-20 at 11 37 20" src="https://user-images.githubusercontent.com/1402241/77156294-64b2b880-6a9f-11ea-8570-b1d8222feae4.png">
<img width="472" alt="Screen Shot 2020-03-20 at 11 38 01" src="https://user-images.githubusercontent.com/1402241/77156297-65e3e580-6a9f-11ea-93b0-3bf63e33c5f4.png">

<img width="424" alt="Screen Shot 2020-03-20 at 11 38 29" src="https://user-images.githubusercontent.com/1402241/77156298-667c7c00-6a9f-11ea-9e54-e8be6d993906.png">

