### PR TITLE
Fix handling lazy-loaded comments

### DIFF
--- a/source/github-events/on-new-comments.ts
+++ b/source/github-events/on-new-comments.ts
@@ -27,6 +27,10 @@ function removeListeners(): void {
 	observer.disconnect();
 }
 
+function getFragmentLoadHandler(callback: EventListener): delegate.EventHandler {
+	return (event: delegate.Event) => event.delegateTarget.addEventListener('load', callback);
+}
+
 function addListeners(): void {
 	const discussion = select('.js-discussion');
 	if (!discussion || discussionsWithListeners.has(discussion)) {
@@ -47,8 +51,8 @@ function addListeners(): void {
 	// When hidden comments are loaded by clicking "Load more…"
 	delegates.add(delegate(document, '.js-ajax-pagination', 'submit', paginationSubmitHandler));
 
-	// Outdated comment are loaded later using an include-fragment element
-	delegates.add(delegate(document, 'details.outdated-comment > include-fragment', 'load', run, true));
+	// Collapsed comments are loaded later using an include-fragment element
+	delegates.add(delegate(document, 'details.js-comment-container include-fragment', 'loadstart', getFragmentLoadHandler(run), true));
 }
 
 export default function onNewComments(callback: VoidFunction): void {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes

-->

This is similar to how lazy handlers are added in `on-pr-file-load`, and as `include-fragment` is not a direct descendant of `details` element.

Related to #2852, but doesn't exactly fix that. Stilling figuring out on how to handle that.