### PR TITLE
Improve PR commit 404 page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7245,9 +7245,9 @@
 			}
 		},
 		"github-url-detection": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.2.0.tgz",
-			"integrity": "sha512-Ps1bL0rCWTzbmToofBcQ8Z8ge/FsJVDMqIdN3xoTRndY8tr7mXFnC+852VtQ7jPa0w+maD8REUc6UuzlWurXhA=="
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.2.2.tgz",
+			"integrity": "sha512-mELEJc5Z+qCG43L/m8aNzeX0l9NMUhMnWlhxMF8EHMPexO4KuxwHUMX+uI1x8FB1jaZ3ajKrDe6Uki/X84pizA=="
 		},
 		"glob": {
 			"version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
 		"github-reserved-names": "^1.1.8",
-		"github-url-detection": "^1.2.0",
+		"github-url-detection": "^1.2.2",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.0.1",
 		"linkify-issues": "2.0.0-nolookbehind",

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -30,7 +30,7 @@ void features.add({
 		pageDetect.isCommit
 	],
 	exclude: [
-		() => document.title.startsWith('Commit range not found · Pull Request')
+		pageDetect.isPRCommit404
 	],
 	init
 });

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -12,7 +12,8 @@ function init(): void {
 		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
 	}
 
-	select('.commit-meta > :last-child')!.append(
+	// Do nothing on not found PR commits (404 pages)
+	select('.commit-meta > :last-child')?.append(
 		<span className="sha-block patch-diff-links">
 			<a href={`${commitUrl}.patch`} className="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -12,8 +12,7 @@ function init(): void {
 		commitUrl = commitUrl.replace(/\/pull\/\d+\/commits/, '/commit');
 	}
 
-	// Do nothing on not found PR commits (404 pages)
-	select('.commit-meta > :last-child')?.append(
+	select('.commit-meta > :last-child')!.append(
 		<span className="sha-block patch-diff-links">
 			<a href={`${commitUrl}.patch`} className="sha">patch</a>
 			{ ' ' /* Workaround for: JSX eats whitespace between elements */ }
@@ -29,6 +28,9 @@ void features.add({
 }, {
 	include: [
 		pageDetect.isCommit
+	],
+	exclude: [
+		() => document.title.startsWith('Commit range not found · Pull Request')
 	],
 	init
 });

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -130,7 +130,10 @@ void features.add({
 	init
 }, {
 	include: [
-		() => document.title.startsWith('Commit range not found · Pull Request')
+		pageDetect.isPRCommit
+	],
+	exclude: [
+		() => !document.title.startsWith('Commit range not found · Pull Request')
 	],
 	waitForDomReady: false,
 	repeatOnAjax: false,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -5,6 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import {getCleanPathname} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
+import elementReady from 'element-ready';
 
 async function is404(url: string): Promise<boolean> {
 	const {status} = await fetch(url, {method: 'head'});
@@ -108,6 +109,19 @@ function init(): false | void {
 	}
 }
 
+async function initPRCommit(): Promise<void | false> {
+	const blankSlateParagraph = await elementReady('.blankslate p');
+	if (!blankSlateParagraph) {
+		// The PR commit exists
+		return false;
+	}
+
+	const commitUrl = location.pathname.replace(/\/$/, '').replace(/\/pull\/\d+\/commits/, '/commit');
+	blankSlateParagraph.after(
+		<p>You can also try to <a href={commitUrl}>view the detached standalone commit</a>.</p>
+	);
+}
+
 void features.add({
 	id: __filebasename,
 	description: 'Adds possible related pages and alternatives on 404 pages.',
@@ -118,4 +132,11 @@ void features.add({
 	],
 	repeatOnAjax: false,
 	init
+}, {
+	include: [
+		pageDetect.isPRCommit
+	],
+	waitForDomReady: false,
+	repeatOnAjax: false,
+	init: initPRCommit
 });

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -109,7 +109,7 @@ function init(): false | void {
 	}
 }
 
-async function initPRCommit(): Promise<void | false> {
+async function initPRCommit(): Promise<void> {
 	const commitUrl = location.pathname.replace(/pull\/\d+\/commits/, 'commit');
 
 	const blankSlateParagraph = await elementReady('.blankslate p');

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -110,7 +110,7 @@ function init(): false | void {
 }
 
 async function initPRCommit(): Promise<void | false> {
-	const commitUrl = location.pathname.replace(/\/$/, '').replace(/\/pull\/\d+\/commits/, '/commit');
+	const commitUrl = location.pathname.replace(/pull\/\d+\/commits/, 'commit');
 
 	const blankSlateParagraph = await elementReady('.blankslate p');
 	blankSlateParagraph!.after(

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -130,10 +130,7 @@ void features.add({
 	init
 }, {
 	include: [
-		pageDetect.isPRCommit
-	],
-	exclude: [
-		() => !document.title.startsWith('Commit range not found · Pull Request')
+		pageDetect.isPRCommit404
 	],
 	waitForDomReady: false,
 	repeatOnAjax: false,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -110,14 +110,10 @@ function init(): false | void {
 }
 
 async function initPRCommit(): Promise<void | false> {
-	const blankSlateParagraph = await elementReady('.blankslate p');
-	if (!blankSlateParagraph) {
-		// The PR commit exists
-		return false;
-	}
-
 	const commitUrl = location.pathname.replace(/\/$/, '').replace(/\/pull\/\d+\/commits/, '/commit');
-	blankSlateParagraph.after(
+
+	const blankSlateParagraph = await elementReady('.blankslate p');
+	blankSlateParagraph!.after(
 		<p>You can also try to <a href={commitUrl}>view the detached standalone commit</a>.</p>
 	);
 }
@@ -134,7 +130,7 @@ void features.add({
 	init
 }, {
 	include: [
-		pageDetect.isPRCommit
+		() => document.title.startsWith('Commit range not found · Pull Request')
 	],
 	waitForDomReady: false,
 	repeatOnAjax: false,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -1,11 +1,11 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {getCleanPathname} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
-import elementReady from 'element-ready';
 
 async function is404(url: string): Promise<boolean> {
 	const {status} = await fetch(url, {method: 'head'});

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -109,8 +109,11 @@ function init(): false | void {
 	}
 }
 
-async function initPRCommit(): Promise<void> {
-	const commitUrl = location.pathname.replace(/pull\/\d+\/commits/, 'commit');
+async function initPRCommit(): Promise<void | false> {
+	const commitUrl = location.href.replace(/pull\/\d+\/commits/, 'commit');
+	if (await is404(commitUrl)) {
+		return false;
+	}
 
 	const blankSlateParagraph = await elementReady('.blankslate p');
 	blankSlateParagraph!.after(


### PR DESCRIPTION
Add a second `init` function in `useful-not-found-page` that acts on not found PR commits. These can happen if you link to the PR commit (`/repo/pull/number/commits/commit_ref`) instead of the commit itself (`/repo/commit/commit_ref`)<sup>1</sup> and the PR gets force-pushed.

Test: [`32c8a88` (#3227)](https://github.com/sindresorhus/refined-github/pull/3227/commits/32c8a88360a85739f151566eae0225d530ce6a15) (should link to https://github.com/sindresorhus/refined-github/commit/32c8a88360a85739f151566eae0225d530ce6a15)

![Unbenannt](https://user-images.githubusercontent.com/202916/84600562-68759180-ae7a-11ea-8838-9030d82361f6.png)

<sup>1</sup>: We actually encourage to do so in `prevent-pr-commit-link-loss`, maybe that's the reason why GitHub doesn't use PR commit links by default.