### PR TITLE
Make `batch-open-issues` faster

### DIFF
--- a/source/features/batch-open-issues.tsx
+++ b/source/features/batch-open-issues.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import elementReady from 'element-ready';
 import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
 
@@ -32,8 +33,8 @@ function openIssues(): void {
 	});
 }
 
-function init(): void | false {
-	if (select.all('.js-issue-row').length < 2) {
+async function init(): Promise<void | false> {
+	if (!await elementReady('.js-issue-row + .js-issue-row')) {
 		return false;
 	}
 
@@ -72,5 +73,6 @@ features.add({
 	include: [
 		pageDetect.isDiscussionList
 	],
+	waitForDomReady: false,
 	init
 });


### PR DESCRIPTION
Closes #2671 (or at least ticks its last checkbox).

Test here: https://github.com/sindresorhus/refined-github/pulls
Or here: https://github.com/sindresorhus/refined-github/issues