### PR TITLE
Fix `download-folder-button` and `latest-tag-button`

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -42,7 +42,7 @@ void features.add({
 		pageDetect.isRepoTree
 	],
 	exclude: [
-		() => select.exists('get-repo-controller') // Already has an native download ZIP button
+		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -6,12 +6,15 @@ import DownloadIcon from 'octicon/download.svg';
 import features from '.';
 
 function init(): void {
+	const downloadUrl = new URL('https://download-directory.github.io/')
+	downloadUrl.searchParams.set('url', location.href);
+
 	const folderButtonGroup = select('.file-navigation .BtnGroup.float-right');
 	if (folderButtonGroup) {
 		folderButtonGroup.prepend(
 			<a
 				className="btn btn-sm BtnGroup-item"
-				href={`https://download-directory.github.io/?url=${location.href}`}
+				href={downloadUrl.href}
 			>
 				Download
 			</a>
@@ -21,7 +24,7 @@ function init(): void {
 		select('.file-navigation > .d-flex')!.append(
 			<a
 				className="btn ml-2"
-				href={`https://download-directory.github.io/?url=${location.href}`}
+				href={downloadUrl.href}
 			>
 				<DownloadIcon className="mr-1"/>
 				Download

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -39,7 +39,7 @@ void features.add({
 		pageDetect.isRepoTree
 	],
 	exclude: [
-		pageDetect.isRepoRoot // Already has an native download ZIP button
+		() => select.exists('get-repo-controller') // Already has an native download ZIP button
 	],
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -6,7 +6,7 @@ import DownloadIcon from 'octicon/download.svg';
 import features from '.';
 
 function init(): void {
-	const downloadUrl = new URL('https://download-directory.github.io/')
+	const downloadUrl = new URL('https://download-directory.github.io/');
 	downloadUrl.searchParams.set('url', location.href);
 
 	const folderButtonGroup = select('.file-navigation .BtnGroup.float-right');

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -133,7 +133,7 @@ async function init(): Promise<false | void> {
 					<DiffIcon/>
 				</a>
 			);
-			groupButtons([link, compareLink]);
+			groupButtons([link, compareLink]).classList.add('flex-self-center');
 		}
 	} else {
 		link.setAttribute('aria-label', 'Visit the latest release');


### PR DESCRIPTION
1. Fixes <https://github.com/sindresorhus/refined-github/pull/3195#issuecomment-646323153>.

   `download-folder-button` doesn't need to be shown when "Clone or download" button exists.

   Problem: `isRepoRoot` seems to not work on branches with slashes. It caused the big button to appear with "Repository refresh" beta disabled and a console error with "Repository refresh" beta enabled.

   Test: https://github.com/yakov116/TestR/tree/this/branch/has/many/slashes

2. Fixes <https://github.com/sindresorhus/refined-github/issues/3081#issuecomment-643198654> again after #3214 was merged.

   Test: https://github.com/OpenLightingProject/open-fixture-library

   Before:  
   ![Screenshot_2020-06-19_00-05-34](https://user-images.githubusercontent.com/202916/85077346-59684980-b1c2-11ea-80d8-af937de77eb7.png)

   After:  
   ![Screenshot_2020-06-19_00-07-56](https://user-images.githubusercontent.com/202916/85077347-5a00e000-b1c2-11ea-8d1e-982d511d7a9b.png)

