### PR TITLE
Hide duplicate "You can also open this in GitHub Desktop" in PRs

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -121,3 +121,8 @@ pr-branches
 .js-issue-row .text-small.text-gray .octicon {
 	vertical-align: middle;
 }
+
+/* Hide duplicate "You can also open this in GitHub Desktop" in PRs’ mergeability box */
+.js-remove-unless-platform {
+	display: none;
+}


### PR DESCRIPTION
GitHub added this: 

<img width="331" alt="" src="https://user-images.githubusercontent.com/1402241/84257595-dab24300-ab15-11ea-98fc-caf4189db2a3.png">

So we can remove most of this:

<img width="685" alt="" src="https://user-images.githubusercontent.com/1402241/84257569-cd955400-ab15-11ea-9b71-dda39316e7a0.png">

And now it looks like this:

<img width="678" alt="" src="https://user-images.githubusercontent.com/1402241/84257568-ccfcbd80-ab15-11ea-839f-0f2271d3d1dd.png">


Related: https://github.com/sindresorhus/refined-github/issues/963 
Partially undoes: https://github.com/sindresorhus/refined-github/pull/2553