### PR TITLE
Support timestamps in `parseRoute`

### DIFF
--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -11,7 +11,7 @@ interface Pathname {
 
 const timeStampRegex = /.*@{(\d{4}([.\-/ ])\d{2}\2\d{2}T\d\d:\d\d:\d\dZ)}/;
 function isTimeStamp(part1: string): boolean {
-	return Boolean(timeStampRegex.exec(decodeURIComponent(part1)));
+	return timeStampRegex.test(decodeURIComponent(part1));
 }
 
 export default function parseRoute(pathname: string): Pathname {

--- a/source/github-helpers/parse-route.ts
+++ b/source/github-helpers/parse-route.ts
@@ -8,10 +8,17 @@ interface Pathname {
 	filePath: string;
 	toString: () => string;
 }
+
+const timeStampRegex = /.*@{(\d{4}([.\-/ ])\d{2}\2\d{2}T\d\d:\d\d:\d\dZ)}/;
+function isTimeStamp(part1: string): boolean {
+	return Boolean(timeStampRegex.exec(decodeURIComponent(part1)));
+}
+
 export default function parseRoute(pathname: string): Pathname {
 	const [user, repository, route, ...next] = pathname.replace(/^\/|\/$/g, '').split('/');
-	const parts = next.join('/');
 	const branch = getCurrentBranch();
+	next[0] = isTimeStamp(next[0]) ? branch + '/' : next[0];
+	const parts = next.join('/');
 	if (parts !== branch && !parts.startsWith(branch + '/')) {
 		throw new Error('The branch of the current page must match the branch in the `pathname` parameter');
 	}


### PR DESCRIPTION
See https://github.com/sindresorhus/refined-github/pull/3135#issuecomment-633622883
Test URL's
https://github.com/sindresorhus/refined-github/blob/master@%7B2019-04-20T03:27:17Z%7D/license
https://github.com/sindresorhus/refined-github/blob/master@%7B2019-12-11T10:12:11Z%7D/source/features/comments-time-machine-links.tsx
https://github.com/sindresorhus/eslint-plugin-unicorn/tree/HEAD@%7B2020-05-24T16:33:08Z%7D

@fregante I dont have much time. (I did this very quickly)