### PR TITLE
Fix position of `warning-for-disallow-edits`

### DIFF
--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -17,11 +17,9 @@ function update(checkbox: HTMLInputElement): void {
 	if (checkbox.checked) {
 		getWarning().remove();
 	} else {
-		// Select every time because the sidebar content may be replaced
-		select(`
-				.new-pr-form .timeline-comment,
-				#partial-discussion-sidebar .js-collab-form + .js-dropdown-details
-			`)!.after(getWarning());
+		checkbox
+			.closest('.timeline-comment, .discussion-sidebar-item > .d-inline-flex')!
+			.after(getWarning());
 	}
 }
 


### PR DESCRIPTION
Bug:

<img width="237" alt="" src="https://user-images.githubusercontent.com/1402241/81511881-cd3e4900-931c-11ea-8ac2-ff959d26b84d.png">

# Test

1. Open any PRs from https://github.com/pulls (that you made from a fork)
2. Toggle checkbox