### PR TITLE
Replace switched off rawgit html preview

### DIFF
--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -15,7 +15,7 @@ function init(): void {
 		.prepend(
 			<a
 				className="btn btn-sm BtnGroup-item"
-				href={`https://ghcdn.rawgit.org${link.join('/')}`}
+				href={`https://htmlpreview.github.io/?https://github.com/${link.join('/')}`}
 			>
 				Preview
 			</a>


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
   Add some test URLs

3. SCREENSHOT:
   Add a screenshot here if your PR makes visual changes

-->

Rawgit announced to shutdown a while ago and now https://ghcdn.rawgit.org/ stopped working and only shows a cloudflare cached page. I have found https://htmlpreview.github.io online and it works quiet good but I am not settled on it. If someone knows a better alternative it should be used.

Test URLs:
https://htmlpreview.github.io/?https://github.com//sindresorhus/refined-github/master/source/options.html ( thanks @kidonng. The rawgit alternative does not work and returns a 502 https://ghcdn.rawgit.org/sindresorhus/refined-github/master/source/options.html.)