### PR TITLE
Add `align-repository-header` feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 			"selector-type-no-unknown": null,
 			"declaration-no-important": null,
 			"selector-class-pattern": null,
-			"selector-id-pattern": null
+			"selector-id-pattern": null,
+			"selector-max-universal": null
 		}
 	},
 	"ava": {

--- a/readme.md
+++ b/readme.md
@@ -331,6 +331,7 @@ Thanks for contributing! 🦋🙌
 - [](# "unwrap-useless-dropdowns") [Makes some dropdowns 1-click instead of unnecessarily 2-click.](https://user-images.githubusercontent.com/1402241/80859624-9bfdb300-8c62-11ea-837f-7b7a28e6fdfc.png)
 - [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png)
 - [](# "prevent-pr-commit-link-loss") [Suggests fixing your PR Commit links before commenting. GitHub has a bug that causes these link to appear as plain commit links, without association to the PR.](https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif)
+- [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,0 +1,9 @@
+/* Align repo header to the content, just on the left side*/
+.repohead > * {
+    padding-left: calc(50% - 1280px / 2) !important;
+}
+
+/* Restore the original padding on those 2 elements */
+.repohead > * > :first-child {
+    margin-left: 32px;
+}

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,9 +1,19 @@
-/* Align repo header to the content, just on the left side*/
+/* Align repo header to the content, just on the left side */
 .repohead > * {
 	padding-left: calc(50% - 1280px / 2) !important;
 }
 
-/* Restore the original padding on those 2 elements */
-.repohead > * > :first-child {
-	margin-left: 32px;
+/* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
+.repohead > * > * {
+	margin-left: 16px;
+}
+@media (min-width: 768px) {
+	.repohead > * > * {
+		margin-left: 24px;
+	}
+}
+@media (min-width: 1012px) {
+	.repohead > * > * {
+		margin-left: 32px;
+	}
 }

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,21 +1,22 @@
 /* Align repo header to the content, just on the left side */
 .repohead > * {
 	padding-left: calc(50% - 1280px / 2) !important;
+	--page-margin: 16px
 }
 
 /* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
 .repohead > * > * {
-	margin-left: 16px;
+	margin-left: 16px !important;
 }
 
 @media (min-width: 768px) {
 	.repohead > * > * {
-		margin-left: 24px;
+		margin-left: 24px !important;
 	}
 }
 
 @media (min-width: 1012px) {
 	.repohead > * > * {
-		margin-left: 32px;
+		margin-left: 32px !important;
 	}
 }

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,7 +1,6 @@
 /* Align repo header to the content, just on the left side */
 .repohead > * {
 	padding-left: calc(50% - 1280px / 2) !important;
-	--page-margin: 16px
 }
 
 /* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,9 +1,9 @@
 /* Align repo header to the content, just on the left side*/
 .repohead > * {
-    padding-left: calc(50% - 1280px / 2) !important;
+	padding-left: calc(50% - 1280px / 2) !important;
 }
 
 /* Restore the original padding on those 2 elements */
 .repohead > * > :first-child {
-    margin-left: 32px;
+	margin-left: 32px;
 }

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -7,11 +7,13 @@
 .repohead > * > * {
 	margin-left: 16px;
 }
+
 @media (min-width: 768px) {
 	.repohead > * > * {
 		margin-left: 24px;
 	}
 }
+
 @media (min-width: 1012px) {
 	.repohead > * > * {
 		margin-left: 32px;

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -19,6 +19,7 @@ import './features/repo-stats-spacing.css';
 import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
 import './features/clean-pinned-issues.css';
+import './features/align-repository-header.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3280
Replaces and closes #3250

Instead of aligning both sides and limiting the available space for the tabs, this only aligns the left side

<img width="1680" alt="" src="https://user-images.githubusercontent.com/1402241/86476593-21770f80-bd47-11ea-8b5f-213ccb22a348.png">
