### PR TITLE
Adds back New Pull Request button.

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -43,11 +43,6 @@
 	margin-left: 0;
 }
 
-/* Hide `New pull request button` near file list */
-.file-navigation .new-pull-request-btn {
-	display: none;
-}
-
 @keyframes fade-in {
 	from {
 		opacity: 0;


### PR DESCRIPTION
The New Pull Request button was removed in #1876 in favor of the buttons. Because the buttons no longer exist anymore, this PR adds the New Pull Request button back. 

Before: 
<img width="464" alt="image" src="https://user-images.githubusercontent.com/8728954/78605699-0e2cd480-782a-11ea-90c6-58ed7e57f893.png">

After:
<img width="414" alt="image" src="https://user-images.githubusercontent.com/8728954/78605776-2bfa3980-782a-11ea-8b41-23bb1510ea3f.png">
