### PR TITLE
Add `fix-first-tab-length` feature

### DIFF
--- a/source/features/fix-first-tab-length.css
+++ b/source/features/fix-first-tab-length.css
@@ -1,0 +1,13 @@
+/* Fixed a GitHub bug: In diffs, the first tab on each line appears 2 characters shorter than it should be. #3055 */
+
+/* Remove diff signs the layout flow */
+.blob-code-marker::before {
+	position: absolute;
+	transform: translate(-100%, 2px);
+}
+
+/* Restore the space that collapsed as a consequence of the previous rule */
+.code-review.blob-code {
+	padding-left: 26px; /* GitHub sets it to 18px */
+	text-indent: 0; /* GitHub sets it to -7px */
+}

--- a/source/features/fix-first-tab-length.css
+++ b/source/features/fix-first-tab-length.css
@@ -8,6 +8,6 @@
 
 /* Restore the space that collapsed as a consequence of the previous rule */
 .code-review.blob-code {
-	padding-left: 26px; /* GitHub sets it to 18px */
+	padding-left: 25px; /* GitHub sets it to 18px */
 	text-indent: 0; /* GitHub sets it to -7px */
 }

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -19,6 +19,7 @@ import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
 import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
+import './features/fix-first-tab-length.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3055

**Note:** this works regardless of `remove-diff-signs`’ status.

# Test

Needs further testing, but this is the starting point:

https://github.com/sindresorhus/refined-github/commit/a741080862a6a5c2f6f85a331feabd8f81684403#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R161

Before (short first tab) and after (all tabs are 4-characters long)
![demo2](https://user-images.githubusercontent.com/1402241/80924437-39eb9d80-8d89-11ea-9c88-38804074aefa.gif)

