### PR TITLE
Move `user-profile-follower-badge` position

### DIFF
--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -22,9 +22,14 @@ const doesUserFollow = cache.function(async (userA: string, userB: string): Prom
 
 async function init(): Promise<void> {
 	if (await doesUserFollow(getCleanPathname(), getUsername())) {
-		select('.vcard-names-container:not(.is-placeholder)')!.after(
-			<div className="rgh-follower-badge">Follows you</div>
-		);
+		const newProfileElement = select('.js-profile-editable-area a:last-child');
+		if (newProfileElement) {
+			newProfileElement.after(<span className="text-gray"> · Follows you</span>);
+		} else {
+			select('.vcard-names-container:not(.is-placeholder)')!.after(
+				<div className="rgh-follower-badge">Follows you</div>
+			);
+		}
 	}
 }
 

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -26,6 +26,7 @@ async function init(): Promise<void> {
 		if (newProfileElement) {
 			newProfileElement.after(<span className="text-gray"> · Follows you</span>);
 		} else {
+			// Pre "Repository refresh" layout
 			select('.vcard-names-container:not(.is-placeholder)')!.after(
 				<div className="rgh-follower-badge">Follows you</div>
 			);


### PR DESCRIPTION
The badge position always looks weird for me, especially with the new design. The new stats area seems like a better place for it.

**Before:**

![image](https://user-images.githubusercontent.com/44045911/85497989-78773900-b611-11ea-9c23-c3126e1580f1.png)

**After (wide view):**
![image](https://user-images.githubusercontent.com/44045911/85497907-52ea2f80-b611-11ea-808d-443f47eb9b45.png)

**After (narrow view):**
![image](https://user-images.githubusercontent.com/44045911/85497920-58e01080-b611-11ea-8667-146a929a865e.png)
