### PR TITLE
Update `parse-backticks` style

### DIFF
--- a/source/features/parse-backticks.css
+++ b/source/features/parse-backticks.css
@@ -1,7 +1,7 @@
 /* Style copied from GitHub's <code> */
 .rgh-parse-backticks {
 	background-color: rgb(27 31 35 / 5%);
-	border-radius: 3px;
+	border-radius: 6px;
 	font-size: 85%;
 	margin: 0;
 	padding: 0.2em 0.4em;


### PR DESCRIPTION
Match `.markdown-body code`'s `border-radius`.

I'm testing other `border-radius` style to see if they need updating too.