### PR TITLE
Use Parcel instead of Webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 yarn.lock
 distribution
+distribution-parcel
+.cache
+.parcel-cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,17 @@
 				"@babel/highlight": "^7.0.0"
 			}
 		},
+		"@babel/compat-data": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.1.tgz",
+			"integrity": "sha512-Z+6ZOXvyOWYxJ50BwxzdhRnRsGST8Y3jaZgxYig575lTjVSs3KtJnmESwZegg6e2Dn0td1eDhoWlp1wI4BTCPw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.8.2",
+				"invariant": "^2.2.4",
+				"semver": "^5.5.0"
+			}
+		},
 		"@babel/core": {
 			"version": "7.7.5",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
@@ -99,6 +110,289 @@
 				"@babel/types": "^7.7.4"
 			}
 		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.0.tgz",
+			"integrity": "sha512-KbBloNiBHM3ZyHg1ViDRs4QcnAunwMJ+rLpAEA8l3cWb3Z1xof7ag1iHvX16EwhUfaTG3+YSvTRPv4xHIrseUQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.8.0",
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-builder-react-jsx": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.8.0.tgz",
+			"integrity": "sha512-Zg7VLtZzcAHoQ13S0pEIGKo8OAG3s5kjsk/4keGmUeNuc810T9fVp6izIaL8ZVeAErRFWJdvqFItY3QMTHMsSg==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.8.0",
+				"esutils": "^2.0.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-call-delegate": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.8.0.tgz",
+			"integrity": "sha512-Vi8K1LScr8ZgLicfuCNSE7JWUPG/H/9Bw9zn+3vQyy4vA54FEGTCuUTOXCFwmBM93OD6jHfjrQ6ZnivM5U+bHg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.8.0",
+				"@babel/traverse": "^7.8.0",
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+					"integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+					"integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/generator": "^7.8.0",
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.1.tgz",
+			"integrity": "sha512-Fsrljg8DHSdnKSzC0YFopX7lseRpVfWMYuC1Dnvf7tw972E2KDjZ4XEaqjO9aJL0sLcG4KNRXxowDxHYIcZ+Cw==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.8.1",
+				"browserslist": "^4.8.2",
+				"invariant": "^2.2.4",
+				"levenary": "^1.1.0",
+				"semver": "^5.5.0"
+			}
+		},
+		"@babel/helper-create-class-features-plugin": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.8.0.tgz",
+			"integrity": "sha512-ctCvqYBTlwEl2uF4hCxE0cd/sSw71Zfag0jKa39y4HDLh0BQ4PVBX1384Ye8GqrEZ69xgLp9fwPbv3GgIDDF2Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.8.0",
+				"@babel/helper-member-expression-to-functions": "^7.8.0",
+				"@babel/helper-optimise-call-expression": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/helper-replace-supers": "^7.8.0",
+				"@babel/helper-split-export-declaration": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
 		"@babel/helper-create-regexp-features-plugin": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.7.4.tgz",
@@ -107,6 +401,211 @@
 			"requires": {
 				"@babel/helper-regex": "^7.4.4",
 				"regexpu-core": "^4.6.0"
+			}
+		},
+		"@babel/helper-define-map": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.8.0.tgz",
+			"integrity": "sha512-Go06lUlZ4YImNEmdyAH5iO38yh5mbpOPSwA2PtV1vyczFhTZfX0OtzkiIL2pACo6AOYf89pLh42nhhDrqgzC3A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.8.0",
+				"@babel/types": "^7.8.0",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-explode-assignable-expression": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.0.tgz",
+			"integrity": "sha512-w4mRQqKAh4M7BSLwvDMm8jYFroEzpqMCtXDhFHP+kNjMIQWpbC6b0Q/RUQsJNSf54rIx6XMdci1Stf60DWw+og==",
+			"dev": true,
+			"requires": {
+				"@babel/traverse": "^7.8.0",
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+					"integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+					"integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/generator": "^7.8.0",
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -127,6 +626,50 @@
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-hoist-variables": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.0.tgz",
+			"integrity": "sha512-jDl66KvuklTXUADcoXDMur1jDtAZUZZkzLIaQ54+z38ih8C0V0hC56hMaoVoyoxN60MwQmmrHctBwcLqP0c/Lw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.0.tgz",
+			"integrity": "sha512-0m1QabGrdXuoxX/g+KOAGndoHwskC70WweqHRQyCsaO67KOEELYh4ECcGw6ZGKjDKa5Y7SW4Qbhw6ly4Fah/jQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -150,6 +693,28 @@
 				"@babel/template": "^7.7.4",
 				"@babel/types": "^7.7.4",
 				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.0.tgz",
+			"integrity": "sha512-aiJt1m+K57y0n10fTw+QXcCXzmpkG+o+NoQmAZqlZPstkTE0PZT+Z27QSd/6Gf00nuXJQO4NiJ0/YagSW5kC2A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -178,6 +743,132 @@
 				"@babel/template": "^7.7.4",
 				"@babel/traverse": "^7.7.4",
 				"@babel/types": "^7.7.4"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.0.tgz",
+			"integrity": "sha512-R2CyorW4tcO3YzdkClLpt6MS84G+tPkOi0MmiCn1bvYVnmDpdl9R15XOi3NQW2mhOAEeBnuQ4g1Bh7pT2sX8fg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.8.0",
+				"@babel/helper-optimise-call-expression": "^7.8.0",
+				"@babel/traverse": "^7.8.0",
+				"@babel/types": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+					"integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+					"integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/generator": "^7.8.0",
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -260,6 +951,60 @@
 				"@babel/plugin-syntax-dynamic-import": "^7.7.4"
 			}
 		},
+		"@babel/plugin-proposal-json-strings": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.0.tgz",
+			"integrity": "sha512-pSpuhwn926vtNeUH2FHx1OzIXaUMgklG0MzlFZJVEg37fB904gOxN572NgBae+KDwFyZDpkLMyEkVA011lBJrQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.0.tgz",
+			"integrity": "sha512-cQMI+RQdcK2IyMm13NKKFCYfOSBUtFxEeRBOdFCi2Pubv/CpkrCubc/ikdeKMT6Lu+uQ+lNSDEJvDCOQZkUy0g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-proposal-object-rest-spread": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.0.tgz",
+			"integrity": "sha512-SjJ2ZXCylpWC+5DTES0/pbpNmw/FnjU/3dF068xF0DU9aN+oOKah+3MCSFcb4pnZ9IwmxfOy4KnbGJSQR+hAZA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/plugin-proposal-optional-catch-binding": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.7.4.tgz",
@@ -268,6 +1013,61 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.0.tgz",
+			"integrity": "sha512-PNBHxPHE91m+LLOdGwlvyGicWfrMgiVwng5WdB3CMjd61+vn3vPw0GbgECIAUCZnyi7Jqs5htUIZRztGuV8/5g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-proposal-unicode-property-regex": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.0.tgz",
+			"integrity": "sha512-3oK0Qt5w4arb+es3rWBribDbtc0TYJP7dFZ1dXcYul3cXderqfIOoSx9YUC1oD208nJwJO/++fvrgLmkYSbe8A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.0.tgz",
+					"integrity": "sha512-vJj2hPbxxLUWJEV86iZiac5curAnC3ZVc+rFmFeWZigUOcuCPpbF+KxoEmxrkmuCGylHFF9t4lkpcDUcxnhQ5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-regex": "^7.8.0",
+						"regexpu-core": "^4.6.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.0.tgz",
+					"integrity": "sha512-haD8fRsPtyFZkbtxBIaGBBHRtbn0YsyecdYrxNgO0Bl6SlGokJPQX9M2tDuVbeQBYHZVLUPMSwGQn4obHevsMQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				}
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -288,6 +1088,91 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-flow": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.8.0.tgz",
+			"integrity": "sha512-MDK9WdjDccrxzz+4sthpSDnqdf5McJwTtfBYGitOweC/j0Zg6e8wHmP4RGLTeyGYe/IySoRgKC5hvSm6ddrNRw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-json-strings": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.0.tgz",
+			"integrity": "sha512-LPykaAbH86L5NnDfCRSpNxtEHZk+6GaFzXfWEFU/6R4v69EXQr6GOp7hwH+Uw0QlYVN++s6TukTJ3flFcspahA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-jsx": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.0.tgz",
+			"integrity": "sha512-zLDUckAuKeOtxJhfNE0TlR7iEApb2u7EYRlh5cxKzq6A5VzUbYEdyJGJlug41jDbjRbHTtsLKZUnUcy/8V3xZw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.0.tgz",
+			"integrity": "sha512-Rv2hnBToN6rbA9hO2a4vtwXZLzNa+TWkoSIMMvUezFz5+D9NPeX7SFrArwtFzzbwndmWiqboTr5rNpzAz0MPpA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-object-rest-spread": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.0.tgz",
+			"integrity": "sha512-dt89fDlkfkTrQcy5KavMQPyF2A6tR0kYp8HAnIoQv5hO34iAUffHghP/hMGd7Gf/+uYTmLQO0ar7peX1SUWyIA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
 		"@babel/plugin-syntax-optional-catch-binding": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
@@ -295,6 +1180,427 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.0.tgz",
+			"integrity": "sha512-LV1c+TTAO8Vawe3t+WXBHYWbS7endP8MSlqKPKEZOyWPEJX2akl3jfvFG828/OE7RpyoC3JXfLJDFj/jN7A8hg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-top-level-await": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.0.tgz",
+			"integrity": "sha512-iXR/Cw32fMfWlD1sK2zD/nXtuLStkalRv+xee6VrX84CFrn2LKwb/EOs/4UaDNUpUsws8YZYKeQjPagacFquug==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.0.tgz",
+			"integrity": "sha512-LrvVrabb993Ve5fzXsyEkfYCuhpXBwsUFjlvgD8UmXXg3r/8/ceooSdRvjdmtPXXz+lHaqZHZooV1jMWer2qkA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-arrow-functions": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.0.tgz",
+			"integrity": "sha512-9KfteDp9d8cF388dxFMOh3Dum41qpOVUPVjQhXGd1kPyQBE05FJgYndiAriML2yhMIbZ2bjgweh2nnvBXDH2MQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-async-to-generator": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.0.tgz",
+			"integrity": "sha512-9dvBvJnEdsDWYMrykoMyLNVRPGoub6SFlARtsYgSQ1riTjnyBjhctihSME4XsSku86F59PDeFpC9PCU+9I154w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/helper-remap-async-to-generator": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+					"integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.0.tgz",
+					"integrity": "sha512-WWj+1amBdowU2g18p3/KUc1Y5kWnaNm1paohq2tT4/RreeMNssYkv6ul9wkE2iIqjwLBwNMZGH4pTGlMSUqMMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+					"integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.0.tgz",
+					"integrity": "sha512-+aKyBd4oHAaIZgOLq/uLjkUz7ExZ0ppdNBc8Qr72BmtKNAy3A6EJa/ifjj0//CIzQtUDPs3E6HjKM2cV6bnXsQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.8.0",
+						"@babel/helper-wrap-function": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/traverse": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.0.tgz",
+					"integrity": "sha512-2j6idN2jt8Y+8nJ4UPN/6AZa53DAkcETMVmroJQh50qZc59PuQKVjgOIIqmrLoQf6Ia9bs90MHRcID1OW5tfag==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/traverse": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+					"integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/generator": "^7.8.0",
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-block-scoped-functions": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.0.tgz",
+			"integrity": "sha512-bim6gUfHq2kPN+aQst33ZEMeglpaUXAo6PWTZvOA8BOnWpNKgZcUzBvpZhh2ofL6YhZgzGoRwVVfzwynDEf47g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-block-scoping": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.0.tgz",
+			"integrity": "sha512-FKTK4hzg7W950Yu9iqMl12WBixCmusMc5HBt3/ErvpFLnvr3/6mu/EBTZoCEJ0mw/lQUDfU01vTcZY9oEahlMg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"lodash": "^4.17.13"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-classes": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.0.tgz",
+			"integrity": "sha512-18RLDwKtGXCLLbf5V03GojebPH7dKYCmIBqQGhgfZDoYsyEzR9kMZ6IxlJP72K5ROC9ADa4KPI6ywuh7NfQOgQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.0",
+				"@babel/helper-define-map": "^7.8.0",
+				"@babel/helper-function-name": "^7.8.0",
+				"@babel/helper-optimise-call-expression": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/helper-replace-supers": "^7.8.0",
+				"@babel/helper-split-export-declaration": "^7.8.0",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.0.tgz",
+					"integrity": "sha512-WWj+1amBdowU2g18p3/KUc1Y5kWnaNm1paohq2tT4/RreeMNssYkv6ul9wkE2iIqjwLBwNMZGH4pTGlMSUqMMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-computed-properties": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.0.tgz",
+			"integrity": "sha512-FaODHuQRdnWFVwxLPlTN85Lk/aitfvQBHTXahf58FnatCynfhkeNUO8ID+AqAxY4IJsZjeH6OnKDzcGfgKJcVw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.0.tgz",
+			"integrity": "sha512-D+69HT//cE86aBTLULzSBFLC5A7HcPQzJPiny6P4SLHkDF750MylRKO3iWvdgvb+OSp5dOrOxwXajvaxk1ZfYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
@@ -305,6 +1611,305 @@
 			"requires": {
 				"@babel/helper-create-regexp-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-transform-duplicate-keys": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.0.tgz",
+			"integrity": "sha512-REtYWvpP4TDw4oVeP01vQJcAeewjgk8/i7tPFP11vUjvarUGGyxJLeq79WEnIdnKPQJirZaoDRT4kEWEdSWkDw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.0.tgz",
+			"integrity": "sha512-vaDgF3gPLzVcoe3UZqnra6FA7O797sZc+UCHPd9eQTI34cPtpCA270LzopIXS3Fhc3UmFrijLmre9mHTmUKVgg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-flow-strip-types": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.8.0.tgz",
+			"integrity": "sha512-yKcww1yWfAHWk4R7OeU0YnrWEIrSodFr1TibfkrP8t0RDXSyGIDnahz8lzXagNT/XlZC3sWpsYXhty9xAU3ULQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-flow": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-for-of": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.0.tgz",
+			"integrity": "sha512-9j9g0qViCAo8E5qCBSaQdghymn7A9bRXSfS9jU7oLpYccYFZg9A+1KO8X+HV7fhJYH6mZ+e7MRg4p3sLo+RG6Q==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-function-name": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.0.tgz",
+			"integrity": "sha512-YL8Ol54UKeIyY1uUGfry+B9ppXAB3aVBB1gG9gxqhg/OBCPpV2QUNswmjvfmyXEdaWv8qODssBgX7on792h44w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-function-name": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-literals": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.0.tgz",
+			"integrity": "sha512-7UDPKG+uVltsZt98Hw+rMbLg772r8fQC6YJ2fNDckcpAXgIWqQbMCmCpfYo0hBNhdhqocM73auk4P/zziQshQw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-member-expression-literals": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.0.tgz",
+			"integrity": "sha512-lJSdaWR56wmrosCiyqKFRVnLrFYoVAk2mtZAyegt7akeJky/gguv0Rukx9GV3XwHGuM1ZPE06cZMjNlcLp8LrQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-modules-amd": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.0.tgz",
+			"integrity": "sha512-mFr1O3TaDL4XozM3AzNPz9AsxzzjTxwn4aOShYP5TlO+4rufvjagV2KKDTPMZTQm1ZA/C/PxJDsDekEnnUGz5A==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+					"integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.0.tgz",
+					"integrity": "sha512-fvGhX4FY7YwRdWW/zfddNaKpYl8TaA8hvwONIYhv1/a1ZbgxbTrjsmH6IGWUgUNki7QzbpZ27OEh88sZdft3YA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.8.0",
+						"@babel/helper-simple-access": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.0.tgz",
+					"integrity": "sha512-I+7yKZJnxp7VIC2UFzXfVjLiJuU16rYFF59x27c+boINkO/pLETgZcoesCryg9jmU4jxEa0foFueW+2wjc9Gsw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
@@ -319,6 +1924,653 @@
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
+		"@babel/plugin-transform-modules-systemjs": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.0.tgz",
+			"integrity": "sha512-tKF9KLiIsiKyWTVU0yo+NcNAylGn7euggYwXw63/tMxGtDTPsB9Y7Ecqv4EoXEwtoJOJ0Lewf17oaWQtindxIA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-hoist-variables": "^7.8.0",
+				"@babel/helper-module-transforms": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"babel-plugin-dynamic-import-node": "^2.3.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+					"integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.0.tgz",
+					"integrity": "sha512-fvGhX4FY7YwRdWW/zfddNaKpYl8TaA8hvwONIYhv1/a1ZbgxbTrjsmH6IGWUgUNki7QzbpZ27OEh88sZdft3YA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.8.0",
+						"@babel/helper-simple-access": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.0.tgz",
+					"integrity": "sha512-I+7yKZJnxp7VIC2UFzXfVjLiJuU16rYFF59x27c+boINkO/pLETgZcoesCryg9jmU4jxEa0foFueW+2wjc9Gsw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-modules-umd": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.0.tgz",
+			"integrity": "sha512-lAwNfXwmfTy7fl2XOyoVpMXnLkJANgH0vdSYNFcS4RuJPBtHfunGA+Y0L7wsHmfPzyVYt8sUglLjaWtdZMNJNg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-transforms": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+					"integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.0.tgz",
+					"integrity": "sha512-fvGhX4FY7YwRdWW/zfddNaKpYl8TaA8hvwONIYhv1/a1ZbgxbTrjsmH6IGWUgUNki7QzbpZ27OEh88sZdft3YA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.8.0",
+						"@babel/helper-simple-access": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.0.tgz",
+					"integrity": "sha512-I+7yKZJnxp7VIC2UFzXfVjLiJuU16rYFF59x27c+boINkO/pLETgZcoesCryg9jmU4jxEa0foFueW+2wjc9Gsw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-named-capturing-groups-regex": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.0.tgz",
+			"integrity": "sha512-kq1rxQ1HviCP13SMGZ4WjBBpdogTGK7yn/g/+p+g1AQledgHOWKVeMY1DwKYGlGJ/grDGTOqpJLF1v3Sb7ghKA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.0.tgz",
+					"integrity": "sha512-vJj2hPbxxLUWJEV86iZiac5curAnC3ZVc+rFmFeWZigUOcuCPpbF+KxoEmxrkmuCGylHFF9t4lkpcDUcxnhQ5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-regex": "^7.8.0",
+						"regexpu-core": "^4.6.0"
+					}
+				},
+				"@babel/helper-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.0.tgz",
+					"integrity": "sha512-haD8fRsPtyFZkbtxBIaGBBHRtbn0YsyecdYrxNgO0Bl6SlGokJPQX9M2tDuVbeQBYHZVLUPMSwGQn4obHevsMQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-new-target": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.0.tgz",
+			"integrity": "sha512-hH1Afz9Xy/wkcxhoI0vYw48kTBJqYUhMmhp3SLI1p817iByM6ItH4LS8tZatDAIKmAQAXj8d3Ups1BgVJECDrA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-object-super": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.0.tgz",
+			"integrity": "sha512-2DYqQ811nRlFVlni6iqfxBVVGqkBgfvEv/lcvmdNu2CaG+EA7zSP1hqYUsqamR+uCdDbsrV7uY6/0rkXbJo5YQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/helper-replace-supers": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.0.tgz",
+			"integrity": "sha512-9R2yykk7H92rntETO0fq52vJ4OFaTcDA49K9s8bQPyoD4o3/SkWEklukArCsQC6fowEuraPkH/umopr9uO539g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-call-delegate": "^7.8.0",
+				"@babel/helper-get-function-arity": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-property-literals": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.0.tgz",
+			"integrity": "sha512-vjZaQlojnZIahu5ofEW+hPJfDI5A6r2Sbi5C0RuCaAOFj7viDIR5kOR7ul3Fz5US8V1sVk5Zd2yuPaz7iBeysg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-react-constant-elements": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.8.0.tgz",
+			"integrity": "sha512-Rv1xUzuQK1tC66/4FxaG750bDr/Nv5AiSBmIwAK4bhksGUsl8XHPznASFchvsM7JMjI50gZvXMKmDJiKbyAfLw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.0.tgz",
+					"integrity": "sha512-WWj+1amBdowU2g18p3/KUc1Y5kWnaNm1paohq2tT4/RreeMNssYkv6ul9wkE2iIqjwLBwNMZGH4pTGlMSUqMMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-react-display-name": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.8.0.tgz",
+			"integrity": "sha512-oozdOhU2hZ6Tb9LS9BceGqDSmiUrlZX8lmRqnxQuiGzqWlhflIRQ1oFBHdV+hv+Zi9e5BhRkfSYtMLRLEkuOVA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-react-jsx": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.8.0.tgz",
+			"integrity": "sha512-r5DgP2ZblaGmW/azRS9rlaf3oY4r/ByXRDA5Lcr3iHUkx3cCfL9RM10gU7AQmzwKymoq8LZ55sHyq9VeQFHwyQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-builder-react-jsx": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-jsx": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-react-jsx-self": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.8.0.tgz",
+			"integrity": "sha512-hJXfJdLDDlJoxW/rAjkuIpGUUTizQ6fN9tIciW1M8KIqFsmpEf9psBPNTXYRCOLYLEsra+/WgVq+sc+1z05nQw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-jsx": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-react-jsx-source": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.8.0.tgz",
+			"integrity": "sha512-W+0VXOhMRdUTL7brjKXND+BiXbsxczfMdZongQ/Jtti0JVMtcTxWo66NMxNNtbPYvbc4aUXmgjl3eMms41sYtg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-jsx": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-regenerator": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.0.tgz",
+			"integrity": "sha512-n88GT8PZuOHWxqxCJORW3g1QaYzQhHu5sEslxYeQkHVoewfnfuWN37t7YGaRLaNUdaZUlRPXhDcLGT7zBa/u0g==",
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "^0.14.0"
+			}
+		},
+		"@babel/plugin-transform-reserved-words": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.0.tgz",
+			"integrity": "sha512-DnshRyDTXZhmAgO2c1QKZI4CfZjoP2t3fSwRsnbCP9P/FSBpf9I7ovnAELswklw5OeY+/D/JIiaGLoUt2II3LA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.0.tgz",
+			"integrity": "sha512-sExhzq63Gl2PMbl7ETpN7Z1A38rLD6GeCT6EEEIIKjTVt9u6dRqJ6nHhaquL7QgR3egj/8fcvq23UvzfPqGAYA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-spread": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.0.tgz",
+			"integrity": "sha512-6Zjl0pv6x10YmFVRI0VhwJ/rE++geVHNJ9xwd+UIt3ON2VMRO7qI2lPsyLnzidR5HYNd/JXj47kdU9Rrn4YcnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-sticky-regex": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.0.tgz",
+			"integrity": "sha512-uksok0Bqox8YeIRFhr6RRtlBXeGpN1ogiEVjEd7A7rVLPZBXKGbL7kODpE7MQ+avjDLv5EEKtDCeYuWZK7FF7g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/helper-regex": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.0.tgz",
+					"integrity": "sha512-haD8fRsPtyFZkbtxBIaGBBHRtbn0YsyecdYrxNgO0Bl6SlGokJPQX9M2tDuVbeQBYHZVLUPMSwGQn4obHevsMQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-template-literals": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.0.tgz",
+			"integrity": "sha512-EF7Q7LEgeMpogHcvmHMNXBWdLWG1tpA1ErXH3i8zTu3+UEKo6aBn+FldPAJ16UbbbOwSCUCiDP6oZxvVRPhwnQ==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-annotate-as-pure": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.0.tgz",
+					"integrity": "sha512-WWj+1amBdowU2g18p3/KUc1Y5kWnaNm1paohq2tT4/RreeMNssYkv6ul9wkE2iIqjwLBwNMZGH4pTGlMSUqMMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
+			}
+		},
+		"@babel/plugin-transform-typeof-symbol": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.0.tgz",
+			"integrity": "sha512-rEUBEFzsA9mCS2r7EtXFlM/6GqtzgLdC4WVYM9fIgJX+HcSJ8oMmj8LinfKhbo0ipRauvUM2teE2iNDNqDwO1g==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.8.0.tgz",
+			"integrity": "sha512-RhMZnNWcyvX+rM6mk888MaeoVl5pGfmYP3as709n4+0d15SRedz4r+LPRg2a9s4z+t+DM+gy8uz/rmM3Cb8JBw==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-syntax-typescript": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/plugin-transform-unicode-regex": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.0.tgz",
+			"integrity": "sha512-qDg8wsnE47B/Sj8ZtOndPHrGBxJMssZJ71SzXrItum9n++iVFN7kYuJO+OHhjom7+/or0zzYqvJNzCkUjyNKqg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-create-regexp-features-plugin": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.0.tgz",
+					"integrity": "sha512-vJj2hPbxxLUWJEV86iZiac5curAnC3ZVc+rFmFeWZigUOcuCPpbF+KxoEmxrkmuCGylHFF9t4lkpcDUcxnhQ5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-regex": "^7.8.0",
+						"regexpu-core": "^4.6.0"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.0.tgz",
+					"integrity": "sha512-haD8fRsPtyFZkbtxBIaGBBHRtbn0YsyecdYrxNgO0Bl6SlGokJPQX9M2tDuVbeQBYHZVLUPMSwGQn4obHevsMQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				}
+			}
+		},
 		"@babel/polyfill": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.6.0.tgz",
