### PR TITLE
Disable `more-dropdown`

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -78,6 +78,7 @@ async function init(): Promise<void> {
 }
 
 void features.add({
+	disabled: '#3215',
 	id: __filebasename,
 	description: 'Adds links to `Commits`, `Branches`, `Dependencies`, and `Compare` in a new `More` dropdown.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png'


### PR DESCRIPTION
While we haven't figured out a solution to #3215, the feature will throw an error on every repo page.

By disabling the feature, we can prevent issues like #3265.