### PR TITLE
Fix position of `more-dropdown` and `releases-tab`

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -17,7 +17,7 @@ const repoUrl = getRepoURL();
 
 function createDropdown(): void {
 	// Markup copied from native GHE dropdown
-	appendBefore('.reponav', '[data-selected-links^="repo_settings"]',
+	appendBefore('.reponav > ul', '[data-selected-links^="repo_settings"]',
 		<details className="reponav-dropdown details-overlay details-reset">
 			<summary className="btn-link reponav-item" aria-haspopup="menu">
 				{'More '}

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -17,7 +17,10 @@ const repoUrl = getRepoURL();
 
 function createDropdown(): void {
 	// Markup copied from native GHE dropdown
-	appendBefore('.reponav > ul', '[data-selected-links^="repo_settings"]',
+	appendBefore(
+		// GHE doesn't have `reponav > ul`
+		select('.reponav > ul') ?? select('.reponav')!,
+		'[data-selected-links^="repo_settings"]',
 		<details className="reponav-dropdown details-overlay details-reset">
 			<summary className="btn-link reponav-item" aria-haspopup="menu">
 				{'More '}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -60,7 +60,7 @@ async function init(): Promise<false | void> {
 	);
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
-	appendBefore('.reponav', '.reponav-dropdown, [data-selected-links^="repo_settings"]', releasesTab);
+	appendBefore('.reponav > ul', '.reponav-dropdown, [data-selected-links^="repo_settings"]', releasesTab);
 
 	// Update "selected" tab mark
 	if (pageDetect.isReleasesOrTags()) {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -60,7 +60,12 @@ async function init(): Promise<false | void> {
 	);
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
-	appendBefore('.reponav > ul', '.reponav-dropdown, [data-selected-links^="repo_settings"]', releasesTab);
+	appendBefore(
+		// GHE doesn't have `reponav > ul`
+		select('.reponav > ul') ?? select('.reponav')!,
+		'.reponav-dropdown, [data-selected-links^="repo_settings"]',
+		releasesTab
+	);
 
 	// Update "selected" tab mark
 	if (pageDetect.isReleasesOrTags()) {


### PR DESCRIPTION
Fixes #3102.

GitHub likely changed their DOM and moved all the items inside `.reponav` into an unordered list. This change makes sure that we add elements inside that list, and not as its siblings.

Bug explained at https://github.com/sindresorhus/refined-github/issues/3102#issuecomment-630102823 and https://github.com/sindresorhus/refined-github/issues/3102#issuecomment-630209900.

### Test

On any repo that you are admin of, take a look at navigation tab order.
