### PR TITLE
Restore `open-all-notifications` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,7 @@ Thanks for contributing! 🦋🙌
 - [](# "parse-backticks") [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
-- [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80848822-e7897000-8c14-11ea-87cc-6140ce48d1a8.gif)
+- [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png) *(<kbd>?</kbd> hotkey)*
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/readme.md
+++ b/readme.md
@@ -308,7 +308,7 @@ Thanks for contributing! 🦋🙌
 - [](# "parse-backticks") [Renders text in <code>\`backticks\`</code> in issue titles and commit titles.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
-- [](# "open-all-notifications") [Open all your notifications at once.](https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png)
+- [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80848822-e7897000-8c14-11ea-87cc-6140ce48d1a8.gif)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png) *(<kbd>?</kbd> hotkey)*
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/source/features/open-all-notifications.css
+++ b/source/features/open-all-notifications.css
@@ -1,15 +1,9 @@
-.notifications-list .boxed-group-action {
-	margin: 5px 6px;
+/* Hide main button when user has selected some notifications */
+.js-notifications-mark-selected-actions:not([hidden]) ~ .rgh-open-notifications-button {
+	display: none;
 }
 
-.notifications-list .boxed-group-action button {
-	padding: 3px 10px;
-	border: none;
-	margin-left: 2px;
-	color: #586069;
-	background: none;
-}
-
-.mark-all-as-read-confirmed .open-repo-notifications {
-	visibility: hidden;
+/* Align right */
+.js-notifications-mark-selected-actions ~ .rgh-open-notifications-button {
+	margin-left: auto;
 }

--- a/source/features/open-all-notifications.css
+++ b/source/features/open-all-notifications.css
@@ -1,9 +1,9 @@
-/* Hide main button when user has selected some notifications */
-.js-notifications-mark-selected-actions:not([hidden]) ~ .rgh-open-notifications-button {
-	display: none;
-}
-
 /* Align right */
 .js-notifications-mark-selected-actions ~ .rgh-open-notifications-button {
 	margin-left: auto;
+}
+
+/* Hide main button when user has selected some notifications */
+.js-notifications-mark-selected-actions:not([hidden]) ~ .rgh-open-notifications-button {
+	display: none;
 }

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -85,8 +85,8 @@ function init(): void {
 
 features.add({
 	id: __filebasename,
-	description: 'Open all your notifications at once.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/31700005-1b3be428-b38c-11e7-90a6-8f572968993b.png'
+	description: 'Adds button to open all your unread notifications at once.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/80848822-e7897000-8c14-11ea-87cc-6140ce48d1a8.gif'
 }, {
 	include: [
 		pageDetect.isNotifications

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -8,10 +8,10 @@ import * as pageDetect from '../libs/page-detect';
 import {groupButtons} from '../libs/group-buttons';
 
 const confirmationRequiredCount = 10;
-const unreadNotificationsClass = '.unread .js-notification-target';
+const unreadNotificationsClass = '.notification-unread .notification-list-item-link';
 
 function openNotifications({delegateTarget}: delegate.Event): void {
-	const container = delegateTarget.closest('.boxed-group, .notification-center')!;
+	const container = delegateTarget.closest('.js-notifications-group, .js-check-all-container')!;
 
 	// Ask for confirmation
 	const unreadNotifications = select.all<HTMLAnchorElement>(unreadNotificationsClass, container);
@@ -27,56 +27,44 @@ function openNotifications({delegateTarget}: delegate.Event): void {
 	});
 
 	// Mark all as read
-	for (const notification of select.all('.unread', container)) {
-		notification.classList.replace('unread', 'read');
+	for (const notification of select.all('.notification-unread', container)) {
+		notification.classList.replace('notification-unread', 'notification-read');
 	}
 
 	// Remove all now-useless buttons
-	for (const button of select.all(`
-		.rgh-open-notifications-button,
-		.open-repo-notifications,
-		.mark-all-as-read,
-		[href='#mark_as_read_confirm_box']
-	`, container)) {
+	for (const button of select.all('.rgh-open-notifications-button', container)) {
 		button.remove();
 	}
 }
 
 function addOpenReposButton(): void {
-	for (const repoNotifications of select.all('.boxed-group')) {
-		if (select.exists('.open-repo-notifications', repoNotifications)) {
-			continue;
-		}
+	for (const markRepoAsDoneButton of select.all('.js-grouped-notifications-mark-all-read-button')) {
+		console.log(markRepoAsDoneButton);
 
-		const unreadCount = select.all('.unread', repoNotifications).length;
+		const repoNotifications = markRepoAsDoneButton.closest('.js-notifications-group')!;
+		console.log(repoNotifications);
+
+		const unreadCount = select.all('.notification-unread', repoNotifications).length;
+		console.log(unreadCount);
 		if (unreadCount === 0) {
 			continue;
 		}
 
-		const [, repo] = select<HTMLAnchorElement>('.notifications-repo-link', repoNotifications)!.title.split('/');
-
-		select('.mark-all-as-read', repoNotifications)!.before(
-			<button type="button" className="open-repo-notifications tooltipped tooltipped-w rgh-open-notifications-button" aria-label={`Open all unread \`${repo}\` notifications in tabs`}>
-				<LinkExternalIcon/>
+		const openRepoUnreadButton = (
+			<button type="button" className="btn btn-sm mr-2 tooltipped tooltipped-w rgh-open-notifications-button" aria-label="Open all unread notifications from this repo">
+				<LinkExternalIcon width="16"/> Open unread
 			</button>
 		);
+		markRepoAsDoneButton.before(openRepoUnreadButton);
 	}
 }
 
 function addOpenAllButton(): void {
-	if (!select.exists('.rgh-open-notifications-button')) {
-		// Move out the extra node that messes with .BtnGroup-item:last-child
-		document.body.append(select('#mark_as_read_confirm_box') ?? '');
-
-		// Create an open button and add it into a button group
-		const button = <button className="btn btn-sm rgh-open-notifications-button" type="button">Open all unread in tabs</button>;
-		select('.tabnav .float-right')!.prepend(button);
-
-		// There is no sibling on `/<org>/<repo>/notifications` page
-		if (button.nextElementSibling) {
-			groupButtons([button, button.nextElementSibling]);
-		}
-	}
+	select('.js-check-all-container .Box-header')!.append(
+		<button className="btn btn-sm rgh-open-notifications-button" type="button">
+			<LinkExternalIcon className="mr-1"/>Open all unread
+		</button>
+	);
 }
 
 function update(): void {

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -77,7 +77,7 @@ function init(): void {
 features.add({
 	id: __filebasename,
 	description: 'Adds button to open all your unread notifications at once.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80848822-e7897000-8c14-11ea-87cc-6140ce48d1a8.gif'
+	screenshot: 'https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png'
 }, {
 	include: [
 		pageDetect.isNotifications


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/2911
Replaces #3046

## Test

https://github.com/notifications

Try both the "Grouped by date" and "Grouped by repository" representations

## Demo

![](https://user-images.githubusercontent.com/1402241/80848822-e7897000-8c14-11ea-87cc-6140ce48d1a8.gif)
