### PR TITLE
Restore `toggle-files-button` in "Repository refresh" beta

### DIFF
--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -12,7 +12,7 @@
 	transform: rotate(0.5turn);
 }
 
-.rgh-files-hidden .files,
+.rgh-files-hidden .files, /* Pre "Repository refresh" layout */
 .rgh-files-hidden #files ~ .Details {
 	display: none;
 }

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -12,7 +12,8 @@
 	transform: rotate(0.5turn);
 }
 
-.rgh-files-hidden .files {
+.rgh-files-hidden .files,
+.rgh-files-hidden #files ~ .Details {
 	display: none;
 }
 


### PR DESCRIPTION
Relates to #3081.

With feature preview enabled:

![Screenshot_2020-06-06_14-12-13](https://user-images.githubusercontent.com/202916/83943908-e80ebb00-a7ff-11ea-8e0c-f676251e2d30.png)

With feature preview disabled:

![Screenshot_2020-06-06_14-12-38](https://user-images.githubusercontent.com/202916/83943907-e7762480-a7ff-11ea-9d8c-b9246a541e6a.png)