### PR TITLE
Fix deployment cronjob

### DIFF
--- a/.github/workflows/deploy-auto.yml
+++ b/.github/workflows/deploy-auto.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: fregante/setup-git-token@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TAGGER_TOKEN }}
       - run: |
           if [[ $(git tag -l --points-at HEAD) = "" ]]; then
             export VER=$(npx daily-version)


### PR DESCRIPTION
Due to https://github.com/notlmn/browser-extension-template/issues/25

@sindresorhus can you generate and set a token in the secrets? E.g. `TAGGER_TOKEN`