### PR TITLE
Fix `wait-for-build` checkbox display

### DIFF
--- a/source/github-helpers/pr-ci-status.ts
+++ b/source/github-helpers/pr-ci-status.ts
@@ -29,7 +29,7 @@ export function get(): CommitStatus {
 			return FAILURE;
 		}
 
-		if (lastCommit.querySelector('.octicon-primitive-dot')) {
+		if (lastCommit.querySelector('.octicon-dot-fill')) {
 			return PENDING;
 		}
 	}


### PR DESCRIPTION
Seems like the icon was updated recently which meant the commit status check selector was incorrect and the checkbox was not displayed.

<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes

-->
Closes #1067 

- Go to a PR that has some CI running, click on merge and see that the checkbox is displayed:

seems to work for the current design:
![Screenshot 2020-06-23 at 11 02 33](https://user-images.githubusercontent.com/1215056/85385190-4b0f8a00-b542-11ea-9270-439c99ca78a7.png)
but also in the preview:
![Screenshot 2020-06-23 at 11 01 19](https://user-images.githubusercontent.com/1215056/85385317-72665700-b542-11ea-98ba-923278688b43.png)

