### PR TITLE
Add `linkify-notification-repository-header` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -327,7 +327,7 @@ Thanks for contributing! 🦋🙌
 - [](# "fix-view-file-link-in-pr") [Points the "View file" in PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.](https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png)
 - [](# "linkify-labels-on-dashboard") [Makes labels clickable in the dashboard’s "Recent activity" box.](https://user-images.githubusercontent.com/1402241/69045444-6ef97300-0a29-11ea-99a3-9a622c395709.png)
 - [](# "reload-failed-proxied-images") [Retries downloading images that failed downloading due to GitHub limited proxying.](https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png)
-- [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](#TODO)
+- [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -327,6 +327,7 @@ Thanks for contributing! 🦋🙌
 - [](# "fix-view-file-link-in-pr") [Points the "View file" in PRs to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.](https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png)
 - [](# "linkify-labels-on-dashboard") [Makes labels clickable in the dashboard’s "Recent activity" box.](https://user-images.githubusercontent.com/1402241/69045444-6ef97300-0a29-11ea-99a3-9a622c395709.png)
 - [](# "reload-failed-proxied-images") [Retries downloading images that failed downloading due to GitHub limited proxying.](https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png)
+- [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](#TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -7,7 +7,12 @@ import {wrap} from '../libs/dom-utils';
 
 function init(): void {
 	for (const header of select.all('.js-notifications-group h6')) {
-		wrap(header, <a className={header.className + ' text-inherit'} href={'/' + header.textContent!.trim()}/>);
+		wrap(
+			header,
+			<a
+				className={header.className + ' text-inherit'}
+				href={'/' + header.textContent!.trim()}
+			/>);
 	}
 }
 

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -3,16 +3,14 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
-import {wrap} from '../libs/dom-utils';
 
 function init(): void {
 	for (const header of select.all('.js-notifications-group h6')) {
-		wrap(
-			header,
-			<a
-				className={header.className + ' text-inherit'}
-				href={'/' + header.textContent!.trim()}
-			/>);
+		header.append(
+			<a className="text-inherit" href={'/' + header.textContent!.trim()}>
+				{header.firstChild}
+			</a>
+		);
 	}
 }
 

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -1,4 +1,3 @@
-
 import React from 'dom-chef';
 import select from 'select-dom';
 import features from '../libs/features';

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -1,0 +1,22 @@
+
+import React from 'dom-chef';
+import select from 'select-dom';
+import features from '../libs/features';
+import * as pageDetect from '../libs/page-detect';
+import {wrap} from '../libs/dom-utils';
+
+function init(): void {
+	for (const header of select.all('.js-notifications-group h6')) {
+		wrap(header, <a className={header.className + ' text-inherit'} href={'/' + header.textContent!.trim()}/>);
+	}
+}
+
+features.add({
+	id: __filebasename,
+	description: 'Linkifies the header of each notification group (when grouped by repository).'
+}, {
+	include: [
+		pageDetect.isNotifications
+	],
+	init
+});

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -13,7 +13,8 @@ function init(): void {
 
 features.add({
 	id: __filebasename,
-	description: 'Linkifies the header of each notification group (when grouped by repository).'
+	description: 'Linkifies the header of each notification group (when grouped by repository).',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png'
 }, {
 	include: [
 		pageDetect.isNotifications

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -173,6 +173,7 @@ import './features/clear-pr-merge-commit-message';
 import './features/go-to-action-from-file';
 import './features/action-used-by-link';
 import './features/batch-mark-files-as-viewed';
+import './features/linkify-notification-repository-header';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Partial fix for #3030 

## Test

https://github.com/notifications (only the inbox has this kind of grouping)

## Demo

<img width="431" alt="" src="https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png">
