### PR TITLE
Don't run `comments-time-machine-links` if comment is after latest commit

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -71,8 +71,10 @@ async function showTimemachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		// "Repository refresh" layout uses the itemprop="dateModified"
-		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time, [itemprop="dateModified"] relative-time');
+		const lastCommitDate = await elementReady([
+			'.repository-content .Box.Box--condensed relative-time',
+			'[itemprop="dateModified"] relative-time' // "Repository refresh" beta
+		].join());
 		if (date > lastCommitDate?.attributes.datetime.value!) {
 			return false;
 		}

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -71,6 +71,11 @@ async function showTimemachineBar(): Promise<void | false> {
 			return false;
 		}
 
+		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time');
+		if (date > lastCommitDate?.attributes.datetime.value!) {
+			return false;
+		}
+
 		const parsedUrl = new GitHubURL(location.href);
 		parsedUrl.branch = `${parsedUrl.branch}@{${date}}`;
 		url.pathname = parsedUrl.pathname;

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -65,13 +65,14 @@ async function showTimemachineBar(): Promise<void | false> {
 		url.pathname = pathnameParts.join('/');
 	} else {
 		// This feature only makes sense if the URL points to a non-permalink
-		const branchSelector = await elementReady('.branch-select-menu i');
+		const branchSelector = await elementReady('[data-hotkey="w"] i');
 		const isPermalink = /Tag|Tree/.test(branchSelector!.textContent!);
 		if (isPermalink) {
 			return false;
 		}
 
-		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time');
+		// "Repository refresh" layout uses the itemprop="dateModified"
+		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time, [itemprop="dateModified"] relative-time');
 		if (date > lastCommitDate?.attributes.datetime.value!) {
 			return false;
 		}

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -73,7 +73,7 @@ async function showTimemachineBar(): Promise<void | false> {
 
 		const lastCommitDate = await elementReady([
 			'.repository-content .Box.Box--condensed relative-time',
-			'[itemprop="dateModified"] relative-time' // "Repository refresh" beta
+			'[itemprop="dateModified"] relative-time' // "Repository refresh" layout
 		].join());
 		if (date > lastCommitDate?.attributes.datetime.value!) {
 			return false;


### PR DESCRIPTION
1. LINKED ISSUES:
   Closes #3244

2. TEST URLS:
Should not show
	https://github.com/sindresorhus/refined-github/blob/master/source/features/comments-time-machine-links.tsx

Should show
```
https://github.com/sindresorhus/refined-github/blob/master/source/features/comments-time-machine-links.tsx?rgh-link-date=2019-12-11T10%3A12%3A11Z
```

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes