### PR TITLE
Add `clean-pinned-issues` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,7 @@ Thanks for contributing! 🦋🙌
 - [](# "extend-discussion-status-filters") [Lets you toggle between is:open/is:closed/is:merged filters in searches.](https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif)
 - [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
 - [](# "pinned-issue-update-time") [Adds the updated time to pinned issues.](https://user-images.githubusercontent.com/1402241/75525936-bb524700-5a4b-11ea-9225-466bda58b7de.png)
+- [](# "clean-pinned-issues") [Changes the layout of pinned issues from side-by-side to a standard list.](https://user-images.githubusercontent.com/1402241/84509958-c82a3c00-acc4-11ea-8399-eaf06a59e9e4.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -3,40 +3,40 @@
 	display: none !important;
 }
 
-:root .js-pinned-issues-reorder-list {
-	display: table !important;
-	width: 100%;
-	margin: 0;
-	margin-bottom: 20px;
-	border-radius: 3px;
-	box-shadow: 0 0 0 1px #d1d5da; /* Rounded table border https://stackoverflow.com/a/2586780/288906 */
-	border-style: hidden;
-	border-collapse: collapse;
-}
+@media (min-width: 700px) {
+	:root .js-pinned-issues-reorder-list {
+		display: table !important;
+		width: 100%;
+		margin: 0;
+		margin-bottom: 20px;
+		border-radius: 3px;
+		box-shadow: 0 0 0 1px #d1d5da; /* Rounded table border https://stackoverflow.com/a/2586780/288906 */
+		border-style: hidden;
+		border-collapse: collapse;
+	}
+	:root .pinned-issue-item {
+		display: table-row !important;
+		border-color: #e1e4e8 !important;
+	}
+	.pinned-issue-item > * {
+		display: table-cell !important;
+	}
 
-:root .pinned-issue-item {
-	display: table-row !important;
-	border-color: #e1e4e8 !important;
-}
+	:root .pinned-issue-item > * {
+		padding: 6px 12px;
+	}
 
-.pinned-issue-item > * {
-	display: table-cell !important;
-}
+	.pinned-issue-item > :first-child {
+		display: flex !important;
+	}
 
-:root .pinned-issue-item > * {
-	padding: 6px 12px;
-}
+	.pinned-issue-handle {
+		order: -1;
+		margin-top: -2px;
+	}
 
-.pinned-issue-item > :first-child {
-	display: flex !important;
-}
-
-.pinned-issue-handle {
-	order: -1;
-	margin-top: -2px;
-}
-
-[action$='unpin'] svg {
-	margin-left: -10px;
-	margin-right: 10px !important;
+	[action$="unpin"] svg {
+		margin-left: -10px;
+		margin-right: 10px !important;
+	}
 }

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -40,7 +40,7 @@
 		margin-top: -2px;
 	}
 
-	[action$="unpin"] svg {
+	[action$='unpin'] svg {
 		margin-left: -10px;
 		margin-right: 10px !important;
 	}

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -1,6 +1,6 @@
 /* Changes the layout of pinned issues from side-by-side to a standard list. */
 .js-pinned-issues-reorder-container .f4 {
-	display: none !important;
+	display: none !important; /* Hide title */
 }
 
 @media (min-width: 700px) {
@@ -9,15 +9,19 @@
 		width: 100%;
 		margin: 0;
 		margin-bottom: 20px;
-		border-radius: 3px;
-		box-shadow: 0 0 0 1px #d1d5da; /* Rounded table border https://stackoverflow.com/a/2586780/288906 */
-		border-style: hidden;
+
+		/* Rounded table border https://stackoverflow.com/a/2586780/288906 */
+		box-shadow: 0 0 0 1px #d1d5da;
 		border-collapse: collapse;
+		border-radius: 3px;
+		border-style: hidden;
 	}
+
 	:root .pinned-issue-item {
 		display: table-row !important;
 		border-color: #e1e4e8 !important;
 	}
+
 	.pinned-issue-item > * {
 		display: table-cell !important;
 	}
@@ -26,6 +30,7 @@
 		padding: 6px 12px;
 	}
 
+	/* Move `x` before the title and align both icons */
 	.pinned-issue-item > :first-child {
 		display: flex !important;
 	}

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -3,44 +3,28 @@
 	display: none !important;
 }
 
-.js-pinned-issues-reorder-list {
-	flex-direction: column;
-	width: 100% !important;
+:root .js-pinned-issues-reorder-list {
+	display: table !important;
+	width: 100%;
 	margin: 0;
 	margin-bottom: 20px;
-	padding: 0 !important;
+	border-radius: 3px;
+	box-shadow: 0 0 0 1px #d1d5da; /* Rounded table border https://stackoverflow.com/a/2586780/288906 */
+	border-style: hidden;
+	border-collapse: collapse;
 }
 
 :root .pinned-issue-item {
-	width: 100%;
-	padding: 3px !important;
-	margin-bottom: -1px !important;
-	flex-flow: row !important;
-	flex-wrap: wrap;
+	display: table-row !important;
+	border-color: #e1e4e8 !important;
 }
 
-.pinned-issue-item:not(:last-child) {
-	border-bottom-left-radius: none !important;
-	border-bottom-right-radius: none !important;
-}
-
-.pinned-issue-item:not(:first-child) {
-	border-top-left-radius: none !important;
-	border-top-right-radius: none !important;
-}
-
-.pinned-issue-item > :last-child {
-	min-width: 12em;
-	font-size: 12px !important; /* Needed to match the alignment */
+.pinned-issue-item > * {
+	display: table-cell !important;
 }
 
 :root .pinned-issue-item > * {
-	padding: 2px 12px;
-}
-
-:root .pinned-item-desc {
-	flex: initial;
-	margin-left: auto;
+	padding: 6px 12px;
 }
 
 .pinned-issue-item > :first-child {
@@ -49,7 +33,6 @@
 
 .pinned-issue-handle {
 	order: -1;
-	margin-left: -20px;
 	margin-top: -2px;
 }
 

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -1,0 +1,59 @@
+/* Changes the layout of pinned issues from side-by-side to a standard list. */
+.js-pinned-issues-reorder-container .f4 {
+	display: none !important;
+}
+
+.js-pinned-issues-reorder-list {
+	flex-direction: column;
+	width: 100% !important;
+	margin: 0;
+	margin-bottom: 20px;
+	padding: 0 !important;
+}
+
+:root .pinned-issue-item {
+	width: 100%;
+	padding: 3px !important;
+	margin-bottom: -1px !important;
+	flex-flow: row !important;
+	flex-wrap: wrap;
+}
+
+.pinned-issue-item:not(:last-child) {
+	border-bottom-left-radius: none !important;
+	border-bottom-right-radius: none !important;
+}
+
+.pinned-issue-item:not(:first-child) {
+	border-top-left-radius: none !important;
+	border-top-right-radius: none !important;
+}
+
+.pinned-issue-item > :last-child {
+	min-width: 12em;
+	font-size: 12px !important; /* Needed to match the alignment */
+}
+
+:root .pinned-issue-item > * {
+	padding: 2px 12px;
+}
+
+:root .pinned-item-desc {
+	flex: initial;
+	margin-left: auto;
+}
+
+.pinned-issue-item > :first-child {
+	display: flex !important;
+}
+
+.pinned-issue-handle {
+	order: -1;
+	margin-left: -20px;
+	margin-top: -2px;
+}
+
+[action$='unpin'] svg {
+	margin-left: -10px;
+	margin-right: 10px !important;
+}

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -43,9 +43,11 @@ async function init(): Promise<void | false> {
 	for (const pinnedIssue of pinnedIssues) {
 		const issueNumber = getPinnedIssueNumber(pinnedIssue);
 		const {updatedAt} = lastUpdated[api.escapeKey(issueNumber)];
-		pinnedIssue.lastElementChild!.append(
-			<span className="ml-3 text-gray"><ClockIcon/></span>,
-			<span className="text-gray text-small"> Updated <relative-time datetime={updatedAt}/></span>
+		pinnedIssue.lastElementChild!.before(
+			<span className="text-small mt-1">
+				<span className="ml-3 text-gray"><ClockIcon/></span>
+				<span className="text-gray"> Updated <relative-time datetime={updatedAt}/></span>
+			</span>
 		);
 	}
 }

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -1,7 +1,6 @@
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import ClockIcon from 'octicon/clock.svg';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -43,10 +42,10 @@ async function init(): Promise<void | false> {
 	for (const pinnedIssue of pinnedIssues) {
 		const issueNumber = getPinnedIssueNumber(pinnedIssue);
 		const {updatedAt} = lastUpdated[api.escapeKey(issueNumber)];
-		pinnedIssue.lastElementChild!.before(
-			<span className="text-small mt-1">
-				<span className="ml-3 text-gray"><ClockIcon/></span>
-				<span className="text-gray"> Updated <relative-time datetime={updatedAt}/></span>
+		select('.pinned-item-desc', pinnedIssue)!.append(
+			' • ',
+			<span className="text-gray d-inline-block">
+				updated <relative-time datetime={updatedAt}/>
 			</span>
 		);
 	}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -19,6 +19,7 @@ import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
 import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
+import './features/clean-pinned-issues.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
Closes #3179 

## Test

https://github.com/sindresorhus/refined-github/issues (3 pinned issues)
https://github.com/avajs/ava/issues (2 pinned issues)
https://github.com/facebook/react/issues (0 pinned issues)

## Before

<img width="1000" alt="before" src="https://user-images.githubusercontent.com/1402241/84509774-7b466580-acc4-11ea-8f3e-317f71b7505d.png">

## After

<img width="999" alt="after" src="https://user-images.githubusercontent.com/1402241/84509778-7c779280-acc4-11ea-88ad-f0f956063597.png">


<details>
<summary>Old, <code>display:flex</code> version</summary>

## Before

<img width="1153" alt="before" src="https://user-images.githubusercontent.com/1402241/84492592-ab7f0b80-aca6-11ea-98b8-39cac3602880.png">

## After

<img width="1139" alt="after" src="https://user-images.githubusercontent.com/1402241/84492596-ae79fc00-aca6-11ea-9e96-f73c6a3d0dbe.png">

</details>