### PR TITLE
Fix multiple `copy-file` buttons on gist svg files

### DIFF
--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import copyToClipboard from 'copy-text-to-clipboard';
 
 import features from '.';
-import {groupSiblings} from '../github-helpers/group-buttons';
+import {groupButtons} from '../github-helpers/group-buttons';
 
 function handleClick({delegateTarget: button}: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	const file = button.closest('.Box, .js-gist-file-update-container')!;

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -36,7 +36,8 @@ function renderButton(): void {
 				Copy
 			</button>
 		);
-		if (pageDetect.isGist() && button.href.endsWith('.svg')) { // SVG files have a render blob button
+		const hasRenderButtons = button.parentElement!.querySelector('.rendered');
+		if (pageDetect.isGist() && hasRenderButtons) {
 			button.before(copyButton);
 		} else {
 			button

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -36,16 +36,12 @@ function renderButton(): void {
 				Copy
 			</button>
 		);
-		const hasRenderButtons = button.parentElement!.querySelector('.rendered');
-		if (pageDetect.isGist() && hasRenderButtons) {
-			button.before(copyButton);
+		const group = button.closest('.BtnGroup');
+		if (group) {
+			group.prepend(copyButton);
 		} else {
-			button
-				.parentElement! // `BtnGroup`
-				.prepend(copyButton);
+			groupButtons([button, copyButton]);
 		}
-
-		groupSiblings(button);
 	}
 }
 

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -5,6 +5,7 @@ import * as pageDetect from 'github-url-detection';
 import copyToClipboard from 'copy-text-to-clipboard';
 
 import features from '.';
+import {groupSiblings} from '../github-helpers/group-buttons';
 
 function handleClick({delegateTarget: button}: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	const file = button.closest('.Box, .js-gist-file-update-container')!;
@@ -22,18 +23,28 @@ function handleClick({delegateTarget: button}: delegate.Event<MouseEvent, HTMLBu
 }
 
 function renderButton(): void {
-	for (const button of select.all('.file-actions .btn, [data-hotkey="b"]')) {
-		button
-			.parentElement! // `BtnGroup`
-			.prepend(
-				<button
-					className="btn btn-sm tooltipped tooltipped-n BtnGroup-item rgh-copy-file"
-					aria-label="Copy file to clipboard"
-					type="button"
-				>
-					Copy
-				</button>
-			);
+	for (const button of select.all<HTMLAnchorElement>([
+		'.file-actions .btn[href*="/raw/"]', // `isGist`
+		'[data-hotkey="b"]'
+	])) {
+		const copyButton = (
+			<button
+				className="btn btn-sm tooltipped tooltipped-n BtnGroup-item rgh-copy-file"
+				aria-label="Copy file to clipboard"
+				type="button"
+			>
+				Copy
+			</button>
+		);
+		if (pageDetect.isGist() && button.href.endsWith('.svg')) { // SVG files have a render blob button
+			button.before(copyButton);
+		} else {
+			button
+				.parentElement! // `BtnGroup`
+				.prepend(copyButton);
+		}
+
+		groupSiblings(button);
 	}
 }
 


### PR DESCRIPTION
1. LINKED ISSUES:
   Fixes #3323 

2. TEST URLS:
https://gist.github.com/cimi/8c9674e587d3f05131e42353ab1282c3?short_path=939f372

   https://github.com/jmeridth/jmeridth.github.io/blob/gh-pages/_posts/2012-03-30-do-not-issue-pull-requests-from-your-master-branch.md (No changes)

3. SCREENSHOT:
   Before
![image](https://user-images.githubusercontent.com/16872793/86920440-cdc64680-c0f7-11ea-96b2-187910c2ebb4.png)

After

![image](https://user-images.githubusercontent.com/16872793/86920449-d28afa80-c0f7-11ea-9a6f-2d5a286cd895.png)
