### PR TITLE
Keep `clone-branch` after a search

### DIFF
--- a/source/features/clone-branch.tsx
+++ b/source/features/clone-branch.tsx
@@ -102,6 +102,5 @@ features.add({
 	],
 	init: () => {
 		observeElement('[data-target="branch-filter-controller.results"]', init);
-		return false;
 	}
 });

--- a/source/features/clone-branch.tsx
+++ b/source/features/clone-branch.tsx
@@ -8,6 +8,7 @@ import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 import loadingIcon from '../libs/icon-loading';
 import {getRepoURL, getRepoGQL} from '../libs/utils';
+import observeElement from '../libs/simplified-element-observer';
 
 const getBranchBaseSha = async (branchName: string): Promise<string> => {
 	const {repository} = await api.v4(`
@@ -99,5 +100,8 @@ features.add({
 	include: [
 		pageDetect.isBranches
 	],
-	init
+	init: () => {
+		observeElement('[data-target="branch-filter-controller.results"]', init);
+		return false;
+	}
 });


### PR DESCRIPTION
I know you said https://github.com/sindresorhus/refined-github/pull/2896#issuecomment-599794812
>Ah you're talking about the filter: when used, the buttons don't appear. That's ok, not a big deal enough to add observeElement

But with #3022 it looks funny that the dom changes when you do a search

Test on: https://github.com/sindresorhus/refined-github/branches

If you need a gif ping me...
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes
