### PR TITLE
Update `highest-rated-comment` style to match a Discussion "Answer"

### DIFF
--- a/source/features/highest-rated-comment.css
+++ b/source/features/highest-rated-comment.css
@@ -1,18 +1,8 @@
-.rgh-highest-rated-comment {
+a.timeline-chosen-answer {
 	border: 2px solid #2cbe4e !important;
 }
 
-.rgh-highest-rated-comment.timeline-comment--caret::before {
-	border-right-color: #2cbe4e !important;
-}
-
-.rgh-highest-rated-comment.timeline-comment--caret::after {
-	border-width: 5px;
-	margin-left: 6px;
-	margin-top: 3px;
-}
-
-a.rgh-highest-rated-comment .timeline-comment-header-text {
+a.timeline-chosen-answer .timeline-comment-header-text {
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	overflow: hidden;

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -1,6 +1,7 @@
 import './highest-rated-comment.css';
 import React from 'dom-chef';
 import select from 'select-dom';
+import CheckIcon from 'octicon/check.svg';
 import ArrowDownIcon from 'octicon/arrow-down.svg';
 import features from '../libs/features';
 import * as pageDetect from '../libs/page-detect';
@@ -61,10 +62,10 @@ function highlightBestComment(bestComment: Element): void {
 	select('.unminimized-comment', bestComment)!.classList.add('timeline-chosen-answer');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span
-			className="timeline-comment-label tooltipped tooltipped-n"
+			className="d-flex flex-items-center text-green mr-1 tooltipped tooltipped-n"
 			aria-label="This comment has the most positive reactions on this issue."
 		>
-			Highest-rated comment
+			<CheckIcon/>
 		</span>
 	);
 }

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -59,6 +59,11 @@ function getBestComment(): HTMLElement | null {
 }
 
 function highlightBestComment(bestComment: Element): void {
+	const avatar = select('.TimelineItem-avatar', bestComment)!;
+	avatar.classList.add('flex-column', 'flex-items-center', 'd-md-flex');
+	avatar.append(
+		<CheckIcon width={24} height={32} className="mt-4 text-green"/>
+	);
 	select('.unminimized-comment', bestComment)!.classList.add('timeline-chosen-answer');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -58,7 +58,7 @@ function getBestComment(): HTMLElement | null {
 }
 
 function highlightBestComment(bestComment: Element): void {
-	select('.unminimized-comment', bestComment)!.classList.add('rgh-highest-rated-comment');
+	select('.unminimized-comment', bestComment)!.classList.add('timeline-chosen-answer');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span
 			className="timeline-comment-label tooltipped tooltipped-n"
@@ -92,7 +92,7 @@ function linkBestComment(bestComment: HTMLElement): void {
 			<div className="timeline-comment-wrapper pl-0 my-0">
 				{avatar}
 
-				<a href={hash} className="no-underline rounded-1 rgh-highest-rated-comment bg-gray px-2 d-flex flex-items-center">
+				<a href={hash} className="no-underline rounded-1 timeline-chosen-answer timeline-comment bg-gray px-2 d-flex flex-items-center">
 					<span className="btn btn-sm mr-2">
 						<ArrowDownIcon/>
 					</span>

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -60,6 +60,7 @@ declare namespace JSX {
 
 	interface IntrinsicAttributes extends BaseIntrinsicElement {
 		width?: number;
+		height?: number;
 	}
 }
 


### PR DESCRIPTION
[GitHub Discussions](https://github.com/zeit/next.js/discussions/12559#discussioncomment-9555) have a "Selected answer" style we can reuse.

# Test

https://github.com/facebook/create-react-app/issues/1333#issuecomment-327776666

# Comment

<img width="831" alt="a" src="https://user-images.githubusercontent.com/1402241/81222085-0b1d3380-8fe4-11ea-8641-03e25b71311a.png">




# Link (unchanged)

<img width="756" alt="" src="https://user-images.githubusercontent.com/1402241/81212630-6f84c680-8fd5-11ea-8e9e-7bea7cdfc5e9.png">
