### PR TITLE
Fix `recently-pushed-branches-enhancements` in responsive views

### DIFF
--- a/source/features/recently-pushed-branches-enhancements.css
+++ b/source/features/recently-pushed-branches-enhancements.css
@@ -40,8 +40,10 @@
 	width: 32px;
 	text-indent: -999999px; /* Hide text */
 }
-.rgh-recently-pushed-branches .Header .RecentBranches:not(:hover) .btn {
-	background: #5d5d5d;
+@media (min-width: 1010px) {
+	.rgh-recently-pushed-branches .Header .RecentBranches:not(:hover) .btn {
+		background: #5d5d5d;
+	}
 }
 .rgh-recently-pushed-branches .Header .RecentBranches .btn + div {
 	margin-right: 8px;
@@ -67,6 +69,13 @@
 .rgh-recently-pushed-branches .Header .RecentBranches:not(:hover) .RecentBranches-item:last-child {
 	border-bottom-width: 2px;
 }
+/* Hide branch information on smaller screens */
+@media (max-width: 1010px) {
+	.rgh-recently-pushed-branches .Header:not(:hover) .RecentBranches-item div {
+		display: none;
+	}
+}
+
 .rgh-recently-pushed-branches .Header .RecentBranches-item-link {
 	max-width: 250px !important;
 	font-size: 14px;

--- a/source/features/recently-pushed-branches-enhancements.tsx
+++ b/source/features/recently-pushed-branches-enhancements.tsx
@@ -47,7 +47,7 @@ async function init(): Promise<false | void> {
 	document.body.classList.add('rgh-recently-pushed-branches');
 
 	// Move or add list next to the notifications bell
-	select('.Header-item--full,.HeaderMenu nav')!.after(widget);
+	select.last('.Header-item--full, .HeaderMenu nav')!.after(widget);
 }
 
 features.add({


### PR DESCRIPTION
Fixes #2940

Easiest way to test is to clone a branch

![Video_2020-04-19_140321](https://user-images.githubusercontent.com/16872793/79697050-78903c80-824e-11ea-8674-47695a609773.gif)

<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
