### PR TITLE
Add `action-used-by-link` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -297,6 +297,12 @@ Thanks for contributing! 🦋🙌
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
+### Marketplace
+
+- [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
+
+<!-- Refer to style guide above. Keep this message between sections. -->
+
 ### Global
 
 - [](# "useful-not-found-page") 🔥 [Adds possible related pages and alternatives on 404 pages.](https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png)

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,7 @@ Thanks for contributing! 🦋🙌
 - [](# "content") [Reduces tabs’ size to 4 spaces instead of 8.](https://cloud.githubusercontent.com/assets/170270/14170088/d3be931e-f755-11e5-8edf-c5f864336382.png)
 - [](# "esc-to-deselect-line") [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 - [](# "html-preview-link") [Adds a link to preview HTML files.](https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png)
+- [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -294,12 +295,6 @@ Thanks for contributing! 🦋🙌
 - [](# "hide-own-stars") Hides "starred" events for your own repos.
 - [](# "hide-useless-newsfeed-events") Hides other inutile events (commits, forks, new followers).
 - [](# "infinite-scroll") Automagically expands the newsfeed when you scroll down.
-
-<!-- Refer to style guide above. Keep this message between sections. -->
-
-### Marketplace
-
-- [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -27,7 +27,7 @@ function init(): void {
 
 features.add({
 	id: __filebasename,
-	description: 'Adds a direct link to search worklows using an action when browsing an action page on the Marketplace.',
+	description: 'Lets you see how others are using the current Action in the Marketplace.',
 	screenshot: 'https://user-images.githubusercontent.com/8360597/80221147-2cc20680-8645-11ea-8493-befb47ddebd4.png'
 }, {
 	include: [

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -6,10 +6,11 @@ export const isActionPage = (): boolean => location.pathname.split('/', 3).join(
 
 async function init(): Promise<void> {
 	const actionRepo = select('.d-block.mb-2')!
-		.href
-		.replace(location.origin, '');
+		.getAttribute("href")!
+		.replace(location.origin, '')
+		.replace("/", "");
 
-	const actionURL = new URL('https://github.com');
+	const actionURL = new URL('https://github.com/search');
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
 	actionURL.searchParams.set('o', 'desc');
 	actionURL.searchParams.set('s', 'indexed');
@@ -18,7 +19,7 @@ async function init(): Promise<void> {
 	select('.d-block.mb-2')!
 		.parentElement!
 		.append(
-			<a href="{String(actionURL)}" class="d-block mb-2">
+			<a href={String(actionURL)} class="d-block mb-2">
 				<svg class="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>Used by (find workflows)
 			</a>
 		);
@@ -26,7 +27,7 @@ async function init(): Promise<void> {
 
 features.add({
 	id: __filebasename,
-	description: 'Adds a link to access worklows using an action when seeing an action page on the Marketplace.',
+	description: 'Adds a direct link to search worklows using an action when browsing an action page on the Marketplace.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/80146153-ab6d6400-85b1-11ea-9f38-e87950692a62.png'
 }, {
 	include: [

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,0 +1,29 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+
+export const isActionPage = (): boolean => location.pathname.split("/", 3).join("/") == "/marketplace/actions";
+
+async function init(): Promise<void> {
+console.log(select('.d-block.mb-2')!);
+	select('.d-block.mb-2')!
+	.parentElement!
+	.append(
+		<a href="https://github.com/abinoda/assignee-to-reviewer-action" class="d-block mb-2">
+      <svg class="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"></path></svg>Used by
+    </a>
+	);
+
+}
+
+
+features.add({
+	id: __filebasename,
+	description: 'Adds a link to access worklows using an action when seeing an action page on the Marketplace.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/80146153-ab6d6400-85b1-11ea-9f38-e87950692a62.png'
+}, {
+	include: [
+		isActionPage
+	],
+	init
+});

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -6,8 +6,8 @@ import searchIcon from 'octicon/search.svg';
 
 function init(): void {
 	const actionRepo = (select('.py-3.border-bottom.border-gray-light .octicon.octicon-issue-opened.text-gray-dark.mr-2')!.parentElement as HTMLAnchorElement)
-	  .pathname.slice(1)
-	  .replace('/issues', '');
+		.pathname.slice(1)
+		.replace('/issues', '');
 
 	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -4,7 +4,7 @@ import features from '../libs/features';
 
 export const isActionPage = (): boolean => location.pathname.split('/', 3).join('/') === '/marketplace/actions';
 
-async function init(): Promise<void> {
+function init(): void {
 	const actionRepo = select('.d-block.mb-2')!
 		.getAttribute('href')!
 		.replace(location.origin, '')

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -8,8 +8,6 @@ function init(): void {
 	const actionRepo = (select('.octicon-issue-opened.text-gray-dark')!.parentElement as HTMLAnchorElement)
 		.pathname.slice(1)
 		.replace('/issues', '');
-		.pathname.slice(1)
-		.replace('/issues', '');
 
 	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -5,9 +5,10 @@ import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 
 function init(): void {
-	const actionRepo = (select('.octicon-issue-opened.text-gray-dark')!.parentElement as HTMLAnchorElement)
-		.pathname.slice(1)
-		.replace('/issues', '');
+	const actionRepo = select('aside .octicon-repo')!
+		.closest('a')!
+		.pathname
+		.slice(1);
 
 	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -5,10 +5,9 @@ import * as pageDetect from '../libs/page-detect';
 import searchIcon from 'octicon/search.svg';
 
 function init(): void {
-	const actionRepo = select('.d-block.mb-2')!
-		.getAttribute('href')!
-		.replace(location.origin, '')
-		.replace('/', '');
+	const actionRepo = (select('.py-3.border-bottom.border-gray-light .octicon.octicon-issue-opened.text-gray-dark.mr-2')!!.parentElement as HTMLAnchorElement)
+	  .pathname.slice(1)
+	  .replace('/issues', '');
 
 	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
@@ -22,7 +21,7 @@ function init(): void {
 
 	select('.d-block.mb-2[href^="/contact"]')!.after(
 		<a href={String(actionURL)} className="d-block mb-2">
-			{styledSearchIcon} Usage examples
+			{styledSearchIcon}Usage examples
 		</a>
 	);
 }

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -10,7 +10,7 @@ function init(): void {
 		.replace(location.origin, '')
 		.replace('/', '');
 
-	const actionURL = new URL('https://github.com/search');
+	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
 	actionURL.searchParams.set('o', 'desc');
 	actionURL.searchParams.set('s', 'indexed');

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -2,20 +2,27 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 
-export const isActionPage = (): boolean => location.pathname.split("/", 3).join("/") == "/marketplace/actions";
+export const isActionPage = (): boolean => location.pathname.split('/', 3).join('/') === '/marketplace/actions';
 
 async function init(): Promise<void> {
-console.log(select('.d-block.mb-2')!);
+	const actionRepo = select('.d-block.mb-2')!
+		.href
+		.replace(location.origin, '');
+
+	const actionURL = new URL('https://github.com');
+	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
+	actionURL.searchParams.set('o', 'desc');
+	actionURL.searchParams.set('s', 'indexed');
+	actionURL.searchParams.set('type', 'Code');
+
 	select('.d-block.mb-2')!
-	.parentElement!
-	.append(
-		<a href="https://github.com/abinoda/assignee-to-reviewer-action" class="d-block mb-2">
-      <svg class="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"></path></svg>Used by
-    </a>
-	);
-
+		.parentElement!
+		.append(
+			<a href="{String(actionURL)}" class="d-block mb-2">
+				<svg class="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>Used by (find workflows)
+			</a>
+		);
 }
-
 
 features.add({
 	id: __filebasename,

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -11,9 +11,9 @@ function init(): void {
 
 	const actionURL = new URL('search', location.origin);
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
-	actionURL.searchParams.set('o', 'desc');
-	actionURL.searchParams.set('s', 'indexed');
 	actionURL.searchParams.set('type', 'Code');
+	actionURL.searchParams.set('s', 'indexed');
+	actionURL.searchParams.set('o', 'desc');
 
 	const styledSearchIcon = searchIcon();
 	styledSearchIcon.setAttribute('width', '14');

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -28,7 +28,7 @@ async function init(): Promise<void> {
 features.add({
 	id: __filebasename,
 	description: 'Adds a direct link to search worklows using an action when browsing an action page on the Marketplace.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80146153-ab6d6400-85b1-11ea-9f38-e87950692a62.png'
+	screenshot: 'https://user-images.githubusercontent.com/8360597/80221147-2cc20680-8645-11ea-8493-befb47ddebd4.png'
 }, {
 	include: [
 		isActionPage

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -29,7 +29,7 @@ function init(): void {
 features.add({
 	id: __filebasename,
 	description: 'Lets you see how others are using the current Action in the Marketplace.',
-	screenshot: 'https://user-images.githubusercontent.com/8360597/80221147-2cc20680-8645-11ea-8493-befb47ddebd4.png'
+	screenshot: 'https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png'
 }, {
 	include: [
 		pageDetect.isActionPage

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import features from '../libs/features';
 import searchIcon from 'octicon/search.svg';
+import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 
 function init(): void {

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -5,7 +5,9 @@ import * as pageDetect from '../libs/page-detect';
 import searchIcon from 'octicon/search.svg';
 
 function init(): void {
-	const actionRepo = (select('.py-3.border-bottom.border-gray-light .octicon.octicon-issue-opened.text-gray-dark.mr-2')!.parentElement as HTMLAnchorElement)
+	const actionRepo = (select('.octicon-issue-opened.text-gray-dark')!.parentElement as HTMLAnchorElement)
+		.pathname.slice(1)
+		.replace('/issues', '');
 		.pathname.slice(1)
 		.replace('/issues', '');
 

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from '../libs/page-detect';
 import searchIcon from 'octicon/search.svg';
 
 function init(): void {
-	const actionRepo = (select('.py-3.border-bottom.border-gray-light .octicon.octicon-issue-opened.text-gray-dark.mr-2')!!.parentElement as HTMLAnchorElement)
+	const actionRepo = (select('.py-3.border-bottom.border-gray-light .octicon.octicon-issue-opened.text-gray-dark.mr-2')!.parentElement as HTMLAnchorElement)
 	  .pathname.slice(1)
 	  .replace('/issues', '');
 

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
+import * as pageDetect from '../libs/page-detect';
 import searchIcon from 'octicon/search.svg';
 
 function init(): void {

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -6,9 +6,9 @@ export const isActionPage = (): boolean => location.pathname.split('/', 3).join(
 
 async function init(): Promise<void> {
 	const actionRepo = select('.d-block.mb-2')!
-		.getAttribute("href")!
+		.getAttribute('href')!
 		.replace(location.origin, '')
-		.replace("/", "");
+		.replace('/', '');
 
 	const actionURL = new URL('https://github.com/search');
 	actionURL.searchParams.set('q', `${actionRepo} path:.github/workflows/ language:YAML`);
@@ -19,8 +19,8 @@ async function init(): Promise<void> {
 	select('.d-block.mb-2')!
 		.parentElement!
 		.append(
-			<a href={String(actionURL)} class="d-block mb-2">
-				<svg class="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>Used by (find workflows)
+			<a href={String(actionURL)} className="d-block mb-2">
+				<svg className="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>Used by (find workflows)
 			</a>
 		);
 }

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,8 +1,8 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
-import * as pageDetect from '../libs/page-detect';
 import searchIcon from 'octicon/search.svg';
+import * as pageDetect from '../libs/page-detect';
 
 function init(): void {
 	const actionRepo = (select('.octicon-issue-opened.text-gray-dark')!.parentElement as HTMLAnchorElement)

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -3,8 +3,6 @@ import select from 'select-dom';
 import features from '../libs/features';
 import searchIcon from 'octicon/search.svg';
 
-export const isActionPage = (): boolean => location.pathname.split('/', 3).join('/') === '/marketplace/actions';
-
 function init(): void {
 	const actionRepo = select('.d-block.mb-2')!
 		.getAttribute('href')!
@@ -20,12 +18,13 @@ function init(): void {
 	const styledSearchIcon = searchIcon();
 	styledSearchIcon.setAttribute('width', '14');
 	styledSearchIcon.classList.add('text-gray-dark', 'mr-2');
-	
+
 	select('.d-block.mb-2[href^="/contact"]')!.after(
 		<a href={String(actionURL)} className="d-block mb-2">
 			{styledSearchIcon} Usage examples
 		</a>
 	);
+}
 
 features.add({
 	id: __filebasename,
@@ -33,7 +32,7 @@ features.add({
 	screenshot: 'https://user-images.githubusercontent.com/8360597/80221147-2cc20680-8645-11ea-8493-befb47ddebd4.png'
 }, {
 	include: [
-		isActionPage
+		pageDetect.isActionPage
 	],
 	init
 });

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -16,14 +16,15 @@ function init(): void {
 	actionURL.searchParams.set('s', 'indexed');
 	actionURL.searchParams.set('type', 'Code');
 
-	select('.d-block.mb-2')!
-		.parentElement!
-		.append(
-			<a href={String(actionURL)} className="d-block mb-2">
-				<svg className="octicon octicon-search text-gray-dark mr-2" width="14" height="16" viewBox="0 0 16 16" version="1.1" aria-hidden="true"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0013 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 000-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>Used by (find workflows)
-			</a>
-		);
-}
+	const styledSearchIcon = searchIcon();
+	styledSearchIcon.setAttribute('width', '14');
+	styledSearchIcon.classList.add('text-gray-dark', 'mr-2');
+	
+	select('.d-block.mb-2[href^="/contact"]')!.after(
+		<a href={String(actionURL)} className="d-block mb-2">
+			{styledSearchIcon}Used by (find workflows)
+		</a>
+	);
 
 features.add({
 	id: __filebasename,

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
+import searchIcon from 'octicon/search.svg';
 
 export const isActionPage = (): boolean => location.pathname.split('/', 3).join('/') === '/marketplace/actions';
 
@@ -22,7 +23,7 @@ function init(): void {
 	
 	select('.d-block.mb-2[href^="/contact"]')!.after(
 		<a href={String(actionURL)} className="d-block mb-2">
-			{styledSearchIcon}Used by (find workflows)
+			{styledSearchIcon} Usage examples
 		</a>
 	);
 

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -408,7 +408,7 @@ export const hasCode = (): boolean => // Static code, not the editor
 	isCompare() ||
 	isBlame();
 
-export const isActionPage = (): boolean => /\/marketplace\/actions\/.*/.test(location.pathname);
+export const isActionPage = (): boolean => location.pathname.startsWith('/marketplace/actions/');
 export const _isActionPage = [
 	'https://github.com/marketplace/actions/urlchecker-action',
 	'https://github.com/marketplace/actions/github-action-for-assignee-to-reviewer',

--- a/source/libs/page-detect.ts
+++ b/source/libs/page-detect.ts
@@ -407,3 +407,10 @@ export const hasCode = (): boolean => // Static code, not the editor
 	isGist() ||
 	isCompare() ||
 	isBlame();
+
+export const isActionPage = (): boolean => /\/marketplace\/actions\/.*/.test(location.pathname);
+export const _isActionPage = [
+	'https://github.com/marketplace/actions/urlchecker-action',
+	'https://github.com/marketplace/actions/github-action-for-assignee-to-reviewer',
+	'https://github.com/marketplace/actions/hugo-actions'
+];

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -171,6 +171,7 @@ import './features/clone-branch';
 import './features/deep-reblame';
 import './features/clear-pr-merge-commit-message';
 import './features/go-to-action-from-file';
+import './features/action-used-by-link';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Fix #3009

URLs to check it from
* https://github.com/marketplace/actions/urlchecker-action
* https://github.com/marketplace/actions/github-action-for-assignee-to-reviewer (no result! which I think is not a bug but surprised me because it was the first action featured on https://github.com/marketplace?type=actions)
* https://github.com/marketplace/actions/hugo-actions

![image](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)

