### PR TITLE
Only look for `ci-link` in the last 2 days of commits

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -5,10 +5,10 @@ import fetchDom from '../libs/fetch-dom';
 import {getRepoURL} from '../libs/utils';
 import {appendBefore} from '../libs/dom-utils';
 
-// Look for the CI icon in the latest 3 days of commits #2884
+// Look for the CI icon in the latest 2 days of commits #2990
 export const getIcon = oneTime(fetchDom.bind(null,
 	`/${getRepoURL()}/commits`,
-	'.commit-group:nth-of-type(-n+3) .commit-build-statuses'
+	'.commit-group:nth-of-type(-n+2) .commit-build-statuses'
 ));
 
 async function init(): Promise<false | void> {

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -1,23 +1,24 @@
 import './ci-link.css';
+import oneTime from 'onetime';
 import features from '../libs/features';
 import fetchDom from '../libs/fetch-dom';
 import {getRepoURL} from '../libs/utils';
 import {appendBefore} from '../libs/dom-utils';
 
-let callCount = 0;
-export function getIcon(): Promise<HTMLElement | undefined> {
-	callCount += 1;
-	return fetchDom(`/${getRepoURL()}/commits`, '.commit-build-statuses');
-}
+// Look for the CI icon in the latest 3 days of commits #2884
+export const getIcon = oneTime(fetchDom.bind(null,
+	`/${getRepoURL()}/commits`,
+	'.commit-group:nth-of-type(-n+3) .commit-build-statuses'
+));
 
 async function init(): Promise<false | void> {
-	const icon = await getIcon();
+	const icon = await getIcon() as HTMLElement | undefined;
 	if (!icon) {
 		return false;
 	}
 
 	icon.classList.add('rgh-ci-link');
-	if (callCount > 1) {
+	if (oneTime.callCount(getIcon) > 1) {
 		icon.style.animation = 'none';
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/2884#issuecomment-611991396

# Test

Has icon: https://github.com/sindresorhus/refined-github/commits/master
Every commit has a CI run, `ci-link` should be shown

No icon: https://github.com/samuelmeuli/font-picker/commits/master
The last CI run was last year, `ci-link` should **not** be shown
