### PR TITLE
Show `open-all-notifications` on unsaved filters

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -55,7 +55,11 @@ function addOpenReposButton(): void {
 }
 
 function addOpenAllButton(): void {
-	select('.js-check-all-container .Box-header')!.append(
+	// Selector works on:
+	// https://github.com/notifications (Grouped by date)
+	// https://github.com/notifications (Grouped by repo)
+	// https://github.com/notifications?query=reason%3Acomment (which is an unsaved filter)
+	select('.js-check-all-container .js-bulk-action-toasts ~ div .Box-header')!.append(
 		<button className="btn btn-sm rgh-open-notifications-button" type="button">
 			<LinkExternalIcon className="mr-1"/>Open all unread
 		</button>


### PR DESCRIPTION
Fixes #3066

On unsaved filters like https://github.com/notifications?query=reason%3Acomment, the button was being added to the wrong place:

<img width="825" alt="" src="https://user-images.githubusercontent.com/1402241/81802562-a0558600-9516-11ea-93f9-0ed01a3ea3d0.png">


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#3066: "Open (all) unread" is not shown on repository specific notifications list](https://issuehunt.io/repos/51769689/issues/3066)
---
</details>
<!-- /Issuehunt content-->