### PR TITLE
Stop `expand-all-collapsed-code` with `esc`

### DIFF
--- a/source/features/expand-all-collapsed-code.tsx
+++ b/source/features/expand-all-collapsed-code.tsx
@@ -14,12 +14,12 @@ const expandingCodeObserver = new MutationObserver(([mutation]) => {
 	}
 });
 
-const disconnectOnEscape = (event: KeyboardEvent): void => {
+function disconnectOnEscape(event: KeyboardEvent): void {
 	if (event.key === 'Escape') {
 		document.body.removeEventListener('keyup', disconnectOnEscape);
-		return expandingCodeObserver.disconnect();
+		expandingCodeObserver.disconnect();
 	}
-};
+}
 
 function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	if (!event.altKey) {

--- a/source/features/expand-all-collapsed-code.tsx
+++ b/source/features/expand-all-collapsed-code.tsx
@@ -14,10 +14,19 @@ const expandingCodeObserver = new MutationObserver(([mutation]) => {
 	}
 });
 
+const disconnectOnEscape = (event: KeyboardEvent): void => {
+	if (event.key === 'Escape') {
+		document.body.removeEventListener('keyup', disconnectOnEscape);
+		return expandingCodeObserver.disconnect();
+	}
+};
+
 function handleAltClick(event: DelegateEvent<MouseEvent, HTMLButtonElement>): void {
 	if (!event.altKey) {
 		return;
 	}
+
+	document.body.addEventListener('keyup', disconnectOnEscape);
 
 	expandingCodeObserver.observe(
 		event.delegateTarget.closest('.diff-table > tbody')!,


### PR DESCRIPTION
Closes #2939
https://github.com/microsoft/TypeScript/commit/55218d64a58a9964229daa0a38bdfb0a6be717e5#diff-46fd87925e4552c166ec188712741c3f

Not sure if this is what you had in mind.
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
