### PR TITLE
Fix `Add-tag-to-commits` and `mark-merge-commits-in-list`

### DIFF
--- a/source/features/add-tag-to-commits.tsx
+++ b/source/features/add-tag-to-commits.tsx
@@ -6,6 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
+import {getCommitHash} from './mark-merge-commits-in-list';
 import {getRepoURL, getRepoGQL} from '../github-helpers';
 
 interface CommitTags {
@@ -120,11 +121,11 @@ async function init(): Promise<void | false> {
 	const cacheKey = `tags:${getRepoURL()}`;
 
 	const commitsOnPage = select.all('li.commit');
-	const lastCommitOnPage = commitsOnPage[commitsOnPage.length - 1].dataset.channel!.split(':')[3];
+	const lastCommitOnPage = getCommitHash(commitsOnPage[commitsOnPage.length - 1]);
 	let cached = await cache.get<{[commit: string]: string[]}>(cacheKey) ?? {};
 	const commitsWithNoTags = [];
 	for (const commit of commitsOnPage) {
-		const targetCommit = commit.dataset.channel!.split(':')[3];
+		const targetCommit = getCommitHash(commit);
 		let targetTags = cached[targetCommit];
 		if (!targetTags) {
 			// No tags for this commit found in the cache, check in github

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -36,7 +36,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
 	// Pre "Repository refresh" layout
-	return 	commit.dataset.channel!.split(':')[3] ||
+	return 	commit.dataset.channel!.split(':')[3] ??
 	commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()!;
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -33,8 +33,11 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 	return mergeCommits;
 };
 
-function getCommitHash(commit: HTMLElement): string {
-	return commit.dataset.channel!.split(':')[3];
+// eslint-disable-next-line import/prefer-default-export
+export function getCommitHash(commit: HTMLElement): string {
+	return commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()! ??
+	// Pre "Repository refresh" layout
+	commit.dataset.channel!.split(':')[3];
 }
 
 async function init(): Promise<void> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -35,8 +35,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	// Pre "Repository refresh" layout
-	return 	commit.dataset.channel!.split(':')[3] ??
+	return 	commit.dataset.channel!.split(':')[3] ?? // Pre "Repository refresh" layout
 	commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()!;
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -36,7 +36,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
 	// Pre "Repository refresh" layout
-	return 	commit.dataset?.channel!.split(':')[3] ??
+	return 	commit.dataset.channel!.split(':')[3] ||
 	commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()!;
 }
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -35,9 +35,9 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	return commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()! ??
 	// Pre "Repository refresh" layout
-	commit.dataset.channel!.split(':')[3];
+	return 	commit.dataset?.channel!.split(':')[3] ??
+	commit.querySelector<HTMLAnchorElement>('a[href]')!.href.split('/').pop()!;
 }
 
 async function init(): Promise<void> {


### PR DESCRIPTION
Fixes #3294

This fixes both features that relied on the same dataset and the dom changed.

Test On:
https://github.com/sindresorhus/refined-github/commits/master 