### PR TITLE
Match border radius in GitHub new design

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -18,7 +18,7 @@
 .dashboard .js-all-activity-header + div {
 	background-color: #fff;
 	border: 1px solid #d1d5da;
-	border-radius: 3px;
+	border-radius: 6px;
 	margin-top: 8px !important;
 }
 

--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -13,7 +13,7 @@
 		/* Rounded table border https://stackoverflow.com/a/2586780/288906 */
 		box-shadow: 0 0 0 1px #d1d5da;
 		border-collapse: collapse;
-		border-radius: 3px;
+		border-radius: 6px;
 		border-style: hidden;
 	}
 

--- a/source/features/hide-watch-and-fork-count.css
+++ b/source/features/hide-watch-and-fork-count.css
@@ -1,10 +1,5 @@
 /* The Watchers count visible (and clickable) when the dropdown is open */
 /* This isn't possible for the Forks count because of an incompatible DOM structure and #2368 */
-.rgh-hide-watch-and-fork-count:not(.rgh-forked-to) .btn-with-count[title^='Fork your own'],
-.rgh-hide-watch-and-fork-count details:not([open]) .btn-with-count[data-ga-click^='Repository, click Watch'] {
-	border-radius: 0.25em; /* Matches GitHub's default */
-}
-
 .rgh-hide-watch-and-fork-count .social-count[href$='/network/members'],
 .rgh-hide-watch-and-fork-count details:not([open]) ~ .social-count[href$='/watchers'] {
 	display: none;

--- a/source/features/highlight-collaborators-and-own-discussions.css
+++ b/source/features/highlight-collaborators-and-own-discussions.css
@@ -1,5 +1,5 @@
 .rgh-collaborator {
 	border: 1px solid #c0d3eb;
-	border-radius: 3px;
+	border-radius: 2em;
 	padding: 2px 5px;
 }

--- a/source/features/minimize-upload-bar.css
+++ b/source/features/minimize-upload-bar.css
@@ -5,5 +5,4 @@
 
 .rgh-minimize-upload-bar .js-upload-markdown-image.is-default textarea {
 	border-bottom-style: solid;
-	border-radius: 3px;
 }

--- a/source/features/parse-backticks.css
+++ b/source/features/parse-backticks.css
@@ -1,7 +1,7 @@
 /* Style copied from GitHub's <code> */
 .rgh-parse-backticks {
 	background-color: rgb(27 31 35 / 5%);
-	border-radius: 3px;
+	border-radius: 6px;
 	font-size: 85%;
 	margin: 0;
 	padding: 0.2em 0.4em;

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -21,7 +21,6 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	display: inline-block;
 	width: 2em;
 	height: 2em;
-	border-radius: 3px;
 	margin-top: -0.3em;
 	margin-left: -0.5em;
 	vertical-align: middle;
@@ -45,6 +44,5 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item a img { /* `a` required for #3237 */
 	max-width: 100%;
-	border-radius: inherit;
 	background-color: var(--background);
 }

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -62,7 +62,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 		container.append(
 			// Without this, Firefox will follow the link instead of submitting the reaction button
 			<a href={isFirefox ? undefined : `/${username}`} className="rounded-1 avatar-user">
-				<img src={imageUrl} style={{ borderRadius: 'inherit' }}/>
+				<img src={imageUrl} style={{borderRadius: 'inherit'}}/>
 			</a>
 		);
 	}

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -61,8 +61,8 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 	for (const {container, username, imageUrl} of flatParticipants) {
 		container.append(
 			// Without this, Firefox will follow the link instead of submitting the reaction button
-			<a href={isFirefox ? undefined : `/${username}`}>
-				<img src={imageUrl}/>
+			<a href={isFirefox ? undefined : `/${username}`} className="rounded-1 avatar-user">
+				<img src={imageUrl} className="avatar-user rounded-1"/>
 			</a>
 		);
 	}

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -62,7 +62,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 		container.append(
 			// Without this, Firefox will follow the link instead of submitting the reaction button
 			<a href={isFirefox ? undefined : `/${username}`} className="rounded-1 avatar-user">
-				<img src={imageUrl} className="avatar-user rounded-1"/>
+				<img src={imageUrl} style={{ borderRadius: 'inherit' }}/>
 			</a>
 		);
 	}

--- a/source/features/recently-pushed-branches-enhancements.css
+++ b/source/features/recently-pushed-branches-enhancements.css
@@ -36,7 +36,6 @@
 	background: none;
 	border-color: currentColor !important;
 	border-top: 1px solid !important;
-	border-radius: 5px;
 	background-color: #24292e;
 }
 
@@ -74,7 +73,7 @@
 	font-size: 0;
 	line-height: 0;
 	border: solid 1px;
-	border-radius: 0.2rem;
+	border-radius: 6px;
 }
 
 .rgh-recently-pushed-branches [data-url$='recently_touched_branches_list'] .btn-link[href$='?expand=1']:not(:hover) {


### PR DESCRIPTION
Related to #3081
Fixes #3248

Match border radius with GitHub's new design.

Features and test URLs:
- `reactions-avatars`: here

  <details>

  "Design updates" feature preview **disabled**:
  ![image](https://user-images.githubusercontent.com/44045911/84969101-95f85e80-b14a-11ea-95df-29eeed437989.png)
  "Design updates" feature preview **enabled**:
  ![image](https://user-images.githubusercontent.com/44045911/84969098-94c73180-b14a-11ea-9f40-5a3ad559a1ce.png)

  </details>
- `parse-backticks`: https://github.com/sindresorhus/refined-github/pulls
- `clean-dashboard`: https://github.com/
- `clean-pinned-issues`: https://github.com/sindresorhus/refined-github/issues
- `hide-watch-and-fork-count`: here
- `highlight-collaborators-and-own-discussions`: https://github.com/sindresorhus/refined-github/pulls
- `minimize-upload-bar`: here
- `recently-pushed-branches-enhancements`: 🤷