### PR TITLE
Be consistent with the rest of the notif buttons

### DIFF
--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -47,7 +47,7 @@ function addOpenReposButton(): void {
 		}
 
 		select('.js-grouped-notifications-mark-all-read-button', repository)!.before(
-			<button type="button" className="btn btn-sm mr-2 tooltipped tooltipped-w rgh-open-notifications-button" aria-label="Open all unread notifications from this repo">
+			<button type="button" className="btn btn-sm mr-2 rgh-open-notifications-button" title="Open all unread notifications from this repo">
 				<LinkExternalIcon width={16}/> Open unread
 			</button>
 		);


### PR DESCRIPTION
Instead of a custom tooltip, the other GitHub buttons on this page use `title`.

**GitHub button**

![image](https://user-images.githubusercontent.com/923242/83358223-01c88200-a36a-11ea-8e7c-55bc6e1b1f91.png)

**Existing open unread button**

![image](https://user-images.githubusercontent.com/923242/83358240-160c7f00-a36a-11ea-9603-5f9260f82f22.png)

**New open unread button**

![image](https://user-images.githubusercontent.com/923242/83358252-2ae91280-a36a-11ea-8264-7b498d23b1ea.png)


<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes

-->