### PR TITLE
Fix console errors and make `releases-tab` more reliable

### DIFF
--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -34,7 +34,9 @@ async function initReviewButtonEnhancements(): Promise<void> {
 	delegate(document, '.js-reviews-container > details', 'toggle', focusReviewTextarea, true);
 
 	const reviewDropdownButton = await elementReady<HTMLElement>('.js-reviews-toggle');
-	reviewDropdownButton!.dataset.hotkey = 'v';
+	if (reviewDropdownButton) {
+		reviewDropdownButton.dataset.hotkey = 'v';
+	}
 }
 
 void features.add({

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -13,11 +13,7 @@ import {getRepoURL, getRepoGQL, looseParseInt} from '../github-helpers';
 const repoUrl = getRepoURL();
 const cacheKey = `releases-count:${repoUrl}`;
 
-function parseCountFromDom(): number | undefined {
-	if (!pageDetect.isRepoRoot()) {
-		return;
-	}
-
+function parseCountFromDom(): number  {
 	const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
 	if (releasesCountElement) {
 		return looseParseInt(releasesCountElement.textContent!);
@@ -44,7 +40,7 @@ async function fetchFromApi(): Promise<number> {
 	return repository.refs.totalCount;
 }
 
-const getReleaseCount = cache.function(async () => parseCountFromDom() ?? fetchFromApi(), {
+const getReleaseCount = cache.function(async () => pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi(), {
 	maxAge: 1,
 	staleWhileRevalidate: 4,
 	cacheKey: () => cacheKey

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -13,23 +13,23 @@ import {getRepoURL, getRepoGQL, looseParseInt} from '../github-helpers';
 const repoUrl = getRepoURL();
 const cacheKey = `releases-count:${repoUrl}`;
 
-function parseCountFromDom(): number | false {
-	if (pageDetect.isRepoRoot()) {
-		const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
-		if (releasesCountElement) {
-			return looseParseInt(releasesCountElement.textContent!);
-		}
-
-		// In "Repository refresh" layout, look for the "+ XXX releases" link in the sidebar
-		const moreReleasesCountElement = select('.BorderGrid .text-small[href$="/releases"]');
-		if (moreReleasesCountElement) {
-			return looseParseInt(moreReleasesCountElement.textContent!) + 1;
-		}
-
-		return 0;
+function parseCountFromDom(): number | undefined {
+	if (!pageDetect.isRepoRoot()) {
+		return;
 	}
 
-	return false;
+	const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
+	if (releasesCountElement) {
+		return looseParseInt(releasesCountElement.textContent!);
+	}
+
+	// In "Repository refresh" layout, look for the "+ XXX releases" link in the sidebar
+	const moreReleasesCountElement = select('.BorderGrid .text-small[href$="/releases"]');
+	if (moreReleasesCountElement) {
+		return looseParseInt(moreReleasesCountElement.textContent!) + 1;
+	}
+
+	return 0;
 }
 
 async function fetchFromApi(): Promise<number> {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -13,7 +13,7 @@ import {getRepoURL, getRepoGQL, looseParseInt} from '../github-helpers';
 const repoUrl = getRepoURL();
 const cacheKey = `releases-count:${repoUrl}`;
 
-function parseCountFromDom(): number  {
+function parseCountFromDom(): number {
 	const releasesCountElement = select('.numbers-summary a[href$="/releases"] .num');
 	if (releasesCountElement) {
 		return looseParseInt(releasesCountElement.textContent!);

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -22,7 +22,7 @@ Example tag content on public repositories: https://github.com/sindresorhus/refi
 Example tag content on private repositories https://github.com/private/private/commits/master.atom?token=AEAXKWNRHXA2XJ2ZWCMGUUN44LM62
 */
 export const getCurrentBranch = (): string => {
-	return new URL(select<HTMLLinkElement>('[type="application/atom+xml"]')!.href)
+	return new URL(select.last<HTMLLinkElement>('[type="application/atom+xml"]')!.href)
 		.pathname
 		.split('/')
 		.slice(4) // Drops the initial /user/repo/route/ part

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -22,6 +22,7 @@ Example tag content on public repositories: https://github.com/sindresorhus/refi
 Example tag content on private repositories https://github.com/private/private/commits/master.atom?token=AEAXKWNRHXA2XJ2ZWCMGUUN44LM62
 */
 export const getCurrentBranch = (): string => {
+	// .last needed for #2799
 	return new URL(select.last<HTMLLinkElement>('[type="application/atom+xml"]')!.href)
 		.pathname
 		.split('/')


### PR DESCRIPTION
Fix releases tab not ever running from api. It returned false and were using ??.

I think it may make more sense to do `pageDetect.isRepoRoot() ? parseCountFromDom() : fetchFromApi()` Not sure

Also fixes attempting to apply a shortcut in `faster-reviews` on locked pr's
Test on https://github.com/yakov116/TestR/pull/6
