### PR TITLE
Exclude 1-commit PRs from `clear-pr-merge-commit-message`

### DIFF
--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -23,7 +23,7 @@ features.add({
 	],
 	exclude: [
 		// Don't clear 1-commit PRs #3140
-		() => select.all('.TimelineItem.js-commit').length === 0
+		() => select.all('.TimelineItem.js-commit').length === 1
 	],
 	additionalListeners: [
 		onPrMergePanelOpen

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -21,6 +21,10 @@ features.add({
 	include: [
 		pageDetect.isPRConversation
 	],
+	exclude: [
+		// Don't clear 1-commit PRs #3140
+		() => select.all('.TimelineItem.js-commit').length === 0
+	],
 	additionalListeners: [
 		onPrMergePanelOpen
 	],


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/3140

Testable on your PRs. Try on in https://github.com/pulls?q=is%3Aopen+user%3A%40me+sort%3Aupdated-desc