### PR TITLE
Fix padding for status labels

### DIFF
--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -22,7 +22,6 @@
 }
 
 .rgh-align-issue-labels .js-issue-row .IssueLabel {
-	padding: 2px 3px 3px !important;
 	margin-top: 4px;
 	font-size: 11px !important;
 }

--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -8,7 +8,7 @@ function init(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Aligns labels in lists to the left.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png'
+	screenshot: 'https://user-images.githubusercontent.com/37769974/85866472-11aa7900-b7e5-11ea-80aa-d84e3aee2551.png'
 }, {
 	waitForDomReady: false,
 	repeatOnAjax: false,


### PR DESCRIPTION
Fixes #3291.

![](https://user-images.githubusercontent.com/37769974/85866472-11aa7900-b7e5-11ea-80aa-d84e3aee2551.png)