### PR TITLE
Make `getDefaultBranch` quicker on `isRepoHome`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7245,9 +7245,9 @@
 			}
 		},
 		"github-url-detection": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.2.2.tgz",
-			"integrity": "sha512-mELEJc5Z+qCG43L/m8aNzeX0l9NMUhMnWlhxMF8EHMPexO4KuxwHUMX+uI1x8FB1jaZ3ajKrDe6Uki/X84pizA=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-1.2.3.tgz",
+			"integrity": "sha512-MSmdcZGUs57k8U4vwy/iLD5jHnup86bPKJ3B5JBuDL6qkHy4bd3xW65DdRN0QJIrD33J6Fz3H1/59I4W3LaBnw=="
 		},
 		"glob": {
 			"version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
 		"github-reserved-names": "^1.1.8",
-		"github-url-detection": "^1.2.2",
+		"github-url-detection": "^1.2.3",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.0.1",
 		"linkify-issues": "2.0.0-nolookbehind",

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -1,9 +1,9 @@
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import {isForkedRepo} from 'github-url-detection/esm';
+import * as pageDetect from 'github-url-detection';
 
 import * as api from './api';
-import {RepositoryInfo, getRepositoryInfo, getRepoURL} from '.';
+import {RepositoryInfo, getRepositoryInfo, getRepoURL, getCurrentBranch, getRepoPath} from '.';
 
 // This regex should match all of these combinations:
 // "This branch is even with master."
@@ -14,7 +14,11 @@ const branchInfoRegex = /([^ ]+)\.$/;
 
 export default cache.function(async (repository: Partial<RepositoryInfo> = getRepositoryInfo()): Promise<string> => {
 	if (JSON.stringify(repository) === JSON.stringify(getRepositoryInfo())) {
-		if (!isForkedRepo()) {
+		if (pageDetect.isRepoRoot() && !String(getRepoPath()).startsWith('tree/')) {
+			return getCurrentBranch();
+		}
+
+		if (!pageDetect.isForkedRepo()) {
 			// We can find the name in the infobar, available in folder views
 			const branchInfo = select('.branch-infobar')?.textContent!.trim();
 			const defaultBranch = branchInfoRegex.exec(branchInfo!)?.[1];

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -14,7 +14,7 @@ const branchInfoRegex = /([^ ]+)\.$/;
 
 export default cache.function(async (repository: Partial<RepositoryInfo> = getRepositoryInfo()): Promise<string> => {
 	if (JSON.stringify(repository) === JSON.stringify(getRepositoryInfo())) {
-		if (pageDetect.isRepoRoot() && !String(getRepoPath()).startsWith('tree/')) {
+		if (getRepoPath() === '') {
 			return getCurrentBranch();
 		}
 

--- a/source/github-helpers/get-default-branch.ts
+++ b/source/github-helpers/get-default-branch.ts
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import * as api from './api';
-import {RepositoryInfo, getRepositoryInfo, getRepoURL, getCurrentBranch, getRepoPath} from '.';
+import {RepositoryInfo, getRepositoryInfo, getRepoURL, getCurrentBranch} from '.';
 
 // This regex should match all of these combinations:
 // "This branch is even with master."
@@ -14,7 +14,7 @@ const branchInfoRegex = /([^ ]+)\.$/;
 
 export default cache.function(async (repository: Partial<RepositoryInfo> = getRepositoryInfo()): Promise<string> => {
 	if (JSON.stringify(repository) === JSON.stringify(getRepositoryInfo())) {
-		if (getRepoPath() === '') {
+		if (pageDetect.isRepoHome()) {
 			return getCurrentBranch();
 		}
 


### PR DESCRIPTION
Follows https://github.com/sindresorhus/refined-github/issues/3239#issuecomment-646072282

**Note:** `isRepoTree`cannot be used instead of `!String(getRepoPath()).startsWith('tree/')` since `isRepoTree` includes `isRepoRoot`