### PR TITLE
Fix display of wrapped whitespace in `show-whitespace`

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -7,11 +7,11 @@
 }
 
 [data-rgh-whitespace='tab'] {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 12 24' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' %3E%3Cpath d='M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z' fill='%23545E5D' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' viewBox='0 0 12 14'%3E%3Cstyle%3E %23text %7B font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace; line-height: 100%25; %7D %3C/style%3E%3Ctext id='text' x='4.13' y='-2.07' font-size='14' fill='%2324292e' fill-opacity='0.5' alignment-baseline='before-edge' dominant-baseline='text-before-edge'%3E%3Ctspan x='5.88' dy='0em' alignment-baseline='before-edge' dominant-baseline='text-before-edge' text-anchor='middle'%3E→%3C/tspan%3E%3C/text%3E%3C/svg%3E%0A");
 	background-size: calc(var(--tab-size, 4) * 1ch) 1em;
 }
 
 [data-rgh-whitespace='space'] {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 12 24' xmlns='http://www.w3.org/2000/svg preserveAspectRatio='xMidYMid meet' %3E%3Crect x='4.5' y='9.5' width='3' height='3' rx='1.5' fill='%2324292E' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' viewBox='0 0 12 14'%3E%3Cstyle%3E %23text %7B font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace; line-height: 100%25; %7D %3C/style%3E%3Ctext id='text' x='4.13' y='-2.07' font-size='14' fill='%2324292e' fill-opacity='0.5' alignment-baseline='before-edge' dominant-baseline='text-before-edge'%3E%3Ctspan x='5.88' dy='0em' alignment-baseline='before-edge' dominant-baseline='text-before-edge' text-anchor='middle'%3E·%3C/tspan%3E%3C/text%3E%3C/svg%3E%0A");
 	background-size: 1ch 1em;
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -7,11 +7,11 @@
 }
 
 [data-rgh-whitespace='tab'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E"');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(36,41,46,0.5)"/%3E%3C/svg%3E');
 	background-size: calc(var(--tab-size, 4) * 1ch) 1.25em;
 }
 
 [data-rgh-whitespace='space'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(36,41,46,0.5)"/%3E%3C/svg%3E');
 	background-size: 1ch 1.25em;
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -7,11 +7,11 @@
 }
 
 [data-rgh-whitespace='tab'] {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' viewBox='0 0 12 14'%3E%3Cstyle%3E %23text %7B font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace; line-height: 100%25; %7D %3C/style%3E%3Ctext id='text' x='4.13' y='-2.07' font-size='14' fill='%2324292e' fill-opacity='0.5' alignment-baseline='before-edge' dominant-baseline='text-before-edge'%3E%3Ctspan x='5.88' dy='0em' alignment-baseline='before-edge' dominant-baseline='text-before-edge' text-anchor='middle'%3E→%3C/tspan%3E%3C/text%3E%3C/svg%3E%0A");
-	background-size: calc(var(--tab-size, 4) * 1ch) 1em;
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="%23545E5D" fill-opacity="0.5"/%3E%3C/svg%3E"');
+	background-size: calc(var(--tab-size, 4) * 1ch) 1.25em;
 }
 
 [data-rgh-whitespace='space'] {
-	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' viewBox='0 0 12 14'%3E%3Cstyle%3E %23text %7B font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace; line-height: 100%25; %7D %3C/style%3E%3Ctext id='text' x='4.13' y='-2.07' font-size='14' fill='%2324292e' fill-opacity='0.5' alignment-baseline='before-edge' dominant-baseline='text-before-edge'%3E%3Ctspan x='5.88' dy='0em' alignment-baseline='before-edge' dominant-baseline='text-before-edge' text-anchor='middle'%3E·%3C/tspan%3E%3C/text%3E%3C/svg%3E%0A");
-	background-size: 1ch 1em;
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath xmlns="http://www.w3.org/2000/svg" d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E');
+	background-size: 1ch 1.25em;
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,18 +1,20 @@
 [data-rgh-whitespace] {
-	position: relative;
 	line-height: 1em;
+	white-space: break-spaces;
 }
 
-[data-rgh-whitespace]::before {
-	content: attr(data-rgh-whitespace);
-	pointer-events: none;
-	user-select: none;
-	position: absolute;
-	left: 0;
-	top: 0;
-	opacity: 25%;
+[data-rgh-whitespace='tab'] {
+	background-image: url("data:image/svg+xml,%3Csvg fill='none' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 24' preserveAspectRatio='xMinYMid meet'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z' fill='%23545E5D' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-size: calc(var(--tab-size, 4) * 1ch) 1em;
+	background-clip: border-box;
+	background-repeat: repeat-x;
+	background-position: left center;
 }
 
-[data-rgh-whitespace^='→']::before {
-	letter-spacing: calc((var(--tab-size, 4) * 1ch) - 1ch);
+[data-rgh-whitespace='space'] {
+	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='4.5' y='9.5' width='3' height='3' rx='1.5' fill='%2324292E' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-size: 1ch 1em;
+	background-clip: border-box;
+	background-repeat: repeat-x;
+	background-position: center center;
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,20 +1,17 @@
 [data-rgh-whitespace] {
 	line-height: 1em;
 	white-space: break-spaces;
-}
-
-[data-rgh-whitespace='tab'] {
-	background-image: url("data:image/svg+xml,%3Csvg fill='none' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 24' preserveAspectRatio='xMinYMid meet'%3E%3Cpath xmlns='http://www.w3.org/2000/svg' d='M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z' fill='%23545E5D' fill-opacity='0.5'/%3E%3C/svg%3E");
-	background-size: calc(var(--tab-size, 4) * 1ch) 1em;
 	background-clip: border-box;
 	background-repeat: repeat-x;
 	background-position: left center;
 }
 
+[data-rgh-whitespace='tab'] {
+	background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 12 24' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='xMinYMid meet' %3E%3Cpath d='M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z' fill='%23545E5D' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-size: calc(var(--tab-size, 4) * 1ch) 1em;
+}
+
 [data-rgh-whitespace='space'] {
-	background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 12 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Crect x='4.5' y='9.5' width='3' height='3' rx='1.5' fill='%2324292E' fill-opacity='0.5'/%3E%3C/svg%3E");
+	background-image: url("data:image/svg+xml,%3Csvg fill='none' viewBox='0 0 12 24' xmlns='http://www.w3.org/2000/svg preserveAspectRatio='xMidYMid meet' %3E%3Crect x='4.5' y='9.5' width='3' height='3' rx='1.5' fill='%2324292E' fill-opacity='0.5'/%3E%3C/svg%3E");
 	background-size: 1ch 1em;
-	background-clip: border-box;
-	background-repeat: repeat-x;
-	background-position: center center;
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -7,11 +7,11 @@
 }
 
 [data-rgh-whitespace='tab'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="%23545E5D" fill-opacity="0.5"/%3E%3C/svg%3E"');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E"');
 	background-size: calc(var(--tab-size, 4) * 1ch) 1.25em;
 }
 
 [data-rgh-whitespace='space'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" fill="none" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath xmlns="http://www.w3.org/2000/svg" d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="%2324292E" fill-opacity="0.5"/%3E%3C/svg%3E');
 	background-size: 1ch 1.25em;
 }

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -43,12 +43,8 @@ function showWhiteSpacesOn(line: Element): void {
 			// Update cached variable here because it just changed
 			text = textNode.textContent!;
 
-			const whitespace = textNode.nextSibling!.textContent!
-				.replace(/ /g, '·')
-				.replace(/\t/g, '→');
-
 			textNode.after(
-				<span data-rgh-whitespace={whitespace}>
+				<span data-rgh-whitespace={thisCharacter === '\t' ? 'tab' : 'space'}>
 					{textNode.nextSibling}
 				</span>
 			);


### PR DESCRIPTION
Fixes: #2991

Uses clipped SVG background images for spaces and tabs, this makes it more flexible for text wrapping, and any other future characters (#2150).

## Test

* [text wrapping](https://github.com/discord/discord-api-docs/pull/1396/files#diff-99b76a48d014c043f2f8804f6653ed82R515) issue from #2991

* [standalone file](https://github.com/sindresorhus/refined-github/blob/master/source/features/show-whitespace.tsx)

  ![standalone](https://user-images.githubusercontent.com/37769974/86010553-3008b280-ba39-11ea-8826-48375eeb3dd4.gif)

* [diff](https://github.com/sindresorhus/refined-github/pull/3168/files)

  ![diff](https://user-images.githubusercontent.com/37769974/86010583-3c8d0b00-ba39-11ea-9f7c-2fe92df8b9c2.gif)

* [gist](https://gist.github.com/notlmn/fe7f722971dea345379850bd64516fd2)

  ![gist](https://user-images.githubusercontent.com/37769974/86010614-46af0980-ba39-11ea-9d71-0a89e1044b85.gif)

-----

This PR is still in the works, as SVG content used are static paths, which should ideally be text nodes that inherit font from DOM (Figma still flattens all text nodes while exporting).

I tried to match the existing styles (and size) as much as possible, but we might have to reconsider that anyway (i.e. using actual text).

------

**_Edit:_** Updated GIFs