@@ -327,6 +2579,378 @@
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
+			}
+		},
+		"@babel/preset-env": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.2.tgz",
+			"integrity": "sha512-AF2YUl2bGsLWTtFL68upTTB7nDo05aEcKjHmXJE+aXRvsx5K+9yRsHQP3MjnTrLOWe/eFyUr93dfILROsKC4eg==",
+			"dev": true,
+			"requires": {
+				"@babel/compat-data": "^7.8.0",
+				"@babel/helper-compilation-targets": "^7.8.0",
+				"@babel/helper-module-imports": "^7.8.0",
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-proposal-async-generator-functions": "^7.8.0",
+				"@babel/plugin-proposal-dynamic-import": "^7.8.0",
+				"@babel/plugin-proposal-json-strings": "^7.8.0",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-proposal-object-rest-spread": "^7.8.0",
+				"@babel/plugin-proposal-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-proposal-optional-chaining": "^7.8.0",
+				"@babel/plugin-proposal-unicode-property-regex": "^7.8.0",
+				"@babel/plugin-syntax-async-generators": "^7.8.0",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.0",
+				"@babel/plugin-syntax-json-strings": "^7.8.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.0",
+				"@babel/plugin-syntax-top-level-await": "^7.8.0",
+				"@babel/plugin-transform-arrow-functions": "^7.8.0",
+				"@babel/plugin-transform-async-to-generator": "^7.8.0",
+				"@babel/plugin-transform-block-scoped-functions": "^7.8.0",
+				"@babel/plugin-transform-block-scoping": "^7.8.0",
+				"@babel/plugin-transform-classes": "^7.8.0",
+				"@babel/plugin-transform-computed-properties": "^7.8.0",
+				"@babel/plugin-transform-destructuring": "^7.8.0",
+				"@babel/plugin-transform-dotall-regex": "^7.8.0",
+				"@babel/plugin-transform-duplicate-keys": "^7.8.0",
+				"@babel/plugin-transform-exponentiation-operator": "^7.8.0",
+				"@babel/plugin-transform-for-of": "^7.8.0",
+				"@babel/plugin-transform-function-name": "^7.8.0",
+				"@babel/plugin-transform-literals": "^7.8.0",
+				"@babel/plugin-transform-member-expression-literals": "^7.8.0",
+				"@babel/plugin-transform-modules-amd": "^7.8.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.8.0",
+				"@babel/plugin-transform-modules-systemjs": "^7.8.0",
+				"@babel/plugin-transform-modules-umd": "^7.8.0",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.8.0",
+				"@babel/plugin-transform-new-target": "^7.8.0",
+				"@babel/plugin-transform-object-super": "^7.8.0",
+				"@babel/plugin-transform-parameters": "^7.8.0",
+				"@babel/plugin-transform-property-literals": "^7.8.0",
+				"@babel/plugin-transform-regenerator": "^7.8.0",
+				"@babel/plugin-transform-reserved-words": "^7.8.0",
+				"@babel/plugin-transform-shorthand-properties": "^7.8.0",
+				"@babel/plugin-transform-spread": "^7.8.0",
+				"@babel/plugin-transform-sticky-regex": "^7.8.0",
+				"@babel/plugin-transform-template-literals": "^7.8.0",
+				"@babel/plugin-transform-typeof-symbol": "^7.8.0",
+				"@babel/plugin-transform-unicode-regex": "^7.8.0",
+				"@babel/types": "^7.8.0",
+				"browserslist": "^4.8.2",
+				"core-js-compat": "^3.6.2",
+				"invariant": "^2.2.2",
+				"levenary": "^1.1.0",
+				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.0.tgz",
+					"integrity": "sha512-AN2IR/wCUYsM+PdErq6Bp3RFTXl8W0p9Nmymm7zkpsCmh+r/YYcckaCGpU8Q/mEKmST19kkGRaG42A/jxOWwBA==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.8.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.0.tgz",
+					"integrity": "sha512-2Lp2e02CV2C7j/H4n4D9YvsvdhPVVg9GDIamr6Tu4tU35mL3mzOrzl1lZ8ZJtysfZXh+y+AGORc2rPS7yHxBUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.0.tgz",
+					"integrity": "sha512-WWj+1amBdowU2g18p3/KUc1Y5kWnaNm1paohq2tT4/RreeMNssYkv6ul9wkE2iIqjwLBwNMZGH4pTGlMSUqMMg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-create-regexp-features-plugin": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.0.tgz",
+					"integrity": "sha512-vJj2hPbxxLUWJEV86iZiac5curAnC3ZVc+rFmFeWZigUOcuCPpbF+KxoEmxrkmuCGylHFF9t4lkpcDUcxnhQ5g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-regex": "^7.8.0",
+						"regexpu-core": "^4.6.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.0.tgz",
+					"integrity": "sha512-x9psucuU0Xalw+0Vpr2FYJMLB7/KnPSLZhlkUyOGbYAWRDfmtZBrguYpJYiaNCRV7vGkYjO/gF6/J6yMvdWTDw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.0.tgz",
+					"integrity": "sha512-eUP5grliToMapQiTaYS2AAO/WwaCG7cuJztR1v/a1aPzUzUeGt+AaI9OvLATc/AfFkF8SLJ10d5ugGt/AQ9d6w==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.0.tgz",
+					"integrity": "sha512-ylY9J6ZxEcjmJaJ4P6aVs/fZdrZVctCGnxxfYXwCnSMapqd544zT8lWK2qI/vBPjE5gS0o2jILnH+AkpsPauEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.0.tgz",
+					"integrity": "sha512-fvGhX4FY7YwRdWW/zfddNaKpYl8TaA8hvwONIYhv1/a1ZbgxbTrjsmH6IGWUgUNki7QzbpZ27OEh88sZdft3YA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.8.0",
+						"@babel/helper-simple-access": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				},
+				"@babel/helper-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.8.0.tgz",
+					"integrity": "sha512-haD8fRsPtyFZkbtxBIaGBBHRtbn0YsyecdYrxNgO0Bl6SlGokJPQX9M2tDuVbeQBYHZVLUPMSwGQn4obHevsMQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/helper-remap-async-to-generator": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.0.tgz",
+					"integrity": "sha512-+aKyBd4oHAaIZgOLq/uLjkUz7ExZ0ppdNBc8Qr72BmtKNAy3A6EJa/ifjj0//CIzQtUDPs3E6HjKM2cV6bnXsQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-annotate-as-pure": "^7.8.0",
+						"@babel/helper-wrap-function": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/traverse": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.0.tgz",
+					"integrity": "sha512-I+7yKZJnxp7VIC2UFzXfVjLiJuU16rYFF59x27c+boINkO/pLETgZcoesCryg9jmU4jxEa0foFueW+2wjc9Gsw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.0.tgz",
+					"integrity": "sha512-YhYFhH4T6DlbT6CPtVgLfC1Jp2gbCawU/ml7WJvUpBg01bCrXSzTYMZZXbbIGjq/kHmK8YUATxTppcRGzj31pA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/helper-wrap-function": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.0.tgz",
+					"integrity": "sha512-2j6idN2jt8Y+8nJ4UPN/6AZa53DAkcETMVmroJQh50qZc59PuQKVjgOIIqmrLoQf6Ia9bs90MHRcID1OW5tfag==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/template": "^7.8.0",
+						"@babel/traverse": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.0.tgz",
+					"integrity": "sha512-OsdTJbHlPtIk2mmtwXItYrdmalJ8T0zpVzNAbKSkHshuywj7zb29Y09McV/jQsQunc/nEyHiPV2oy9llYMLqxw==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.0.tgz",
+					"integrity": "sha512-VVtsnUYbd1+2A2vOVhm4P2qNXQE8L/W859GpUHfUcdhX8d3pEKThZuIr6fztocWx9HbK+00/CR0tXnhAggJ4CA==",
+					"dev": true
+				},
+				"@babel/plugin-proposal-async-generator-functions": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.0.tgz",
+					"integrity": "sha512-8vIQf8JYced7gCeKDsGETNGKE+zdD/JmP1LBlRn+w3UXc1aSpZv2Y330bB/fnOEbUgPbuFv+IEi+gopg+Fu0kQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0",
+						"@babel/helper-remap-async-to-generator": "^7.8.0",
+						"@babel/plugin-syntax-async-generators": "^7.8.0"
+					}
+				},
+				"@babel/plugin-proposal-dynamic-import": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.0.tgz",
+					"integrity": "sha512-YzMq0AqeTR4Mh2pz3GrCWqhcEV38HgUMMR/56/YR5GPc4Y2p1KJ4Le6j92vMnW8TJqVj+qJz/KDNglpMeww9Yg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0",
+						"@babel/plugin-syntax-dynamic-import": "^7.8.0"
+					}
+				},
+				"@babel/plugin-proposal-optional-catch-binding": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.0.tgz",
+					"integrity": "sha512-tHP3eez6TrpPJYttBZ/6uItRbIuXUIDpQ9xwvzKwR+RboWGMJ7WzFC5dDJ3vjLuCx0/DG1tM0MVkmgcBybth9w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+					}
+				},
+				"@babel/plugin-syntax-async-generators": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.0.tgz",
+					"integrity": "sha512-a8w8k7pK8nYhem07rXdAq03T+DlTX8LFojUptrh9JEx80AgLqGiuoFIyQOGTWif39kFnDOQqbzl1s6KQqrfV+A==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0"
+					}
+				},
+				"@babel/plugin-syntax-dynamic-import": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.0.tgz",
+					"integrity": "sha512-Mx2RzpCHJaBfmFdA2abXDKRHVJdzJ6R0Wqwb6TxCgM7NRR5wcC4cyiAsRL7Ga+lwG8GG1cKvb+4ENjic8y15jA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0"
+					}
+				},
+				"@babel/plugin-syntax-optional-catch-binding": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.0.tgz",
+					"integrity": "sha512-EIgJVy+u1RvR2gJfX4ReLwAupO/twllUue1wPrRxhu18+eC3bGTEcOSXLQdaE9ya9NG1rE0eQs0GSiloUGFEwg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.8.0"
+					}
+				},
+				"@babel/plugin-transform-dotall-regex": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.0.tgz",
+					"integrity": "sha512-pq/XLkDB4MPvTe9ktHJInfWksalXogrIGRZJUG7RiDXhEfdNrlducoMPbACZQuCFtelVgVpD0VyreiY0l38G7g==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-create-regexp-features-plugin": "^7.8.0",
+						"@babel/helper-plugin-utils": "^7.8.0"
+					}
+				},
+				"@babel/plugin-transform-modules-commonjs": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.0.tgz",
+					"integrity": "sha512-w2g8tmL7NgBYt6alc8YawMcmPiYqnVvvI0kLB++VOUOssqdJMAkfQOMGV+2M8H5uhJYDaAghAVMUYps3s+jMrw==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-transforms": "^7.8.0",
+						"@babel/helper-plugin-utils": "^7.8.0",
+						"@babel/helper-simple-access": "^7.8.0",
+						"babel-plugin-dynamic-import-node": "^2.3.0"
+					}
+				},
+				"@babel/template": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.0.tgz",
+					"integrity": "sha512-0NNMDsY2t3ltAVVK1WHNiaePo3tXPUeJpCX4I3xSKFoEl852wJHG8mrgHVADf8Lz1y+8al9cF7cSSfzSnFSYiw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.0.tgz",
+					"integrity": "sha512-d/6sPXFLGlJHZO/zWDtgFaKyalCOHLedzxpVJn6el1cw+f2TZa7xZEszeXdOw6EUemqRFBAn106BWBvtSck9Qw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.8.0",
+						"@babel/generator": "^7.8.0",
+						"@babel/helper-function-name": "^7.8.0",
+						"@babel/helper-split-export-declaration": "^7.8.0",
+						"@babel/parser": "^7.8.0",
+						"@babel/types": "^7.8.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.0.tgz",
+					"integrity": "sha512-1RF84ehyx9HH09dMMwGWl3UTWlVoCPtqqJPjGuC4JzMe1ZIVDJ2DT8mv3cPv/A7veLD6sgR7vi95lJqm+ZayIg==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/preset-react": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.8.0.tgz",
+			"integrity": "sha512-GP9t18RjtH67ea3DA2k71VqtMnTOupYJx34Z+KUEBRoRxvdETaucmtMWH5uoGHWzAD4qxbuV5ckxpewm39NXkA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.0",
+				"@babel/plugin-transform-react-display-name": "^7.8.0",
+				"@babel/plugin-transform-react-jsx": "^7.8.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.8.0",
+				"@babel/plugin-transform-react-jsx-source": "^7.8.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.8.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.0.tgz",
+					"integrity": "sha512-+hAlRGdf8fHQAyNnDBqTHQhwdLURLdrCROoWaEQYiQhk2sV9Rhs+GoFZZfMJExTq9HG8o2NX3uN2G90bFtmFdA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/runtime": {
@@ -416,6 +3040,12 @@
 				"arrify": "^1.0.1"
 			}
 		},
