### PR TITLE
Limit `expand-all-hidden-comments` to 200

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ Thanks for contributing! 🦋🙌
 - [](# "scrollable-code-and-blockquote") [Limits the height of tall code blocks and quotes.](https://github.com/sindresorhus/refined-github/issues/1123)
 - [](# "hide-comments-faster") [Simplifies the UI to hide comments.](https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif)
 - [](# "open-issue-to-latest-comment") [Links the comments icon to the latest comment.](https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png)
-- [](# "expand-all-hidden-comments") [On long discussions where GitHub hides comments under a "Load more...", <kbd>alt</kbd> <kbd>click</kbd> will load *all* the comments at once instead of part of them.](https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png)
+- [](# "expand-all-hidden-comments") [On long discussions where GitHub hides comments under a "Load more...", alt-clicking it will load up to 200 comments at once instead of 60.](https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -13,7 +13,11 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): vo
 	}
 
 	const form = event.delegateTarget.form!;
-	const hiddenItemsCount = looseParseInt(form.textContent!);
+	let hiddenItemsCount = looseParseInt(form.textContent!);
+	if (hiddenItemsCount > 250) { // https://github.com/sindresorhus/refined-github/issues/2931
+		hiddenItemsCount = 250;
+	}
+
 	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', String(hiddenItemsCount));
 	form.action = url.href;

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -29,7 +29,7 @@ function init(): void {
 
 features.add({
 	id: __featureName__,
-	description: 'On long discussions where GitHub hides comments under a "Load more...", alt-clicking it will load *all* the comments at once instead of part of them.',
+	description: 'On long discussions where GitHub hides comments under a "Load more...", alt-clicking it will load up to 200 comments at once instead of 60.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png',
 	include: [
 		features.isIssue,

--- a/source/features/expand-all-hidden-comments.ts
+++ b/source/features/expand-all-hidden-comments.ts
@@ -13,10 +13,10 @@ function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): vo
 	}
 
 	const form = event.delegateTarget.form!;
-	let hiddenItemsCount = looseParseInt(form.textContent!);
-	if (hiddenItemsCount > 250) { // https://github.com/sindresorhus/refined-github/issues/2931
-		hiddenItemsCount = 250;
-	}
+	const hiddenItemsCount = Math.min(
+		200, // https://github.com/sindresorhus/refined-github/issues/2931
+		looseParseInt(form.textContent!)
+	);
 
 	const url = new URL(form.action);
 	url.searchParams.set('variables[first]', String(hiddenItemsCount));


### PR DESCRIPTION
Fixes #2931

Just saw your comment,
>What we can do, if easy, is to limit it to ~200 items

Should I 200?
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
