### PR TITLE
Clean Up `parseRoute`

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -69,5 +69,9 @@ features.add({
 	include: [
 		pageDetect.isRepoCommitList
 	],
+	exclude: [
+		// Probably looking at the base /commits/<branch> page, not a subfolder or file.
+		() => !select.exists('.breadcrumb')
+	],
 	init
 });

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -101,25 +101,6 @@ export function getLatestVersionTag(tags: string[]): string {
 	return latestVersion;
 }
 
-export function parseRoute(pathname: string): string[] {
-	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
-	const parts = next.join('/');
-	const currentBranch = getCurrentBranch();
-	if (parts !== currentBranch && !parts.startsWith(currentBranch + '/')) {
-		throw new Error('The branch of the current page must match the branch in the `pathname` parameter');
-	}
-
-	const filePath = parts.replace(currentBranch + '/', '');
-	return [
-		'',
-		user,
-		repository,
-		route,
-		currentBranch,
-		filePath
-	];
-}
-
 const escapeRegex = (string: string) => string.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
 export const prCommitRegex = new RegExp(`\\b${escapeRegex(location.origin)}[/][^/]+[/][^/]+[/]pull[/]\\d+[/]commits[/][0-9a-f]{7,40}\\b(?! \\]|\\))`, 'gi');
 

--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -12,7 +12,10 @@ export default function parseRoute(pathname: string): Pathname {
 	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
 	const parts = next.join('/');
 	const branch = getCurrentBranch();
-	if (parts !== branch && !parts.startsWith(branch + '/')) {
+	if (parts.length > 0 && // Dont throw if the branch name is empty #3117
+		parts !== branch && // Dont allow /user/repo/blob/develop on the page /user/repo/blob/dev
+		!parts.startsWith(branch + '/')
+	) {
 		throw new Error('The branch of the current page must match the branch in the `pathname` parameter');
 	}
 

--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -12,10 +12,7 @@ export default function parseRoute(pathname: string): Pathname {
 	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
 	const parts = next.join('/');
 	const branch = getCurrentBranch();
-	if (parts.length > 0 && // Dont throw if the branch name is empty #3117
-		parts !== branch && // Dont allow /user/repo/blob/develop on the page /user/repo/blob/dev
-		!parts.startsWith(branch + '/')
-	) {
+	if (parts !== branch && !parts.startsWith(branch + '/')) {
 		throw new Error('The branch of the current page must match the branch in the `pathname` parameter');
 	}
 


### PR DESCRIPTION
Follows this comment 🌮 
>What a messy merge
>
>_Originally posted by @yakov116 in https://github.com/sindresorhus/refined-github/pull/3109#issuecomment-631089893_

Also fix's `follow-file-renames` to not run when there is no path

TEST URLS:
https://github.com/sindresorhus/refined-github/commits?author=fregante
