### PR TITLE
`stop-redirecting-in-notification-bar` automatically when possible

### DIFF
--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -15,7 +15,9 @@ function handleClick(event: delegate.Event<MouseEvent, HTMLButtonElement>): void
 }
 
 async function init(): Promise<void> {
-	// If the history length is `1` on init, the notification has been opened in a new tab
+	// If the history length is `1` on init, that means there are no
+	// older history states (this means the notification has been opened
+	// in a new browser tab)
 	sessionStorage.rghIsNewTab = history.length === 1;
 	delegate(document, '.notification-shelf .js-notification-action button', 'click', handleClick);
 }

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -8,16 +8,13 @@ const hasNotificationBar = (): boolean =>
 
 function handleClick(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	// Disable the redirect to the Notifications inbox if either:
-	// 1. The alt key was held down during click
-	// 2. The notification has been opened in a new tab
+	// 1. The alt key was held down during click (user choice)
+	// 2. The notification has been opened in a new tab (the inbox is still open in the previous tab)
 	const redirectDisabled = event.altKey || sessionStorage.rghIsNewTab === 'true';
 	event.delegateTarget.form!.toggleAttribute('data-redirect-to-inbox-on-submit', !redirectDisabled);
 }
 
 async function init(): Promise<void> {
-	// If the history length is `1` on init, that means there are no
-	// older history states (this means the notification has been opened
-	// in a new browser tab)
 	sessionStorage.rghIsNewTab = history.length === 1;
 	delegate(document, '.notification-shelf .js-notification-action button', 'click', handleClick);
 }

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -10,7 +10,7 @@ function handleClick(event: delegate.Event<MouseEvent, HTMLButtonElement>): void
 	// Disable the redirect to the Notifications inbox if either:
 	// 1. The alt key was held down during click
 	// 2. The notification has been opened in a new tab
-	const redirectDisabled = event.alt || sessionStorage.rghIsNewTab === "true";
+	const redirectDisabled = event.altKey || sessionStorage.rghIsNewTab === 'true';
 	event.delegateTarget.form!.toggleAttribute('data-redirect-to-inbox-on-submit', !redirectDisabled);
 }
 

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -7,11 +7,16 @@ const hasNotificationBar = (): boolean =>
 	JSON.parse(sessionStorage.notification_shelf ?? '{}').pathname === location.pathname;
 
 function handleClick(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
-	// Also restores the attribute on successive non-alt clicks
-	event.delegateTarget.form!.toggleAttribute('data-redirect-to-inbox-on-submit', !event.altKey);
+	// Disable the redirect to the Notifications inbox if either:
+	// 1. The alt key was held down during click
+	// 2. The notification has been opened in a new tab
+	const redirectDisabled = event.alt || sessionStorage.rghIsNewTab === "true";
+	event.delegateTarget.form!.toggleAttribute('data-redirect-to-inbox-on-submit', !redirectDisabled);
 }
 
 async function init(): Promise<void> {
+	// If the history length is `1` on init, the notification has been opened in a new tab
+	sessionStorage.rghIsNewTab = history.length === 1;
 	delegate(document, '.notification-shelf .js-notification-action button', 'click', handleClick);
 }
 


### PR DESCRIPTION
Closes #3173

Feature originally implemented in #2952 and #3036.