+		"@iarna/toml": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.3.tgz",
+			"integrity": "sha512-FmuxfCuolpLl0AnQ2NHSzoUKWEJDFl63qXjzdoWBVyFCXzMGm1spBzk7LeHNoVCiWCF7mRVms9e6jEV9+MoPbg==",
+			"dev": true
+		},
 		"@mrmlnc/readdir-enhanced": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -452,6 +3082,3100 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@parcel/babel-preset-env": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/babel-preset-env/-/babel-preset-env-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-OXxuA+B113MDWMuOrsIbMBZOZ3uVs+jHseNYae6MT34Op63wistpP9Xlzv8DBChgbZyPS7bPpYYyf8ZK5Da0LA==",
+			"dev": true,
+			"requires": {
+				"@babel/preset-env": "^7.0.0",
+				"semver": "^5.4.1"
+			}
+		},
+		"@parcel/bundler-default": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-p21dHAEn5ewFZ6ZhDL8faKnBobrPVO/3O/uo4yxedQp4Lmf7pVGAo6C9rZEM2HB7pJjCeQBmLVsGdFn0mMZT8w==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/cache": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-KI+mj/YEFxZyCCTcUoyXrS4nEI0CD/HvaayuNt/5QuAZmkJ3iDw0vo5nS8xC9VGL94cZZHG4qZWDigQvHI5vZQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/logger": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/codeframe": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-Y7orGAw9qvrH86RBxpSuidIfR13uqoH/RoeBr3vq4CIYFW6K6JunEWTGAstV5hpuY6pzk7mv2xxhNCUkIYBIFg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2",
+				"emphasize": "^2.1.0"
+			}
+		},
+		"@parcel/config-default": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-tQfvLIzAuASnyoUX0cD2jBr8bcpsZMeFCeZWAWu715b9dHmZ3FHlD6tzsV18O6V+7lMCqJfLDg3vPBGvDA79mA==",
+			"dev": true,
+			"requires": {
+				"@parcel/bundler-default": "^2.0.0-alpha.3.1",
+				"@parcel/namer-default": "^2.0.0-alpha.3.1",
+				"@parcel/optimizer-cssnano": "^2.0.0-alpha.3.1",
+				"@parcel/optimizer-data-url": "^2.0.0-alpha.3.1",
+				"@parcel/optimizer-htmlnano": "^2.0.0-alpha.3.1",
+				"@parcel/optimizer-terser": "^2.0.0-alpha.3.1",
+				"@parcel/packager-css": "^2.0.0-alpha.3.1",
+				"@parcel/packager-html": "^2.0.0-alpha.3.1",
+				"@parcel/packager-js": "^2.0.0-alpha.3.1",
+				"@parcel/packager-raw": "^2.0.0-alpha.3.1",
+				"@parcel/packager-ts": "^2.0.0-alpha.3.1",
+				"@parcel/reporter-cli": "^2.0.0-alpha.3.1",
+				"@parcel/reporter-dev-server": "^2.0.0-alpha.3.1",
+				"@parcel/reporter-hmr-server": "^2.0.0-alpha.3.1",
+				"@parcel/resolver-default": "^2.0.0-alpha.3.1",
+				"@parcel/runtime-browser-hmr": "^2.0.0-alpha.3.1",
+				"@parcel/runtime-js": "^2.0.0-alpha.3.1",
+				"@parcel/runtime-react-refresh": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-babel": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-coffeescript": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-css": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-graphql": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-html": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-inline-string": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-js": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-json": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-less": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-postcss": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-posthtml": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-pug": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-raw": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-react-refresh-babel": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-react-refresh-wrap": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-sass": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-stylus": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-sugarss": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-toml": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-typescript-types": "^2.0.0-alpha.3.1",
+				"@parcel/transformer-yaml": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/core": {
+			"version": "2.0.0-alpha.3.2",
+			"resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.0.0-alpha.3.2.tgz",
+			"integrity": "sha512-Nnr4GOmx0mzUhSLu6MvBpPJDA3YhgWPDwpw1uH/80vRXqLYrX1sZCnOYjGGhoWi7VrYjoHVak+FZLrZrhUlGmw==",
+			"dev": true,
+			"requires": {
+				"@parcel/cache": "^2.0.0-alpha.3.1",
+				"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+				"@parcel/events": "^2.0.0-alpha.3.1",
+				"@parcel/fs": "^2.0.0-alpha.3.1",
+				"@parcel/logger": "^2.0.0-alpha.3.1",
+				"@parcel/package-manager": "^2.0.0-alpha.3.1",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/types": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"@parcel/workers": "^2.0.0-alpha.3.1",
+				"abortcontroller-polyfill": "^1.1.9",
+				"browserslist": "^4.6.6",
+				"clone": "^2.1.1",
+				"dotenv": "^7.0.0",
+				"dotenv-expand": "^5.1.0",
+				"json5": "^1.0.1",
+				"micromatch": "^4.0.2",
+				"nullthrows": "^1.1.1",
+				"pirates": "^4.0.0",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/fs": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-DHXGRX/D9F2RgKecN6Fh7KmqLWD+IQxEraURF4hxw/QCfdQiUaobPS65I3VG7GLRhTeEXMjDibPF5902FJiQuQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"@parcel/watcher": "^2.0.0-alpha.4",
+						"@parcel/workers": "^2.0.0-alpha.3.1",
+						"mkdirp": "^0.5.1",
+						"ncp": "^2.0.0",
+						"nullthrows": "^1.1.1",
+						"rimraf": "^2.6.2"
+					}
+				},
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"@parcel/watcher": {
+					"version": "2.0.0-alpha.4",
+					"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.4.tgz",
+					"integrity": "sha512-J8Detm6Yeh27lNVr02/bTxqQ5dAs040C9OB1Zs7C4kaDCq/Dx7FVph0aRKDhAiZ0BiSBwgZEh7xmD4ZU844kxA==",
+					"dev": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"node-addon-api": "^1.6.2",
+						"prebuild-install": "^5.2.5"
+					}
+				},
+				"@parcel/workers": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-XJqRQ5sCFoDFsCupJcUugTOp2RCtrlDuuwyDj9z3migsZ7tDxGhch/ewOy8qePk++aBEIgsNvn0hiERQHK5/0g==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"chrome-trace-event": "^1.0.2",
+						"nullthrows": "^1.1.1",
+						"physical-cpu-count": "^2.0.0"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"dotenv": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+					"integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/diagnostic": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-45kRMFXFu5LZm77dJ8SJdPF4RdpP+zCBC2Q/ebXWvbgLKJOyapAtnFFvdwCS4xfbvL2xOrC4gEsP0SCvZTVKWQ==",
+			"dev": true,
+			"requires": {
+				"json-source-map": "^0.6.1",
+				"nullthrows": "^1.1.1"
+			}
+		},
+		"@parcel/events": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-s3f54ppFRTxHNZ4cMaqJBf6qYWHEI/Jo6pD//4XU3VTMLyUC9pAj+rEVx7vZi7fAye7FKC5aLsrvFp4dby/pTA==",
+			"dev": true
+		},
+		"@parcel/markdown-ansi": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-e88oynbkLr/l8mbANhtlxwfTFV0O7QZrKz9g+WTWOdouJZz/vEYb1Au4BjdyMiT+H0WXtlFSAJC6XzIaMeZxZA==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.2"
+			}
+		},
+		"@parcel/namer-default": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-w3zB+pvdWSa+an3sYLE74+b2Es1JSX+lcUFM2I0fL996GL0EZiu4teYiN0Bet0sxBlTJdrrnxhIAEGzVtA9B+w==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1"
+			}
+		},
+		"@parcel/optimizer-cssnano": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-cssnano/-/optimizer-cssnano-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-t/rBVgOt6wJ6jd0C7+D0zXcUWSHMPh3YnvcM516INtZJ7t/RrQZM5Z9+hUvD8u1nEDzAKqblLvgAn2q7enNP9g==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"cssnano": "^4.1.10",
+				"postcss": "^7.0.5"
+			}
+		},
+		"@parcel/optimizer-data-url": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-data-url/-/optimizer-data-url-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-1PXp/kjRELe8ie7DHYz3QDDTumaJs3a8WFb3DzYM87VdgB23YEXvoaFgtM04QW17zF8rnH2PqT6HnPeJcYe3bg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"isbinaryfile": "^4.0.2",
+				"mime": "^2.4.4"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"mime": {
+					"version": "2.4.4",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+					"dev": true
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/optimizer-htmlnano": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-Qpw+KLlVhfi/F5DX5mCpYTjJ9vvVrGUSjM+TG6rOcpkPjZnE/7zYtck5Z9IHc78/dUjwFthMQR9R3dBi6aCqOA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"htmlnano": "^0.2.2",
+				"nullthrows": "^1.1.1",
+				"posthtml": "^0.11.3"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/optimizer-terser": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-gNs2ubWubwsARLYexqztYzw6xwvDUzD4HHkIEAg3WIVUSXyBeaaZXiCzBM2wjzLh14WXFc6BmlHSlqeFBNCe/g==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1",
+				"terser": "^4.0.0"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					},
+					"dependencies": {
+						"terser": {
+							"version": "3.17.0",
+							"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+							"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+							"dev": true,
+							"requires": {
+								"commander": "^2.19.0",
+								"source-map": "~0.6.1",
+								"source-map-support": "~0.5.10"
+							}
+						}
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				}
+			}
+		},
+		"@parcel/package-manager": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-5rU0A7cMoNpiZx3fJh9cL+eDqOe5jlSBrFuEp864ZcKTkCoiyysZPza0Hmm368Q0nclcm9ueaR/Dgm2WXgVK7g==",
+			"dev": true,
+			"requires": {
+				"@parcel/fs": "^2.0.0-alpha.3.1",
+				"@parcel/logger": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"@parcel/workers": "^2.0.0-alpha.3.1",
+				"command-exists": "^1.2.6",
+				"cross-spawn": "^6.0.4",
+				"nullthrows": "^1.1.1",
+				"resolve": "^1.12.0",
+				"split2": "^3.1.1"
+			},
+			"dependencies": {
+				"@parcel/fs": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-DHXGRX/D9F2RgKecN6Fh7KmqLWD+IQxEraURF4hxw/QCfdQiUaobPS65I3VG7GLRhTeEXMjDibPF5902FJiQuQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"@parcel/watcher": "^2.0.0-alpha.4",
+						"@parcel/workers": "^2.0.0-alpha.3.1",
+						"mkdirp": "^0.5.1",
+						"ncp": "^2.0.0",
+						"nullthrows": "^1.1.1",
+						"rimraf": "^2.6.2"
+					}
+				},
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"@parcel/watcher": {
+					"version": "2.0.0-alpha.4",
+					"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.4.tgz",
+					"integrity": "sha512-J8Detm6Yeh27lNVr02/bTxqQ5dAs040C9OB1Zs7C4kaDCq/Dx7FVph0aRKDhAiZ0BiSBwgZEh7xmD4ZU844kxA==",
+					"dev": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"node-addon-api": "^1.6.2",
+						"prebuild-install": "^5.2.5"
+					}
+				},
+				"@parcel/workers": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-XJqRQ5sCFoDFsCupJcUugTOp2RCtrlDuuwyDj9z3migsZ7tDxGhch/ewOy8qePk++aBEIgsNvn0hiERQHK5/0g==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"chrome-trace-event": "^1.0.2",
+						"nullthrows": "^1.1.1",
+						"physical-cpu-count": "^2.0.0"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "6.0.5",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"dev": true,
+					"requires": {
+						"nice-try": "^1.0.4",
+						"path-key": "^2.0.1",
+						"semver": "^5.5.0",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
+					}
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/packager-css": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-IvQ8PBC0fPlHvc0SM1BINqNwMqoYS3/yeuxTs0DJ+gnEmbcSwOsxhJT7LoAOne3LUjGjOVmvmHXpItCmqXciiQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/packager-html": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-tpM20z1OUp1J9q8u+aJb61f622vI4J+nGNhVYN6hUQpZLYHWbPYvgms36MCr7uSQrhUZSDmdWCSEKeyHGy0Ltg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/types": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1",
+				"posthtml": "^0.11.3"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/packager-js": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-NpsSXFMV37lklq1m+YOnz2x066ePpJ7mibeDm8zev3cF7Gev0AH8f9zUChV2lMBNdRUnPTKz4ZVNnyDXt4KhIA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/scope-hoisting": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/packager-raw": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-TGyXie5wiwYr4nYqqH606gGmf60/ch3f3MxkCktpaAdKxZLs4ku7io1MUQlg6y7ft7AuCO8+5CNw+A0m37uDyw==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/packager-ts": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-tasZk+79dfwiHdgIec6XWiiDM0+Bc1sndtAcplvzbPbFkgViZZZjGu3103uC/giUbCZd+P8mwgt4I+aFjc1yDA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/plugin": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-Wbo4dXtVRZXP1S9Scii46fE6MeHvZjw6eS7/WLhiapvsthWjXQlljLfbjA5ih+6poQv7jgJLUlwZDPxKcHmH8Q==",
+			"dev": true,
+			"requires": {
+				"@parcel/types": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/reporter-cli": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-pdqlksBEuL6FPa+q5Y9jcQH2csxWUNzf8NDK42RnGNRPWnXfJHviErrvCidscaCbFWlgO/LOjyFQ0QxrqbBtjA==",
+			"dev": true,
+			"requires": {
+				"@parcel/events": "^2.0.0-alpha.3.1",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/types": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"cli-spinners": "^2.0.0",
+				"filesize": "^3.6.0",
+				"grapheme-breaker": "^0.3.2",
+				"ink": "^2.1.1",
+				"ink-spinner": "^3.0.1",
+				"nullthrows": "^1.1.1",
+				"react": "^16.7.0"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/reporter-dev-server": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-orZD40KB6aMqBGaX4TibICMeSgGsGsMUnOMjPAGUlYpW3Z50cu4H/bPcJELVsOQTcRsEnW+f4SX7e1qNUM2+oQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"connect": "^3.7.0",
+				"ejs": "^2.6.1",
+				"http-proxy-middleware": "^0.19.1",
+				"mime": "^2.4.4"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"mime": {
+					"version": "2.4.4",
+					"resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+					"integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+					"dev": true
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/reporter-hmr-server": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/reporter-hmr-server/-/reporter-hmr-server-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-14JfRPwIOo5viexaZwJqNbrtW6ZC4abmcA6bnTdAPkQQkIuaR01vxyToCU2ZZp9m+grg/9KXBukyC9HIQuqd4A==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/reporter-cli": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"ws": "^6.2.0"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
+		"@parcel/resolver-default": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-/m/PicKKalGyYuUh6kgornk6X59gZNtNYPrjFhW2LVlr0+UxrK/QmreI/6GoIrrOfoIQCmz9e9tM2Yh/M22wjg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"micromatch": "^3.0.4",
+				"node-libs-browser": "^2.1.0"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					},
+					"dependencies": {
+						"micromatch": {
+							"version": "4.0.2",
+							"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+							"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+							"dev": true,
+							"requires": {
+								"braces": "^3.0.1",
+								"picomatch": "^2.0.5"
+							}
+						}
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					},
+					"dependencies": {
+						"braces": {
+							"version": "2.3.2",
+							"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+							"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+							"dev": true,
+							"requires": {
+								"arr-flatten": "^1.1.0",
+								"array-unique": "^0.3.2",
+								"extend-shallow": "^2.0.1",
+								"fill-range": "^4.0.0",
+								"isobject": "^3.0.1",
+								"repeat-element": "^1.1.2",
+								"snapdragon": "^0.8.1",
+								"snapdragon-node": "^2.0.1",
+								"split-string": "^3.0.2",
+								"to-regex": "^3.0.1"
+							},
+							"dependencies": {
+								"extend-shallow": {
+									"version": "2.0.1",
+									"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+									"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+									"dev": true,
+									"requires": {
+										"is-extendable": "^0.1.0"
+									}
+								}
+							}
+						}
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
+		"@parcel/runtime-browser-hmr": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-NPmxw+nLnx1boTwJdPMXYXYumb8GXk423Xo2uZaf7VL95gr+CZf7nod1kDn2XEQYgWDFCrNKR5BqcoSX32fnYw==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/runtime-js": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-Q2v2auDNEiLs5Vmdv3u4lBgN+PrpvbAUzi6U1SG65UhDIUWL1Z1qumBctwXV92PoQoi3wwzR1BtV/ErN3cJoJQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/runtime-react-refresh": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-ZT5s/laZSSEjCywiXBxuRzMluWpk8k/gjk3wx0FHYK6Win2Lbi/ViKuOAM4qmNKKSMUZUJPQKfdNMc+Jv3miOg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"react-refresh": "^0.6.0"
+			}
+		},
+		"@parcel/scope-hoisting": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/scope-hoisting/-/scope-hoisting-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-GFdBGxUNDLQcQ+jAm+hp+Zn9faxvfY7qnmd3pCAHGgn6MHC8THJ8VSM0E6MobG8G5Qi6iYU0y+YvQ6rjrNiulw==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.3.3",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.2.2",
+				"@babel/traverse": "^7.2.3",
+				"@babel/types": "^7.3.3",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"babylon-walk": "^1.0.2",
+				"nullthrows": "^1.1.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/source-map": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-3aL1UwzeJUKryXKvUkSiiVGd2vS6tjqInbQTundEmoOY103uzE4Pyg3RiSRzAFbz+H7CJHnhz/aQdaykGO9IJg==",
+			"dev": true,
+			"requires": {
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1",
+				"source-map": "^0.7.3"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"source-map": {
+					"version": "0.7.3",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+					"integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+					"dev": true
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				}
+			}
+		},
+		"@parcel/transformer-babel": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-9NM6huhWNz9i2G32WiP0hzrrUbiLbMDiOnjeTXe+++F0b+WFLvSa7F0AWPcolrElGZoRjXj3tieHgF01gqiZNA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/plugin-transform-flow-strip-types": "^7.0.0",
+				"@babel/plugin-transform-react-jsx": "^7.0.0",
+				"@babel/plugin-transform-typescript": "^7.4.5",
+				"@babel/preset-env": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@parcel/babel-preset-env": "^2.0.0-alpha.3.1",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"browserslist": "^4.6.6",
+				"core-js": "^3.2.1",
+				"nullthrows": "^1.1.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"core-js": {
+					"version": "3.6.3",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.3.tgz",
+					"integrity": "sha512-DOO9b18YHR+Wk5kJ/c5YFbXuUETreD4TrvXb6edzqZE3aAEd0eJIAWghZ9HttMuiON8SVCnU3fqA4rPxRDD1HQ==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-coffeescript": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-coffeescript/-/transformer-coffeescript-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-S6hUsEeeztojZk4Rj7tuWHdOwY7zDWqxF22A3GiRkuDmqC1rGtnZ2snfYiCnC4UAoqB69QkaFpZBdpNltxwz3g==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"coffeescript": "^2.0.3",
+				"nullthrows": "^1.1.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-css": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-oJ3N0acB0O6WQxfwI2D+yjviCm1j3YE7UDULrpqAKciiz65zTt8lMYRinXf9q+grsOcYqEUrosPFlqU5tf1whQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"postcss": "^7.0.5",
+				"postcss-value-parser": "^3.3.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"@parcel/transformer-graphql": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-graphql/-/transformer-graphql-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-E1TDgOaL3FV1FqTZ7TsSVScq98nZAjShjM0+SNdJ3Aw3dvN4REIZgzO9qcSufkefS4OOTHfrKXp/r2VhUtHjPw==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-html": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-FYDeL6iFB0+1EZpM0GTyOo/B2vCNfjEp1Y8X7OOCnuQBuVTW8fb1XI8mFa0RoSfgBx+1vIdaIILQa+qGPvHxtw==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1",
+				"posthtml": "^0.11.3",
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-inline-string": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-inline-string/-/transformer-inline-string-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-NKWm1zEcj3Qq8nna+bSjruwVIlBaNgain5wCPmSRCviFs8KCPNqu0zOiSk6135Gr9fluzGpzefD3eINwlrAyCg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-js": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-9N5p0V/c/gdvXDOMCuCAcYWLGVwjFEBQ31rw3gPNnJyQePZ4icwv2bC8tWJK4V3gynlcTek9hRRHhq69QCNGew==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.0.0",
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/plugin-transform-modules-commonjs": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/traverse": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/scope-hoisting": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"babylon-walk": "^1.0.2",
+				"node-libs-browser": "^2.0.0",
+				"nullthrows": "^1.1.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-json": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-laF4vTyxxdU9ONASbGfWHIy+FoofZMjc0yaJ52SilOdDEa+eIG/UGnetEmml8VsIJStlYH/Qhz3C2XMY2zk/UQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"json5": "^2.1.0"
+			}
+		},
+		"@parcel/transformer-less": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-less/-/transformer-less-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-nsLobEm7uy2YVMWC8hxi1J9IWniJ/UcJMdXfAMy5wQa/1acK4HFpc2xdQhT07sb88HL2qDnqvDEA6Rqs/GYNdQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-postcss": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-ZxUSCBpIXVdK+r7lT6w5nDyvsqic8xRRaM6DthXrRQVV3pQA3YzHFlCV343UY/Hn+N+2AocmG1GrZHi2EP6pyg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"css-modules-loader-core": "^1.1.0",
+				"nullthrows": "^1.1.1",
+				"postcss": "^7.0.5",
+				"postcss-value-parser": "^3.3.1",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-posthtml": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-v+MFsFY1hS8pjaIwWJDrleEmoPMWdBbzuAkcK3M1b2dVEw+dMihdFIZPccFVS+dN6h27x2N0Zg+kLUOSQczHMg==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1",
+				"posthtml": "^0.11.3",
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5",
+				"semver": "^5.4.1"
+			}
+		},
+		"@parcel/transformer-pug": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-pug/-/transformer-pug-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-xq6yqzllQuySxkdep7UF75TDIMryiRmP1+0Dksbyjx8X8hmEBbV45TKBoGqzsKkxTeAxPumT4vgqVq/3Mhfv2A==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-raw": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-Mh13nyQ+NgQLRbuikxM1NK5Qf5Kk3MaWjDyetY0N+QAtiKVhJF7fYCtRpMpo5z+zRBClq8sLHFMAn61YVZWy6w==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-react-refresh-babel": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-babel/-/transformer-react-refresh-babel-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-d6WeHpGk5zP29g/iKZ+Zf7sZq1XEA6VJ52GXDiY1uh82fVm2x4BHx+j2YBOPXhsKlyi7fBQXTUrxGP623jfZVw==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"react-refresh": "^0.6.0"
+			}
+		},
+		"@parcel/transformer-react-refresh-wrap": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-SMSuWlh2J1mZG5yhG+//sRxuf9wSF2XJfmh8FIiFPkE5KdSnngEI5vcDxUpvzEb7eo6Jjzmz0+80rfeUhOmpMg==",
+			"dev": true,
+			"requires": {
+				"@babel/generator": "^7.0.0",
+				"@babel/parser": "^7.0.0",
+				"@babel/template": "^7.0.0",
+				"@babel/types": "^7.0.0",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1",
+				"react-refresh": "^0.6.0",
+				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-sass": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-sass/-/transformer-sass-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-ZElQMiV/Fi4vWQsUNUlfuuK7t+YR7f/ISUvYmKUii5vmnskq4a6UwWqWLT5OuscPk4Zc/QeNctkI33YFAOH3XQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/fs": "^2.0.0-alpha.3.1",
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/fs": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-DHXGRX/D9F2RgKecN6Fh7KmqLWD+IQxEraURF4hxw/QCfdQiUaobPS65I3VG7GLRhTeEXMjDibPF5902FJiQuQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"@parcel/watcher": "^2.0.0-alpha.4",
+						"@parcel/workers": "^2.0.0-alpha.3.1",
+						"mkdirp": "^0.5.1",
+						"ncp": "^2.0.0",
+						"nullthrows": "^1.1.1",
+						"rimraf": "^2.6.2"
+					}
+				},
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"@parcel/watcher": {
+					"version": "2.0.0-alpha.4",
+					"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.4.tgz",
+					"integrity": "sha512-J8Detm6Yeh27lNVr02/bTxqQ5dAs040C9OB1Zs7C4kaDCq/Dx7FVph0aRKDhAiZ0BiSBwgZEh7xmD4ZU844kxA==",
+					"dev": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"node-addon-api": "^1.6.2",
+						"prebuild-install": "^5.2.5"
+					}
+				},
+				"@parcel/workers": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-XJqRQ5sCFoDFsCupJcUugTOp2RCtrlDuuwyDj9z3migsZ7tDxGhch/ewOy8qePk++aBEIgsNvn0hiERQHK5/0g==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"chrome-trace-event": "^1.0.2",
+						"nullthrows": "^1.1.1",
+						"physical-cpu-count": "^2.0.0"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-stylus": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-stylus/-/transformer-stylus-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-QYyvDESfk6KuPv5qG4M+MdBSrONLYMjbDsHkBF9pMATy3WLyFD2bfwv7eVVHwFnp/zuRnuHy7h2GU9zk//y5tA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/utils": "^2.0.0-alpha.3.1"
+			},
+			"dependencies": {
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
+		"@parcel/transformer-sugarss": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-sugarss/-/transformer-sugarss-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-E2I2pBHmALE6Bbu6/X4lfuP3a0JWeLmaJRxtWlVNjWVQwyRIKeEuuUZ70wwl9Gydhv9mBmgDuS9jyPxsCDo3dQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"postcss": "^7.0.5"
+			}
+		},
+		"@parcel/transformer-toml": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-toml/-/transformer-toml-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-hkOhaUIVvghKuo7pyU3gUYZ+8kJk+lfrIFnbYujwqzys9m0WhAQGELc2syb9IYrD7zVZaeI0hB5cJpnHUodBLQ==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/transformer-typescript-types": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-duMzWnq49AOSUU9W18GvdycPw/DSfOzKZcY/znYE65eSmEYgcNgWGI6TaluY52FA0cfgLakUe013KmGGI9tyjA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1",
+				"@parcel/source-map": "^2.0.0-alpha.3.1",
+				"@parcel/ts-utils": "^2.0.0-alpha.3.1",
+				"nullthrows": "^1.1.1"
+			}
+		},
+		"@parcel/transformer-yaml": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/transformer-yaml/-/transformer-yaml-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-sX+8B111x9q1+BgCPq2w08+nfSvXJ/ijdC+YkpqbKeWkcmHDfXI8esajKWW6xSaeaX6UgNfoZopDCsqUWBAxLA==",
+			"dev": true,
+			"requires": {
+				"@parcel/plugin": "^2.0.0-alpha.3.1"
+			}
+		},
+		"@parcel/ts-utils": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-AaafmGAtiBDtO9Ly3ZvyQViF1FCjHFe97QzIC1HShBmQrzD918LZTH7vAnUjUIDYuudn9Gq/26PfQdPM5dYGzA==",
+			"dev": true,
+			"requires": {
+				"nullthrows": "^1.1.1"
+			}
+		},
+		"@parcel/types": {
+			"version": "2.0.0-alpha.3.1",
+			"resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.0.0-alpha.3.1.tgz",
+			"integrity": "sha512-+RrfckMkA9BQtR/O987gwD/1fXWeMd5v8k4pBBsmSHtLh7ASnoViRkg9drIQJs6uU17uKgvYNsSYwUNxJzf+0Q==",
+			"dev": true
+		},
 		"@primer/octicons": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.3.1.tgz",
