### PR TITLE
Improve Reviewers hiding in `clean-sidebar`

### DIFF
--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -6,6 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../libs/features';
 import onReplacedElement from '../libs/on-replaced-element';
+import onElementRemoval from '../libs/on-element-removal';
 
 const canEditSidebar = oneTime((): boolean => select.exists('.sidebar-labels .octicon-gear'));
 
@@ -35,7 +36,8 @@ function cleanSection(containerSelector: string): boolean {
 	const container = select(containerSelector)!;
 	const header = select(':scope > details, :scope > .discussion-sidebar-heading', container)!;
 
-	// Magic. Do not touch
+	// Magic. Do not touch.
+	// Section is empty if: no sibling element OR empty sibling element
 	if (header.nextElementSibling?.firstElementChild) {
 		return false;
 	}
@@ -51,7 +53,7 @@ function cleanSection(containerSelector: string): boolean {
 	return true;
 }
 
-function clean(): void {
+async function clean(): Promise<void> {
 	if (select.exists('.rgh-clean-sidebar')) {
 		return;
 	}
@@ -75,7 +77,19 @@ function clean(): void {
 
 	// Reviewers
 	if (pageDetect.isPR()) {
-		cleanSection('[aria-label="Select reviewers"]');
+		const possibleReviewers = select('[src$="/suggested-reviewers"]');
+		if (possibleReviewers) {
+			await onElementRemoval(possibleReviewers);
+		}
+
+		const content = select('[aria-label="Select reviewers"] > .css-truncate')!;
+		if (!content.firstElementChild) {
+			if (select.exists('.js-convert-to-draft')) {
+				content.remove(); // Drop "No reviews"
+			} else {
+				cleanSection('[aria-label="Select reviewers"]');
+			}
+		}
 	}
 
 	// Labels


### PR DESCRIPTION
Fixes #3076 
Follows https://github.com/sindresorhus/refined-github/pull/2916

1. Allows "Convert to draft"
1. Hides "No reviewers" when `canEditSidebar` (because GitHub tries suggesting reviewers in that case)


![](https://user-images.githubusercontent.com/1402241/81506958-2fd21d80-92fa-11ea-81de-f74dafc842e6.gif)

I hope at some point they move this awkward "Convert to draft" button, it should not be in the Reviewers section