### PR TITLE
Add `open-and-closed-issues-sort-by-update-time`

### DIFF
--- a/source/features/open-and-closed-issues-sort-by-update-time.tsx
+++ b/source/features/open-and-closed-issues-sort-by-update-time.tsx
@@ -1,0 +1,38 @@
+import select from 'select-dom';
+import elementReady from 'element-ready';
+import features from '../libs/features';
+import SearchQuery from '../libs/search-query';
+
+function init(): void {
+	// Get issues links that don't already have a specific sorting applied
+	for (const link of select.all<HTMLAnchorElement>(`
+		[href*="/issues"]:not([href*="sort%3A"]):not(.issues-reset-query),
+		[href*="/pulls" ]:not([href*="sort%3A"]):not(.issues-reset-query)
+	`)) {
+		// Pick only links to lists, not single issues
+		// + skip pagination links
+		// + skip pr/issue filter dropdowns (some are lazyloaded)
+		if (/(issues|pulls)\/?$/.test(link.pathname) && !link.closest('.pagination, .table-list-filters')) {
+			new SearchQuery(link).add('is:closed sort:updated-desc');
+		}
+	}
+}
+
+async function cleanBar(): Promise<void> {
+	(await elementReady<HTMLInputElement>('.header-search-input'))!.value = '';
+}
+
+features.add({
+	id: __featureName__,
+	description: 'Shows both open and closed issues and PRs and sorts them by `Recently updated`.',
+	screenshot: false
+}, {
+	init
+}, {
+	include: [
+		features.isGlobalDiscussionList
+	],
+	waitForDomReady: false,
+	repeatOnAjax: false,
+	init: cleanBar
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -63,6 +63,7 @@ import './features/discussion-links-on-repo-lists';
 import './features/global-discussion-list-filters';
 import './features/filter-comments-by-you';
 import './features/sort-issues-by-update-time'; // Must be after global-discussion-list-filters and filter-comments-by-you and discussion-links-on-repo-lists
+import './features/display-all-issues-by-update-time'; // Must be after global-discussion-list-filters and filter-comments-by-you and discussion-links-on-repo-lists
 import './features/pinned-issues-update-time';
 import './features/latest-tag-button';
 import './features/default-branch-button';


### PR DESCRIPTION
This is fork of `sort-issues-by-update-time` which displays both open and closed issues.

The reason I made this is because I often search for an issue in some repo, and I like it being sorted by `Recently updated`. I am not interested whether it's open or closed, I just want more info on the issue.
However the `sort-issues-by-update-time` feature keeps the search query like: `is:issue is:open sort:updated-desc` and it makes it inconvenient to update - I have to select the innermost filter is:open, remove it, and then type my search term. In case I want to change the term, I need to repeat the process, or move the search term to be the last parameter.

I'm open for suggestions regarding naming. Also, this could just be an update on existing `sort-issues-by-update-time` if people think that's better. And in case you think this functionality is not needed, I'll keep it for myself.

1. LINKED ISSUES:
   No existing issues.

2. TEST URLS:
   https://github.com/sindresorhus/refined-github (check the link to Issues)

3. SCREENSHOT:
   
![desktop-2020-04-20T17:47:26+0200](https://user-images.githubusercontent.com/3995223/79771938-c4ff7900-832f-11ea-9556-13719b75eefc.png)


