### PR TITLE
Faster `pr-commit-lines-changed`

### DIFF
--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -1,6 +1,5 @@
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
-import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
@@ -27,10 +26,11 @@ const getCommitChanges = cache.function(async (commit: string): Promise<[number,
 });
 
 async function init(): Promise<void> {
-	const commitSha = (await elementReady('.sha.user-select-contain'))!.textContent!;
+	const commitSha = location.pathname.split('/').pop()!;
 	const [additions, deletions] = await getCommitChanges(commitSha);
 	const tooltip = pluralize(additions + deletions, '1 line changed', '$$ lines changed');
-	select('.diffstat')!.replaceWith(
+	const diffstat = await elementReady('.diffstat');
+	diffstat!.replaceWith(
 		<span className="ml-2 diffstat tooltipped tooltipped-s" aria-label={tooltip}>
 			<span className="text-green">+{additions}</span>{' '}
 			<span className="text-red">−{deletions}</span>{' '}


### PR DESCRIPTION
We can get the commit hash from the pathname then just wait for diffstat to be available

Test On:
[https://github.com/sindresorhus/refined-github/pull/3145/commits/3d3d50b01f47a230758aae1095e4116527591f7f ](https://github.com/sindresorhus/refined-github/pull/3145/commits/3d3d50b01f47a230758aae1095e4116527591f7f) 