### PR TITLE
Avoid console error in `preserve-file-finder-term`

### DIFF
--- a/source/features/preserve-file-finder-term.tsx
+++ b/source/features/preserve-file-finder-term.tsx
@@ -14,7 +14,7 @@ function unloadHandler(): void {
 
 // Set the input field value & trigger event
 async function setValueInField(): Promise<void> {
-	const preservedValue = history.state.rghFileFinderTerm;
+	const preservedValue = history.state?.rghFileFinderTerm;
 	const inputElement = select<HTMLInputElement>('#tree-finder-field');
 	if (inputElement && !inputElement.value && preservedValue) {
 		await elementReady('.js-tree-browser-results > li', {stopOnDomReady: false});	// For search to work


### PR DESCRIPTION
Don't throw an error when there is no history
Error mentioned in #2907

<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
