### PR TITLE
Disable `remove-upload-files-button` in "Repository refresh" beta

### DIFF
--- a/source/features/remove-upload-files-button.tsx
+++ b/source/features/remove-upload-files-button.tsx
@@ -5,10 +5,10 @@ import features from '.';
 import {getRepoURL} from '../github-helpers';
 
 function init(): void {
-	const uploadButton = select(`.file-navigation a[href^="/${getRepoURL()}/upload"]`)!;
+	const uploadButton = select(`.file-navigation a[href^="/${getRepoURL()}/upload"]`);
 
 	// In "Repository refresh" layout, it's part of an "Add file" dropdown, don't delete it there
-	if (!uploadButton.classList.contains('dropdown-item')) {
+	if (uploadButton && !uploadButton.classList.contains('dropdown-item')) {
 		uploadButton.remove();
 	}
 }
@@ -21,6 +21,5 @@ void features.add({
 	include: [
 		pageDetect.isRepoTree
 	],
-	repeatOnAjax: false,
 	init
 });

--- a/source/features/remove-upload-files-button.tsx
+++ b/source/features/remove-upload-files-button.tsx
@@ -5,12 +5,8 @@ import features from '.';
 import {getRepoURL} from '../github-helpers';
 
 function init(): void {
-	const uploadButton = select(`.file-navigation a[href^="/${getRepoURL()}/upload"]`);
-
 	// In "Repository refresh" layout, it's part of an "Add file" dropdown, don't delete it there
-	if (uploadButton && !uploadButton.classList.contains('dropdown-item')) {
-		uploadButton.remove();
-	}
+	select(`.file-navigation a[href^="/${getRepoURL()}/upload"]:not(.dropdown-item)`)?.remove();
 }
 
 void features.add({

--- a/source/features/remove-upload-files-button.tsx
+++ b/source/features/remove-upload-files-button.tsx
@@ -5,7 +5,12 @@ import features from '.';
 import {getRepoURL} from '../github-helpers';
 
 function init(): void {
-	select(`.file-navigation a[href^="/${getRepoURL()}/upload"]`)?.remove();
+	const uploadButton = select(`.file-navigation a[href^="/${getRepoURL()}/upload"]`)!;
+
+	// In "Repository refresh" layout, it's part of an "Add file" dropdown, don't delete it there
+	if (!uploadButton.classList.contains('dropdown-item')) {
+		uploadButton.remove();
+	}
 }
 
 void features.add({


### PR DESCRIPTION
It's no longer needed there:

### Before

![Screenshot_2020-06-06_19-56-31](https://user-images.githubusercontent.com/202916/83951168-f248ad80-a82f-11ea-801b-f3509ff7915c.png)

### After

![Screenshot_2020-06-06_19-56-04](https://user-images.githubusercontent.com/202916/83951169-f379da80-a82f-11ea-98d1-f3308a8a2399.png)
