### PR TITLE
Simplify Octicons build by dropping Buble

### DIFF
--- a/octicon-svg-loader.ts
+++ b/octicon-svg-loader.ts
@@ -8,6 +8,6 @@ export default function (this: webpack.loader.LoaderContext, source: string): st
 		`<svg class="octicon octicon-${iconName}"`
 	);
 	return `
-	import React from 'dom-chef';
-	export default () => ${svgWithClass}`;
+	import doma from 'doma';
+	export default () => doma.one('${svgWithClass.replace('\'', '\\\'')}')`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -996,12 +996,6 @@
 			"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
 			"dev": true
 		},
-		"acorn-dynamic-import": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-			"dev": true
-		},
 		"acorn-globals": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
@@ -2651,88 +2645,6 @@
 				"electron-to-chromium": "^1.3.390",
 				"node-releases": "^1.1.53",
 				"pkg-up": "^2.0.0"
-			}
-		},
-		"buble": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/buble/-/buble-0.20.0.tgz",
-			"integrity": "sha512-/1gnaMQE8xvd5qsNBl+iTuyjJ9XxeaVxAMF86dQ4EyxFJOZtsgOS8Ra+7WHgZTam5IFDtt4BguN0sH0tVTKrOw==",
-			"dev": true,
-			"requires": {
-				"acorn": "^6.4.1",
-				"acorn-dynamic-import": "^4.0.0",
-				"acorn-jsx": "^5.2.0",
-				"chalk": "^2.4.2",
-				"magic-string": "^0.25.7",
-				"minimist": "^1.2.5",
-				"regexpu-core": "4.5.4"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^1.9.0"
-					}
-				},
-				"chalk": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^3.2.1",
-						"escape-string-regexp": "^1.0.5",
-						"supports-color": "^5.3.0"
-					}
-				},
-				"color-convert": {
-					"version": "1.9.3",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
-					"requires": {
-						"color-name": "1.1.3"
-					}
-				},
-				"color-name": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
-				},
-				"escape-string-regexp": {
-					"version": "1.0.5",
-					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
-		"buble-loader": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/buble-loader/-/buble-loader-0.5.1.tgz",
-			"integrity": "sha512-ytp2BqL4NfyImoXQUFcIkM2EgKJI2e8KEc9R5/7MbUmdu952CYkhkwydZcKreuC6VAUBp9R7rxS88TZ7RQq/3A==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0"
 			}
 		},
 		"buf-compare": {
@@ -8846,12 +8758,6 @@
 				}
 			}
 		},
-		"jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-			"dev": true
-		},
 		"json-buffer": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -9373,15 +9279,6 @@
 			"dev": true,
 			"requires": {
 				"yallist": "^3.0.2"
-			}
-		},
-		"magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-			"dev": true,
-			"requires": {
-				"sourcemap-codec": "^1.4.4"
 			}
 		},
 		"make-dir": {
@@ -11671,21 +11568,6 @@
 				}
 			}
 		},
-		"regenerate": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-			"integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-			"dev": true
-		},
-		"regenerate-unicode-properties": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
-			"integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0"
-			}
-		},
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
@@ -11724,20 +11606,6 @@
 			"integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
 			"dev": true
 		},
-		"regexpu-core": {
-			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.4.tgz",
-			"integrity": "sha512-BtizvGtFQKGPUcTy56o3nk1bGRp4SZOTYrDtGNlqCQufptV5IkkLN6Emw+yunAJjzf+C9FQFtvq7IoA3+oMYHQ==",
-			"dev": true,
-			"requires": {
-				"regenerate": "^1.4.0",
-				"regenerate-unicode-properties": "^8.0.2",
-				"regjsgen": "^0.5.0",
-				"regjsparser": "^0.6.0",
-				"unicode-match-property-ecmascript": "^1.0.4",
-				"unicode-match-property-value-ecmascript": "^1.1.0"
-			}
-		},
 		"registry-auth-token": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
@@ -11754,21 +11622,6 @@
 			"dev": true,
 			"requires": {
 				"rc": "^1.2.8"
-			}
-		},
-		"regjsgen": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.1.tgz",
-			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg==",
-			"dev": true
-		},
-		"regjsparser": {
-			"version": "0.6.4",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
-			"integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
-			"dev": true,
-			"requires": {
-				"jsesc": "~0.5.0"
 			}
 		},
 		"relaxed-json": {
@@ -12758,12 +12611,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-			"dev": true
-		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"dev": true
 		},
 		"spawn-sync": {
@@ -14264,34 +14111,6 @@
 				"inherits": "^2.0.0",
 				"xtend": "^4.0.0"
 			}
-		},
-		"unicode-canonical-property-names-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
-			"dev": true
-		},
-		"unicode-match-property-ecmascript": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-			"dev": true,
-			"requires": {
-				"unicode-canonical-property-names-ecmascript": "^1.0.4",
-				"unicode-property-aliases-ecmascript": "^1.0.4"
-			}
-		},
-		"unicode-match-property-value-ecmascript": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
-			"integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
-			"dev": true
-		},
-		"unicode-property-aliases-ecmascript": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
-			"integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
-			"dev": true
 		},
 		"unified": {
 			"version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
 		"@types/react": "^16.9.32",
 		"@types/terser-webpack-plugin": "^2.2.0",
 		"ava": "^3.6.0",
-		"buble": "^0.20.0",
-		"buble-loader": "^0.5.1",
 		"chrome-webstore-upload-cli": "^1.2.0",
 		"copy-webpack-plugin": "^5.1.1",
 		"css-loader": "^3.5.1",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -87,11 +87,10 @@ const config: Configuration = {
 				]
 			},
 			{
-				// Allows us to import SVG as JSX modules
 				test: /\.svg$/i,
 				use: [
-					'buble-loader', // Converts JSX to vanilla `React.createElement` calls because TypeScript can't handle JSX outside jsx/tsx files: https://github.com/microsoft/TypeScript/issues/10939
-					path.resolve(__dirname, 'octicon-svg-loader.ts') // Converts the SVG file into a JSX module with default export
+					// Converts SVG files into a `export default () => actualDomElement`
+					path.resolve(__dirname, 'octicon-svg-loader.ts')
 				]
 			}
 		]


### PR DESCRIPTION
The build used to:

1. For every SVG, create a module that exports JSX
2. Use Buble to transpile that JSX into `dom-chef` calls

Now:

1. For every SVG, create a module that exported an SVG element

This is done by using [doma](https://github.com/fregante/doma)/`innerHTML` instead of going through JSX first

Pros:

- 89 bytes saved (!!!)
- 0s build time shaved (_!**!**!_)
- 2 fewer dependencies (and a dozen subs)
- an enviable `+4 -188` diff stat

This is what webpack outputs:

```diff
-   var check = function() {
-     return dom_chef["a"].createElement("svg", {
-       class: "octicon octicon-check",
-       xmlns: "http://www.w3.org/2000/svg",
-       width: "12",
-       height: "16",
-       viewBox: "0 0 12 16"
-     }, dom_chef["a"].createElement("path", {
-       "fill-rule": "evenodd",
-       d: "M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"
-     }));
-   };
+   var check = () => node_modules_doma.one('<svg class="octicon octicon-check" xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>');
```

The only way this could be further optimized would be by finding a way to do this without creating a loader, probably. PR welcome for that too!