### PR TITLE
Limit `align-repository-header` to non-full-width pages

### DIFF
--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,21 +1,21 @@
 /* Align repo header to the content, just on the left side */
-.page-responsive .repohead > * {
+body:not(.full-width) .repohead > * {
 	padding-left: calc(50% - 1280px / 2) !important;
 }
 
 /* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
-.page-responsive .repohead > * > * {
+body:not(.full-width) .repohead > * > * {
 	margin-left: 16px !important;
 }
 
 @media (min-width: 768px) {
-	.page-responsive .repohead > * > * {
+	body:not(.full-width) .repohead > * > * {
 		margin-left: 24px !important;
 	}
 }
 
 @media (min-width: 1012px) {
-	.page-responsive .repohead > * > * {
+	body:not(.full-width) .repohead > * > * {
 		margin-left: 32px !important;
 	}
 }

--- a/source/features/align-repository-header.css
+++ b/source/features/align-repository-header.css
@@ -1,21 +1,21 @@
 /* Align repo header to the content, just on the left side */
-.repohead > * {
+.page-responsive .repohead > * {
 	padding-left: calc(50% - 1280px / 2) !important;
 }
 
 /* Restore the original padding on those 2 elements. The media queries follows GitHub’s values */
-.repohead > * > * {
+.page-responsive .repohead > * > * {
 	margin-left: 16px !important;
 }
 
 @media (min-width: 768px) {
-	.repohead > * > * {
+	.page-responsive .repohead > * > * {
 		margin-left: 24px !important;
 	}
 }
 
 @media (min-width: 1012px) {
-	.repohead > * > * {
+	.page-responsive .repohead > * > * {
 		margin-left: 32px !important;
 	}
 }


### PR DESCRIPTION
Some pages are full-width, so they don't need to be "aligned".

- Centered: https://github.com/sindresorhus/refined-github
- Centered: this very page
- Centered: https://github.com/sindresorhus/refined-github/pull/3322/files?diff=unified
- Full width: https://github.com/sindresorhus/refined-github/pull/3322/files?diff=split
- Full width: https://github.com/sindresorhus/refined-github/blame/master/.gitattributes
- Full width: https://github.com/sindresorhus/refined-github/commit/f87c46617028be1882047bc3cf3166de94c86e14?diff=split