### PR TITLE
Restore `download-folder-button` in "Repository refresh" beta

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -1,18 +1,33 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
+import DownloadIcon from 'octicon/download.svg';
 
 import features from '.';
 
 function init(): void {
-	select('.file-navigation .BtnGroup.float-right')?.prepend(
-		<a
-			className="btn btn-sm BtnGroup-item"
-			href={`https://download-directory.github.io/?url=${location.href}`}
-		>
-			Download
-		</a>
-	);
+	const folderButtonGroup = select('.file-navigation .BtnGroup.float-right');
+	if (folderButtonGroup) {
+		folderButtonGroup.prepend(
+			<a
+				className="btn btn-sm BtnGroup-item"
+				href={`https://download-directory.github.io/?url=${location.href}`}
+			>
+				Download
+			</a>
+		);
+	} else {
+		// "Repository refresh" layout
+		select('.file-navigation > .d-flex')!.append(
+			<a
+				className="btn ml-2"
+				href={`https://download-directory.github.io/?url=${location.href}`}
+			>
+				<DownloadIcon className="mr-1"/>
+				Download
+			</a>
+		);
+	}
 }
 
 void features.add({


### PR DESCRIPTION
References #3081.

![Screenshot_2020-06-06_21-15-56](https://user-images.githubusercontent.com/202916/83952722-ed3d2b80-a83a-11ea-96dc-25de67f5a7b1.png)