### PR TITLE
Highlight debugging tools when side-loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,11 @@
 			"selector-class-pattern": null,
 			"selector-id-pattern": null,
 			"rule-empty-line-before": null,
-			"at-rule-empty-line-before": null
+			"at-rule-empty-line-before": null,
+			"function-parentheses-newline-inside": "always-multi-line",
+			"function-parentheses-space-inside": "never-single-line",
+			"function-comma-newline-after": "always-multi-line",
+			"function-comma-space-after": "always-single-line"
 		}
 	}
 }

--- a/source/options.css
+++ b/source/options.css
@@ -67,3 +67,27 @@ p {
 .sr-only {
 	display: none;
 }
+
+#debugging {
+	position: relative;
+	padding: 1em 0;
+	margin-bottom: 1em;
+}
+#debugging p:last-child {
+	margin-bottom: 0;
+}
+#debugging::before,
+#debugging::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	border-top: dashed var(--github-red);
+	transform: skewX(45deg);
+}
+
+#debugging::after {
+	bottom: 0;
+	top: auto;
+}

--- a/source/options.css
+++ b/source/options.css
@@ -69,25 +69,21 @@ p {
 }
 
 #debugging {
+	--background:
+		repeating-linear-gradient(
+			45deg,
+			var(--github-red),
+			var(--github-red) 7px,
+			transparent 7px,
+			transparent 14px
+		) no-repeat;
 	position: relative;
 	padding: 1em 0;
 	margin-bottom: 1em;
+	background:
+		var(--background) top / 100% 3px,
+		var(--background) bottom / 100% 3px;
 }
 #debugging p:last-child {
 	margin-bottom: 0;
-}
-#debugging::before,
-#debugging::after {
-	content: '';
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	border-top: dashed var(--github-red);
-	transform: skewX(45deg);
-}
-
-#debugging::after {
-	bottom: 0;
-	top: auto;
 }

--- a/source/options.html
+++ b/source/options.html
@@ -30,7 +30,7 @@
 		</label>
 	</p>
 
-	<hr>
+	<hr id="debugging-position">
 
 	<div>
 		<p>
@@ -51,19 +51,23 @@
 
 	<hr>
 
-	<h2>Debugging</h2>
-	<p>
-		<label>
-			<input type="checkbox" name="logging">
-			Show the features enabled on each page in the console
-		</label>
-	</p>
+	<div id="debugging">
+		<p>
+			<strong>Debugging</strong>
+		</p>
+		<p>
+			<label>
+				<input type="checkbox" name="logging">
+				Show the features enabled on each page in the console
+			</label>
+		</p>
 
-	<p>
-		<label>
-			<button id="clear-cache">Clear cache</button>
-		</label>
-	</p>
+		<p>
+			<label>
+				<button id="clear-cache">Clear cache</button>
+			</label>
+		</p>
+	</div>
 
 </form>
 <script src="browser-polyfill.min.js"></script>

--- a/source/options.html
+++ b/source/options.html
@@ -49,8 +49,6 @@
 		<div class="js-features"></div>
 	</div>
 
-	<hr>
-
 	<div id="debugging">
 		<p>
 			<strong>Debugging</strong>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -133,8 +133,7 @@ async function init(): Promise<void> {
 	}
 
 	// Move debugging tools higher when side-loaded
-	const extension = await browser.management.getSelf();
-	if (extension.installType === 'development') {
+	if (process.env.NODE_ENV === 'development') {
 		select('#debugging-position')!.replaceWith(select('#debugging')!);
 	}
 }

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -131,6 +131,12 @@ async function init(): Promise<void> {
 			select<HTMLAnchorElement>('#personal-token-link')!.host = dropdown.value;
 		});
 	}
+
+	// Move debugging tools higher when side-loaded
+	const extension = await browser.management.getSelf();
+	if (extension.installType === 'development') {
+		select('#debugging-position')!.replaceWith(select('#debugging')!);
+	}
 }
 
 init();

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -5,8 +5,8 @@ import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import fitTextarea from 'fit-textarea';
 import {applyToLink} from 'shorten-repo-url';
-import * as indentTextarea from 'indent-textarea';
 import {getAllOptions} from './options-storage';
+import * as indentTextarea from 'indent-textarea';
 import * as domFormatters from './libs/dom-formatters';
 
 function parseDescription(description: string): DocumentFragment {


### PR DESCRIPTION
Debugging tools are useful during development, they should be more visible then.

This PR moves them higher (only during development) and highlights them.

<img width="646" alt="" src="https://user-images.githubusercontent.com/1402241/80872246-0a696200-8cb1-11ea-91c0-23b638873571.png">


