### PR TITLE
Lint and add missing screenshots

### DIFF
--- a/source/features/add-tag-to-commits.tsx
+++ b/source/features/add-tag-to-commits.tsx
@@ -121,11 +121,11 @@ async function init(): Promise<void | false> {
 	const cacheKey = `tags:${getRepoURL()}`;
 
 	const commitsOnPage = select.all('li.commit');
-	const lastCommitOnPage = (commitsOnPage[commitsOnPage.length - 1].dataset.channel as string).split(':')[3];
+	const lastCommitOnPage = commitsOnPage[commitsOnPage.length - 1].dataset.channel!.split(':')[3];
 	let cached = await cache.get<{[commit: string]: string[]}>(cacheKey) ?? {};
 	const commitsWithNoTags = [];
 	for (const commit of commitsOnPage) {
-		const targetCommit = (commit.dataset.channel as string).split(':')[3];
+		const targetCommit = commit.dataset.channel!.split(':')[3];
 		let targetTags = cached[targetCommit];
 		if (!targetTags) {
 			// No tags for this commit found in the cache, check in github

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -26,20 +26,19 @@ const hasAnyProjects = cache.function(async (): Promise<boolean> => {
 	cacheKey: () => `has-projects:${getRepoURL()}`
 });
 
-function getCount(element: Element): number {
+function getCount(element: HTMLElement): number {
 	return Number(element.textContent!.trim());
 }
 
 async function hideMilestones(): Promise<void> {
-	const milestones = await elementReady('[data-selected-links^="repo_milestones"] .Counter');
-	if (getCount(milestones!) === 0) {
-		const milestonesDropdown = await elementReady('[data-hotkey="m"]');
-		milestonesDropdown!.parentElement!.remove();
+	const milestones = select('[data-selected-links^="repo_milestones"] .Counter')!;
+	if (getCount(milestones) === 0) {
+		select('[data-hotkey="m"]')!.parentElement!.remove();
 	}
 }
 
 async function hasProjects(): Promise<boolean> {
-	const activeProjectsCounter = await elementReady('[data-hotkey="g b"] .Counter');
+	const activeProjectsCounter = select('[data-hotkey="g b"] .Counter');
 	if (activeProjectsCounter && getCount(activeProjectsCounter) > 0) {
 		return true;
 	}

--- a/source/features/clean-issue-filters.tsx
+++ b/source/features/clean-issue-filters.tsx
@@ -26,19 +26,20 @@ const hasAnyProjects = cache.function(async (): Promise<boolean> => {
 	cacheKey: () => `has-projects:${getRepoURL()}`
 });
 
-function getCount(element: HTMLElement): number {
+function getCount(element: Element): number {
 	return Number(element.textContent!.trim());
 }
 
 async function hideMilestones(): Promise<void> {
-	const milestones = select('[data-selected-links^="repo_milestones"] .Counter')!;
-	if (getCount(milestones) === 0) {
-		select('[data-hotkey="m"]')!.parentElement!.remove();
+	const milestones = await elementReady('[data-selected-links^="repo_milestones"] .Counter');
+	if (getCount(milestones!) === 0) {
+		const milestonesDropdown = await elementReady('[data-hotkey="m"]');
+		milestonesDropdown!.parentElement!.remove();
 	}
 }
 
 async function hasProjects(): Promise<boolean> {
-	const activeProjectsCounter = select('[data-hotkey="g b"] .Counter');
+	const activeProjectsCounter = await elementReady('[data-hotkey="g b"] .Counter');
 	if (activeProjectsCounter && getCount(activeProjectsCounter) > 0) {
 		return true;
 	}

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -201,9 +201,8 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 	}
 
 	// Register feature shortcuts
-	for (const hotkey of Object.keys(shortcuts)) {
-		// TODO: use Object.entries, change format of shortcutMap
-		const description = shortcuts[hotkey];
+	for (const [hotkey, description] of Object.entries(shortcuts)) {
+		// TODO: change format of shortcutMap
 		shortcutMap.set(hotkey, {hotkey, description});
 	}
 

--- a/source/features/mark-unread.tsx
+++ b/source/features/mark-unread.tsx
@@ -79,7 +79,7 @@ function addMarkUnreadButton(): void {
 	}
 }
 
-async function markRead(urls: string|string[]): Promise<void> {
+async function markRead(urls: string | string[]): Promise<void> {
 	if (!Array.isArray(urls)) {
 		urls = [urls];
 	}

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -14,7 +14,7 @@ function getProjectsTab() {
 }
 
 // We can't detect whether the user can create projects on a repo, so this link is potentially a 404
-async function addNewProjectLink(): Promise<void |false> {
+async function addNewProjectLink(): Promise<void | false> {
 	if (!await getProjectsTab()) {
 		return false;
 	}

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<void> {
 features.add({
 	id: __filebasename,
 	description: 'Fix merge conflicts in a click',
-	screenshot: false
+	screenshot: 'https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png'
 }, {
 	include: [
 		pageDetect.isConflict

--- a/source/features/show-followers-you-know.tsx
+++ b/source/features/show-followers-you-know.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<false | void> {
 features.add({
 	id: __filebasename,
 	description: 'Followers you know are shown on profile pages',
-	screenshot: false
+	screenshot: 'https://user-images.githubusercontent.com/2906365/42009293-b1503f62-7a57-11e8-88f5-9c2fb3651a14.png'
 }, {
 	include: [
 		pageDetect.isUserProfile

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -17,8 +17,8 @@ function parseBranchFromDom(): string | undefined {
 	}
 
 	// We can find the name in the infobar, available in folder views
-	const branchInfo = select('.branch-infobar')?.textContent!.trim()!;
-	return branchInfoRegex.exec(branchInfo)?.[1];
+	const branchInfo = select('.branch-infobar')?.textContent!.trim();
+	return branchInfoRegex.exec(branchInfo!)?.[1];
 }
 
 async function fetchFromApi(): Promise<string> {

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -17,8 +17,8 @@ function parseBranchFromDom(): string | undefined {
 	}
 
 	// We can find the name in the infobar, available in folder views
-	const branchInfo = select('.branch-infobar')?.textContent?.trim();
-	return branchInfoRegex.exec(branchInfo!)?.[1];
+	const branchInfo = select('.branch-infobar')?.textContent!.trim()!;
+	return branchInfoRegex.exec(branchInfo)?.[1];
 }
 
 async function fetchFromApi(): Promise<string> {

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -4,6 +4,9 @@ import {getScopedSelector} from '../github-helpers';
 
 /**
  * Append to an element, but before a element that might not exist.
+ * @param  parent  Element (or its selector) to which append the `child`
+ * @param  before  Selector of the element that `child` should be inserted before
+ * @param  child   Element to append
  * @example
  *
  * <parent>

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -4,7 +4,7 @@ import {getScopedSelector} from '../github-helpers';
 
 /**
  * Append to an element, but before a element that might not exist.
- * @param  {Element|string} parent  Element (or its selector) to which append the `child`
+ * @param  {Element | string} parent  Element (or its selector) to which append the `child`
  * @param  {string}         before  Selector of the element that `child` should be inserted before
  * @param  {Element}        child   Element to append
  * @example
@@ -24,7 +24,7 @@ import {getScopedSelector} from '../github-helpers';
  *   <nope/>
  * </parent>
  */
-export const appendBefore = (parent: string|Element, before: string, child: Element): void => {
+export const appendBefore = (parent: string | Element, before: string, child: Element): void => {
 	if (typeof parent === 'string') {
 		parent = select(parent)!;
 	}

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import {getScopedSelector} from '../github-helpers';
 
 /**
+ * Append to an element, but before a element that might not exist.
  * @example
  *
  * <parent>

--- a/source/helpers/dom-utils.ts
+++ b/source/helpers/dom-utils.ts
@@ -3,10 +3,6 @@ import select from 'select-dom';
 import {getScopedSelector} from '../github-helpers';
 
 /**
- * Append to an element, but before a element that might not exist.
- * @param  {Element | string} parent  Element (or its selector) to which append the `child`
- * @param  {string}         before  Selector of the element that `child` should be inserted before
- * @param  {Element}        child   Element to append
  * @example
  *
  * <parent>


### PR DESCRIPTION
Fixes one error and lint's a few more

- Wait for milestone and project dropdowns to be ready
	Looks like Github does not **always** load them right away. ( I dont get the error every time)

```javascript
refined-github.js:12163 Uncaught (in promise) TypeError: Cannot read property 'parentElement' of null
    at hideMilestones (refined-github.js:12163)
    at clean_issue_filters_init (refined-github.js:12189)
    at async runFeature (refined-github.js:5637)
    at async setupPageLoad (refined-github.js:5651)
hideMilestones @ refined-github.js:12163
clean_issue_filters_init @ refined-github.js:12189
async function (async)
clean_issue_filters_init @ refined-github.js:12185
runFeature @ refined-github.js:5637
setupPageLoad @ refined-github.js:5651
add @ refined-github.js:5708
async function (async)
add @ refined-github.js:5682
./source/refined-github.ts @ refined-github.js:12192
__webpack_require__ @ refined-github.js:20
(anonymous) @ refined-github.js:84
(anonymous) @ refined-github.js:87
refined-github.js:12181 Uncaught (in promise) TypeError: Cannot read property 'parentElement' of null
    at hideProjects (refined-github.js:12181)
```

- Simple linting https://github.com/sindresorhus/refined-github/commit/6ce246a52fede2e51fe2b2292975addf8e321bbb
- Add screenshot links to features that had them in the readme but not in the feature itself https://github.com/sindresorhus/refined-github/commit/2c4ea713787b50fe27cb7915c422418ccb82e503

-  Switch shortcut map to Object.entries (TODO comment) https://github.com/sindresorhus/refined-github/commit/dfc42b9ed21d4794b3b1fc22878e8c23de05be5c