@@ -471,6 +6195,136 @@
 			"resolved": "https://registry.npmjs.org/@sindresorhus/tsconfig/-/tsconfig-0.6.0.tgz",
 			"integrity": "sha512-9ZqIfvW6bPjOHRaId57L/63N79QM+sUcf+ONuVfXLksXCHDfOkS+NUw6cchjkndHlRY0eXM3ri5PfWUZ61lbwg==",
 			"dev": true
+		},
+		"@svgr/babel-plugin-add-jsx-attribute": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-5.0.1.tgz",
+			"integrity": "sha512-av76JbSudaN2CUOGuKQp5BVqLFidtojg4ApRTg1PBOVsskXK2ORwKnBYhIu0JLA6ynmuNDprlHNCD6IwLiYidw==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-remove-jsx-attribute": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-5.0.1.tgz",
+			"integrity": "sha512-oXyByaDQEK4Ut/eC75698MDKnaadbWmp/LS2w22cZAaoObCkkiwYYgZTZ+bvb3moo//AxvKkBtNrlz6+xBb9ZQ==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-remove-jsx-empty-expression": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-5.0.1.tgz",
+			"integrity": "sha512-LA72+88A11ND/yFIMzyuLRSMJ+tRKeYKeQ+mR3DcAZ5I4h5CPWN9AHyUzJbWSYp/u2u0xhmgOe0+E41+GjEueA==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-replace-jsx-attribute-value": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-5.0.1.tgz",
+			"integrity": "sha512-PoiE6ZD2Eiy5mK+fjHqwGOS+IXX0wq/YDtNyIgOrc6ejFnxN4b13pRpiIPbtPwHEc+NT2KCjteAcq33/F1Y9KQ==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-svg-dynamic-title": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-5.0.1.tgz",
+			"integrity": "sha512-IbFiDBvq5WpANPndjEom1Y9k1pHCNfJs87jCN1Lt8NEA7yrNVPSoAjBVmmfi0aVBERfp8IT/lgjn2a/S85lXGg==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-svg-em-dimensions": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-5.0.1.tgz",
+			"integrity": "sha512-7kL9LtqCm1ca+zAbBsrD4ME3EQeVcRxkdrf2GsbKPgkzWJ+399vS4VqCP462+WvFRbG13jSwpNCrvhekdyvXsA==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-transform-react-native-svg": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-5.0.1.tgz",
+			"integrity": "sha512-ITG1jJ0zHQ4yft6ISQqlMW4fHIzsrSB/FmrMxAcJtkTjh9M2/9M8wfKxQya9NnTfZ5WMSlQjXMQNZmGQsuxRrw==",
+			"dev": true
+		},
+		"@svgr/babel-plugin-transform-svg-component": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-5.0.1.tgz",
+			"integrity": "sha512-TYJ5L0QJgWqeMnuc8GEVy2jorwj/jp7y/mGLPwJhNrvrtAuVN7wEvc/Dzi1o1krsKKN7h6WpW/w3AQ6Na7qYEw==",
+			"dev": true
+		},
+		"@svgr/babel-preset": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-5.0.1.tgz",
+			"integrity": "sha512-V2u6rAHLD//0xu+p/Il6laOLfuU5ySpaU1t2HBBXsRp6G9GTTNpAjxUw0iRulfd56AoWcr2j+Fap/J1yz/cx0w==",
+			"dev": true,
+			"requires": {
+				"@svgr/babel-plugin-add-jsx-attribute": "^5.0.1",
+				"@svgr/babel-plugin-remove-jsx-attribute": "^5.0.1",
+				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
+				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
+				"@svgr/babel-plugin-svg-dynamic-title": "^5.0.1",
+				"@svgr/babel-plugin-svg-em-dimensions": "^5.0.1",
+				"@svgr/babel-plugin-transform-react-native-svg": "^5.0.1",
+				"@svgr/babel-plugin-transform-svg-component": "^5.0.1"
+			}
+		},
+		"@svgr/core": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/core/-/core-5.0.1.tgz",
+			"integrity": "sha512-F/HXJpKbN6Cab31ngiSFiUXYV9y+yiJaDaOZuc7Yqzc19+ncIrM+wSKoytjwcwc+Haj8gvEHsPqRX9L4yM1ftA==",
+			"dev": true,
+			"requires": {
+				"@svgr/plugin-jsx": "^5.0.1",
+				"camelcase": "^5.3.1",
+				"cosmiconfig": "^6.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				}
+			}
+		},
+		"@svgr/hast-util-to-babel-ast": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-5.0.1.tgz",
+			"integrity": "sha512-G7UHNPNhLyDK5p6RJvSh4TRpHszTxG8jPp5lAxC6Ez6O6rj1plEAjrCDdYj50mvilUuT9IKjqn87F8+agpKaSw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.4.4"
+			}
+		},
+		"@svgr/parcel-plugin-svgr": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/parcel-plugin-svgr/-/parcel-plugin-svgr-5.0.1.tgz",
+			"integrity": "sha512-ooLq2jeVsQMOZ6SWsovrXKNachGlljABHVCK5hywsXKeoKboLl/0kq0b4byCIr61bwQhTPySlB26wbZTpr8BJA==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.7.5",
+				"@babel/plugin-transform-react-constant-elements": "^7.7.4",
+				"@babel/preset-env": "^7.7.6",
+				"@babel/preset-react": "^7.7.4",
+				"@svgr/core": "^5.0.1",
+				"@svgr/plugin-jsx": "^5.0.1",
+				"@svgr/plugin-svgo": "^5.0.1"
+			}
+		},
+		"@svgr/plugin-jsx": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-5.0.1.tgz",
+			"integrity": "sha512-9mEinzosJshc/VdLqVkoBZQgs2d+ASbL61sX/2XCxcJ+/81KXdZcxmxSycJN37BvlM7F5fuj2ZF7IZwZ7ZOKaQ==",
+			"dev": true,
+			"requires": {
+				"@babel/core": "^7.7.5",
+				"@svgr/babel-preset": "^5.0.1",
+				"@svgr/hast-util-to-babel-ast": "^5.0.1",
+				"svg-parser": "^2.0.2"
+			}
+		},
+		"@svgr/plugin-svgo": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-5.0.1.tgz",
+			"integrity": "sha512-h/V30j1swWANLV1mB0w+1YYZ0U0CnWm721xyUKVHJrvMe4wl5XronZdvVAD2hhQf9+JgaQARrRJ0Vg1Dxi+SFg==",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "^6.0.0",
+				"merge-deep": "^3.0.2",
+				"svgo": "^1.2.2"
+			}
 		},
 		"@szmarczak/http-timer": {
 			"version": "1.1.2",
@@ -624,6 +6478,12 @@
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
 			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+			"dev": true
+		},
+		"@types/q": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
 		"@types/react": {
@@ -990,6 +6850,18 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
 			"integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+			"dev": true
+		},
+		"abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"dev": true
+		},
+		"abortcontroller-polyfill": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.4.0.tgz",
+			"integrity": "sha512-3ZFfCRfDzx3GFjO6RAkYx81lPGpUS20ISxux9gLxuKnqafNcFQo59+IoZqpO2WvQlyc287B62HDnDdNYRmlvWA==",
 			"dev": true
 		},
 		"acorn": {
@@ -1618,6 +7490,12 @@
 				"json-merge-patch": "^0.2.3"
 			}
 		},
