### PR TITLE
Make `repo-age` a clickable link

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -16,7 +16,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	day: 'numeric'
 });
 
-const getFirstCommitDate = cache.function(async (): Promise<string[] | undefined> => {
+const getFirstCommit = cache.function(async (): Promise<string[] | undefined> => {
 	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>('a.commit-tease-sha, include-fragment.commit-tease');
 	const commitUrl = commitInfo instanceof HTMLAnchorElement ? commitInfo.href : commitInfo!.src;
 	const commitSha = commitUrl.split('/').pop()!;

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -16,7 +16,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	day: 'numeric'
 });
 
-const getFirstCommit = cache.function(async (): Promise<string[] | undefined> => {
+const getFirstCommit = cache.function(async (): Promise<[string, string] | undefined> => {
 	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>('a.commit-tease-sha, include-fragment.commit-tease');
 	const commitUrl = commitInfo instanceof HTMLAnchorElement ? commitInfo.href : commitInfo!.src;
 	const commitSha = commitUrl.split('/').pop()!;
@@ -42,7 +42,7 @@ const getFirstCommit = cache.function(async (): Promise<string[] | undefined> =>
 	return [timeStamp, href];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
-	isExpired: value => typeof value === 'string'
+	shouldRevalidate: value => typeof value === 'string'
 });
 
 async function init(): Promise<void> {

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -42,7 +42,7 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 	return [timeStamp, pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
-	shouldRevalidate: value => typeof value === 'string'
+	shouldRevalidate: value => typeof value === 'string' // Rmove after June 2020
 });
 
 async function init(): Promise<void> {

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -35,7 +35,7 @@ const getFirstCommitDate = cache.function(async (): Promise<string[] | undefined
 
 	const commit = await fetchDom(
 		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
-		'.commit-group .commit'
+		'.commit'
 	);
 	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
 	const {href} = select<HTMLAnchorElement>('a.message', commit)!;

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -39,14 +39,14 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 	);
 	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
 	const {pathname} = select<HTMLAnchorElement>('a.message', commit)!;
-	return [new Date(timeStamp).getTime(), pathname];
+	return [timeStamp, pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
 	shouldRevalidate: value => typeof value === 'string' // TODO: Remove after June 2020
 });
 
 async function init(): Promise<void> {
-	const [firstCommitDate, firstCommitUrl] = await getFirstCommit() ?? [];
+	const [firstCommitDate, firstCommitHref] = await getFirstCommit() ?? [];
 
 	if (!firstCommitDate) {
 		return;

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -38,8 +38,8 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 		'.commit'
 	);
 	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
-	const {href} = select<HTMLAnchorElement>('a.message', commit)!;
-	return [timeStamp, href];
+	const {pathname} = select<HTMLAnchorElement>('a.message', commit)!;
+	return [timeStamp, pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
 	shouldRevalidate: value => typeof value === 'string'

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -16,7 +16,7 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
 	day: 'numeric'
 });
 
-const getFirstCommit = cache.function(async (): Promise<[string, string] | undefined> => {
+const getFirstCommit = cache.function(async (): Promise<[string, number, string] | undefined> => {
 	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>('a.commit-tease-sha, include-fragment.commit-tease');
 	const commitUrl = commitInfo instanceof HTMLAnchorElement ? commitInfo.href : commitInfo!.src;
 	const commitSha = commitUrl.split('/').pop()!;
@@ -30,39 +30,38 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 	}
 
 	if (commitsCount === 1) {
-		return [select('.commit-tease-sha + span relative-time')!.attributes.datetime.value, commitUrl];
+		const timeStamp = new Date(select('.commit-tease-sha + span relative-time')!.attributes.datetime.value);
+		return [dateFormatter.format(timeStamp), timeStamp.getTime(), commitUrl];
 	}
 
 	const commit = await fetchDom(
 		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
 		'.commit'
 	);
-	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
+	const timeStamp = new Date(select('relative-time', commit)!.attributes.datetime.value);
 	const {pathname} = select<HTMLAnchorElement>('a.message', commit)!;
-	return [new Date(timeStamp).getTime(), pathname];
+	return [dateFormatter.format(timeStamp), timeStamp.getTime(), pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
 	shouldRevalidate: value => typeof value === 'string' // TODO: Remove after June 2020
 });
 
 async function init(): Promise<void> {
-	const [firstCommitDate, firstCommitUrl] = await getFirstCommit() ?? [];
+	const [firstCommitDate, firstCommitTime, firstCommitUrl] = await getFirstCommit() ?? [];
 
 	if (!firstCommitDate) {
 		return;
 	}
 
-	const date = new Date(firstCommitDate);
-
 	// `twas` could also return `an hour ago` or `just now`
-	const [value, unit] = twas(date.getTime())
+	const [value, unit] = twas(firstCommitTime!)
 		.replace('just now', '1 second')
 		.replace(/^an?/, '1')
 		.split(' ');
 
 	const element = (
-		<li className="text-gray" title={`First commit dated ${dateFormatter.format(date)}`}>
-			<a href={firstCommitHref}>
+		<li className="text-gray" title={`First commit dated ${firstCommitDate}`}>
+			<a href={firstCommitUrl}>
 				<RepoIcon/> <span className="num text-emphasized">{value}</span> {unit} old
 			</a>
 		</li>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -42,7 +42,7 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 	return [timeStamp, pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
-	shouldRevalidate: value => typeof value === 'string' // Rmove after June 2020
+	shouldRevalidate: value => typeof value === 'string' // TODO: Remove after June 2020
 });
 
 async function init(): Promise<void> {

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -37,15 +37,16 @@ const getFirstCommitDate = cache.function(async (): Promise<string[] | undefined
 		`${getRepoURL()}/commits?after=${commitSha}+${commitsCount - 2}`,
 		'.commit-group .commit'
 	);
-	const timeStamp = select('.commit-meta relative-time', commit)!.attributes.datetime.value;
-	const href = select<HTMLAnchorElement>('a.message', commit)!.href;
+	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
+	const {href} = select<HTMLAnchorElement>('a.message', commit)!;
 	return [timeStamp, href];
 }, {
-	cacheKey: () => __filebasename + ':' + getRepoURL()
+	cacheKey: () => __filebasename + ':' + getRepoURL(),
+	isExpired: value => typeof value === 'string'
 });
 
 async function init(): Promise<void> {
-	const [firstCommitDate, firstCommitHref] = await getFirstCommitDate() ?? [];
+	const [firstCommitDate, firstCommitHref] = await getFirstCommit() ?? [];
 
 	if (!firstCommitDate) {
 		return;

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -39,14 +39,14 @@ const getFirstCommit = cache.function(async (): Promise<[string, string] | undef
 	);
 	const timeStamp = select('relative-time', commit)!.attributes.datetime.value;
 	const {pathname} = select<HTMLAnchorElement>('a.message', commit)!;
-	return [timeStamp, pathname];
+	return [new Date(timeStamp).getTime(), pathname];
 }, {
 	cacheKey: () => __filebasename + ':' + getRepoURL(),
 	shouldRevalidate: value => typeof value === 'string' // TODO: Remove after June 2020
 });
 
 async function init(): Promise<void> {
-	const [firstCommitDate, firstCommitHref] = await getFirstCommit() ?? [];
+	const [firstCommitDate, firstCommitUrl] = await getFirstCommit() ?? [];
 
 	if (!firstCommitDate) {
 		return;


### PR DESCRIPTION
Follows 
>Hardik can you implement the link to the first commit as well? https://github.com/sindresorhus/refined-github/pull/2667/files#diff-9d82f672e2199b6b2b455fa80d3373f2R86

>_Originally posted by @fregante in https://github.com/sindresorhus/refined-github/pull/2783#issuecomment-636680756_

This will cause issues, with the cache due to the href being empty. I am not sure how to go about it.