### PR TITLE
Remove useless exclude from `profile-gists-link`

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -45,9 +45,6 @@ features.add({
 	include: [
 		features.isUserProfile
 	],
-	exclude: [
-		features.isOrganizationProfile
-	],
 	load: features.nowAndOnAjaxedPages,
 	init
 });


### PR DESCRIPTION
Follows https://github.com/sindresorhus/refined-github/pull/2981#discussion_r404920120

There was (never) any need to exclude. `isUserProfile`'s selector does not exist on `isOrganizationProfile`

Test on
https://github.com/highlightjs

<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