+		"alphanum-sort": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+			"integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+			"dev": true
+		},
 		"ansi-align": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -1666,6 +7544,12 @@
 			"requires": {
 				"type-fest": "^0.8.1"
 			}
+		},
+		"ansi-html": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+			"integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+			"dev": true
 		},
 		"ansi-regex": {
 			"version": "5.0.0",
@@ -1772,6 +7656,16 @@
 						"remove-trailing-separator": "^1.0.1"
 					}
 				}
+			}
+		},
+		"are-we-there-yet": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
+			"requires": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^2.0.6"
 			}
 		},
 		"arg": {
@@ -1977,6 +7871,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true
+		},
+		"auto-bind": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-3.0.0.tgz",
+			"integrity": "sha512-v0A231a/lfOo6kxQtmEkdBfTApvC21aJYukA8pkKnoTvVqh3Wmm7/Rwy4GBCHTTHVoLVA5qsBDDvf1XY1nIV2g==",
 			"dev": true
 		},
 		"autoprefixer": {
@@ -2304,6 +8204,37 @@
 				}
 			}
 		},
+		"babel-types": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
+			},
+			"dependencies": {
+				"to-fast-properties": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+					"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+					"dev": true
+				}
+			}
+		},
+		"babylon-walk": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/babylon-walk/-/babylon-walk-1.0.2.tgz",
+			"integrity": "sha1-OxWl3btIKni0zpwByLoYFwLZ1s4=",
+			"dev": true,
+			"requires": {
+				"babel-runtime": "^6.11.6",
+				"babel-types": "^6.15.0",
+				"lodash.clone": "^4.5.0"
+			}
+		},
 		"bail": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
@@ -2409,7 +8340,6 @@
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -2523,6 +8453,18 @@
 			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
+			}
+		},
+		"brfs": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+			"integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+			"dev": true,
+			"requires": {
+				"quote-stream": "^1.0.1",
+				"resolve": "^1.1.5",
+				"static-module": "^2.2.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"brorand": {
@@ -2680,6 +8622,12 @@
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+			"dev": true
+		},
+		"buffer-equal": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+			"integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
 			"dev": true
 		},
 		"buffer-equal-constant-time": {
@@ -2845,6 +8793,23 @@
 			"integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
 			"dev": true
 		},
+		"caller-callsite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+			"integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+			"dev": true,
+			"requires": {
+				"callsites": "^2.0.0"
+			},
+			"dependencies": {
+				"callsites": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+					"integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+					"dev": true
+				}
+			}
+		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -2881,6 +8846,18 @@
 				"camelcase": "^4.1.0",
 				"map-obj": "^2.0.0",
 				"quick-lru": "^1.0.0"
+			}
+		},
+		"caniuse-api": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"caniuse-lite": "^1.0.0",
+				"lodash.memoize": "^4.1.2",
+				"lodash.uniq": "^4.5.0"
 			}
 		},
 		"caniuse-lite": {
@@ -3550,6 +9527,45 @@
 			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
 			"dev": true
 		},
+		"clone-deep": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+			"integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+			"dev": true,
+			"requires": {
+				"for-own": "^0.1.3",
+				"is-plain-object": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"lazy-cache": "^1.0.3",
+				"shallow-clone": "^0.1.2"
+			},
+			"dependencies": {
+				"is-plain-object": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+					"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+					"dev": true,
+					"requires": {
+						"isobject": "^3.0.1"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
 		"clone-regexp": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -3568,11 +9584,28 @@
 				"mimic-response": "^1.0.0"
 			}
 		},
+		"clones": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/clones/-/clones-1.2.0.tgz",
+			"integrity": "sha512-FXDYw4TjR8wgPZYui2LeTqWh1BLpfQ8lB6upMtlpDF6WlOOxghmTTxWyngdKTgozqBgKnHbTVwTE+hOHqAykuQ==",
+			"dev": true
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
 			"dev": true
+		},
+		"coa": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
+			"integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
+			"dev": true,
+			"requires": {
+				"@types/q": "^1.5.1",
+				"chalk": "^2.4.1",
+				"q": "^1.1.2"
+			}
 		},
 		"code-excerpt": {
 			"version": "2.1.1",
@@ -3587,6 +9620,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
+		},
+		"coffeescript": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.0.tgz",
+			"integrity": "sha512-RgTKZhAeKVFuGtce/d3U1x1h5W75AoYFQszNlGrtSIbexC9jowaZo574uUvc9zoNQSDLMWXVtsus9usMtbFU+w==",
 			"dev": true
 		},
 		"collapse-white-space": {
@@ -3605,6 +9644,16 @@
 				"object-visit": "^1.0.0"
 			}
 		},
+		"color": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+			"integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.1",
+				"color-string": "^1.5.2"
+			}
+		},
 		"color-convert": {
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3619,6 +9668,16 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 			"dev": true
+		},
+		"color-string": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+			"dev": true,
+			"requires": {
+				"color-name": "^1.0.0",
+				"simple-swizzle": "^0.2.2"
+			}
 		},
 		"colors": {
 			"version": "0.5.1",
@@ -3661,6 +9720,12 @@
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
+		},
+		"command-exists": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
+			"integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
+			"dev": true
 		},
 		"commander": {
 			"version": "2.20.3",
@@ -3763,6 +9828,16 @@
 				}
 			}
 		},
+		"config-chain": {
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+			"integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+			"dev": true,
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
 		"configstore": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
@@ -3814,10 +9889,45 @@
 				}
 			}
 		},
+		"connect": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+			"integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"finalhandler": "1.1.2",
+				"parseurl": "~1.3.3",
+				"utils-merge": "1.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
+			}
+		},
 		"console-browserify": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
 			"integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+			"dev": true
+		},
+		"console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true
 		},
 		"constants-browserify": {
@@ -4011,6 +10121,58 @@
 			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
 			"dev": true
 		},
+		"core-js-compat": {
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.6.3.tgz",
+			"integrity": "sha512-Y3YNGU3bU1yrnzVodop23ghArbKv4IqkZg9MMOWv/h7KT6NRk1/SzHhWDDlubg2+tlcUzAqgj1/GyeJ9fUKMeg==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.8.3",
+				"semver": "7.0.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.8.3",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.3.tgz",
+					"integrity": "sha512-iU43cMMknxG1ClEZ2MDKeonKE1CCrFVkQK2AqO2YWFmvIrx4JWrvQ4w4hQez6EpVI8rHTtqh/ruHHDHSOKxvUg==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001017",
+						"electron-to-chromium": "^1.3.322",
+						"node-releases": "^1.1.44"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001020",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001020.tgz",
+					"integrity": "sha512-yWIvwA68wRHKanAVS1GjN8vajAv7MBFshullKCeq/eKpK7pJBVDgFFEqvgWTkcP2+wIDeQGYFRXECjKZnLkUjA==",
+					"dev": true
+				},
+				"node-releases": {
+					"version": "1.1.45",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.45.tgz",
+					"integrity": "sha512-cXvGSfhITKI8qsV116u2FTzH5EWZJfgG7d4cpqwF8I8+1tWpD6AsvvGRKq2onR0DNj1jfqsjkXZsm14JMS7Cyg==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "6.3.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+							"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+							"dev": true
+						}
+					}
+				},
+				"semver": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+					"integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+					"dev": true
+				}
+			}
+		},
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4169,6 +10331,22 @@
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
 			"dev": true
 		},
+		"css-color-names": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+			"dev": true
+		},
+		"css-declaration-sorter": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-4.0.1.tgz",
+			"integrity": "sha512-BcxQSKTSEEQUftYpBVnsH4SF05NTuBokb19/sBt6asXGKZ/6VP7PLG1CBCkFDYOnhXhPh0jMhO6xZ71oYHXHBA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.1",
+				"timsort": "^0.3.0"
+			}
+		},
 		"css-loader": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.3.2.tgz",
@@ -4207,6 +10385,141 @@
 				}
 			}
 		},
+		"css-modules-loader-core": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
+			"integrity": "sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=",
+			"dev": true,
+			"requires": {
+				"icss-replace-symbols": "1.1.0",
+				"postcss": "6.0.1",
+				"postcss-modules-extract-imports": "1.1.0",
+				"postcss-modules-local-by-default": "1.2.0",
+				"postcss-modules-scope": "1.1.0",
+				"postcss-modules-values": "1.3.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+					"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+					"dev": true
+				},
+				"chalk": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^2.2.1",
+						"escape-string-regexp": "^1.0.2",
+						"has-ansi": "^2.0.0",
+						"strip-ansi": "^3.0.0",
+						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+							"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+							"dev": true
+						}
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
+				"postcss": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
+					"integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
+					"dev": true,
+					"requires": {
+						"chalk": "^1.1.3",
+						"source-map": "^0.5.6",
+						"supports-color": "^3.2.3"
+					}
+				},
+				"postcss-modules-extract-imports": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+					"integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+					"dev": true,
+					"requires": {
+						"postcss": "^6.0.1"
+					}
+				},
+				"postcss-modules-local-by-default": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+					"integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+					"dev": true,
+					"requires": {
+						"css-selector-tokenizer": "^0.7.0",
+						"postcss": "^6.0.1"
+					}
+				},
+				"postcss-modules-scope": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+					"integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+					"dev": true,
+					"requires": {
+						"css-selector-tokenizer": "^0.7.0",
+						"postcss": "^6.0.1"
+					}
+				},
+				"postcss-modules-values": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+					"integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+					"dev": true,
+					"requires": {
+						"icss-replace-symbols": "^1.1.0",
+						"postcss": "^6.0.1"
+					}
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+					"dev": true,
+					"requires": {
+						"has-flag": "^1.0.0"
+					}
+				}
+			}
+		},
 		"css-select": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -4231,6 +10544,79 @@
 				}
 			}
 		},
+		"css-select-base-adapter": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
+			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+			"dev": true
+		},
+		"css-selector-tokenizer": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+			"integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+			"dev": true,
+			"requires": {
+				"cssesc": "^0.1.0",
+				"fastparse": "^1.1.1",
+				"regexpu-core": "^1.0.0"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+					"integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+					"dev": true
+				},
+				"jsesc": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+					"dev": true
+				},
+				"regexpu-core": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+					"dev": true,
+					"requires": {
+						"regenerate": "^1.2.1",
+						"regjsgen": "^0.2.0",
+						"regjsparser": "^0.1.4"
+					}
+				},
+				"regjsgen": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+					"integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+					"dev": true
+				},
+				"regjsparser": {
+					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+					"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+					"dev": true,
+					"requires": {
+						"jsesc": "~0.5.0"
+					}
+				}
+			}
+		},
+		"css-tree": {
+			"version": "1.0.0-alpha.37",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+			"integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+			"dev": true,
+			"requires": {
+				"mdn-data": "2.0.4",
+				"source-map": "^0.6.1"
+			}
+		},
+		"css-unit-converter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
+			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+			"dev": true
+		},
 		"css-what": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
@@ -4242,6 +10628,131 @@
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
 			"dev": true
+		},
+		"cssnano": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.10.tgz",
+			"integrity": "sha512-5wny+F6H4/8RgNlaqab4ktc3e0/blKutmq8yNlBFXA//nSFFAqAngjNVRzUvCgYROULmZZUoosL/KSoZo5aUaQ==",
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "^5.0.0",
+				"cssnano-preset-default": "^4.0.7",
+				"is-resolvable": "^1.0.0",
+				"postcss": "^7.0.0"
+			},
+			"dependencies": {
+				"caller-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+					"integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+					"dev": true,
+					"requires": {
+						"caller-callsite": "^2.0.0"
+					}
+				},
+				"cosmiconfig": {
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+					"integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^2.0.0",
+						"is-directory": "^0.3.1",
+						"js-yaml": "^3.13.1",
+						"parse-json": "^4.0.0"
+					}
+				},
+				"import-fresh": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+					"integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+					"dev": true,
+					"requires": {
+						"caller-path": "^2.0.0",
+						"resolve-from": "^3.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
+			}
+		},
+		"cssnano-preset-default": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-4.0.7.tgz",
+			"integrity": "sha512-x0YHHx2h6p0fCl1zY9L9roD7rnlltugGu7zXSKQx6k2rYw0Hi3IqxcoAGF7u9Q5w1nt7vK0ulxV8Lo+EvllGsA==",
+			"dev": true,
+			"requires": {
+				"css-declaration-sorter": "^4.0.1",
+				"cssnano-util-raw-cache": "^4.0.1",
+				"postcss": "^7.0.0",
+				"postcss-calc": "^7.0.1",
+				"postcss-colormin": "^4.0.3",
+				"postcss-convert-values": "^4.0.1",
+				"postcss-discard-comments": "^4.0.2",
+				"postcss-discard-duplicates": "^4.0.2",
+				"postcss-discard-empty": "^4.0.1",
+				"postcss-discard-overridden": "^4.0.1",
+				"postcss-merge-longhand": "^4.0.11",
+				"postcss-merge-rules": "^4.0.3",
+				"postcss-minify-font-values": "^4.0.2",
+				"postcss-minify-gradients": "^4.0.2",
+				"postcss-minify-params": "^4.0.2",
+				"postcss-minify-selectors": "^4.0.2",
+				"postcss-normalize-charset": "^4.0.1",
+				"postcss-normalize-display-values": "^4.0.2",
+				"postcss-normalize-positions": "^4.0.2",
+				"postcss-normalize-repeat-style": "^4.0.2",
+				"postcss-normalize-string": "^4.0.2",
+				"postcss-normalize-timing-functions": "^4.0.2",
+				"postcss-normalize-unicode": "^4.0.1",
+				"postcss-normalize-url": "^4.0.1",
+				"postcss-normalize-whitespace": "^4.0.2",
+				"postcss-ordered-values": "^4.1.2",
+				"postcss-reduce-initial": "^4.0.3",
+				"postcss-reduce-transforms": "^4.0.2",
+				"postcss-svgo": "^4.0.2",
+				"postcss-unique-selectors": "^4.0.1"
+			}
+		},
+		"cssnano-util-get-arguments": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-arguments/-/cssnano-util-get-arguments-4.0.0.tgz",
+			"integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+			"dev": true
+		},
+		"cssnano-util-get-match": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cssnano-util-get-match/-/cssnano-util-get-match-4.0.0.tgz",
+			"integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+			"dev": true
+		},
+		"cssnano-util-raw-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-raw-cache/-/cssnano-util-raw-cache-4.0.1.tgz",
+			"integrity": "sha512-qLuYtWK2b2Dy55I8ZX3ky1Z16WYsx544Q0UWViebptpwn/xDBmog2TLg4f+DBMg1rJ6JDWtn96WHbOKDWt1WQA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"cssnano-util-same-parent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-util-same-parent/-/cssnano-util-same-parent-4.0.1.tgz",
+			"integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q==",
+			"dev": true
+		},
+		"csso": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
+			"integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
+			"dev": true,
+			"requires": {
+				"css-tree": "1.0.0-alpha.37"
+			}
 		},
 		"cssom": {
 			"version": "0.4.4",
@@ -4332,6 +10843,16 @@
 			"dev": true,
 			"requires": {
 				"time-zone": "^1.0.0"
+			}
+		},
+		"deasync": {
+			"version": "0.1.19",
+			"resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.19.tgz",
+			"integrity": "sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^1.7.1"
 			}
 		},
 		"debounce": {
@@ -4586,6 +11107,12 @@
 			"resolved": "https://registry.npmjs.org/delegate-it/-/delegate-it-1.1.0.tgz",
 			"integrity": "sha512-LlTfgGPHPXUQjho5qZ6llimoJCRBnbety1V0spXLoGHqr7lQzyBOI7SAr/a99x5Zkb7G0LN1pWa8kVCU3rJuPw=="
 		},
+		"delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
+		},
 		"des.js": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -4606,6 +11133,12 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
 			"integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+			"dev": true
+		},
+		"detect-libc": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"dev": true
 		},
 		"diff": {
@@ -4891,6 +11424,12 @@
 				"is-obj": "^2.0.0"
 			}
 		},
+		"dotenv-expand": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+			"integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+			"dev": true
+		},
 		"dtrace-provider": {
 			"version": "0.8.8",
 			"resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
@@ -4906,6 +11445,15 @@
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
+		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
 		},
 		"duplexer3": {
 			"version": "0.1.4",
@@ -4943,6 +11491,30 @@
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
+		},
+		"editorconfig": {
+			"version": "0.15.3",
+			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.19.0",
+				"lru-cache": "^4.1.5",
+				"semver": "^5.6.0",
+				"sigmund": "^1.0.1"
+			}
+		},
+		"ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+			"dev": true
+		},
+		"ejs": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+			"integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+			"dev": true
 		},
 		"electron-to-chromium": {
 			"version": "1.3.322",
@@ -4992,6 +11564,17 @@
 			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
 			"dev": true
 		},
