### PR TITLE
Add `faster-reviews` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,7 @@ Thanks for contributing! 🦋🙌
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "separate-draft-pr-button") [Lets you create draft pull requests in one click.](https://user-images.githubusercontent.com/202916/67269317-cd791300-f4b6-11e9-89d1-392de7ef71e1.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
-- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83146442-93c85480-a0f6-11ea-8422-d042dd734e02.png)
+- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,7 @@ Thanks for contributing! 🦋🙌
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "separate-draft-pr-button") [Lets you create draft pull requests in one click.](https://user-images.githubusercontent.com/202916/67269317-cd791300-f4b6-11e9-89d1-392de7ef71e1.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
-- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](TODO)
+- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](https://user-images.githubusercontent.com/202916/83146442-93c85480-a0f6-11ea-8422-d042dd734e02.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -255,7 +255,7 @@ Thanks for contributing! 🦋🙌
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "separate-draft-pr-button") [Lets you create draft pull requests in one click.](https://user-images.githubusercontent.com/202916/67269317-cd791300-f4b6-11e9-89d1-392de7ef71e1.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
-- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>g</kbd> <kbd>r</kbd>.](TODO)
+- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>v</kbd>.](TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,7 @@ Thanks for contributing! 🦋🙌
 - [](# "pr-branch-auto-delete") Automatically deletes the branch right after merging a PR, if possible.
 - [](# "separate-draft-pr-button") [Lets you create draft pull requests in one click.](https://user-images.githubusercontent.com/202916/67269317-cd791300-f4b6-11e9-89d1-392de7ef71e1.png)
 - [](# "clear-pr-merge-commit-message") [Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.](https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png)
+- [](# "faster-reviews") [Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: <kbd>g</kbd> <kbd>r</kbd>.](TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -84,7 +84,7 @@ async function clean(): Promise<void> {
 
 		const content = select('[aria-label="Select reviewers"] > .css-truncate')!;
 		if (!content.firstElementChild) {
-			content.remove();
+			content.remove(); // Drop "No reviews"
 		}
 	}
 

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -84,11 +84,7 @@ async function clean(): Promise<void> {
 
 		const content = select('[aria-label="Select reviewers"] > .css-truncate')!;
 		if (!content.firstElementChild) {
-			if (select.exists('.js-convert-to-draft')) {
-				content.remove(); // Drop "No reviews"
-			} else {
-				cleanSection('[aria-label="Select reviewers"]');
-			}
+			content.remove();
 		}
 	}
 

--- a/source/features/faster-reviews.css
+++ b/source/features/faster-reviews.css
@@ -1,3 +1,0 @@
-.rgh-faster-reviews #submit-review {
-	cursor: auto;
-}

--- a/source/features/faster-reviews.css
+++ b/source/features/faster-reviews.css
@@ -1,0 +1,3 @@
+.rgh-faster-reviews #submit-review {
+	cursor: auto;
+}

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -14,7 +14,7 @@ async function addSidebarReviewButton(): Promise<void> {
 
 	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
 		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
-			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="g r">review</a>
+			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review</a>
 		</span>
 	);
 }
@@ -35,15 +35,15 @@ async function initReviewButtonEnhancements(): Promise<void> {
 	delegate(document, '.js-reviews-container > details', 'toggle', focusReviewTextarea, true);
 
 	const reviewDropdownButton = await elementReady('.js-reviews-toggle');
-	reviewDropdownButton!.setAttribute('data-hotkey', 'g r');
+	reviewDropdownButton!.setAttribute('data-hotkey', 'v');
 }
 
 features.add({
 	id: __filebasename,
-	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `g` `r`.',
+	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `v`.',
 	screenshot: 'TODO',
 	shortcuts: {
-		'g r': 'Open review popup in PRs'
+		'v': 'Open PR review popup'
 	}
 }, {
 	include: [

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -13,7 +13,7 @@ async function addSidebarReviewButton(): Promise<void> {
 	reviewFormUrl.hash = 'submit-review';
 
 	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
-		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
+		<span style={{fontWeight: 'normal'}}>
 			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review</a>
 		</span>
 	);

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -10,7 +10,7 @@ import onReplacedElement from '../helpers/on-replaced-element';
 async function addSidebarReviewButton(): Promise<void> {
 	const reviewFormUrl = new URL(location.href);
 	reviewFormUrl.pathname += '/files';
-	reviewFormUrl.hash = 'submit-review'
+	reviewFormUrl.hash = 'submit-review';
 
 	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
 		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
@@ -34,8 +34,8 @@ function focusReviewTextarea({delegateTarget}: delegate.Event<Event, HTMLDetails
 async function initReviewButtonEnhancements(): Promise<void> {
 	delegate(document, '.js-reviews-container > details', 'toggle', focusReviewTextarea, true);
 
-	const reviewDropdownButton = await elementReady('.js-reviews-toggle');
-	reviewDropdownButton!.setAttribute('data-hotkey', 'v');
+	const reviewDropdownButton = await elementReady<HTMLElement>('.js-reviews-toggle');
+	reviewDropdownButton!.dataset.hotkey = 'v';
 }
 
 features.add({
@@ -43,7 +43,7 @@ features.add({
 	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `v`.',
 	screenshot: 'https://user-images.githubusercontent.com/202916/83146442-93c85480-a0f6-11ea-8422-d042dd734e02.png',
 	shortcuts: {
-		'v': 'Open PR review popup'
+		v: 'Open PR review popup'
 	}
 }, {
 	include: [

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -52,10 +52,12 @@ features.add({
 	additionalListeners: [
 		() => onReplacedElement('#partial-discussion-sidebar', addSidebarReviewButton)
 	],
+	waitForDomReady: false,
 	init: initSidebar
 }, {
 	include: [
 		pageDetect.isPRFiles
 	],
+	waitForDomReady: false,
 	init: initReviewButtonEnhancements
 });

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -10,9 +10,11 @@ import fetchDom from '../helpers/fetch-dom';
 import onReplacedElement from '../helpers/on-replaced-element';
 
 async function addSidebarReviewButton(): Promise<void> {
-	const reviewDetailsDropdown = <details className="rgh-faster-reviews details-reset details-overlay js-dropdown-details d-inline text-gray-dark">
-		<summary className="btn-link muted-link" data-hotkey="g r">review</summary>
-	</details>;
+	const reviewDetailsDropdown = (
+		<details className="rgh-faster-reviews details-reset details-overlay js-dropdown-details d-inline text-gray-dark">
+			<summary className="btn-link muted-link" data-hotkey="g r">review</summary>
+		</details>
+	);
 
 	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
 		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
@@ -21,7 +23,7 @@ async function addSidebarReviewButton(): Promise<void> {
 	);
 
 	const prFilesUrl = new URL(location.href);
-	prFilesUrl.pathname += '/files'
+	prFilesUrl.pathname += '/files';
 
 	const reviewMenu = await fetchDom<HTMLDivElement>(
 		prFilesUrl.href,

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -12,17 +12,12 @@ async function addSidebarReviewButton(): Promise<void> {
 	reviewFormUrl.pathname += '/files';
 	reviewFormUrl.hash = 'submit-review';
 
-	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
+	const sidebarReviewsSection = await elementReady('[aria-label="Select reviewers"] .discussion-sidebar-heading');
+	sidebarReviewsSection!.append(
 		<span style={{fontWeight: 'normal'}}>
 			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review</a>
 		</span>
 	);
-}
-
-async function initSidebar(): Promise<void> {
-	if (await elementReady('[aria-label="Select reviewers"] .discussion-sidebar-heading')) {
-		addSidebarReviewButton();
-	}
 }
 
 function focusReviewTextarea({delegateTarget}: delegate.Event<Event, HTMLDetailsElement>) {
@@ -53,7 +48,7 @@ features.add({
 		() => onReplacedElement('#partial-discussion-sidebar', addSidebarReviewButton)
 	],
 	waitForDomReady: false,
-	init: initSidebar
+	init: addSidebarReviewButton
 }, {
 	include: [
 		pageDetect.isPRFiles

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -1,4 +1,3 @@
-import './faster-reviews.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
@@ -6,31 +5,18 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import fetchDom from '../helpers/fetch-dom';
 import onReplacedElement from '../helpers/on-replaced-element';
 
 async function addSidebarReviewButton(): Promise<void> {
-	const reviewDetailsDropdown = (
-		<details className="rgh-faster-reviews details-reset details-overlay js-dropdown-details d-inline text-gray-dark">
-			<summary className="btn-link muted-link" data-hotkey="g r">review</summary>
-		</details>
-	);
+	const reviewFormUrl = new URL(location.href);
+	reviewFormUrl.pathname += '/files';
+	reviewFormUrl.hash = 'submit-review'
 
 	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
 		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
-			– {reviewDetailsDropdown}
+			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="g r">review</a>
 		</span>
 	);
-
-	const prFilesUrl = new URL(location.href);
-	prFilesUrl.pathname += '/files';
-
-	const reviewMenu = await fetchDom<HTMLDivElement>(
-		prFilesUrl.href,
-		'#submit-review'
-	);
-
-	reviewDetailsDropdown.append(reviewMenu!);
 }
 
 async function initSidebar(): Promise<void> {
@@ -45,11 +31,11 @@ function focusReviewTextarea({delegateTarget}: delegate.Event<Event, HTMLDetails
 	}
 }
 
-async function init(): Promise<void> {
+async function initReviewButtonEnhancements(): Promise<void> {
 	delegate(document, '.js-reviews-container > details', 'toggle', focusReviewTextarea, true);
 
 	const reviewDropdownButton = await elementReady('.js-reviews-toggle');
-	reviewDropdownButton?.setAttribute('data-hotkey', 'g r');
+	reviewDropdownButton!.setAttribute('data-hotkey', 'g r');
 }
 
 features.add({
@@ -69,7 +55,7 @@ features.add({
 	init: initSidebar
 }, {
 	include: [
-		pageDetect.isPR
+		pageDetect.isPRFiles
 	],
-	init
+	init: initReviewButtonEnhancements
 });

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -1,0 +1,73 @@
+import './faster-reviews.css';
+import React from 'dom-chef';
+import select from 'select-dom';
+import delegate from 'delegate-it';
+import elementReady from 'element-ready';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import fetchDom from '../helpers/fetch-dom';
+import onReplacedElement from '../helpers/on-replaced-element';
+
+async function addSidebarReviewButton(): Promise<void> {
+	const reviewDetailsDropdown = <details className="rgh-faster-reviews details-reset details-overlay js-dropdown-details d-inline text-gray-dark">
+		<summary className="btn-link muted-link" data-hotkey="g r">review</summary>
+	</details>;
+
+	select('[aria-label="Select reviewers"] .discussion-sidebar-heading')!.append(
+		<span style={{fontWeight: 'normal'}} className="js-reviews-container">
+			– {reviewDetailsDropdown}
+		</span>
+	);
+
+	const prFilesUrl = new URL(location.href);
+	prFilesUrl.pathname += '/files'
+
+	const reviewMenu = await fetchDom<HTMLDivElement>(
+		prFilesUrl.href,
+		'#submit-review'
+	);
+
+	reviewDetailsDropdown.append(reviewMenu!);
+}
+
+async function initSidebar(): Promise<void> {
+	if (await elementReady('[aria-label="Select reviewers"] .discussion-sidebar-heading')) {
+		addSidebarReviewButton();
+	}
+}
+
+function focusReviewTextarea({delegateTarget}: delegate.Event<Event, HTMLDetailsElement>) {
+	if (delegateTarget.open) {
+		select('textarea', delegateTarget)!.focus();
+	}
+}
+
+async function init(): Promise<void> {
+	delegate(document, '.js-reviews-container > details', 'toggle', focusReviewTextarea, true);
+
+	const reviewDropdownButton = await elementReady('.js-reviews-toggle');
+	reviewDropdownButton?.setAttribute('data-hotkey', 'g r');
+}
+
+features.add({
+	id: __filebasename,
+	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `g` `r`.',
+	screenshot: 'TODO',
+	shortcuts: {
+		'g r': 'Open review popup in PRs'
+	}
+}, {
+	include: [
+		pageDetect.isPRConversation
+	],
+	additionalListeners: [
+		() => onReplacedElement('#partial-discussion-sidebar', addSidebarReviewButton)
+	],
+	init: initSidebar
+}, {
+	include: [
+		pageDetect.isPR
+	],
+	init
+});

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -41,7 +41,7 @@ async function initReviewButtonEnhancements(): Promise<void> {
 features.add({
 	id: __filebasename,
 	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `v`.',
-	screenshot: 'TODO',
+	screenshot: 'https://user-images.githubusercontent.com/202916/83146442-93c85480-a0f6-11ea-8422-d042dd734e02.png',
 	shortcuts: {
 		'v': 'Open PR review popup'
 	}

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -36,7 +36,7 @@ async function initReviewButtonEnhancements(): Promise<void> {
 features.add({
 	id: __filebasename,
 	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `v`.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/83146442-93c85480-a0f6-11ea-8422-d042dd734e02.png',
+	screenshot: 'https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png',
 	shortcuts: {
 		v: 'Open PR review popup'
 	}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -180,6 +180,7 @@ import './features/stop-redirecting-in-notification-bar';
 import './features/prevent-pr-commit-link-loss';
 import './features/first-published-tag-for-merged-pr';
 import './features/show-associated-branch-prs-on-fork';
+import './features/faster-reviews';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Closes #3095, closes #1069, closes #883.

Test this on any PRs, both ones you can request reviews for and ones you can't.

![rgh-faster-reviews](https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png)

## TODO

1. ~`quick-review-buttons` (and maybe other features?) don't run in this popup.~ Changed behavior based on https://github.com/sindresorhus/refined-github/pull/3149#discussion_r431683606
2. ~Update the screenshot after the other features are enabled.~ Done