### PR TITLE
`parse-route` should not error when no branch is passed

### DIFF
--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -12,7 +12,10 @@ export default function parseRoute(pathname: string): Pathname {
 	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
 	const parts = next.join('/');
 	const branch = getCurrentBranch();
-	if (parts !== branch && !parts.startsWith(branch + '/')) {
+	if (parts.length > 0 && // Dont throw if the branch name is empty #3117
+		parts !== branch && // Dont allow /user/repo/blob/develop on the page /user/repo/blob/dev
+		!parts.startsWith(branch + '/')
+	) {
 		throw new Error('The branch of the current page must match the branch in the `pathname` parameter');
 	}
 

--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -12,7 +12,7 @@ export default function parseRoute(pathname: string): Pathname {
 	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
 	const parts = next.join('/');
 	const branch = getCurrentBranch();
-	if (parts.length > 0 && // Dont throw if the branch name is empty #3117
+	if (parts.length > 0 && // Dont throw if the branch name is empty #3118
 		parts !== branch && // Dont allow /user/repo/blob/develop on the page /user/repo/blob/dev
 		!parts.startsWith(branch + '/')
 	) {


### PR DESCRIPTION
Fix's `follow-file-renames` when there is no branch in the path`

1. LINKED ISSUES:
   None

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/commits?author=fregante

3. SCREENSHOT:
	None

The branch will be blank, not sure if this is the correct way of handling it.