### PR TITLE
Restore `reactions-avatars` again

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -52,23 +52,7 @@ function getParticipants(container: HTMLElement): Participant[] {
 	return participants;
 }
 
-function loadUsernames(commentReactions: Element): void {
-	commentReactions.firstElementChild!.dispatchEvent(new MouseEvent('mouseenter'));
-}
-
 async function showAvatarsOn(commentReactions: Element): Promise<void> {
-	// The event listener might not have been attached yet, so we can try twice
-	await domLoaded;
-	loadUsernames(commentReactions);
-	setTimeout(loadUsernames, 1000, commentReactions);
-
-	await observeOneMutation(commentReactions.firstElementChild!, {
-		attributes: true,
-		attributeFilter: [
-			'aria-label'
-		]
-	});
-
 	const avatarLimit = arbitraryAvatarLimit - (commentReactions.children.length * approximateHeaderLength);
 
 	const participantByReaction = select

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -2,12 +2,10 @@ import './reactions-avatars.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import {flatZip} from 'flat-zip';
-import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onReplacedElement from '../helpers/on-replaced-element';
-import {observeOneMutation} from '../helpers/simplified-element-observer';
 import {getUsername, isFirefox} from '../github-helpers';
 
 const arbitraryAvatarLimit = 36;


### PR DESCRIPTION
Closes #3122
>PR welcome to drop the first ~10 lines of `showAvatarsOn`
>
>_Originally posted by @fregante in https://github.com/sindresorhus/refined-github/issues/3122#issuecomment-639110887_