### PR TITLE
Fix `clean-pinned-issues` layout

### DIFF
--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -40,8 +40,9 @@
 		margin-top: -2px;
 	}
 
-	[action$='unpin'] svg {
+	.pinned-issue-item form button {
+		float: unset !important;
 		margin-left: -10px;
-		margin-right: 10px !important;
+		margin-right: 2px !important;
 	}
 }


### PR DESCRIPTION
Fix #3298

Test: some repo you have admin access, with only 1 pinned issue

**Before**

![](https://user-images.githubusercontent.com/44045911/85970421-05990400-b9fd-11ea-854f-3ad5df9660b2.png)

**After**

![image](https://user-images.githubusercontent.com/44045911/86260717-38571e00-bbf0-11ea-82ff-5d3c33ead733.png)
