### PR TITLE
Restore `releases-tab` in "Repository refresh" beta

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -62,28 +62,46 @@ async function init(): Promise<false | void> {
 	const releasesTab = (
 		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r">
 			<TagIcon/>
-			<span> Releases </span>
+			<span data-content="Releases"> Releases </span>
 			{count === undefined ? '' : <span className="Counter">{count}</span>}
 		</a>
 	);
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
+
+	const repoNavigationBar = select('.js-repo-nav')!;
+
+	if (repoNavigationBar.classList.contains('UnderlineNav')) {
+		// Adapt releases tab to GitHub's repository redesign
+		releasesTab.classList.remove('reponav-item');
+		releasesTab.classList.add(
+			'js-selected-navigation-item',
+			'UnderlineNav-item',
+			'hx_underlinenav-item',
+			'no-wrap',
+			'js-responsive-underlinenav-item'
+		);
+		select('svg', releasesTab)!.classList.add('UnderlineNav-octicon');
+	}
+
 	appendBefore(
-		// GHE doesn't have `reponav > ul`
-		select('.reponav > ul') ?? select('.reponav')!,
+		// GHE doesn't have `.js-repo-nav > ul`
+		select(':scope > ul', repoNavigationBar) ?? repoNavigationBar,
 		'.reponav-dropdown, [data-selected-links^="repo_settings"]',
 		releasesTab
 	);
 
 	// Update "selected" tab mark
 	if (pageDetect.isReleasesOrTags()) {
-		const selected = select('.reponav-item.selected');
+		const selected = select('.reponav-item.selected, .UnderlineNav-item.selected');
 		if (selected) {
 			selected.classList.remove('js-selected-navigation-item', 'selected');
+			selected.removeAttribute('aria-current');
 		}
 
 		releasesTab.classList.add('js-selected-navigation-item', 'selected');
 		releasesTab.dataset.selectedLinks = 'repo_releases'; // Required for ajaxLoad
+		releasesTab.setAttribute('aria-current', 'page');
 	}
 }
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -25,6 +25,8 @@ function parseCountFromDom(): number | false {
 		if (moreReleasesCountElement) {
 			return looseParseInt(moreReleasesCountElement.textContent!) + 1;
 		}
+
+		return 0;
 	}
 
 	return false;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -60,7 +60,7 @@ async function init(): Promise<false | void> {
 	}
 
 	const releasesTab = (
-		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r">
+		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r" data-tab-item="releases-tab">
 			<TagIcon/>
 			<span data-content="Releases"> Releases </span>
 			{count === undefined ? '' : <span className="Counter">{count}</span>}
@@ -103,6 +103,15 @@ async function init(): Promise<false | void> {
 		releasesTab.dataset.selectedLinks = 'repo_releases'; // Required for ajaxLoad
 		releasesTab.setAttribute('aria-current', 'page');
 	}
+
+	const repoNavOverflowMenu = select('.js-responsive-underlinenav-overflow ul', repoNavigationBar);
+	repoNavOverflowMenu?.append(
+		<li data-menu-item="releases-tab">
+			<a role="menuitem" className="js-selected-navigation-item dropdown-item" data-selected-links={`/${repoUrl}/releases`} href={`/${repoUrl}/releases`}>
+				Releases
+			</a>
+		</li>
+	);
 }
 
 void features.add({

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -20,7 +20,7 @@ function parseCountFromDom(): number | false {
 			return looseParseInt(releasesCountElement.textContent!);
 		}
 
-		// In GitHub's repository redesign, look for the "+ XXX releases" link in the sidebar
+		// In "Repository refresh" layout, look for the "+ XXX releases" link in the sidebar
 		const moreReleasesCountElement = select('.BorderGrid .text-small[href$="/releases"]');
 		if (moreReleasesCountElement) {
 			return looseParseInt(moreReleasesCountElement.textContent!) + 1;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -16,7 +16,15 @@ const cacheKey = `releases-count:${repoUrl}`;
 function parseCountFromDom(): number | false {
 	if (pageDetect.isRepoRoot()) {
 		const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
-		return Number(releasesCountElement ? looseParseInt(releasesCountElement.textContent!) : 0);
+		if (releasesCountElement) {
+			return looseParseInt(releasesCountElement.textContent!);
+		}
+
+		// In GitHub's repository redesign, look for the "+ XXX releases" link in the sidebar
+		const moreReleasesCountElement = select('.BorderGrid .text-small[href$="/releases"]');
+		if (moreReleasesCountElement) {
+			return looseParseInt(moreReleasesCountElement.textContent!) + 1;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Relates to #3081.

With feature preview enabled:

![Screenshot_2020-06-06_13-59-03](https://user-images.githubusercontent.com/202916/83943645-0ffd1f00-a7fe-11ea-834a-47a3b3927bdf.png)

With feature preview disabled:

![Screenshot_2020-06-06_13-59-31](https://user-images.githubusercontent.com/202916/83943635-0378c680-a7fe-11ea-9892-ba8554ebdc6d.png)