### PR TITLE
Improve `dim-bots`’s behavior

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -1,55 +1,44 @@
 /*
-READ BEFORE EDITING. Some selectors match the same items ("hovered" selector vs non-hovered); make sure to update them in tandem.
+READ BEFORE EDITING. Some selectors match the same items ("focused" selector vs non-focused); make sure to update them in tandem.
 Commits that have a long commit message will not be dimmed after the user uncollapses the `<details>` element.
 
-In PR lists we can hide the meta just by acting on `max-height` + `overflow: hidden`
-In Commit lists however this is not possible because they are tables, so we need to hack around `margin-bottom`
-
-Transitions are used to delay the "hover" status so it's not too annoying when moving the mouse over a list of dimmed items.
+Transitions are used to delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items.
 */
-.rgh-dim-bot.commit .commit-title,
-.rgh-dim-bot.commit .commit-meta,
-.rgh-dim-bot.commit summary,
-.rgh-dim-bot.commit .commit-links-group,
-.rgh-dim-bot.commit .commit-links-group + .btn {
+
+.rgh-dim-bot .commit-title,
+.rgh-dim-bot .commit-meta,
+.rgh-dim-bot .signed-commit-badge, /* `Verified` badge */
+.rgh-dim-bot .commit-links-group, /* Hash and Copy hash buttons */
+.rgh-dim-bot .commit-links-group + .btn, /* Browse repository button */
+.rgh-dim-bot.Box-row > .d-flex, /* PR titles */
+.rgh-dim-bot .labels, /* PR labels */
+.rgh-dim-bot .labels + .text-small /* PR meta */ {
 	transition: 0.1s 0.3s;
 	transition-property: opacity, margin-bottom;
 }
 
-.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-title {
-	opacity: 30%;
-	transition-delay: 0s;
-}
+/*
+ALL the following rules define the non-focused state
+*/
 
-.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-meta,
-.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) summary, /* `Verified` badge */
-.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons */
-.rgh-dim-bot.commit:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn { /* Browse repository button */
-	opacity: 0%;
-	visibility: hidden;
-	margin-bottom: -2em;
-	transition-delay: 0s;
-}
-
-/* PRs’ whole box, reduce height */
-.rgh-dim-bot.Box-row:not(.Details--on) {
-	overflow: hidden;
-	max-height: 10em; /* This value is only needed to transition the height since `max-height: none` can't be transitioned */
-	transition: max-height 0.1s 0.3s;
-}
-
-.rgh-dim-bot.Box-row:not(.navigation-focus):not(.Details--on) {
-	overflow: hidden;
-	max-height: 2.7em;
-	transition-delay: 0s;
-}
-
-/* PRs’ titles, dim */
-.rgh-dim-bot.Box-row > .d-table {
-	transition: opacity 0.1s 0.3s;
-}
-
-.rgh-dim-bot.Box-row:not(.navigation-focus) > .d-table {
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-title, /* Commit titles, dim */
+.rgh-dim-bot.Box-row:not(.navigation-focus) > .d-flex { /* PR titles, dim */
 	opacity: 20%; /* This can't applied to .Box-row because that includes the top border. */
+	transition-delay: 0s;
+}
+
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-meta,
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .signed-commit-badge, /* `Verified` badge */
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons */
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn /* Browse repository button */ {
+	opacity: 0%;
+	margin-bottom: -1.6em;
+	transition-delay: 0s;
+}
+
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .labels, /* PR labels */
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .labels + .text-small /* PR meta */ {
+	opacity: 0%;
+	margin-bottom: -2em;
 	transition-delay: 0s;
 }

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -33,6 +33,7 @@ Transitions are used to delay the "hover" status so it's not too annoying when m
 
 /* PRs’ whole box, reduce height */
 .rgh-dim-bot.Box-row:not(.Details--on) {
+	overflow: hidden;
 	max-height: 10em; /* This value is only needed to transition the height since `max-height: none` can't be transitioned */
 	transition: max-height 0.1s 0.3s;
 }

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -1,8 +1,6 @@
 /*
 READ BEFORE EDITING. Some selectors match the same items ("focused" selector vs non-focused); make sure to update them in tandem.
 Commits that have a long commit message will not be dimmed after the user uncollapses the `<details>` element.
-
-Transitions are used to delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items.
 */
 
 .rgh-dim-bot .commit-title,
@@ -13,7 +11,9 @@ Transitions are used to delay the "focused" status so it's not too annoying when
 .rgh-dim-bot .Box-row--drag-hide, /* PR row */
 .rgh-dim-bot .labels, /* PR labels */
 .rgh-dim-bot .labels + .text-small /* PR meta */ {
-	transition: 0.1s 0.3s;
+	/* Delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items. */
+	transition: 0.1s;
+	transition-delay: 0.3s;
 	transition-property: opacity, margin-bottom;
 }
 

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -10,7 +10,7 @@ Transitions are used to delay the "focused" status so it's not too annoying when
 .rgh-dim-bot .signed-commit-badge, /* `Verified` badge */
 .rgh-dim-bot .commit-links-group, /* Hash and Copy hash buttons */
 .rgh-dim-bot .commit-links-group + .btn, /* Browse repository button */
-.rgh-dim-bot.Box-row > .d-flex, /* PR titles */
+.rgh-dim-bot .Box-row--drag-hide, /* PR row */
 .rgh-dim-bot .labels, /* PR labels */
 .rgh-dim-bot .labels + .text-small /* PR meta */ {
 	transition: 0.1s 0.3s;
@@ -22,8 +22,8 @@ ALL the following rules define the non-focused state
 */
 
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-title, /* Commit titles, dim */
-.rgh-dim-bot.Box-row:not(.navigation-focus) > .d-flex { /* PR titles, dim */
-	opacity: 20%; /* This can't applied to .Box-row because that includes the top border. */
+.rgh-dim-bot:not(.navigation-focus) .Box-row--drag-hide { /* PR row, dim */
+	opacity: 20%;
 	transition-delay: 0s;
 }
 
@@ -36,8 +36,8 @@ ALL the following rules define the non-focused state
 	transition-delay: 0s;
 }
 
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .labels, /* PR labels */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .labels + .text-small /* PR meta */ {
+.rgh-dim-bot:not(.navigation-focus) .labels, /* PR labels */
+.rgh-dim-bot:not(.navigation-focus) .labels + .text-small /* PR meta */ {
 	opacity: 0%;
 	margin-bottom: -2em;
 	transition-delay: 0s;

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -4,16 +4,18 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function init(): void {
-	const bots = select.all([
-		/* Commits */
-		'.commit-author[href$="%5Bbot%5D"]:first-child',
-		'.commit-author[href$="renovate-bot"]:first-child',
+// eslint-disable-next-line import/prefer-default-export
+export const botSelectors = [
+	/* Commits */
+	'.commit-author[href$="%5Bbot%5D"]:first-child',
+	'.commit-author[href$="renovate-bot"]:first-child',
 
-		/* Issues/PRs */
-		'.opened-by [href*="author%3Aapp%2F"]'
-	]);
-	for (const bot of bots) {
+	/* Issues/PRs */
+	'.opened-by [href*="author%3Aapp%2F"]'
+];
+
+function init(): void {
+	for (const bot of select.all(botSelectors)) {
 		bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 	}
 }

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -97,7 +97,7 @@ function createLink(reference: RepositoryReference): HTMLSpanElement {
 async function init(): Promise<false | void> {
 	const prLinks = select.all('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]')
 		// Exclude bots
-		.filter(link => !link.parentElement?.querySelector(botSelectors.join(',')));
+		.filter(link => !link.parentElement?.querySelector(botSelectors.join()));
 	if (prLinks.length === 0) {
 		return false;
 	}

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -7,6 +7,7 @@ import features from '.';
 import * as api from '../github-helpers/api';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getRepositoryInfo, getRepoGQL} from '../github-helpers';
+import {botSelectors} from './dim-bots';
 
 type RepositoryReference = {
 	owner: string;
@@ -94,7 +95,9 @@ function createLink(reference: RepositoryReference): HTMLSpanElement {
 }
 
 async function init(): Promise<false | void> {
-	const prLinks = select.all('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]');
+	const prLinks = select.all('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]')
+		// Exclude bots
+		.filter(link => !link.parentElement?.querySelector(botSelectors.join(',')));
 	if (prLinks.length === 0) {
 		return false;
 	}


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3232

Follows https://github.com/sindresorhus/refined-github/pull/3128 
Follows https://github.com/sindresorhus/refined-github/pull/2864

Instead of clipping via `height` and `overflow: hidden`, I'm just using negative margins to collapse the meta information.

- No more visible overflow
- No more clipped titles (because there's no fixed height)

Also some selectors needed to be updated because lists no longer use `display: table` :tada:

# Test

## PR List

https://github.com/facebook/react/pulls?q=bump

![](https://user-images.githubusercontent.com/1402241/85140968-5747ce80-b246-11ea-81bf-3608885757e3.gif)

## Commit list

https://github.com/kulshekhar/ts-jest/commits/master?after=3247ae409af4d9e47acf1ac31707b970f829e990+104

![11s](https://user-images.githubusercontent.com/1402241/85140997-63339080-b246-11ea-9d94-af860b7978d9.gif)

