### PR TITLE
Preserve "Edit comment" in dropdown

### DIFF
--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -15,20 +15,6 @@ function init(): void {
 		button.append(<PencilIcon/>);
 		button.classList.replace('dropdown-item', 'timeline-comment-action');
 		item.closest('details')!.before(button);
-
-		// Hide `Edit` from dropdown
-		item.hidden = true;
-		if (
-			item.matches(':last-child') &&
-			item.previousElementSibling?.matches('.dropdown-divider')
-		) {
-			item.previousElementSibling.remove();
-		} else if (
-			item.previousElementSibling?.matches('.dropdown-divider') &&
-			item.nextElementSibling?.matches('.dropdown-divider')
-		) {
-			item.nextElementSibling.remove();
-		}
 	}
 }
 


### PR DESCRIPTION
Sometimes the the `edit-files-faster` doesn't act or doesn't act in time, moving the button outside **after** I open the dropdown. https://github.com/sindresorhus/refined-github/issues/3279

There's no direct need to hide it from the dropdown. Also this piece of code is pretty ugly (I wrote it) 🤓