### PR TITLE
Refresh `more-dropdown` feature

### DIFF
--- a/source/features/more-dropdown.css
+++ b/source/features/more-dropdown.css
@@ -10,3 +10,7 @@
 .rgh-reponav-more svg {
 	width: 16px;
 }
+
+:root .rgh-has-more-dropdown {
+	overflow: visible !important;
+}

--- a/source/features/more-dropdown.css
+++ b/source/features/more-dropdown.css
@@ -11,10 +11,12 @@
 	width: 16px;
 }
 
+/* Always show the overflow menu button */
 .js-responsive-underlinenav-overflow {
 	visibility: visible !important;
 }
 
+/* Only show the divider if there are other items above it */
 .js-responsive-underlinenav-overflow [hidden] + .dropdown-divider {
 	display: none;
 }

--- a/source/features/more-dropdown.css
+++ b/source/features/more-dropdown.css
@@ -11,6 +11,10 @@
 	width: 16px;
 }
 
-:root .rgh-has-more-dropdown {
-	overflow: visible !important;
+.js-responsive-underlinenav-overflow {
+	visibility: visible !important;
+}
+
+.js-responsive-underlinenav-overflow [hidden] + .dropdown-divider {
+	display: none;
 }

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -8,7 +8,6 @@ import DiffIcon from 'octicon/diff.svg';
 import BranchIcon from 'octicon/git-branch.svg';
 import HistoryIcon from 'octicon/history.svg';
 import PackageIcon from 'octicon/package.svg';
-import KebabHorizontalIcon from 'octicon/kebab-horizontal.svg';
 
 import features from '.';
 import {appendBefore} from '../helpers/dom-utils';
@@ -38,40 +37,13 @@ export function createDropdownItem(label: string, url: string, overflow: boolean
 	const id = `rgh-${label.toLowerCase()}-item`;
 	const item = overflow ?
 		<li data-menu-item={id}/> :
-		<li data-tab-item={id} className="js-responsive-underlinenav-item"/>;
+		<li/>;
 	item.append(
 		<a role="menuitem" className="dropdown-item" href={url}>
 			{label}
 		</a>
 	);
 	return item;
-}
-
-function createDropdown(): Element {
-	const reference = getCurrentBranch();
-	const compareUrl = `/${repoUrl}/compare/${reference}`;
-	const commitsUrl = `/${repoUrl}/commits/${reference}`;
-	const dependenciesUrl = `/${repoUrl}/network/dependencies`;
-	return (
-		<li className="d-flex js-responsive-underlinenav-item" data-tab-item="rgh-more-dropdown">
-			<details className="details-overlay details-reset position-relative">
-				<summary role="button" aria-haspopup="menu">
-					<div className="UnderlineNav-item mr-0 border-0">
-						<KebabHorizontalIcon/>
-						<span className="sr-only">More</span>
-					</div>
-				</summary>
-				<details-menu className="dropdown-menu dropdown-menu-sw" role="menu">
-					<ul>
-						{createDropdownItem('Compare', compareUrl, false)}
-						{pageDetect.isEnterprise() || createDropdownItem('Dependencies', dependenciesUrl, false)}
-						{createDropdownItem('Commits', commitsUrl, false)}
-						{createDropdownItem('Branches', `/${repoUrl}/branches`, false)}
-					</ul>
-				</details-menu>
-			</details>
-		</li>
-	);
 }
 
 async function init(): Promise<void> {
@@ -81,23 +53,16 @@ async function init(): Promise<void> {
 	if (nav) {
 		// "Repository refresh" layout
 		nav.parentElement!.classList.add('rgh-has-more-dropdown');
-		const settingsTab = select('[data-tab-item="settings-tab"]');
-		if (settingsTab) {
-			settingsTab.parentElement!.after(createDropdown());
-		} else {
-			nav.append(createDropdown());
-		}
-
 		const reference = getCurrentBranch();
 		const compareUrl = `/${repoUrl}/compare/${reference}`;
 		const commitsUrl = `/${repoUrl}/commits/${reference}`;
 		const dependenciesUrl = `/${repoUrl}/network/dependencies`;
 		select('.js-responsive-underlinenav-overflow ul')!.append(
-			<div data-menu-item="rgh-more-dropdown"/>,
-			createDropdownItem('Compare', compareUrl, true),
-			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl, true),
-			createDropdownItem('Commits', commitsUrl, true),
-			createDropdownItem('Branches', `/${repoUrl}/branches`, true)
+			<li className="dropdown-divider" role="separator"/>,
+			createDropdownItem('Compare', compareUrl, false),
+			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl, false),
+			createDropdownItem('Commits', commitsUrl, false),
+			createDropdownItem('Branches', `/${repoUrl}/branches`, false)
 		);
 		return;
 	}

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -64,7 +64,7 @@ function createDropdown(): Element {
 				<details-menu className="dropdown-menu dropdown-menu-sw" role="menu">
 					<ul>
 						{createDropdownItem('Compare', compareUrl, false)}
-						{pageDetect.isEnterprise() && createDropdownItem('Dependencies', dependenciesUrl, false)}
+						{pageDetect.isEnterprise() || createDropdownItem('Dependencies', dependenciesUrl, false)}
 						{createDropdownItem('Commits', commitsUrl, false)}
 						{createDropdownItem('Branches', `/${repoUrl}/branches`, false)}
 					</ul>
@@ -92,16 +92,13 @@ async function init(): Promise<void> {
 		const compareUrl = `/${repoUrl}/compare/${reference}`;
 		const commitsUrl = `/${repoUrl}/commits/${reference}`;
 		const dependenciesUrl = `/${repoUrl}/network/dependencies`;
-		const menu = select('.js-responsive-underlinenav-overflow ul')!;
-
-		menu.append(
+		select('.js-responsive-underlinenav-overflow ul')!.append(
 			<div data-menu-item="rgh-more-dropdown"/>,
 			createDropdownItem('Compare', compareUrl, true),
 			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl, true),
 			createDropdownItem('Commits', commitsUrl, true),
 			createDropdownItem('Branches', `/${repoUrl}/branches`, true)
 		);
-
 		return;
 	}
 

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -8,6 +8,7 @@ import DiffIcon from 'octicon/diff.svg';
 import BranchIcon from 'octicon/git-branch.svg';
 import HistoryIcon from 'octicon/history.svg';
 import PackageIcon from 'octicon/package.svg';
+import KebabHorizontalIcon from 'octicon/kebab-horizontal.svg';
 
 import features from '.';
 import {appendBefore} from '../helpers/dom-utils';
@@ -15,7 +16,8 @@ import {getRepoURL, getCurrentBranch} from '../github-helpers';
 
 const repoUrl = getRepoURL();
 
-function createDropdown(): void {
+// Pre "Repository refresh" layout
+function createLegacyDropdown(): void {
 	// Markup copied from native GHE dropdown
 	appendBefore(
 		// GHE doesn't have `reponav > ul`
@@ -31,10 +33,80 @@ function createDropdown(): void {
 	);
 }
 
+/* eslint-disable-next-line import/prefer-default-export */
+export function createDropdownItem(label: string, url: string, overflow: boolean): Element {
+	const id = `rgh-${label.toLowerCase()}-item`;
+	const item = overflow ?
+		<li data-menu-item={id}/> :
+		<li data-tab-item={id} className="js-responsive-underlinenav-item"/>;
+	item.append(
+		<a role="menuitem" className="dropdown-item" href={url}>
+			{label}
+		</a>
+	);
+	return item;
+}
+
+function createDropdown(): Element {
+	const reference = getCurrentBranch();
+	const compareUrl = `/${repoUrl}/compare/${reference}`;
+	const commitsUrl = `/${repoUrl}/commits/${reference}`;
+	const dependenciesUrl = `/${repoUrl}/network/dependencies`;
+	return (
+		<li className="d-flex js-responsive-underlinenav-item" data-tab-item="rgh-more-dropdown">
+			<details className="details-overlay details-reset position-relative">
+				<summary role="button" aria-haspopup="menu">
+					<div className="UnderlineNav-item mr-0 border-0">
+						<KebabHorizontalIcon/>
+						<span className="sr-only">More</span>
+					</div>
+				</summary>
+				<details-menu className="dropdown-menu dropdown-menu-sw" role="menu">
+					<ul>
+						{createDropdownItem('Compare', compareUrl, false)}
+						{pageDetect.isEnterprise() && createDropdownItem('Dependencies', dependenciesUrl, false)}
+						{createDropdownItem('Commits', commitsUrl, false)}
+						{createDropdownItem('Branches', `/${repoUrl}/branches`, false)}
+					</ul>
+				</details-menu>
+			</details>
+		</li>
+	);
+}
+
 async function init(): Promise<void> {
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
+
+	const nav = select('.js-responsive-underlinenav .UnderlineNav-body');
+	if (nav) {
+		// "Repository refresh" layout
+		nav.parentElement!.classList.add('rgh-has-more-dropdown');
+		const settingsTab = select('[data-tab-item="settings-tab"]');
+		if (settingsTab) {
+			settingsTab.parentElement!.after(createDropdown());
+		} else {
+			nav.append(createDropdown());
+		}
+
+		const reference = getCurrentBranch();
+		const compareUrl = `/${repoUrl}/compare/${reference}`;
+		const commitsUrl = `/${repoUrl}/commits/${reference}`;
+		const dependenciesUrl = `/${repoUrl}/network/dependencies`;
+		const menu = select('.js-responsive-underlinenav-overflow ul')!;
+
+		menu.append(
+			<div data-menu-item="rgh-more-dropdown"/>,
+			createDropdownItem('Compare', compareUrl, true),
+			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl, true),
+			createDropdownItem('Commits', commitsUrl, true),
+			createDropdownItem('Branches', `/${repoUrl}/branches`, true)
+		);
+
+		return;
+	}
+
 	if (!select.exists('.reponav-dropdown')) {
-		createDropdown();
+		createLegacyDropdown();
 	}
 
 	const reference = getCurrentBranch();

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -15,8 +15,7 @@ import {getRepoURL, getCurrentBranch} from '../github-helpers';
 
 const repoUrl = getRepoURL();
 
-// Pre "Repository refresh" layout
-function createLegacyDropdown(): void {
+function createDropdown(): void {
 	// Markup copied from native GHE dropdown
 	appendBefore(
 		// GHE doesn't have `reponav > ul`
@@ -33,50 +32,44 @@ function createLegacyDropdown(): void {
 }
 
 /* eslint-disable-next-line import/prefer-default-export */
-export function createDropdownItem(label: string, url: string, overflow: boolean): Element {
-	const id = `rgh-${label.toLowerCase()}-item`;
-	const item = overflow ?
-		<li data-menu-item={id}/> :
-		<li/>;
-	item.append(
-		<a role="menuitem" className="dropdown-item" href={url}>
-			{label}
-		</a>
+export function createDropdownItem(label: string, url: string, attributes?: Record<string, string>): Element {
+	return (
+		<li {...attributes}>
+			<a role="menuitem" className="dropdown-item" href={url}>
+				{label}
+			</a>
+		</li>
 	);
-	return item;
 }
 
 async function init(): Promise<void> {
 	await elementReady('.pagehead + *'); // Wait for the tab bar to be loaded
 
+	const reference = getCurrentBranch();
+	const compareUrl = `/${repoUrl}/compare/${reference}`;
+	const commitsUrl = `/${repoUrl}/commits/${reference}`;
+	const dependenciesUrl = `/${repoUrl}/network/dependencies`;
+
 	const nav = select('.js-responsive-underlinenav .UnderlineNav-body');
 	if (nav) {
 		// "Repository refresh" layout
 		nav.parentElement!.classList.add('rgh-has-more-dropdown');
-		const reference = getCurrentBranch();
-		const compareUrl = `/${repoUrl}/compare/${reference}`;
-		const commitsUrl = `/${repoUrl}/commits/${reference}`;
-		const dependenciesUrl = `/${repoUrl}/network/dependencies`;
 		select('.js-responsive-underlinenav-overflow ul')!.append(
 			<li className="dropdown-divider" role="separator"/>,
-			createDropdownItem('Compare', compareUrl, false),
-			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl, false),
-			createDropdownItem('Commits', commitsUrl, false),
-			createDropdownItem('Branches', `/${repoUrl}/branches`, false)
+			createDropdownItem('Compare', compareUrl),
+			pageDetect.isEnterprise() ? '' : createDropdownItem('Dependencies', dependenciesUrl),
+			createDropdownItem('Commits', commitsUrl),
+			createDropdownItem('Branches', `/${repoUrl}/branches`)
 		);
 		return;
 	}
 
+	// Pre "Repository refresh" layout
 	if (!select.exists('.reponav-dropdown')) {
-		createLegacyDropdown();
+		createDropdown();
 	}
 
-	const reference = getCurrentBranch();
-	const compareUrl = `/${repoUrl}/compare/${reference}`;
-	const commitsUrl = `/${repoUrl}/commits/${reference}`;
-
 	const menu = select('.reponav-dropdown .dropdown-menu')!;
-
 	menu.append(
 		<a href={compareUrl} className="rgh-reponav-more dropdown-item">
 			<DiffIcon/> Compare

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -68,7 +68,7 @@ async function init(): Promise<false | void> {
 			<a href={`/${repoUrl}/releases`} className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-hotkey="g r" data-selected-links="repo_releases" data-tab-item="rgh-releases-item">
 				<TagIcon className="UnderlineNav-octicon"/>
 				<span data-content="Releases">Releases</span>
-				{count ?? <span className="Counter">{count}</span>}
+				{count && <span className="Counter">{count}</span>}
 			</a>
 		);
 
@@ -105,7 +105,7 @@ async function init(): Promise<false | void> {
 		<a href={`/${repoUrl}/releases`} className="reponav-item" data-hotkey="g r">
 			<TagIcon/>
 			<span> Releases </span>
-			{count === undefined ? '' : <span className="Counter">{count}</span>}
+			{count && <span className="Counter">{count}</span>}
 		</a>
 	);
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -8,6 +8,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import * as api from '../github-helpers/api';
 import {appendBefore} from '../helpers/dom-utils';
+import {createDropdownItem} from './more-dropdown';
 import {getRepoURL, getRepoGQL, looseParseInt} from '../github-helpers';
 
 const repoUrl = getRepoURL();
@@ -64,14 +65,18 @@ async function init(): Promise<false | void> {
 		// "Repository refresh" layout
 
 		const releasesTab = (
-			<a href={`/${repoUrl}/releases`} className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-hotkey="g r" data-selected-links="repo_releases" data-tab-item="releases-tab">
+			<a href={`/${repoUrl}/releases`} className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-hotkey="g r" data-selected-links="repo_releases" data-tab-item="rgh-releases-item">
 				<TagIcon className="UnderlineNav-octicon"/>
 				<span data-content="Releases">Releases</span>
 				{count === undefined ? '' : <span className="Counter">{count}</span>}
 			</a>
 		);
 
-		select(':scope > ul', repoNavigationBar)!.append(releasesTab);
+		appendBefore(
+			select(':scope > ul', repoNavigationBar)!,
+			'[data-tab-item="rgh-more-dropdown"]',
+			releasesTab
+		);
 
 		// Update "selected" tab mark
 		if (pageDetect.isReleasesOrTags()) {
@@ -85,12 +90,8 @@ async function init(): Promise<false | void> {
 			releasesTab.setAttribute('aria-current', 'page');
 		}
 
-		select('.js-responsive-underlinenav-overflow ul', repoNavigationBar)!.append(
-			<li data-menu-item="releases-tab">
-				<a role="menuitem" className="js-selected-navigation-item dropdown-item" data-selected-links={`/${repoUrl}/releases`} href={`/${repoUrl}/releases`}>
-					Releases
-				</a>
-			</li>
+		select('[data-menu-item="insights-tab"]', repoNavigationBar)!.after(
+			createDropdownItem('Releases', `/${repoUrl}/releases`, true)
 		);
 
 		return;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -75,7 +75,9 @@ async function init(): Promise<false | void> {
 		appendBefore(
 			select(':scope > ul', repoNavigationBar)!,
 			'[data-tab-item="rgh-more-dropdown"]',
-			releasesTab
+			<li className="d-flex">
+				{releasesTab}
+			</li>
 		);
 
 		// Update "selected" tab mark

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -63,9 +63,14 @@ async function init(): Promise<false | void> {
 	const repoNavigationBar = select('.js-repo-nav.UnderlineNav');
 	if (repoNavigationBar) {
 		// "Repository refresh" layout
-
 		const releasesTab = (
-			<a href={`/${repoUrl}/releases`} className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-hotkey="g r" data-selected-links="repo_releases" data-tab-item="rgh-releases-item">
+			<a
+				href={`/${repoUrl}/releases`}
+				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item"
+				data-hotkey="g r"
+				data-selected-links="repo_releases"
+				data-tab-item="rgh-releases-item"
+			>
 				<TagIcon className="UnderlineNav-octicon"/>
 				<span data-content="Releases">Releases</span>
 				{count && <span className="Counter">{count}</span>}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -72,9 +72,7 @@ async function init(): Promise<false | void> {
 			</a>
 		);
 
-		appendBefore(
-			select(':scope > ul', repoNavigationBar)!,
-			'[data-tab-item="rgh-more-dropdown"]',
+		select(':scope > ul', repoNavigationBar)!.append(
 			<li className="d-flex">
 				{releasesTab}
 			</li>

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -68,7 +68,7 @@ async function init(): Promise<false | void> {
 			<a href={`/${repoUrl}/releases`} className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item" data-hotkey="g r" data-selected-links="repo_releases" data-tab-item="rgh-releases-item">
 				<TagIcon className="UnderlineNav-octicon"/>
 				<span data-content="Releases">Releases</span>
-				{count === undefined ? '' : <span className="Counter">{count}</span>}
+				{count ?? <span className="Counter">{count}</span>}
 			</a>
 		);
 
@@ -93,7 +93,9 @@ async function init(): Promise<false | void> {
 		}
 
 		select('[data-menu-item="insights-tab"]', repoNavigationBar)!.after(
-			createDropdownItem('Releases', `/${repoUrl}/releases`, true)
+			createDropdownItem('Releases', `/${repoUrl}/releases`, {
+				'data-menu-item': 'rgh-releases-item'
+			})
 		);
 
 		return;


### PR DESCRIPTION
Fixes #3215 


<details>
<summary>First implementation</summary>

I'm not entirely sure that this is the right approach to this and the code is hacky and repetitive. 

Thoughts?

![](https://user-images.githubusercontent.com/1402241/87451621-6da43880-c600-11ea-8950-1861755beea6.gif)


</details>


Edit: this might be better and less repetitive:

![](https://user-images.githubusercontent.com/1402241/87452962-25861580-c602-11ea-80a2-8997b4096a24.gif)


## Next


I noticed a problem with `releases-tab` not always disappearing: https://github.com/sindresorhus/refined-github/issues/3347

This will have to be added separately:

- [ ] Also move Security and Insights tabs