+		"emphasize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-2.1.0.tgz",
+			"integrity": "sha512-wRlO0Qulw2jieQynsS3STzTabIhHCyjTjZraSkchOiT8rdvWZlahJAJ69HRxwGkv2NThmci2MSnDfJ60jB39tw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.0",
+				"highlight.js": "~9.12.0",
+				"lowlight": "~1.9.0"
+			}
+		},
 		"empower-core": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
@@ -5001,6 +11584,12 @@
 				"call-signature": "0.0.2",
 				"core-js": "^2.0.0"
 			}
+		},
+		"encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+			"dev": true
 		},
 		"encoding": {
 			"version": "0.1.12",
@@ -5210,6 +11799,12 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-1.3.0.tgz",
 			"integrity": "sha512-E2nU1Y39N5UgfLU8qwMlK0vZrZprIwWLeVmDYN8wd/e37hMtGzu2w1DBiREts0XHfgyZEQlj/hYr0H0izF0HDQ=="
+		},
+		"escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "2.0.0",
@@ -6420,6 +13015,12 @@
 			"integrity": "sha1-S4TxF3K28l93Uvx02XFTGsb1tiY=",
 			"dev": true
 		},
+		"eventemitter3": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
+			"integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+			"dev": true
+		},
 		"events": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -6523,6 +13124,12 @@
 					"dev": true
 				}
 			}
+		},
+		"expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -6674,6 +13281,32 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
+		"falafel": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+			"integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+			"dev": true,
+			"requires": {
+				"acorn": "^5.0.0",
+				"foreach": "^2.0.5",
+				"isarray": "0.0.1",
+				"object-keys": "^1.0.6"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.3",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+					"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+					"dev": true
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				}
+			}
+		},
 		"fast-deep-equal": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -6732,6 +13365,12 @@
 			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
 			"dev": true
 		},
+		"fastparse": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+			"dev": true
+		},
 		"fastq": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
@@ -6739,6 +13378,15 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.0"
+			}
+		},
+		"fault": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
+			"integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+			"dev": true,
+			"requires": {
+				"format": "^0.2.2"
 			}
 		},
 		"fd-slicer": {
@@ -6786,8 +13434,13 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
+			"dev": true
+		},
+		"filesize": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+			"integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
+			"dev": true
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -6796,6 +13449,38 @@
 			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
+			}
+		},
+		"finalhandler": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+			"integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+			"dev": true,
+			"requires": {
+				"debug": "2.6.9",
+				"encodeurl": "~1.0.2",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.3.0",
+				"parseurl": "~1.3.3",
+				"statuses": "~1.5.0",
+				"unpipe": "~1.0.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "2.6.9",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
+				}
 			}
 		},
 		"find-cache-dir": {
@@ -7133,6 +13818,21 @@
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
 		},
+		"for-own": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.1"
+			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
+		},
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -7277,6 +13977,12 @@
 				"mime-types": "^2.1.12"
 			}
 		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
+			"dev": true
+		},
 		"fragment-cache": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -7412,6 +14118,59 @@
 				}
 			}
 		},
+		"gauge": {
+			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
+			"requires": {
+				"aproba": "^1.0.3",
+				"console-control-strings": "^1.0.0",
+				"has-unicode": "^2.0.0",
+				"object-assign": "^4.1.0",
+				"signal-exit": "^3.0.0",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1",
+				"wide-align": "^1.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"dev": true,
+					"requires": {
+						"number-is-nan": "^1.0.0"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"dev": true,
+					"requires": {
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^2.0.0"
+					}
+				}
+			}
+		},
 		"generate-function": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
@@ -7530,6 +14289,12 @@
 					}
 				}
 			}
+		},
+		"github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+			"dev": true
 		},
 		"github-reserved-names": {
 			"version": "1.1.7",
@@ -7683,6 +14448,16 @@
 			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
 			"dev": true
 		},
+		"grapheme-breaker": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/grapheme-breaker/-/grapheme-breaker-0.3.2.tgz",
+			"integrity": "sha1-W55reMODJFLSuiuxy4MPlidkEKw=",
+			"dev": true,
+			"requires": {
+				"brfs": "^1.2.0",
+				"unicode-trie": "^0.3.1"
+			}
+		},
 		"growly": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -7765,6 +14540,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
 			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"dev": true
+		},
+		"has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true
 		},
 		"has-value": {
@@ -7863,6 +14644,18 @@
 				"type-fest": "^0.8.0"
 			}
 		},
+		"hex-color-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
+			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
+			"dev": true
+		},
+		"highlight.js": {
+			"version": "9.12.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=",
+			"dev": true
+		},
 		"hmac-drbg": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -7888,6 +14681,24 @@
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
 			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg=="
 		},
+		"hsl-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz",
+			"integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+			"dev": true
+		},
+		"hsla-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/hsla-regex/-/hsla-regex-1.0.0.tgz",
+			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+			"dev": true
+		},
+		"html-comment-regex": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.2.tgz",
+			"integrity": "sha512-P+M65QY2JQ5Y0G9KKdlDpo0zK+/OHptU5AaBwUfAIDJZk1MYf32Frm84EcOytfJE0t5JvkAnKlmjsXDnWzCJmQ==",
+			"dev": true
+		},
 		"html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -7901,6 +14712,34 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-2.0.0.tgz",
 			"integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos="
+		},
+		"htmlnano": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.5.tgz",
+			"integrity": "sha512-X1iPSwXG/iF9bVs+/obt2n6F64uH0ETkA8zp7qFDmLW9/+A6ueHGeb/+qD67T21qUY22owZPMdawljN50ajkqA==",
+			"dev": true,
+			"requires": {
+				"cssnano": "^4.1.10",
+				"normalize-html-whitespace": "^1.0.0",
+				"posthtml": "^0.12.0",
+				"posthtml-render": "^1.1.5",
+				"purgecss": "^1.4.0",
+				"svgo": "^1.3.2",
+				"terser": "^4.3.9",
+				"uncss": "^0.17.2"
+			},
+			"dependencies": {
+				"posthtml": {
+					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.12.0.tgz",
+					"integrity": "sha512-aNUEP/SfKUXAt+ghG51LC5MmafChBZeslVe/SSdfKIgLGUVRE68mrMF4V8XbH07ZifM91tCSuxY3eHIFLlecQw==",
+					"dev": true,
+					"requires": {
+						"posthtml-parser": "^0.4.1",
+						"posthtml-render": "^1.1.5"
+					}
+				}
+			}
 		},
 		"htmlparser2": {
 			"version": "3.10.1",
@@ -7935,6 +14774,140 @@
 			"integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
 			"dev": true
 		},
+		"http-proxy": {
+			"version": "1.18.0",
+			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
+			"integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+			"dev": true,
+			"requires": {
+				"eventemitter3": "^4.0.0",
+				"follow-redirects": "^1.0.0",
+				"requires-port": "^1.0.0"
+			}
+		},
+		"http-proxy-middleware": {
+			"version": "0.19.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+			"integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
+			"dev": true,
+			"requires": {
+				"http-proxy": "^1.17.0",
+				"is-glob": "^4.0.0",
+				"lodash": "^4.17.11",
+				"micromatch": "^3.1.10"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"to-regex-range": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+					"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+					"dev": true,
+					"requires": {
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1"
+					}
+				}
+			}
+		},
 		"http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7960,6 +14933,12 @@
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
+		},
+		"icss-replace-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+			"integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+			"dev": true
 		},
 		"icss-utils": {
 			"version": "4.1.1",
@@ -8092,6 +15071,97 @@
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 			"dev": true
 		},
+		"ink": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/ink/-/ink-2.6.0.tgz",
+			"integrity": "sha512-nD/wlSuB6WnFsFB0nUcOJdy28YvvDer3eo+gezjvZqojGA4Rx5sQpacvN//Aai83DRgwrRTyKBl5aciOcfP3zQ==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^4.2.1",
+				"arrify": "^2.0.1",
+				"auto-bind": "^3.0.0",
+				"chalk": "^3.0.0",
+				"cli-cursor": "^3.1.0",
+				"cli-truncate": "^2.0.0",
+				"is-ci": "^2.0.0",
+				"lodash.throttle": "^4.1.1",
+				"log-update": "^3.0.0",
+				"prop-types": "^15.6.2",
+				"react-reconciler": "^0.24.0",
+				"scheduler": "^0.18.0",
+				"signal-exit": "^3.0.2",
+				"slice-ansi": "^3.0.0",
+				"string-length": "^3.1.0",
+				"widest-line": "^3.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoga-layout-prebuilt": "^1.9.3"
+			},
+			"dependencies": {
+				"arrify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+					"integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"widest-line": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+					"integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					}
+				}
+			}
+		},
+		"ink-spinner": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-3.0.1.tgz",
+			"integrity": "sha512-AVR4Z/NXDQ7dT5ltWcCzFS9Dd4T8eaO//E2UO8VYNiJcZpPCSJ11o5A0UVPcMlZxGbGD6ikUFDR3ZgPUQk5haQ==",
+			"dev": true,
+			"requires": {
+				"cli-spinners": "^1.0.0",
+				"prop-types": "^15.5.10"
+			},
+			"dependencies": {
+				"cli-spinners": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
+					"integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
+					"dev": true
+				}
+			}
+		},
 		"inquirer": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
@@ -8124,6 +15194,15 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
 		"invert-kv": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-3.0.0.tgz",
@@ -8150,6 +15229,12 @@
 			"requires": {
 				"is-relative": "^0.1.0"
 			}
+		},
+		"is-absolute-url": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+			"integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+			"dev": true
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -8234,6 +15319,20 @@
 				"ci-info": "^2.0.0"
 			}
 		},
+		"is-color-stop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
+			"integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+			"dev": true,
+			"requires": {
+				"css-color-names": "^0.0.4",
+				"hex-color-regex": "^1.1.0",
+				"hsl-regex": "^1.0.0",
+				"hsla-regex": "^1.0.0",
+				"rgb-regex": "^1.0.1",
+				"rgba-regex": "^1.0.0"
+			}
+		},
 		"is-data-descriptor": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -8284,6 +15383,12 @@
 					"dev": true
 				}
 			}
+		},
+		"is-directory": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+			"integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+			"dev": true
 		},
 		"is-error": {
 			"version": "2.2.2",
@@ -8342,6 +15447,23 @@
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
 			"integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA==",
 			"dev": true
+		},
+		"is-html": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-html/-/is-html-1.1.0.tgz",
+			"integrity": "sha1-4E8cGNOUhRETlvmgJz6rUa8hhGQ=",
+			"dev": true,
+			"requires": {
+				"html-tags": "^1.0.0"
+			},
+			"dependencies": {
+				"html-tags": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
+					"integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
+					"dev": true
+				}
+			}
 		},
 		"is-installed-globally": {
 			"version": "0.1.0",
@@ -8537,6 +15659,15 @@
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
 			"dev": true
 		},
+		"is-svg": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
+			"integrity": "sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==",
+			"dev": true,
+			"requires": {
+				"html-comment-regex": "^1.1.0"
+			}
+		},
 		"is-symbol": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -8600,6 +15731,12 @@
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true
 		},
+		"isbinaryfile": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.4.tgz",
+			"integrity": "sha512-pEutbN134CzcjlLS1myKX/uxNjwU5eBVSprvkpv3+3dqhBHUZLIWJQowC40w5c0Zf19vBY8mrZl88y5J4RAPbQ==",
+			"dev": true
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -8654,6 +15791,25 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/jetpack-id/-/jetpack-id-1.0.0.tgz",
 			"integrity": "sha1-LPn7rkbYB0/Ba33gBxyO/rykc6Y=",
+			"dev": true
+		},
+		"js-beautify": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.10.2.tgz",
+			"integrity": "sha512-ZtBYyNUYJIsBWERnQP0rPN9KjkrDfJcMjuVGcvXOUJrD1zmOGwhRwQ4msG+HJ+Ni/FA7+sRQEMYVzdTQDvnzvQ==",
+			"dev": true,
+			"requires": {
+				"config-chain": "^1.1.12",
+				"editorconfig": "^0.15.3",
+				"glob": "^7.1.3",
+				"mkdirp": "~0.5.1",
+				"nopt": "~4.0.1"
+			}
+		},
+		"js-levenshtein": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+			"integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
 			"dev": true
 		},
 		"js-select": {
@@ -8784,6 +15940,12 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
+		},
+		"json-source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+			"integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
 			"dev": true
 		},
 		"json-stable-stringify": {
@@ -8943,6 +16105,12 @@
 				"package-json": "^6.3.0"
 			}
 		},
+		"lazy-cache": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+			"integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+			"dev": true
+		},
 		"lazystream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -8966,6 +16134,15 @@
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
 			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
 			"dev": true
+		},
+		"levenary": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/levenary/-/levenary-1.1.0.tgz",
+			"integrity": "sha512-VHcwhO0UTpUW7rLPN2/OiWJdgA1e9BqEDALhrgCe/F+uUJnep6CoUsTzMeP8Rh0NGr9uKquXxqe7lwLZo509nQ==",
+			"dev": true,
+			"requires": {
+				"leven": "^3.1.0"
+			}
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -9104,6 +16281,12 @@
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
 			"dev": true
 		},
+		"lodash.clone": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"dev": true
+		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -9182,6 +16365,12 @@
 			"integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
 			"dev": true
 		},
+		"lodash.memoize": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+			"dev": true
+		},
 		"lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9212,6 +16401,12 @@
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
 			"dev": true
 		},
+		"lodash.throttle": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+			"integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+			"dev": true
+		},
 		"lodash.topairs": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.topairs/-/lodash.topairs-4.3.0.tgz",
@@ -9222,6 +16417,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
 			"integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
+			"dev": true
+		},
+		"lodash.uniq": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+			"integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
 			"dev": true
 		},
 		"lodash.upperfirst": {
@@ -9243,6 +16444,59 @@
 			"dev": true,
 			"requires": {
 				"chalk": "^2.0.1"
+			}
+		},
+		"log-update": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-3.3.0.tgz",
+			"integrity": "sha512-YSKm5n+YjZoGZT5lfmOqasVH1fIH9xQA9A81Y48nZ99PxAP62vdCCtua+Gcu6oTn0nqtZd/LwRV+Vflo53ZDWA==",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.2.0",
+				"cli-cursor": "^2.1.0",
+				"wrap-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+					"integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+					"dev": true
+				},
+				"cli-cursor": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+					"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^2.0.0"
+					}
+				},
+				"mimic-fn": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+					"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+					"dev": true
+				},
+				"onetime": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+					"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^1.0.0"
+					}
+				},
+				"restore-cursor": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+					"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+					"dev": true,
+					"requires": {
+						"onetime": "^2.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				}
 			}
 		},
 		"longest-streak": {
@@ -9274,6 +16528,16 @@
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
 			"integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
 			"dev": true
+		},
+		"lowlight": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+			"dev": true,
+			"requires": {
+				"fault": "^1.0.2",
+				"highlight.js": "~9.12.0"
+			}
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -9450,6 +16714,12 @@
 				"extend": "3.0.2"
 			}
 		},
+		"mdn-data": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+			"dev": true
+		},
 		"mem": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-6.0.1.tgz",
@@ -9496,6 +16766,45 @@
 				"redent": "^2.0.0",
 				"trim-newlines": "^2.0.0",
 				"yargs-parser": "^10.0.0"
+			}
+		},
+		"merge-deep": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
+			"integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"clone-deep": "^0.2.4",
+				"kind-of": "^3.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
+			}
+		},
+		"merge-source-map": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+			"integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+			"dev": true,
+			"requires": {
+				"source-map": "^0.5.6"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				}
 			}
 		},
 		"merge-stream": {
@@ -9728,6 +17037,24 @@
 				}
 			}
 		},
+		"mixin-object": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
+			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+			"dev": true,
+			"requires": {
+				"for-in": "^0.1.3",
+				"is-extendable": "^0.1.1"
+			},
+			"dependencies": {
+				"for-in": {
+					"version": "0.1.8",
+					"resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+					"integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE=",
+					"dev": true
+				}
+			}
+		},
 		"mkdirp": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -9880,6 +17207,12 @@
 				"to-regex": "^3.0.1"
 			}
 		},
+		"napi-build-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+			"integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+			"dev": true
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -9896,8 +17229,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
 			"integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
-			"dev": true,
-			"optional": true
+			"dev": true
 		},
 		"neo-async": {
 			"version": "2.6.1",
@@ -9915,6 +17247,21 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+			"dev": true
+		},
+		"node-abi": {
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
+			"integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+			"dev": true,
+			"requires": {
+				"semver": "^5.4.1"
+			}
+		},
+		"node-addon-api": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.1.tgz",
+			"integrity": "sha512-2+DuKodWvwRTrCfKOeR24KIc5unKjOh8mz17NCzVnHWfjAdDqbfbjqh7gUT+BkXBRQM52+xCHciKWonJ3CbJMQ==",
 			"dev": true
 		},
 		"node-forge": {
@@ -9972,6 +17319,12 @@
 					"dev": true
 				}
 			}
+		},
+		"node-modules-regexp": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+			"integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+			"dev": true
 		},
 		"node-notifier": {
 			"version": "6.0.0",
@@ -10051,6 +17404,28 @@
 					"dev": true
 				}
 			}
+		},
+		"noop-logger": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+			"dev": true
+		},
+		"nopt": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+			"dev": true,
+			"requires": {
+				"abbrev": "1",
+				"osenv": "^0.1.4"
+			}
+		},
+		"normalize-html-whitespace": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-html-whitespace/-/normalize-html-whitespace-1.0.0.tgz",
+			"integrity": "sha512-9ui7CGtOOlehQu0t/OhhlmDyc71mKVlv+4vF+me4iZLPrNtRL2xoquEdfZxasC/bdQi/Hr3iTrpyRKIG+ocabA==",
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -10137,6 +17512,18 @@
 				"path-key": "^2.0.0"
 			}
 		},
