### PR TITLE
Restore `toggle-files-button`+`repo-age` in "Repository refresh"

### DIFF
--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -43,12 +43,20 @@ const getRepoAge = async (commitSha: string, commitsCount: number): Promise<[str
 };
 
 const getFirstCommit = cache.function(async (): Promise<[string, string] | undefined> => {
-	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>('.commit-tease a[href*="/commit/"], include-fragment.commit-tease');
+	const commitInfo = await elementReady<HTMLAnchorElement | HTMLScriptElement>([
+		// "Repository refresh" layout
+		'.Box-header--blue .hx_avatar_stack_commit + div a[href*="/commit/"]',
+		'include-fragment[aria-label="Loading latest commit"]',
+
+		// Pre "Repository refresh" layout
+		'a.commit-tease-sha',
+		'include-fragment.commit-tease'
+	].join());
 	const commitUrl = commitInfo instanceof HTMLAnchorElement ? commitInfo.href : commitInfo!.src;
 	const commitSha = commitUrl.split('/').pop()!;
 
 	// In "Repository refresh" layout, the number of commits may not be rendered yet
-	const commitsCountElement = select('li.commits .num') ?? await elementReady('.commit-tease + * a[href*="/commits/"] strong');
+	const commitsCountElement = select('li.commits .num') ?? (await elementReady('.Box-header--blue [aria-label^="Commits on "]'))!.parentElement;
 	const commitsCount = looseParseInt(commitsCountElement!.textContent!);
 
 	// Returning undefined will make sure that it is not cached. It will check again for commits on the next load.

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -8,8 +8,8 @@
 	border-radius: 3px;
 }
 
-.repository-content:not(.rgh-files-hidden) .commit-tease .octicon-unfold,
-.repository-content.rgh-files-hidden .commit-tease .octicon-fold {
+.repository-content:not(.rgh-files-hidden) .rgh-toggle-files .octicon-unfold,
+.repository-content.rgh-files-hidden .rgh-toggle-files .octicon-fold {
 	display: none;
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -12,7 +12,10 @@ import observeElement from '../helpers/simplified-element-observer';
 
 function addButton(): void {
 	// `div` excludes `include-fragment`, which means the list is still loading. #2160
-	const filesHeader = select('div.commit-tease');
+	const filesHeader = select([
+		'div.commit-tease',
+		'.Box-header--blue .Details > :last-child > ul' // "Repository refresh" layout
+	]);
 	if (!filesHeader || select.exists('.rgh-toggle-files')) {
 		return;
 	}


### PR DESCRIPTION
Follows #3187 and #3225, related to #3081. GitHub updated the design of the "latest commit" box in the "Repository refresh" beta, so our selectors broke.

## Restore `repo-age`

Test URLs:

* https://github.com/sindresorhus/refined-github
* https://github.com/sindresorhus/refined-github/tree/fregante-patch-1
* https://github.com/sindresorhus/refined-github/tree/20.6.18

Make sure to clear the cache to test if the selectors work properly.

## Restore `toggle-files-button`

Test URLs: see above

![Screenshot_2020-06-22_23-29-51](https://user-images.githubusercontent.com/202916/85337188-4dd99300-b4e0-11ea-8188-24c18858b9d5.png)