### PR TITLE
Minor bug fixes

### DIFF
--- a/source/features/add-tag-to-commits.tsx
+++ b/source/features/add-tag-to-commits.tsx
@@ -118,6 +118,8 @@ async function getTags(lastCommit: string, after?: string): Promise<CommitTags> 
 }
 
 async function init(): Promise<void | false> {
+	const cacheKey = `tags:${getRepoURL()}`;
+
 	const commitsOnPage = select.all('li.commit');
 	const lastCommitOnPage = (commitsOnPage[commitsOnPage.length - 1].dataset.channel as string).split(':')[3];
 	let cached = await cache.get<{[commit: string]: string[]}>(cacheKey) ?? {};
@@ -156,7 +158,6 @@ async function init(): Promise<void | false> {
 		}
 	}
 
-	const cacheKey = `tags:${getRepoURL()}`;
 	await cache.set(cacheKey, cached, 1);
 }
 

--- a/source/features/add-tag-to-commits.tsx
+++ b/source/features/add-tag-to-commits.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getOwnerAndRepo, getRepoURL, getRepoGQL} from '../github-helpers';
+import {getRepoURL, getRepoGQL} from '../github-helpers';
 
 interface CommitTags {
 	[name: string]: string[];
@@ -31,9 +31,6 @@ interface TagNode {
 	name: string;
 	target: CommonTarget;
 }
-
-const {ownerName, repoName} = getOwnerAndRepo();
-const cacheKey = `tags:${ownerName!}/${repoName!}`;
 
 function mergeTags(oldTags: CommitTags, newTags: CommitTags): CommitTags {
 	const result: CommitTags = {...oldTags};
@@ -159,6 +156,7 @@ async function init(): Promise<void | false> {
 		}
 	}
 
+	const cacheKey = `tags:${getRepoURL()}`;
 	await cache.set(cacheKey, cached, 1);
 }
 

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -71,7 +71,8 @@ async function init(): Promise<void | false> {
 	new SearchQuery(bugsLink).add('label:bug');
 
 	// Change the Selected tab if necessary
-	bugsLink.classList.toggle('selected', isBugsPage);
+	const isPRTab = new SearchQuery(location).includes('is:pr');
+	bugsLink.classList.toggle('selected', isBugsPage && !isPRTab);
 	select('.selected', issuesTab)?.classList.toggle('selected', !isBugsPage);
 
 	issuesTab.after(bugsTab);

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -71,8 +71,7 @@ async function init(): Promise<void | false> {
 	new SearchQuery(bugsLink).add('label:bug');
 
 	// Change the Selected tab if necessary
-	const isPRTab = new SearchQuery(location).includes('is:pr');
-	bugsLink.classList.toggle('selected', isBugsPage && !isPRTab);
+	bugsLink.classList.toggle('selected', isBugsPage && !pageDetect.isPRList());
 	select('.selected', issuesTab)?.classList.toggle('selected', !isBugsPage);
 
 	issuesTab.after(bugsTab);

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -1,3 +1,5 @@
+import * as pageDetect from 'github-url-detection';
+
 import features from '.';
 import {isEditable} from '../helpers/dom-utils';
 
@@ -29,6 +31,9 @@ features.add({
 	description: 'Adds a keyboard shortcut to deselect the current line: `esc`.',
 	screenshot: false
 }, {
+	include: [
+		pageDetect.hasCode
+	],
 	waitForDomReady: false,
 	repeatOnAjax: false,
 	init

--- a/source/features/recently-pushed-branches-enhancements.tsx
+++ b/source/features/recently-pushed-branches-enhancements.tsx
@@ -48,7 +48,7 @@ async function init(): Promise<false | void> {
 	document.body.classList.add('rgh-recently-pushed-branches');
 
 	// Move or add list next to the notifications bell
-	select('.Header-item--full,.HeaderMenu nav')!.after(widget);
+	select.last('.Header-item--full,.HeaderMenu nav')!.after(widget);
 }
 
 features.add({

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -12,7 +12,7 @@ function init(): void {
 			});
 
 			// Get the list element that contains the unread class and mark it as read.
-			selected.closest('li')?.classList.replace('unread', 'read');
+			selected.closest('.unread')?.classList.replace('unread', 'read');
 		}
 	});
 }

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -12,7 +12,7 @@ function init(): void {
 			});
 
 			// Get the list element that contains the unread class and mark it as read.
-			selected.closest('li')!.classList.replace('unread', 'read');
+			selected.closest('li')?.classList.replace('unread', 'read');
 		}
 	});
 }

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -9,7 +9,7 @@ import {getUsername, compareNames} from '../github-helpers';
 
 async function init(): Promise<false | void> {
 	const usernameElements = select.all([
-		'.js-discussion a.author:not(.rgh-fullname):not([href*="/marketplace/"]):not([data-hovercard-type="organization"])', // `a` selector needed to skip commits by non-GitHub users.
+		'.js-discussion a.author:not(.rgh-fullname):not([href*="/apps/"]):not([href*="/marketplace/"]):not([data-hovercard-type="organization"])', // `a` selector needed to skip commits by non-GitHub users.
 		'#dashboard a.text-bold[data-hovercard-type="user"]:not(.rgh-fullname)' // On dashboard `.text-bold` is required to not fetch avatars.
 	]);
 


### PR DESCRIPTION
Continues #3119

- Reuse filePath var in `revert-file`
- Makes recently-pushed-branches-enhancements not fall off the screen #2940 (Does not fix it, just makes it not as bad)
- Don't run `show-names` on app bots (Revert's the change I made) _Fixes https://github.com/sindresorhus/refined-github/issues/3133_
- Use `getRepoURL` instead of `getOwnerandRepo` for `add-tag-to-commits`
- Don't highlight bugs tab when on the PR tab (Continues fixing #3001)
- Run `esc-to-deselect-line` only on code pages
- Don't error `selection-in-new-tab` if there is no element to mark unread (in RepoRoot for example)