+		"npmlog": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "~1.1.2",
+				"console-control-strings": "~1.1.0",
+				"gauge": "~2.7.3",
+				"set-blocking": "~2.0.0"
+			}
+		},
 		"nth-check": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -10145,6 +17532,12 @@
 			"requires": {
 				"boolbase": "~1.0.0"
 			}
+		},
+		"nullthrows": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+			"integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+			"dev": true
 		},
 		"num2fraction": {
 			"version": "1.2.2",
@@ -10330,6 +17723,15 @@
 			"requires": {
 				"is-observable": "^2.0.0",
 				"symbol-observable": "^1.0.4"
+			}
+		},
+		"on-finished": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+			"dev": true,
+			"requires": {
+				"ee-first": "1.1.1"
 			}
 		},
 		"once": {
@@ -10532,6 +17934,24 @@
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true
 		},
+		"osenv": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+			"dev": true,
+			"requires": {
+				"os-homedir": "^1.0.0",
+				"os-tmpdir": "^1.0.0"
+			},
+			"dependencies": {
+				"os-homedir": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+					"dev": true
+				}
+			}
+		},
 		"p-cancelable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -10638,6 +18058,151 @@
 				"readable-stream": "^2.1.5"
 			}
 		},
+		"parcel": {
+			"version": "2.0.0-alpha.3.2",
+			"resolved": "https://registry.npmjs.org/parcel/-/parcel-2.0.0-alpha.3.2.tgz",
+			"integrity": "sha512-FG8JZtY2MAhxYANtLUlRbPNhTqtDB6zDQ+GVPBgzs6xlzyWSEdzayJ2a25Nnee+SBptV9nSHavkMrtP3YLrnAg==",
+			"dev": true,
+			"requires": {
+				"@parcel/config-default": "^2.0.0-alpha.3.1",
+				"@parcel/core": "^2.0.0-alpha.3.2",
+				"@parcel/fs": "^2.0.0-alpha.3.1",
+				"@parcel/logger": "^2.0.0-alpha.3.1",
+				"@parcel/package-manager": "^2.0.0-alpha.3.1",
+				"chalk": "^2.1.0",
+				"commander": "^2.19.0",
+				"get-port": "^4.2.0",
+				"react": "^16.7.0",
+				"v8-compile-cache": "^2.0.0"
+			},
+			"dependencies": {
+				"@parcel/fs": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-DHXGRX/D9F2RgKecN6Fh7KmqLWD+IQxEraURF4hxw/QCfdQiUaobPS65I3VG7GLRhTeEXMjDibPF5902FJiQuQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"@parcel/watcher": "^2.0.0-alpha.4",
+						"@parcel/workers": "^2.0.0-alpha.3.1",
+						"mkdirp": "^0.5.1",
+						"ncp": "^2.0.0",
+						"nullthrows": "^1.1.1",
+						"rimraf": "^2.6.2"
+					}
+				},
+				"@parcel/logger": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-+Lyk1rtiyezoZor6yKq4lnbfIIQD0pdSSPhomKOa+yTpnWZVLjNZ/QJ+Q4PocJtN+VLOzw23nbPsTKeDTAYtEQ==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/events": "^2.0.0-alpha.3.1"
+					}
+				},
+				"@parcel/utils": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-8j3Sbp3J2ahR/MZREwVYYPEvf3LDjFkb1ZA2bq3PljWc+evDNt0ofunP1fBH9w/GvJEtPSx4bu1Z8mINTA/d4Q==",
+					"dev": true,
+					"requires": {
+						"@iarna/toml": "^2.2.0",
+						"@parcel/codeframe": "^2.0.0-alpha.3.1",
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/markdown-ansi": "^2.0.0-alpha.3.1",
+						"ansi-html": "^0.0.7",
+						"clone": "^2.1.1",
+						"deasync": "^0.1.14",
+						"fast-glob": "^3.0.4",
+						"is-glob": "^4.0.0",
+						"is-url": "^1.2.2",
+						"js-levenshtein": "^1.1.6",
+						"json5": "^1.0.1",
+						"micromatch": "^4.0.2",
+						"node-forge": "^0.8.1",
+						"nullthrows": "^1.1.1",
+						"resolve": "^1.12.0",
+						"serialize-to-js": "^1.1.1",
+						"terser": "^3.7.3"
+					}
+				},
+				"@parcel/watcher": {
+					"version": "2.0.0-alpha.4",
+					"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.0-alpha.4.tgz",
+					"integrity": "sha512-J8Detm6Yeh27lNVr02/bTxqQ5dAs040C9OB1Zs7C4kaDCq/Dx7FVph0aRKDhAiZ0BiSBwgZEh7xmD4ZU844kxA==",
+					"dev": true,
+					"requires": {
+						"bindings": "^1.5.0",
+						"node-addon-api": "^1.6.2",
+						"prebuild-install": "^5.2.5"
+					}
+				},
+				"@parcel/workers": {
+					"version": "2.0.0-alpha.3.1",
+					"resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.0.0-alpha.3.1.tgz",
+					"integrity": "sha512-XJqRQ5sCFoDFsCupJcUugTOp2RCtrlDuuwyDj9z3migsZ7tDxGhch/ewOy8qePk++aBEIgsNvn0hiERQHK5/0g==",
+					"dev": true,
+					"requires": {
+						"@parcel/diagnostic": "^2.0.0-alpha.3.1",
+						"@parcel/logger": "^2.0.0-alpha.3.1",
+						"@parcel/utils": "^2.0.0-alpha.3.1",
+						"chrome-trace-event": "^1.0.2",
+						"nullthrows": "^1.1.1",
+						"physical-cpu-count": "^2.0.0"
+					}
+				},
+				"clone": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+					"integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+					"dev": true
+				},
+				"get-port": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+					"integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
+					"dev": true
+				},
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"node-forge": {
+					"version": "0.8.5",
+					"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+					"integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
+					"dev": true
+				},
+				"serialize-to-js": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/serialize-to-js/-/serialize-to-js-1.2.2.tgz",
+					"integrity": "sha512-mUc8vA5iJghe+O+3s0YDGFLMJcqitVFk787YKiv8a4sf6RX5W0u81b+gcHrp15O0fFa010dRBVZvwcKXOWsL9Q==",
+					"dev": true,
+					"requires": {
+						"js-beautify": "^1.8.9",
+						"safer-eval": "^1.3.0"
+					}
+				},
+				"terser": {
+					"version": "3.17.0",
+					"resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
+					"integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
+					"dev": true,
+					"requires": {
+						"commander": "^2.19.0",
+						"source-map": "~0.6.1",
+						"source-map-support": "~0.5.10"
+					}
+				}
+			}
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10700,6 +18265,12 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+			"dev": true
+		},
+		"parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -10781,6 +18352,12 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
 			"dev": true
 		},
+		"physical-cpu-count": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
+			"integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA=",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
@@ -10832,6 +18409,15 @@
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
 			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
 			"dev": true
+		},
+		"pirates": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+			"integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+			"dev": true,
+			"requires": {
+				"node-modules-regexp": "^1.0.0"
+			}
 		},
 		"pkg-conf": {
 			"version": "3.1.0",
@@ -11032,6 +18618,118 @@
 				}
 			}
 		},
+		"postcss-calc": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
+			"integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+			"dev": true,
+			"requires": {
+				"css-unit-converter": "^1.1.1",
+				"postcss": "^7.0.5",
+				"postcss-selector-parser": "^5.0.0-rc.4",
+				"postcss-value-parser": "^3.3.1"
+			},
+			"dependencies": {
+				"cssesc": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+					"integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+					"integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+					"dev": true,
+					"requires": {
+						"cssesc": "^2.0.0",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-colormin": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-4.0.3.tgz",
+			"integrity": "sha512-WyQFAdDZpExQh32j0U0feWisZ0dmOtPl44qYmJKkq9xFWY3p+4qnRzCHeNrkeRhwPHz9bQ3mo0/yVkaply0MNw==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"color": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-convert-values": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-4.0.1.tgz",
+			"integrity": "sha512-Kisdo1y77KUC0Jmn0OXU/COOJbzM8cImvw1ZFsBgBgMgb1iL23Zs/LXRe3r+EZqM3vGYKdQ2YJVQ5VkJI+zEJQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-discard-comments": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-4.0.2.tgz",
+			"integrity": "sha512-RJutN259iuRf3IW7GZyLM5Sw4GLTOH8FmsXBnv8Ab/Tc2k4SR4qbV4DNbyyY4+Sjo362SyDmW2DQ7lBSChrpkg==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-discard-duplicates": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-4.0.2.tgz",
+			"integrity": "sha512-ZNQfR1gPNAiXZhgENFfEglF93pciw0WxMkJeVmw8eF+JZBbMD7jp6C67GqJAXVZP2BWbOztKfbsdmMp/k8c6oQ==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-discard-empty": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-4.0.1.tgz",
+			"integrity": "sha512-B9miTzbznhDjTfjvipfHoqbWKwd0Mj+/fL5s1QOz06wufguil+Xheo4XpOnc4NqKYBCNqqEzgPv2aPBIJLox0w==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-discard-overridden": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-4.0.1.tgz",
+			"integrity": "sha512-IYY2bEDD7g1XM1IDEsUT4//iEYCxAmP5oDSFMVU/JVvT7gh+l4fmjciLqGgwjdWpQIdb0Che2VX00QObS5+cTg==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
 		"postcss-html": {
 			"version": "0.36.0",
 			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
@@ -11075,6 +18773,168 @@
 			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
 			"dev": true
 		},
+		"postcss-merge-longhand": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-4.0.11.tgz",
+			"integrity": "sha512-alx/zmoeXvJjp7L4mxEMjh8lxVlDFX1gqWHzaaQewwMZiVhLo42TEClKaeHbRf6J7j82ZOdTJ808RtN0ZOZwvw==",
+			"dev": true,
+			"requires": {
+				"css-color-names": "0.0.4",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"stylehacks": "^4.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-merge-rules": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-4.0.3.tgz",
+			"integrity": "sha512-U7e3r1SbvYzO0Jr3UT/zKBVgYYyhAz0aitvGIYOYK5CPmkNih+WDSsS5tvPrJ8YMQYlEMvsZIiqmn7HdFUaeEQ==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"cssnano-util-same-parent": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0",
+				"vendors": "^1.0.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
+			}
+		},
+		"postcss-minify-font-values": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-4.0.2.tgz",
+			"integrity": "sha512-j85oO6OnRU9zPf04+PZv1LYIYOprWm6IA6zkXkrJXyRveDEuQggG6tvoy8ir8ZwjLxLuGfNkCZEQG7zan+Hbtg==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-minify-gradients": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-4.0.2.tgz",
+			"integrity": "sha512-qKPfwlONdcf/AndP1U8SJ/uzIJtowHlMaSioKzebAXSG4iJthlWC9iSWznQcX4f66gIWX44RSA841HTHj3wK+Q==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"is-color-stop": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-minify-params": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-4.0.2.tgz",
+			"integrity": "sha512-G7eWyzEx0xL4/wiBBJxJOz48zAKV2WG3iZOqVhPet/9geefm/Px5uo1fzlHu+DOjT+m0Mmiz3jkQzVHe6wxAWg==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"browserslist": "^4.0.0",
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"uniqs": "^2.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-minify-selectors": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-4.0.2.tgz",
+			"integrity": "sha512-D5S1iViljXBj9kflQo4YutWnJmwm8VvIsU1GeXJGiG9j8CIg9zs4voPMdQDUmIxetUOh60VilsNzCiAFTOqu3g==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
+			}
+		},
 		"postcss-modules-extract-imports": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
@@ -11114,6 +18974,226 @@
 			"requires": {
 				"icss-utils": "^4.0.0",
 				"postcss": "^7.0.6"
+			}
+		},
+		"postcss-normalize-charset": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
+			"integrity": "sha512-gMXCrrlWh6G27U0hF3vNvR3w8I1s2wOBILvA87iNXaPvSNo5uZAMYsZG7XjCUf1eVxuPfyL4TJ7++SGZLc9A3g==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-normalize-display-values": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-4.0.2.tgz",
+			"integrity": "sha512-3F2jcsaMW7+VtRMAqf/3m4cPFhPD3EFRgNs18u+k3lTJJlVe7d0YPO+bnwqo2xg8YiRpDXJI2u8A0wqJxMsQuQ==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-positions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-4.0.2.tgz",
+			"integrity": "sha512-Dlf3/9AxpxE+NF1fJxYDeggi5WwV35MXGFnnoccP/9qDtFrTArZ0D0R+iKcg5WsUd8nUYMIl8yXDCtcrT8JrdA==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-repeat-style": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-4.0.2.tgz",
+			"integrity": "sha512-qvigdYYMpSuoFs3Is/f5nHdRLJN/ITA7huIoCyqqENJe9PvPmLhNLMu7QTjPdtnVf6OcYYO5SHonx4+fbJE1+Q==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-string": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-4.0.2.tgz",
+			"integrity": "sha512-RrERod97Dnwqq49WNz8qo66ps0swYZDSb6rM57kN2J+aoyEAJfZ6bMx0sx/F9TIEX0xthPGCmeyiam/jXif0eA==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-timing-functions": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-4.0.2.tgz",
+			"integrity": "sha512-acwJY95edP762e++00Ehq9L4sZCEcOPyaHwoaFOhIwWCDfik6YvqsYNxckee65JHLKzuNSSmAdxwD2Cud1Z54A==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-unicode": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-4.0.1.tgz",
+			"integrity": "sha512-od18Uq2wCYn+vZ/qCOeutvHjB5jm57ToxRaMeNuf0nWVHaP9Hua56QyMF6fs/4FSUnVIw0CBPsU0K4LnBPwYwg==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-url": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-4.0.1.tgz",
+			"integrity": "sha512-p5oVaF4+IHwu7VpMan/SSpmpYxcJMtkGppYf0VbdH5B6hN8YNmVyJLuY9FmLQTzY3fag5ESUUHDqM+heid0UVA==",
+			"dev": true,
+			"requires": {
+				"is-absolute-url": "^2.0.0",
+				"normalize-url": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"normalize-url": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+					"integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
+					"dev": true
+				},
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-normalize-whitespace": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-4.0.2.tgz",
+			"integrity": "sha512-tO8QIgrsI3p95r8fyqKV+ufKlSHh9hMJqACqbv2XknufqEDhDvbguXGBBqxw9nsQoXWf0qOqppziKJKHMD4GtA==",
+			"dev": true,
+			"requires": {
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-ordered-values": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-4.1.2.tgz",
+			"integrity": "sha512-2fCObh5UanxvSxeXrtLtlwVThBvHn6MQcu4ksNT2tsaV2Fg76R2CV98W7wNSlX+5/pFwEyaDwKLLoEV7uRybAw==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-arguments": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
+		"postcss-reduce-initial": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-4.0.3.tgz",
+			"integrity": "sha512-gKWmR5aUulSjbzOfD9AlJiHCGH6AEVLaM0AV+aSioxUDd16qXP1PCh8d1/BGVvpdWn8k/HiK7n6TjeoXN1F7DA==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"caniuse-api": "^3.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0"
+			}
+		},
+		"postcss-reduce-transforms": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-4.0.2.tgz",
+			"integrity": "sha512-EEVig1Q2QJ4ELpJXMZR8Vt5DQx8/mo+dGWSR7vWXqcob2gQLyQGsionYcGKATXvQzMPn6DSN1vTN7yFximdIAg==",
+			"dev": true,
+			"requires": {
+				"cssnano-util-get-match": "^4.0.0",
+				"has": "^1.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
 			}
 		},
 		"postcss-reporter": {
@@ -11183,17 +19263,96 @@
 				"postcss": "^7.0.17"
 			}
 		},
+		"postcss-svgo": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
+			"integrity": "sha512-C6wyjo3VwFm0QgBy+Fu7gCYOkCmgmClghO+pjcxvrcBKtiKt0uCF+hvbMO1fyv5BMImRK90SMb+dwUnfbGd+jw==",
+			"dev": true,
+			"requires": {
+				"is-svg": "^3.0.0",
+				"postcss": "^7.0.0",
+				"postcss-value-parser": "^3.0.0",
+				"svgo": "^1.0.0"
+			},
+			"dependencies": {
+				"postcss-value-parser": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+					"integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+					"dev": true
+				}
+			}
+		},
 		"postcss-syntax": {
 			"version": "0.36.2",
 			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
 			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
 			"dev": true
 		},
+		"postcss-unique-selectors": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-4.0.1.tgz",
+			"integrity": "sha512-+JanVaryLo9QwZjKrmJgkI4Fn8SBgRO6WXQBJi7KiAVPlmxikB5Jzc4EvXMT2H0/m0RjrVVm9rGNhZddm/8Spg==",
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "^1.0.0",
+				"postcss": "^7.0.0",
+				"uniqs": "^2.0.0"
+			}
+		},
 		"postcss-value-parser": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
 			"integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
 			"dev": true
+		},
+		"posthtml": {
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
+			"integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
+			"dev": true,
+			"requires": {
+				"posthtml-parser": "^0.4.1",
+				"posthtml-render": "^1.1.5"
+			}
+		},
+		"posthtml-parser": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
+			"integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
+			"dev": true,
+			"requires": {
+				"htmlparser2": "^3.9.2"
+			}
+		},
+		"posthtml-render": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.5.tgz",
+			"integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w==",
+			"dev": true
+		},
+		"prebuild-install": {
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+			"dev": true,
+			"requires": {
+				"detect-libc": "^1.0.3",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.0",
+				"mkdirp": "^0.5.1",
+				"napi-build-utils": "^1.0.1",
+				"node-abi": "^2.7.0",
+				"noop-logger": "^0.1.1",
+				"npmlog": "^4.0.1",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^3.0.3",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0",
+				"which-pm-runs": "^1.0.0"
+			}
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -11236,6 +19395,12 @@
 			"requires": {
 				"parse-ms": "^2.1.0"
 			}
+		},
+		"private": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+			"integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+			"dev": true
 		},
 		"probe-image-size": {
 			"version": "5.0.0",
@@ -11284,6 +19449,12 @@
 				"object-assign": "^4.1.1",
 				"react-is": "^16.8.1"
 			}
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
+			"dev": true
 		},
 		"proto-props": {
 			"version": "2.0.0",
@@ -11362,6 +19533,127 @@
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 			"dev": true
 		},
