### PR TITLE
Restore `reactions-avatars`

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -2,12 +2,13 @@ import './reactions-avatars.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import {flatZip} from 'flat-zip';
+import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onReplacedElement from '../helpers/on-replaced-element';
-import {getUsername, isFirefox} from '../github-helpers';
 import {observeOneMutation} from '../helpers/simplified-element-observer';
+import {getUsername, isFirefox} from '../github-helpers';
 
 const arbitraryAvatarLimit = 36;
 const approximateHeaderLength = 3; // Each button header takes about as much as 3 avatars
@@ -51,8 +52,16 @@ function getParticipants(container: HTMLElement): Participant[] {
 	return participants;
 }
 
-async function showAvatarsOn(commentReactions: Element): Promise<void> {
+function loadUsernames(commentReactions: Element): void {
 	commentReactions.firstElementChild!.dispatchEvent(new MouseEvent('mouseenter'));
+}
+
+async function showAvatarsOn(commentReactions: Element): Promise<void> {
+	// The event listener might not have been attached yet, so we can try twice
+	await domLoaded;
+	loadUsernames(commentReactions);
+	setTimeout(loadUsernames, 1000, commentReactions);
+
 	await observeOneMutation(commentReactions.firstElementChild!, {
 		attributes: true,
 		attributeFilter: [

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -88,6 +88,9 @@ const viewportObserver = new IntersectionObserver(changes => {
 			viewportObserver.unobserve(change.target);
 		}
 	}
+}, {
+	// Start loading a little before they become visible
+	rootMargin: '500px'
 });
 
 async function init(): Promise<void> {

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -76,8 +76,8 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 		);
 	}
 
-	const trackableElement = commentReactions.closest<HTMLElement>('.js-updatable-content')!;
-	const trackingSelector = `[data-url="${trackableElement.dataset.url!}"]`;
+	const trackableElement = commentReactions.closest<HTMLElement>('[data-body-version]')!;
+	const trackingSelector = `[data-body-version="${trackableElement.dataset.bodyVersion!}"]`;
 	onReplacedElement(trackingSelector, init);
 }
 


### PR DESCRIPTION
Fixes #3122

The gif shows the initial implementation, which triggers the requests as soon as the reactions become visible.

Adding `rootMargin` to the `IntersectionObserver` will make them load sooner

![](https://user-images.githubusercontent.com/1402241/82734174-5ab86a80-9d19-11ea-8977-c56028c1d2de.gif)


PR best reviewed without whitespace: https://github.com/sindresorhus/refined-github/pull/3126/files?diff=split&w=1
# Test

https://github.com/facebook/react/issues/13991
https://github.com/sindresorhus/refined-github/issues/3122
Any PR/issue like this one ⬇️