### PR TITLE
Don't 404 `deep-reblame` on renamed files

### DIFF
--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -41,7 +41,7 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, c
 
 	const associatedPR = repository.object.associatedPullRequests.nodes[0];
 
-	if (associatedPR?.number !== prNumber || associatedPR.mergeCommit.oid !== commit) {
+	if (!associatedPR || associatedPR.number !== prNumber || associatedPR.mergeCommit.oid !== commit) {
 		throw new Error('The PR linked in the title didn’t create this commit');
 	}
 

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -73,7 +73,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 
 	blameElement.blur(); // Hide tooltip after click, it’s shown on :focus
 
-	const currentFilename = getCleanPathname().split('/').slice(-3).join('/');
+	const [, currentFilename] = getCleanPathname().split(getReference());
 
 	const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
 	if (prBlameCommit) {

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -73,7 +73,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 
 	blameElement.blur(); // Hide tooltip after click, it’s shown on :focus
 
-	const [, currentFilename] = getCleanPathname().split(getReference());
+	const [, currentFilename] = getCleanPathname().split(getReference()! + '/');
 
 	const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
 	if (prBlameCommit) {

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -9,7 +9,7 @@ import features from '../libs/features';
 import loadingIcon from '../libs/icon-loading';
 import {getRepoGQL, getReference, looseParseInt, getCleanPathname} from '../libs/utils';
 
-const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, currentFilename: string): Promise<string | Error> => {
+const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, currentFilename: string): Promise<string> => {
 	const {repository} = await api.v4(`
 		repository(${getRepoGQL()}) {
 			file: object(expression: "${commit}:${currentFilename}") {
@@ -76,7 +76,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 	try {
 		const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
 		const lineNumber = select('.js-line-number', blameHunk)!.textContent!;
-		const href = new URL(location.href.replace(getReference()!, prBlameCommit as string));
+		const href = new URL(location.href.replace(getReference()!, prBlameCommit));
 		href.hash = 'L' + lineNumber;
 		location.href = String(href);
 	} catch (error) {
@@ -89,7 +89,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 			spinner.remove();
 		}
 
-		alert(error);
+		alert(error.message);
 	}
 }
 

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -79,8 +79,8 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 
 	const [, currentFilename] = getCleanPathname().split(getReference()! + '/');
 
-	const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
-	if (prBlameCommit) {
+	try {
+		const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
 		const lineNumber = select('.js-line-number', blameHunk)!.textContent!;
 		const href = new URL(location.href.replace(getReference()!, prBlameCommit));
 		href.hash = 'L' + lineNumber;

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -41,8 +41,12 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, c
 
 	const associatedPR = repository.object.associatedPullRequests.nodes[0];
 
-	if (!associatedPR || !repository.file) {
-		return false;
+	if (!associatedPR) {
+		throw new Error('The PR linked in the title didn’t create this commit');
+	}
+	
+	if (!repository.file) {
+		throw new Error('The file was renamed and Refined GitHub can’t find it');
 	}
 
 	const mergeCommit = associatedPR.mergeCommit.oid;

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -74,7 +74,6 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 	blameElement.blur(); // Hide tooltip after click, it’s shown on :focus
 
 	const currentFilename = getCleanPathname().split('/').slice(-3).join('/');
-	const currentFilename = splitPath.slice(Math.max(splitPath.length - 3, 1)).join('/');
 
 	const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);
 	if (prBlameCommit) {

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -41,7 +41,7 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, c
 
 	const associatedPR = repository.object.associatedPullRequests.nodes[0];
 
-	if (!associatedPR) {
+	if (associatedPR?.number !== prNumber || associatedPR.mergeCommit.oid !== commit) {
 		throw new Error('The PR linked in the title didn’t create this commit');
 	}
 

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -73,7 +73,7 @@ async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchor
 
 	blameElement.blur(); // Hide tooltip after click, it’s shown on :focus
 
-	const splitPath = getCleanPathname().split('/');
+	const currentFilename = getCleanPathname().split('/').slice(-3).join('/');
 	const currentFilename = splitPath.slice(Math.max(splitPath.length - 3, 1)).join('/');
 
 	const prBlameCommit = await getPullRequestBlameCommit(prCommit, prNumber, currentFilename);

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -49,13 +49,7 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, c
 		throw new Error('The file was renamed and Refined GitHub can’t find it');
 	}
 
-	const mergeCommit = associatedPR.mergeCommit.oid;
-
-	if (associatedPR.number === prNumber && mergeCommit === commit) {
-		return associatedPR.commits.nodes[0].commit.oid;
-	}
-
-	throw new Error('The PR linked in the title didn’t create this commit');
+	return associatedPR.commits.nodes[0].commit.oid;
 });
 
 async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchorElement | HTMLButtonElement>): Promise<void> {

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -54,13 +54,11 @@ const getPullRequestBlameCommit = mem(async (commit: string, prNumber: number, c
 
 async function redirectToBlameCommit(event: DelegateEvent<MouseEvent, HTMLAnchorElement | HTMLButtonElement>): Promise<void> {
 	const blameElement = event.delegateTarget;
-	if (blameElement instanceof HTMLAnchorElement) {
-		if (event.altKey) {
-			event.preventDefault();
-		} else {
-			return; // Unmodified click on regular link: let it proceed
-		}
+	if (blameElement instanceof HTMLAnchorElement && !event.altKey) {
+		return; // Unmodified click on regular link: let it proceed
 	}
+
+	event.preventDefault();
 
 	const blameHunk = blameElement.closest('.blame-hunk')!;
 	const prNumber = looseParseInt(select('.issue-link', blameHunk)!.textContent!);


### PR DESCRIPTION
Fixes #2949

@fregante how do you want to handle the message?

# Test

Related PR in commit title: it should "enter" it https://github.com/sindresorhus/refined-github/blame/b5497da33a6c5b99eb518ecc266881780bc11877/contributing.md#L7

Unrelated PR in commit title: it should `alert()` https://github.com/sindresorhus/refined-github/blame/d1e27cb34f18b9d5d57fdbf853e5b15c3a660d85/source/features/deep-reblame.tsx#L67

Renamed file: it should `alert()` 
https://github.com/sindresorhus/refined-github/blame/fad67fb8d8fcf608601c9b8ae1b5f12337cbccce/source/options.html#L1
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
