### PR TITLE
Make `show-open-prs-of-forks`'s cache case-insensitive

### DIFF
--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -37,7 +37,7 @@ const countPRs = cache.function(async (forkedRepo: string): Promise<[number, num
 }, {
 	maxAge: 1 / 2, // Stale after 12 hours
 	staleWhileRevalidate: 2,
-	cacheKey: ([forkedRepo]): string => 'prs-on-forked-repo:' + forkedRepo
+	cacheKey: ([forkedRepo]): string => 'prs-on-forked-repo:' + forkedRepo.toLowerCase()
 });
 
 async function getPRs(): Promise<[number, string] | []> {


### PR DESCRIPTION
Something I spotted when commenting on #2921, it doesn't cause any issues as far as I'm aware but it's there if you want it ;)