### PR TITLE
Simplify `remove-checks-tab`

### DIFF
--- a/source/features/remove-checks-tab.tsx
+++ b/source/features/remove-checks-tab.tsx
@@ -3,7 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '../libs/features';
 
-function init(): false | void {
+function init(): void {
 	// Only remove the tab if it's not the current page and if it has 0 checks
 	const checksCounter = select('.tabnav-tab[href$="/checks"]:not(.selected) .Counter');
 

--- a/source/features/remove-checks-tab.tsx
+++ b/source/features/remove-checks-tab.tsx
@@ -8,7 +8,7 @@ function init(): void {
 	const checksCounter = select('.tabnav-tab[href$="/checks"]:not(.selected) .Counter');
 
 	if (checksCounter?.textContent!.trim() === '0') {
-		checksCounter.parentElement!.remove();
+		checksCounter?.parentElement!.remove();
 	}
 }
 

--- a/source/features/remove-checks-tab.tsx
+++ b/source/features/remove-checks-tab.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	// Only remove the tab if it's not the current page and if it has 0 checks
 	const checksCounter = select('.tabnav-tab[href$="/checks"]:not(.selected) .Counter');
 
-	if (checksCounter?.textContent?.trim() === '0') {
+	if (checksCounter?.textContent!.trim() === '0') {
 		checksCounter.parentElement!.remove();
 	}
 }

--- a/source/features/remove-checks-tab.tsx
+++ b/source/features/remove-checks-tab.tsx
@@ -1,26 +1,13 @@
-/*
-
-*/
-
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '../libs/features';
 
 function init(): false | void {
-	// If there's a settings tab, the current user can enable checks,
-	// so the tab should not be hidden
-	if (select.exists([
-		'.js-repo-nav [data-selected-links^="repo_settings"]', // In repos
-		'.pagehead-tabs-item[href$="/settings/profile"]' // In organizations
-	])) {
-		return false;
-	}
-
 	// Only remove the tab if it's not the current page and if it has 0 checks
 	const checksCounter = select('.tabnav-tab[href$="/checks"]:not(.selected) .Counter');
 
-	if (checksCounter && checksCounter.textContent!.trim() === '0') {
+	if (checksCounter?.textContent?.trim() === '0') {
 		checksCounter.parentElement!.remove();
 	}
 }
@@ -32,6 +19,9 @@ features.add({
 }, {
 	include: [
 		pageDetect.isPR
+	],
+	exclude: [
+		pageDetect.isRepoWithAccess
 	],
 	init
 });


### PR DESCRIPTION
1. LINKED ISSUES:
   None
2. TEST URLS:
   https://github.com/RandomEngy/VidCoder/pull/490

3. SCREENSHOT:
   None


~~One thing to note `pageDetect.isRepoWithAccess`~~ 

~~https://github.com/fregante/github-url-detection/blob/f88d029d45d29a31ec6c91de6b1588ea30874986/index.ts#L318~~

~~does not include~~
```js
'.pagehead-tabs-item[href$="/settings/profile"]' // In organizations
```
~~@busches can you check?~~ sorry I mixed up organizations and enterprises 

Edit: There is no need for that check here its only on `isOrganizationProfile` so it was never needed