### PR TITLE
Fix `releases-tab` selector for "Repository refresh" beta

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -63,7 +63,7 @@ async function init(): Promise<false | void> {
 
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
 
-	const repoNavigationBar = select('.UnderlineNav');
+	const repoNavigationBar = select('.js-repo-nav.UnderlineNav');
 	if (repoNavigationBar) {
 		// "Repository refresh" layout
 


### PR DESCRIPTION
Fixes the issue found by @yakov116 in https://github.com/sindresorhus/refined-github/pull/3186#issuecomment-640546353:

The `.UnderlineNav` selector was too unspecific and also matched the tab bar inside the "Open with" popup.

![Screenshot_2020-06-08_21-02-21](https://user-images.githubusercontent.com/202916/84069772-5c498a00-a9cb-11ea-87fb-25765e684591.png)
