### PR TITLE
Meta: Change format of shortcuts map

### DIFF
--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -16,7 +16,7 @@ function improveShortcutHelp(dialog: Element): void {
 			</div>
 
 			<ul>
-				{features.getShortcuts().map(({hotkey, description}) => (
+				{[...features.shortcutMap].map(([hotkey, description]) => (
 					<li className="Box-row d-flex flex-row">
 						<div className="flex-auto">{description}</div>
 						<div className="ml-2 no-wrap">

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -16,7 +16,7 @@ function improveShortcutHelp(dialog: Element): void {
 			</div>
 
 			<ul>
-				{[...features.shortcutMap].map(([hotkey, description]) => (
+				{[...features.shortcuts].map(([hotkey, description]) => (
 					<li className="Box-row d-flex flex-row">
 						<div className="flex-auto">{description}</div>
 						<div className="ml-2 no-wrap">

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -16,7 +16,7 @@ function improveShortcutHelp(dialog: Element): void {
 			</div>
 
 			<ul>
-				{[...features.shortcuts].map(([hotkey, description]) => (
+				{[...features.shortcutMap].map(([hotkey, description]) => (
 					<li className="Box-row d-flex flex-row">
 						<div className="flex-auto">{description}</div>
 						<div className="ml-2 no-wrap">

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -14,11 +14,6 @@ type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;
 type FeatureInit = () => Promisable<false | void>;
 
-interface Shortcut {
-	hotkey: string;
-	description: string;
-}
-
 interface FeatureMeta {
 	/**
 	If it's disabled, this should be the issue that explains why, as a reference
@@ -158,8 +153,7 @@ const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<
 	}
 };
 
-const shortcutMap = new Map<string, Shortcut>();
-const getShortcuts = (): Shortcut[] => [...shortcutMap.values()];
+const shortcutMap = new Map<string, string>();
 
 const defaultPairs = new Map([
 	[pageDetect.hasComments, onNewComments],
@@ -202,8 +196,7 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 
 	// Register feature shortcuts
 	for (const [hotkey, description] of Object.entries(shortcuts)) {
-		// TODO: change format of shortcutMap
-		shortcutMap.set(hotkey, {hotkey, description});
+		shortcutMap.set(hotkey, description);
 	}
 
 	for (const loader of loaders) {
@@ -261,7 +254,7 @@ add(undefined, {
 const features = {
 	add,
 	error: logError,
-	getShortcuts
+	shortcutMap
 };
 
 export default features;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -153,7 +153,7 @@ const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<
 	}
 };
 
-const shortcuts = new Map<string, string>();
+const shortcutMap = new Map<string, string>();
 
 const defaultPairs = new Map([
 	[pageDetect.hasComments, onNewComments],
@@ -196,7 +196,7 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 
 	// Register feature shortcuts
 	for (const [hotkey, description] of Object.entries(shortcuts)) {
-		shortcuts.set(hotkey, description);
+		shortcutMap.set(hotkey, description);
 	}
 
 	for (const loader of loaders) {
@@ -254,7 +254,7 @@ add(undefined, {
 const features = {
 	add,
 	error: logError,
-	shortcuts
+	shortcutMap
 };
 
 export default features;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -153,7 +153,7 @@ const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<
 	}
 };
 
-const shortcutMap = new Map<string, string>();
+const shortcuts = new Map<string, string>();
 
 const defaultPairs = new Map([
 	[pageDetect.hasComments, onNewComments],
@@ -196,7 +196,7 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 
 	// Register feature shortcuts
 	for (const [hotkey, description] of Object.entries(shortcuts)) {
-		shortcutMap.set(hotkey, description);
+		shortcuts.set(hotkey, description);
 	}
 
 	for (const loader of loaders) {
@@ -254,7 +254,7 @@ add(undefined, {
 const features = {
 	add,
 	error: logError,
-	shortcutMap
+	shortcuts
 };
 
 export default features;


### PR DESCRIPTION
Follows
>I think this is the format I was referring to
>
>```suggestion
>		shortcutMap.set(hotkey, description);
>```
>
>_Originally posted by @fregante in https://github.com/sindresorhus/refined-github/pull/3160_

_Was almost related to this PR_ but https://github.com/fregante/webext-additional-permissions/blob/master/index.ts#L15 uses flatMap and that is only supported from [firefox 62](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#Browser_compatibility) currently were set to 61
