### PR TITLE
Avoid clipping descriptions and CI status messages in `dim-bots`

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -32,12 +32,17 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 
 /* PRs’ whole box, reduce height */
 .rgh-dim-bot.Box-row {
-	overflow: hidden;
 	max-height: 10em; /* This value is only needed to transition the height since `max-height: none` can't be transitioned */
 	transition: max-height 0.1s 0.3s;
 }
 
+.rgh-dim-bot.open.Details--on {
+	/* If the element has text that exceeds the wrapper, add a scroller */
+	overflow: scroll;
+}
+
 .rgh-dim-bot.Box-row:not(.navigation-focus) {
+	overflow: hidden;
 	max-height: 2.7em;
 	transition-delay: 0s;
 }

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -1,5 +1,6 @@
 /*
 READ BEFORE EDITING. Some selectors match the same items ("hovered" selector vs non-hovered); make sure to update them in tandem.
+Commits that have a long commit message will not be dimmed after the user uncollapses the `<details>` element.
 
 In PR lists we can hide the meta just by acting on `max-height` + `overflow: hidden`
 In Commit lists however this is not possible because they are tables, so we need to hack around `margin-bottom`
@@ -15,15 +16,15 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 	transition-property: opacity, margin-bottom;
 }
 
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-title {
+.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-title {
 	opacity: 0.3;
 	transition-delay: 0s;
 }
 
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-meta,
-.rgh-dim-bot.commit:not(.navigation-focus) summary, /* `Verified` badge */
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-group, /* Hash and Copy hash buttons */
-.rgh-dim-bot.commit:not(.navigation-focus) .commit-links-group + .btn { /* Browse repository button */
+.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-meta,
+.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) summary, /* `Verified` badge */
+.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons */
+.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn { /* Browse repository button */
 	opacity: 0;
 	visibility: hidden;
 	margin-bottom: -2em;
@@ -31,17 +32,12 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 }
 
 /* PRs’ whole box, reduce height */
-.rgh-dim-bot.Box-row {
+.rgh-dim-bot.Box-row:not(.Details--on) {
 	max-height: 10em; /* This value is only needed to transition the height since `max-height: none` can't be transitioned */
 	transition: max-height 0.1s 0.3s;
 }
 
-.rgh-dim-bot.open.Details--on {
-	/* If the element has text that exceeds the wrapper, add a scroller */
-	overflow: scroll;
-}
-
-.rgh-dim-bot.Box-row:not(.navigation-focus) {
+.rgh-dim-bot.Box-row:not(.navigation-focus):not(.Details--on) {
 	overflow: hidden;
 	max-height: 2.7em;
 	transition-delay: 0s;


### PR DESCRIPTION
Fixes #3124

Solution:
- The overflow-hidden property is moved to not:navigation-focus
- Implemented a scroller for text that exceeds the container, which was not the case before.

<img width="1023" alt="Skjermbilde 2020-05-23 kl  19 39 57" src="https://user-images.githubusercontent.com/42898343/82736903-49795900-9d2d-11ea-9a7c-826ea3541342.png">
<img width="1025" alt="Skjermbilde 2020-05-23 kl  19 39 21" src="https://user-images.githubusercontent.com/42898343/82736904-4a11ef80-9d2d-11ea-9495-aaa13e3e1964.png">

**TEST URL**
https://github.com/kulshekhar/ts-jest/commits/master

<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes

-->

