### PR TITLE
Fix button styles in "Repository refresh" beta

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -35,13 +35,18 @@ async function init(): Promise<false | void> {
 
 	const defaultLink = (
 		<a
-			className="btn btn-sm tooltipped tooltipped-ne"
+			className="btn tooltipped tooltipped-ne"
 			href={String(url)}
 			aria-label="See this view on the default branch"
 		>
 			<ChevronLeftIcon/>
 		</a>
 	);
+
+	if (branchSelector.classList.contains('btn-sm')) {
+		// Pre "Repository refresh" layout
+		defaultLink.classList.add('btn-sm');
+	}
 
 	branchSelector.before(defaultLink);
 

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -95,7 +95,7 @@ async function init(): Promise<false | void> {
 	});
 
 	const link = (
-		<a className="btn btn-sm btn-outline ml-2" href={String(url)}>
+		<a className="btn btn-sm btn-outline ml-2 flex-self-center" href={String(url)}>
 			<TagIcon/>
 		</a>
 	);

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -16,7 +16,7 @@ function getPRUrl(prNumber: number): string {
 function getDropdown(prs: number[]): HTMLElement {
 	// Markup copied from https://primer.style/css/components/dropdown
 	return (
-		<details className="ml-2 dropdown details-reset details-overlay d-inline-block">
+		<details className="ml-2 dropdown details-reset details-overlay d-inline-block flex-self-center">
 			<summary aria-haspopup="true" className="btn btn-sm">
 				<PullRequestIcon/> {prs.length} <div className="dropdown-caret"/>
 			</summary>
@@ -41,7 +41,7 @@ function getSingleButton(prNumber: number, _?: number, prs?: number[]): HTMLElem
 	return (
 		<a
 			href={getPRUrl(prNumber)}
-			className={'btn btn-sm btn-outline' + (prs ? ' BtnGroup-item' : '')}
+			className={'btn btn-sm btn-outline flex-self-center' + (prs ? ' BtnGroup-item' : '')}
 		>
 			<PullRequestIcon/> #{prNumber}
 		</a>


### PR DESCRIPTION
Design fix for <https://github.com/sindresorhus/refined-github/issues/3081#issuecomment-643198654> / <https://github.com/sindresorhus/refined-github/pull/3205#issuecomment-641926371>.

### Before

![](https://user-images.githubusercontent.com/1402241/84260284-13541b80-ab1a-11ea-925f-0db5f75b20d2.png)

### After

![Screenshot_2020-06-12_14-23-11](https://user-images.githubusercontent.com/202916/84502248-4af8ca00-acb8-11ea-84e1-aa872d3343aa.png)
![Screenshot_2020-06-12_14-22-42](https://user-images.githubusercontent.com/202916/84502250-4af8ca00-acb8-11ea-8cde-bdfe0680f92d.png)

Note that I didn't change the button size for `latest-tag-button` and `list-prs-for-file`; I just centered them, as that looks better IMO.

<details>
<summary>See how it looks with changed button sizes instead:</summary>

![Screenshot_2020-06-12_14-15-01](https://user-images.githubusercontent.com/202916/84501915-a9717880-acb7-11ea-9fcd-213a3e00d9e1.png)
![Screenshot_2020-06-12_14-15-34](https://user-images.githubusercontent.com/202916/84501912-a8404b80-acb7-11ea-8404-aa6bc5ef8703.png)

</details>