### PR TITLE
Fix console errors in `clean-issue-filters`

### DIFF
--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -58,10 +58,10 @@ async function hideProjects(): Promise<void> {
 	}
 }
 
-async function init(): Promise<void> {
+async function init(): Promise<void | false> {
 	if (!await elementReady('#js-issues-toolbar')) {
 		// Repo has no issues, so no toolbar is shown
-		return;
+		return false;
 	}
 
 	hideMilestones();

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -59,6 +59,11 @@ async function hideProjects(): Promise<void> {
 }
 
 function init(): void {
+	if (!select.exists('#js-issues-toolbar')) {
+		// Repo has no issues, so no toolbar is shown
+		return;
+	}
+
 	hideMilestones();
 	hideProjects();
 }

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -32,7 +32,7 @@ function getCount(element: HTMLElement): number {
 async function hideMilestones(): Promise<void> {
 	const milestones = select('[data-selected-links^="repo_milestones"] .Counter')!;
 	if (getCount(milestones) === 0) {
-		(await elementReady('[data-hotkey="m"]'))!.parentElement!.remove();
+		select('[data-hotkey="m"]')!.parentElement!.remove();
 	}
 }
 
@@ -54,12 +54,12 @@ async function hasProjects(): Promise<boolean> {
 
 async function hideProjects(): Promise<void> {
 	if (!await hasProjects()) {
-		(await elementReady('[data-hotkey="p"]'))!.parentElement!.remove();
+		select('[data-hotkey="p"]')!.parentElement!.remove();
 	}
 }
 
-function init(): void {
-	if (!select.exists('#js-issues-toolbar')) {
+async function init(): Promise<void> {
+	if (!await elementReady('#js-issues-toolbar')) {
 		// Repo has no issues, so no toolbar is shown
 		return;
 	}


### PR DESCRIPTION
Test on https://github.com/fregante/slash-tag-test/issues

The errors shows up only on Chrome, apparently because they happen inside Promises:

```
Uncaught (in promise) TypeError: Cannot read property 'parentElement' of undefined
    at hideMilestones (refined-github.js:11936)
Uncaught (in promise) TypeError: Cannot read property 'parentElement' of undefined
    at hideProjects (refined-github.js:11954)
```