### PR TITLE
Reset vertical-align for new octicons in js-issue-row

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -116,3 +116,8 @@ pr-branches
 .js-issue-row .text-small.text-gray {
 	line-height: 1.8;
 }
+
+/* Reset `vertical-align` for .octicons to work with above increased line-height */
+.js-issue-row .text-small.text-gray .octicon {
+	vertical-align: middle !important;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -118,6 +118,6 @@ pr-branches
 }
 
 /* Reset `vertical-align` for .octicons to work with above increased line-height */
-.issue-meta-section .octicon {
+.js-issue-row .text-small.text-gray .octicon {
 	vertical-align: middle;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -118,6 +118,6 @@ pr-branches
 }
 
 /* Reset `vertical-align` for .octicons to work with above increased line-height */
-.js-issue-row .text-small.text-gray .octicon {
-	vertical-align: middle !important;
+.issue-meta-section .octicon {
+	vertical-align: middle;
 }


### PR DESCRIPTION
Hi,
fixes a misaligned icon I noticed after the recent `octicons` update. Not sure if this is the best way to go about it, feel free to close in case there is a better way to achieve this.

Before:

![Screenshot from 2020-05-28 10-07-48](https://user-images.githubusercontent.com/1682504/83118843-6cee2c00-a0be-11ea-8172-900eb993e4ce.png)

After:

![Screenshot from 2020-05-28 10-31-13](https://user-images.githubusercontent.com/1682504/83118865-72e40d00-a0be-11ea-9a5f-275514631a34.png)

Thanks for maintaining this extension! :sunny: 