### PR TITLE
Meta: Reduce GitHub Actions runs on local PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,13 @@
 name: Test
+
 on:
-  - pull_request
-  - push
+  pull_request:
+    branches: 
+      - '*'
+  push:
+    branches: 
+      - master
+
 jobs:
 
   Security:


### PR DESCRIPTION
When opening PRs from the current repo, each commit gets tested twice.

This should limit duplication, but it means that the CI won't run on secondary branches **until you open a PR.** This is fine since we have draft PRs.

<table><th>Before<th>After
<tr><td><img width="399" alt="before" src="https://user-images.githubusercontent.com/1402241/83930196-a695f580-a796-11ea-94d9-967c4b601fbb.png">
<td valign=top><img width="389" alt="after" src="https://user-images.githubusercontent.com/1402241/83930207-b8779880-a796-11ea-8135-f9e9c79a5131.png">
