### PR TITLE
Update `view-markdown-source` selector again

### DIFF
--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,7 +78,7 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	(select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex') ??
+	(select('.repository-content .Box-header.flex-md-items-center .d-flex') ??
 	// Pre "Repository refresh" layout
 	select('.repository-content .Box-header .d-flex')!).prepend(
 		<div className="BtnGroup">

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -80,7 +80,7 @@ async function init(): Promise<void> {
 
 	(select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex') ??
 	// Pre "Repository refresh" layout
-	select('.repository-content .Box-header .d-flex'))!.prepend(
+	select('.repository-content .Box-header .d-flex')!).prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,12 +78,12 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	select('.repository-content .Box-header .d-flex')!.prepend(
+	select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex')!.prepend(
 		<div className="BtnGroup">
-			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-n rgh-md-source" type="button" aria-label="Display the source blob">
+			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>
 			</button>
-			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped-n rgh-md-rendered selected" type="button" aria-label="Display the rendered blob">
+			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw rgh-md-rendered selected" type="button" aria-label="Display the rendered blob">
 				<FileIcon/>
 			</button>
 		</div>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,9 +78,11 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	(select('.repository-content .Box-header.flex-md-items-center .d-flex') ??
-	// Pre "Repository refresh" layout
-	select('.repository-content .Box-header .d-flex')!).prepend(
+	const fileButtons =
+		select('.repository-content .Box-header.flex-md-items-center .d-flex') ??
+		// Pre "Repository refresh" layout
+		select('.repository-content .Box-header .d-flex')!;
+	fileButtons.prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,10 +78,9 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	select([
-		'.repository-content .Box-header .d-flex', // Pre "Repository refresh" layout
-		'.repository-content > .Box:nth-of-type(3) .Box-header .d-flex'
-	].join())!.prepend(
+	(select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex') ||
+	 // Pre "Repository refresh" layout
+	 select('.repository-content .Box-header .d-flex'))!.prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,9 +78,9 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	(select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex') ||
-	 // Pre "Repository refresh" layout
-	 select('.repository-content .Box-header .d-flex'))!.prepend(
+	(select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex') ??
+	// Pre "Repository refresh" layout
+	select('.repository-content .Box-header .d-flex'))!.prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -78,7 +78,10 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-md-source:not(.selected)', 'click', showSource);
 	delegate(document, '.rgh-md-rendered:not(.selected)', 'click', showRendered);
 
-	select('.repository-content > .Box:nth-of-type(3) .Box-header .d-flex')!.prepend(
+	select([
+		'.repository-content .Box-header .d-flex', // Pre "Repository refresh" layout
+		'.repository-content > .Box:nth-of-type(3) .Box-header .d-flex'
+	].join())!.prepend(
 		<div className="BtnGroup">
 			<button className="btn btn-sm BtnGroup-item tooltipped tooltipped tooltipped-nw rgh-md-source" type="button" aria-label="Display the source blob">
 				<CodeIcon/>


### PR DESCRIPTION
Continue of https://github.com/sindresorhus/refined-github/pull/3282#issuecomment-652526963

I forgot that `Element.querySelector` uses depth-first pre-order traversal, so it will match the old selector sometimes.

Test:
- https://github.com/sindresorhus/refined-github/blob/master/readme.md
- https://github.com/sindresorhus/refined-github/blob/master/contributing.md
- https://github.com/kidonng/cherry/blob/master/Bookmarklets.md