### PR TITLE
Use api to get the latest tag ahead count

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -2,13 +2,11 @@ import './latest-tag-button.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import TagIcon from 'octicon/tag.svg';
-
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
-import fetchDom from '../helpers/fetch-dom';
-
 import features from '.';
+import fetchDom from '../helpers/fetch-dom';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 import getDefaultBranch from '../github-helpers/get-default-branch';
@@ -68,7 +66,7 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 	const releaseDate = tagDate.get(latestTag) ?? (await fetchDom(
 		`/${getRepoURL()}/releases/tag/${latestTag}`,
 		'.release-header relative-time'
-	) as HTMLElement).attributes.datetime.value;
+	) as HTMLTimeElement).attributes.datetime.value;
 
 	return {
 		latestTag,

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -99,7 +99,7 @@ const getAheadCountApi = async (timeStamp: string): Promise<number> => {
 		}
 	`);
 
-	return repository.ref.target.history.totalCount;
+	return repository.defaultBranchRef.target.history.totalCount;
 };
 
 async function init(): Promise<false | void> {

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -2,8 +2,11 @@ import './latest-tag-button.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import TagIcon from 'octicon/tag.svg';
+
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
+
+import fetchDom from '../helpers/fetch-dom';
 
 import features from '.';
 import * as api from '../github-helpers/api';
@@ -62,7 +65,10 @@ const getRepoPublishState = cache.function(async (): Promise<RepoPublishState> =
 	}
 
 	const latestTag = getLatestVersionTag([...tags.keys()]);
-	const releaseDate = tagDate.get(latestTag);
+	const releaseDate = tagDate.get(latestTag) ?? (await fetchDom(
+		`/${getRepoURL()}/releases/tag/${latestTag}`,
+		'.release-header relative-time'
+	) as HTMLElement).attributes.datetime.value;
 
 	return {
 		latestTag,


### PR DESCRIPTION
Fixes #2927

@fregante would love your input.

A bit of history of what i thought of doing.

First attempt was to get all the tag release dates in the original call. But github (as usual) does not give it 100% of the time.
So the next thing I did was if there was no date get it from the dom.
But then I realized that you can have commit dates not in order. (Very common by bootstrap on a rebase and merge).

So then I went with the following.

Try to get the ahead count from the dom. If the dom does not have it, take the release date from the dom  and get the aheadcount from the API. With the issue of commit dates not in order, we should not be _that off_.

One issue, if the tag was created locally together with a commit the count will be ahead by one since they both happened the same time. I could fix it, not sure if its worth it.

Let me know what you think.

Test On https://github.com/fregante/delegate-it