### PR TITLE
Show `prevent-pr-commit-link-loss` on "new issue/PR" pages

### DIFF
--- a/source/features/prevent-pr-commit-link-loss.tsx
+++ b/source/features/prevent-pr-commit-link-loss.tsx
@@ -28,6 +28,10 @@ const updateUI = debounceFn(({delegateTarget: field}: delegate.Event<InputEvent,
 	// The replacement logic is not just in the regex, so it alone can't be used to detect the need for the replacement
 	if (field.value === field.value.replace(prCommitUrlRegex, preventPrCommitLinkLoss)) {
 		getUI(field).remove();
+	} else if (pageDetect.isNewIssue() || pageDetect.isCompare()) {
+		select('file-attachment', field.form!)!.append(
+			<div className="m-2">{getUI(field)}</div>
+		);
 	} else {
 		select('.form-actions', field.form!)!.prepend(getUI(field));
 	}
@@ -46,7 +50,7 @@ void features.add({
 	screenshot: 'https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif'
 }, {
 	include: [
-		pageDetect.hasComments
+		pageDetect.hasRichTextEditor
 	],
 	init
 });


### PR DESCRIPTION
Closes #3234
Replaces and closes #3296

Test content:

```
https://github.com/sindresorhus/refined-github/pull/3085/commits/a7b1a8bd85c230ff9ff8e407ca8f6d3646c90eb6       
```

## New PR

To test this, you have to create a PR from another repo. Example URL:

https://github.com/sindresorhus/refined-github/compare/master...fregante:a@b?expand=1

<img width="932" src="https://user-images.githubusercontent.com/1402241/86591409-d6047180-bf91-11ea-8941-1a92e1633989.png">


## New issue

Example URL: https://github.com/sindresorhus/refined-github/issues/new

<img width="927" alt="Screen Shot 2020-07-06 at 14 02 13" src="https://user-images.githubusercontent.com/1402241/86591499-fe8c6b80-bf91-11ea-97d3-99900ae7c3ad.png">

## Comments (unchanged)

Try on this PR

<img width="926" alt="Screen Shot 2020-07-06 at 14 08 12" src="https://user-images.githubusercontent.com/1402241/86591584-24197500-bf92-11ea-981a-cd4a6a369f53.png">
