### PR TITLE
Fix links in `tags-dropdown`

### DIFF
--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -15,7 +15,7 @@ function changeTabToTags(): void {
 
 function updateLinksToTag(): void {
 	// Change links, which point to the content of each tag, to open the tag page instead
-	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown .SelectMenu-list:last-child [href*="/tree/"]')) {
+	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown [role="tabpanel"]:last-child [href*="/tree/"]')) {
 		const pathnameParts = anchorElement.pathname.split('/');
 		pathnameParts[3] = 'releases/tag'; // Replace `tree`
 		anchorElement.pathname = pathnameParts.join('/');

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -15,7 +15,7 @@ function changeTabToTags(): void {
 
 function updateLinksToTag(): void {
 	// Change links, which point to the content of each tag, to open the tag page instead
-	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown [role="tabpanel"]:last-child [href*="/tree/"]')) {
+	for (const anchorElement of select.all<HTMLAnchorElement>('.rgh-tags-dropdown #tags-menu .SelectMenu-item[href*="/tree/"]')) {
 		const pathnameParts = anchorElement.pathname.split('/');
 		pathnameParts[3] = 'releases/tag'; // Replace `tree`
 		anchorElement.pathname = pathnameParts.join('/');


### PR DESCRIPTION
Fixes #3331

It seems the layout structure changed, so I fixed the selector.
There is also an `id="tags-menu"` on the `[role="tabpanel"]:last-child` element so we could also use that instead.