### PR TITLE
Clean `clean-sidebar` and also clean "Linked issues" section

### DIFF
--- a/source/features/clean-sidebar.css
+++ b/source/features/clean-sidebar.css
@@ -3,6 +3,14 @@
 	margin-bottom: -5px;
 }
 
+/* Align sidebar to the top */
+.discussion-sidebar-item:first-child {
+	padding-top: 0;
+}
+.sidebar-labels .sidebar-labels-style:first-child {
+	margin-top: 0;
+}
+
 /* Move message under the `Unsubscribe` button above the button */
 .thread-subscription-status {
 	display: flex;

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -91,6 +91,10 @@ function clean(): void {
 		select('.sidebar-labels div.discussion-sidebar-heading')!.remove();
 	}
 
+	// Linked issues/PRs
+	select('[aria-label="Link issues"] p')!.remove(); // "Successfully merging a pull request may close this issue."
+	cleanSection('[aria-label="Link issues"]', true);
+
 	// Projects
 	cleanSection('[aria-label="Select projects"]', false);
 

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -22,17 +22,8 @@ Expected DOM:
 .discussion-sidebar-item
 	form (may be missing)
 		details or div.discussion-sidebar-heading
-		---
-		--- these are direct children
-		---
-
-.discussion-sidebar-item
-	form (may be missing)
-		details or div.discussion-sidebar-heading
-		(random wrapper element)
-			---
-			--- these are "children of child"
-			---
+		.css-truncate (may be missing)
+			"No issues"
 
 @param containerSelector Element that contains `details` or `.discussion-sidebar-heading`
 */

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -43,8 +43,8 @@ function cleanSection(containerSelector: string): boolean {
 	const isEmpty = header
 		.nextElementSibling // If nextElementSibling is missing, this section is definitely empty
 		?.firstChild?.nodeValue // Get exclusively the textNode value, not `textContent` (which could match a label called "no")
-		?.trim().startsWith('No')
-		?? true; // Missing `nextElementSibling`
+		?.trim().startsWith('No') ??
+		true; // Missing `nextElementSibling`
 	if (!isEmpty) {
 		return false;
 	}
@@ -101,7 +101,6 @@ function clean(): void {
 	cleanSection('[aria-label="Select projects"]');
 
 	// Milestones
-	debugger;
 	cleanSection('[aria-label="Select milestones"]');
 }
 

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -19,11 +19,13 @@ Smartly removes "No content" or the whole section, depending on `canEditSidebar`
 
 Expected DOM:
 
+```pug
 .discussion-sidebar-item
 	form (may be missing)
 		details or div.discussion-sidebar-heading
 		.css-truncate (may be missing)
 			"No issues"
+```
 
 @param containerSelector Element that contains `details` or `.discussion-sidebar-heading`
 */


### PR DESCRIPTION
Closes #2773 

## Test

This feature depends on:

- whether you can edit the issue/pr
- whether each section is full or empty

So open [one of your favorite repos](https://github.com/sindresorhus/refined-github/issues?q=sort%3Aupdated-desc) and go through its issues to double-check their sidebar

## Demos

<table><td><img width="239" alt="b" src="https://user-images.githubusercontent.com/1402241/77234010-9b75f500-6bab-11ea-9b06-7696b308090b.png"></table> <table><td><img width="242" alt="a" src="https://user-images.githubusercontent.com/1402241/77234011-9b75f500-6bab-11ea-9b64-f7d373b851b0.png"></table> <table><td><img width="238" alt="c" src="https://user-images.githubusercontent.com/1402241/77234008-9add5e80-6bab-11ea-9343-db561211ab3f.png"></table>

"Reviewers" sometimes isn't removed because GitHub sets "No reviews" later