### PR TITLE
Update `view-markdown-source` selector

### DIFF
--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,12 +78,12 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	select('.repository-content .Box-header .d-flex')!.prepend(
+	select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex')!.prepend(
 		<div className="BtnGroup">
-			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-n rgh-md-source" type="button" aria-label="Display the source blob">
+			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>
 			</button>
-			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped-n rgh-md-rendered selected" type="button" aria-label="Display the rendered blob">
+			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw rgh-md-rendered selected" type="button" aria-label="Display the rendered blob">
 				<FileIcon/>
 			</button>
 		</div>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,7 +78,10 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex')!.prepend(
+	select([
+		'.repository-content .Box-header .d-flex', // Pre "Repository refresh" layout
+		'.repository-content > .Box:nth-of-type(3) .Box-header .d-flex'
+	].join())!.prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>


### PR DESCRIPTION
- Fix selector
- Match GitHub's tooltip style (position)

Test: https://github.com/sindresorhus/refined-github/blob/master/contributing.md

**Before**
![image](https://user-images.githubusercontent.com/44045911/85735644-6a6c0a00-b730-11ea-8682-4be4b1c26945.png)
**After**
![image](https://user-images.githubusercontent.com/44045911/85735746-8374bb00-b730-11ea-8392-0ea588ad9f43.png)