+		"purgecss": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.4.2.tgz",
+			"integrity": "sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3",
+				"postcss": "^7.0.14",
+				"postcss-selector-parser": "^6.0.0",
+				"yargs": "^14.0.0"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.2",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+					"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"yargs": {
+					"version": "14.2.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+					"integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^15.0.0"
+					}
+				},
+				"yargs-parser": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+					"integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"q": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+			"integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+			"dev": true
+		},
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -11401,6 +19693,17 @@
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
 			"integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
 		},
+		"quote-stream": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+			"integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+			"dev": true,
+			"requires": {
+				"buffer-equal": "0.0.1",
+				"minimist": "^1.1.3",
+				"through2": "^2.0.0"
+			}
+		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11432,10 +19735,39 @@
 				"strip-json-comments": "~2.0.1"
 			}
 		},
+		"react": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
 			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+			"dev": true
+		},
+		"react-reconciler": {
+			"version": "0.24.0",
+			"resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
+			"integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2",
+				"scheduler": "^0.18.0"
+			}
+		},
+		"react-refresh": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.6.0.tgz",
+			"integrity": "sha512-Wv48N+GFt6Azvtl/LMvzNW9hvEyJdRQ48oVKIBAN7hjtvXXfxfVJXbPl/11SM1C/NIquIFXzzWCo6ZNH0I8I4g==",
 			"dev": true
 		},
 		"read-pkg": {
@@ -11556,6 +19888,15 @@
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
 			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
 			"dev": true
+		},
+		"regenerator-transform": {
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
+			"dev": true,
+			"requires": {
+				"private": "^0.1.6"
+			}
 		},
 		"regex-not": {
 			"version": "1.0.2",
@@ -11867,6 +20208,12 @@
 				}
 			}
 		},
+		"requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+			"dev": true
+		},
 		"reserved-words": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/reserved-words/-/reserved-words-0.1.2.tgz",
@@ -11969,6 +20316,18 @@
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
+		"rgb-regex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
+			"integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+			"dev": true
+		},
+		"rgba-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
+			"integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+			"dev": true
+		},
 		"rimraf": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -12055,6 +20414,15 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
 		},
+		"safer-eval": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.6.tgz",
+			"integrity": "sha512-DN9tBsZgtUOHODzSfO1nGCLhZtxc7Qq/d8/2SNxQZ9muYXZspSh1fO7HOsrf4lcelBNviAJLCxB/ggmG+jV1aw==",
+			"dev": true,
+			"requires": {
+				"clones": "^1.2.0"
+			}
+		},
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -12068,6 +20436,16 @@
 			"dev": true,
 			"requires": {
 				"xmlchars": "^2.1.1"
+			}
+		},
+		"scheduler": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+			"integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1"
 			}
 		},
 		"schema-utils": {
@@ -12172,6 +20550,41 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"shallow-clone": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
+			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+			"dev": true,
+			"requires": {
+				"is-extendable": "^0.1.1",
+				"kind-of": "^2.0.1",
+				"lazy-cache": "^0.2.3",
+				"mixin-object": "^2.0.1"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.0.2"
+					}
+				},
+				"lazy-cache": {
+					"version": "0.2.7",
+					"resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+					"integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U=",
+					"dev": true
+				}
+			}
+		},
+		"shallow-copy": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+			"integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA=",
+			"dev": true
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -12217,6 +20630,12 @@
 			"requires": {
 				"github-reserved-names": "^1.0.3"
 			}
+		},
+		"sigmund": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+			"dev": true
 		},
 		"sign-addon": {
 			"version": "0.3.1",
@@ -12372,6 +20791,57 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
+		"simple-concat": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+			"dev": true
+		},
+		"simple-get": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+			"dev": true,
+			"requires": {
+				"decompress-response": "^4.2.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			},
+			"dependencies": {
+				"decompress-response": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+					"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+					"dev": true,
+					"requires": {
+						"mimic-response": "^2.0.0"
+					}
+				},
+				"mimic-response": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+					"integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+					"dev": true
+				}
+			}
+		},
+		"simple-swizzle": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+			"dev": true,
+			"requires": {
+				"is-arrayish": "^0.3.1"
+			},
+			"dependencies": {
+				"is-arrayish": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+					"integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+					"dev": true
+				}
+			}
 		},
 		"size-plugin": {
 			"version": "2.0.1",
@@ -12676,6 +21146,28 @@
 				"extend-shallow": "^3.0.0"
 			}
 		},
+		"split2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+			"integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^3.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -12708,6 +21200,12 @@
 				"figgy-pudding": "^3.5.1"
 			}
 		},
+		"stable": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+			"dev": true
+		},
 		"stack-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
@@ -12719,6 +21217,15 @@
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.2.tgz",
 			"integrity": "sha512-8LpelPGR0qQM4PnfLiplOQNJcIN1/r2Gy0xKB2zKnIW2YzPMt2sR4I/+gtPjhN7Svh9kw+zqEg2SFwpBO9iNiw==",
 			"dev": true
+		},
+		"static-eval": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.3.tgz",
+			"integrity": "sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==",
+			"dev": true,
+			"requires": {
+				"escodegen": "^1.11.1"
+			}
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -12740,6 +21247,70 @@
 					}
 				}
 			}
+		},
+		"static-module": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+			"integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
+			"dev": true,
+			"requires": {
+				"concat-stream": "~1.6.0",
+				"convert-source-map": "^1.5.1",
+				"duplexer2": "~0.1.4",
+				"escodegen": "~1.9.0",
+				"falafel": "^2.1.0",
+				"has": "^1.0.1",
+				"magic-string": "^0.22.4",
+				"merge-source-map": "1.0.4",
+				"object-inspect": "~1.4.0",
+				"quote-stream": "~1.0.2",
+				"readable-stream": "~2.3.3",
+				"shallow-copy": "~0.0.1",
+				"static-eval": "^2.0.0",
+				"through2": "~2.0.3"
+			},
+			"dependencies": {
+				"escodegen": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+					"integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"magic-string": {
+					"version": "0.22.5",
+					"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+					"integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+					"dev": true,
+					"requires": {
+						"vlq": "^0.2.2"
+					}
+				},
+				"object-inspect": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+					"integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw==",
+					"dev": true
+				}
+			}
+		},
+		"statuses": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+			"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+			"dev": true
 		},
 		"stealthy-require": {
 			"version": "1.1.1",
@@ -12857,6 +21428,24 @@
 			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
 			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
 			"dev": true
+		},
+		"string-length": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
+			"integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
+			"dev": true,
+			"requires": {
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^5.2.0"
+			},
+			"dependencies": {
+				"astral-regex": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+					"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+					"dev": true
+				}
+			}
 		},
 		"string-replace-loader": {
 			"version": "2.2.0",
@@ -13012,6 +21601,45 @@
 			"resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
 			"integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
 			"dev": true
+		},
+		"stylehacks": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
+			"integrity": "sha512-7GlLk9JwlElY4Y6a/rmbH2MhVlTyVmiJd1PfTCqFaIBEGMYNsrO/v3SeGTdhBThLg4Z+NbOk/qFMwCa+J+3p/g==",
+			"dev": true,
+			"requires": {
+				"browserslist": "^4.0.0",
+				"postcss": "^7.0.0",
+				"postcss-selector-parser": "^3.0.0"
+			},
+			"dependencies": {
+				"dot-prop": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+					"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+					"dev": true,
+					"requires": {
+						"is-obj": "^1.0.0"
+					}
+				},
+				"is-obj": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+					"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+					"dev": true
+				},
+				"postcss-selector-parser": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+					"integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+					"dev": true,
+					"requires": {
+						"dot-prop": "^4.1.1",
+						"indexes-of": "^1.0.1",
+						"uniq": "^1.0.1"
+					}
+				}
+			}
 		},
 		"stylelint": {
 			"version": "12.0.0",
@@ -13513,6 +22141,12 @@
 				}
 			}
 		},
+		"svg-parser": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.2.tgz",
+			"integrity": "sha512-1gtApepKFweigFZj3sGO8KT8LvVZK8io146EzXrpVuWCDAbISz/yMucco3hWTkpZNoPabM+dnMOpy6Swue68Zg==",
+			"dev": true
+		},
 		"svg-tag-names": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.2.tgz",
@@ -13523,6 +22157,47 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
+		},
+		"svgo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+			"integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.4.1",
+				"coa": "^2.0.2",
+				"css-select": "^2.0.0",
+				"css-select-base-adapter": "^0.1.1",
+				"css-tree": "1.0.0-alpha.37",
+				"csso": "^4.0.2",
+				"js-yaml": "^3.13.1",
+				"mkdirp": "~0.5.1",
+				"object.values": "^1.1.0",
+				"sax": "~1.2.4",
+				"stable": "^0.1.8",
+				"unquote": "~1.1.1",
+				"util.promisify": "~1.0.0"
+			},
+			"dependencies": {
+				"css-select": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+					"integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
+					"dev": true,
+					"requires": {
+						"boolbase": "^1.0.0",
+						"css-what": "^3.2.1",
+						"domutils": "^1.7.0",
+						"nth-check": "^1.0.2"
+					}
+				},
+				"css-what": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+					"integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
+					"dev": true
+				}
+			}
 		},
 		"symbol-observable": {
 			"version": "1.2.0",
@@ -13604,6 +22279,53 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true
+		},
+		"tar-fs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+			"dev": true,
+			"requires": {
+				"chownr": "^1.1.1",
+				"mkdirp": "^0.5.1",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.0.0"
+			},
+			"dependencies": {
+				"bl": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+					"integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "^3.0.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"tar-stream": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+					"integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+					"dev": true,
+					"requires": {
+						"bl": "^3.0.0",
+						"end-of-stream": "^1.4.1",
+						"fs-constants": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.1.1"
+					}
+				}
+			}
 		},
 		"tar-stream": {
 			"version": "1.6.2",
@@ -13810,6 +22532,18 @@
 			"requires": {
 				"setimmediate": "^1.0.4"
 			}
+		},
+		"timsort": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+			"dev": true
+		},
+		"tiny-inflate": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+			"integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+			"dev": true
 		},
 		"tiny-version-compare": {
 			"version": "1.0.0",
@@ -14080,6 +22814,105 @@
 			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
 			"dev": true
 		},
+		"uncss": {
+			"version": "0.17.2",
+			"resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.2.tgz",
+			"integrity": "sha512-hu2HquwDItuGDem4YsJROdAD8SknmWtM24zwhQax6J1se8tPjV1cnwPKhtjodzBaUhaL8Zb3hlGdZ2WAUpbAOg==",
+			"dev": true,
+			"requires": {
+				"commander": "^2.20.0",
+				"glob": "^7.1.4",
+				"is-absolute-url": "^3.0.1",
+				"is-html": "^1.1.0",
+				"jsdom": "^14.1.0",
+				"lodash": "^4.17.15",
+				"postcss": "^7.0.17",
+				"postcss-selector-parser": "6.0.2",
+				"request": "^2.88.0"
+			},
+			"dependencies": {
+				"cssom": {
+					"version": "0.3.8",
+					"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+					"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+					"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
+					"dev": true,
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"is-absolute-url": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+					"integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+					"dev": true
+				},
+				"jsdom": {
+					"version": "14.1.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-14.1.0.tgz",
+					"integrity": "sha512-O901mfJSuTdwU2w3Sn+74T+RnDVP+FuV5fH8tcPWyqrseRAb0s5xOtPgCFiPOtLcyK7CLIJwPyD83ZqQWvA5ng==",
+					"dev": true,
+					"requires": {
+						"abab": "^2.0.0",
+						"acorn": "^6.0.4",
+						"acorn-globals": "^4.3.0",
+						"array-equal": "^1.0.0",
+						"cssom": "^0.3.4",
+						"cssstyle": "^1.1.1",
+						"data-urls": "^1.1.0",
+						"domexception": "^1.0.1",
+						"escodegen": "^1.11.0",
+						"html-encoding-sniffer": "^1.0.2",
+						"nwsapi": "^2.1.3",
+						"parse5": "5.1.0",
+						"pn": "^1.1.0",
+						"request": "^2.88.0",
+						"request-promise-native": "^1.0.5",
+						"saxes": "^3.1.9",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.5.0",
+						"w3c-hr-time": "^1.0.1",
+						"w3c-xmlserializer": "^1.1.2",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.5",
+						"whatwg-mimetype": "^2.3.0",
+						"whatwg-url": "^7.0.0",
+						"ws": "^6.1.2",
+						"xml-name-validator": "^3.0.0"
+					}
+				},
+				"parse5": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+					"integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+					"dev": true
+				},
+				"tough-cookie": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+					"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+					"dev": true,
+					"requires": {
+						"psl": "^1.1.28",
+						"punycode": "^2.1.1"
+					}
+				},
+				"ws": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+					"integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+					"dev": true,
+					"requires": {
+						"async-limiter": "~1.0.0"
+					}
+				}
+			}
+		},
 		"underscore": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
@@ -14133,6 +22966,24 @@
 			"integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
 			"dev": true
 		},
+		"unicode-trie": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
+			"integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
+			"dev": true,
+			"requires": {
+				"pako": "^0.2.5",
+				"tiny-inflate": "^1.0.0"
+			},
+			"dependencies": {
+				"pako": {
+					"version": "0.2.9",
+					"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+					"integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+					"dev": true
+				}
+			}
+		},
 		"unified": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
@@ -14165,6 +23016,12 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
 			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+			"dev": true
+		},
+		"uniqs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
+			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
 			"dev": true
 		},
 		"unique-filename": {
@@ -14260,6 +23117,18 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
+		},
+		"unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
+		},
+		"unquote": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+			"integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
 			"dev": true
 		},
 		"unset-value": {
@@ -14444,6 +23313,12 @@
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
 		},
+		"utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+			"dev": true
+		},
 		"uuid": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
@@ -14464,6 +23339,12 @@
 				"spdx-correct": "^3.0.0",
 				"spdx-expression-parse": "^3.0.0"
 			}
+		},
+		"vendors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+			"integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
+			"dev": true
 		},
 		"verror": {
 			"version": "1.10.0",
@@ -14526,6 +23407,12 @@
 				"@types/unist": "^2.0.0",
 				"unist-util-stringify-position": "^2.0.0"
 			}
+		},
+		"vlq": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+			"integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+			"dev": true
 		},
 		"vm-browserify": {
 			"version": "1.1.2",
@@ -16092,6 +24979,54 @@
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 			"dev": true
 		},
+		"which-pm-runs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				}
+			}
+		},
 		"widest-line": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
@@ -16856,6 +25791,12 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true
+		},
+		"yoga-layout-prebuilt": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.3.tgz",
+			"integrity": "sha512-9SNQpwuEh2NucU83i2KMZnONVudZ86YNcFk9tq74YaqrQfgJWO3yB9uzH1tAg8iqh5c9F5j0wuyJ2z72wcum2w==",
 			"dev": true
 		},
 		"zip-dir": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"lint-fix": "run-p --silent 'lint:* -- --fix'",
 		"test": "run-p --silent test:js lint:* build",
 		"test:js": "ava",
-		"build": "webpack --mode=production",
+		"build": "parcel build source/content.ts",
 		"watch": "webpack --mode=development --watch",
 		"watch:firefox": "web-ext run --source-dir=distribution",
 		"prerelease:version": "dot-json distribution/manifest.json version $VER",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 	},
 	"devDependencies": {
 		"@sindresorhus/tsconfig": "^0.6.0",
+		"@svgr/parcel-plugin-svgr": "^5.0.1",
 		"@types/chrome": "0.0.91",
 		"@types/codemirror": "0.0.81",
 		"@types/copy-webpack-plugin": "^5.0.0",
@@ -81,6 +82,7 @@
 		"jsdom": "^15.2.1",
 		"mini-css-extract-plugin": "^0.8.0",
 		"npm-run-all": "^4.1.3",
+		"parcel": "^2.0.0-alpha.3.2",
 		"size-plugin": "^2.0.1",
 		"string-replace-loader": "^2.2.0",
 		"stylelint": "^12.0.0",
@@ -148,6 +150,15 @@
 			}
 		]
 	},
+	"alias": {
+		"octicon": "@primer/octicons/build/svg",
+		"react": "dom-chef"
+	},
+	"browser": "distribution/content.js",
+	"browserslist": [
+		"last 1 Chrome versions",
+		"last 1 Firefox versions"
+	],
 	"ava": {
 		"files": [
 			"test/*.ts"

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -59,7 +59,7 @@ function wrap(...elements: Node[]): DocumentFragment {
 	if (features.isSingleCommit()) {
 		return (
 			<div className="float-right">
-			{...elements.map(element => <div className="ml-3 BtnGroup">{element}</div>)}
+			{elements.map(element => <div className="ml-3 BtnGroup">{element}</div>)}
 			</div>
 		);
 	}

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -91,7 +91,7 @@ async function init(): Promise<void> {
 					<div className="select-menu-header">
 						<span className="select-menu-title">Your forks</span>
 					</div>
-					{...forks.map(fork => (
+					{forks.map(fork => (
 						<a
 							href={`/${fork}`}
 							className="select-menu-item"


### PR DESCRIPTION
Our Webpack config is huge. I was hoping to be able to use Parcel and extract some code from it, but I don't think it's possible right now.

Maybe this can be revisited when Parcel 2 is out and this is resolved: https://github.com/parcel-bundler/parcel/issues/1039

I used Parcel elsewhere (https://github.com/tanmayrajani/notifications-preview-github/pull/88/files) and the configuration is almost non-existent (also because you _can't_ configure it, sometimes)

https://github.com/tanmayrajani/notifications-preview-github/blob/e60a64294c1bc875a3856b147d66febf8962c564/package.json#L6-L7