### PR TITLE
Chrome: Open the options source/screenshot links in a new tab

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -3,6 +3,7 @@ import './options.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import fitTextarea from 'fit-textarea';
 import {applyToLink} from 'shorten-repo-url';
 import * as indentTextarea from 'indent-textarea';
@@ -135,6 +136,12 @@ function addEventListeners(): void {
 
 	// Add cache clearer
 	select('#clear-cache')!.addEventListener('click', clearCacheHandler);
+
+	// Ensure all links open in a new tab #3181
+	delegate(document, '[href^="http"]', 'click', (event: delegate.Event<MouseEvent, HTMLAnchorElement>) => {
+		event.preventDefault();
+		window.open(event.delegateTarget.href);
+	});
 }
 
 async function init(): Promise<void> {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -48,10 +48,10 @@ function buildFeatureCheckbox({id, description, screenshot, disabled}: FeatureMe
 					<span className="feature-name">{id}</span>
 					{' '}
 					{disabled && <small>{parseDescription(`(Disabled because of ${disabled}) `)}</small>}
-					<a href={`https://github.com/sindresorhus/refined-github/blob/master/source/features/${id}.tsx`}>
+					<a href={`https://github.com/sindresorhus/refined-github/blob/master/source/features/${id}.tsx`} target="_blank" rel="noopener noreferrer">
 						source
 					</a>
-					{screenshot && <>, <a href={screenshot}>screenshot</a></>}
+					{screenshot && <>, <a href={screenshot} target="_blank" rel="noopener noreferrer">screenshot</a></>}
 					<p className="description">{parseDescription(description)}</p>
 				</label>
 			</div>

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -48,10 +48,10 @@ function buildFeatureCheckbox({id, description, screenshot, disabled}: FeatureMe
 					<span className="feature-name">{id}</span>
 					{' '}
 					{disabled && <small>{parseDescription(`(Disabled because of ${disabled}) `)}</small>}
-					<a href={`https://github.com/sindresorhus/refined-github/blob/master/source/features/${id}.tsx`} target="_blank" rel="noopener noreferrer">
+					<a href={`https://github.com/sindresorhus/refined-github/blob/master/source/features/${id}.tsx`}>
 						source
 					</a>
-					{screenshot && <>, <a href={screenshot} target="_blank" rel="noopener noreferrer">screenshot</a></>}
+					{screenshot && <>, <a href={screenshot}>screenshot</a></>}
 					<p className="description">{parseDescription(description)}</p>
 				</label>
 			</div>


### PR DESCRIPTION
Chrome attempts to open them in the options popup which leads to

![image](https://user-images.githubusercontent.com/16872793/83878508-43f71800-a70a-11ea-82bb-ebeb294bdfaa.png)

Firefox does not have this issue

**To be clear:** I am talking about the screenshot and source links