### PR TITLE
Add watch:chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build": "webpack --mode=production",
 		"watch": "webpack --mode=development --watch",
 		"watch:firefox": "web-ext run --source-dir=distribution",
+		"watch:chrome": "web-ext run --source-dir=distribution  --target chromium",
 		"prerelease:version": "dot-json distribution/manifest.json version $VER",
 		"prerelease:source-url": "echo https://github.com/sindresorhus/refined-github/archive/\"${TRAVIS_COMMIT:-$VER}\".zip > distribution/SOURCE_URL",
 		"release:amo": "cd distribution && web-ext-submit",


### PR DESCRIPTION
web-ext added this option.

@fregante is there a simple way to set a secret-key to add the api key. Otherwise its a pain since every time you relaunch you need to set api key again
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
