### PR TITLE
Fix fork popup title style

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -133,7 +133,7 @@ pr-branches
 }
 
 /* Align fork popup's header (GitHub bug) */
-[aria-label^="Fork"] .Box-title {
+[aria-label^='Fork'] .Box-title {
 	min-height: 0;
 	margin: -5px 0;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -132,10 +132,8 @@ pr-branches
 	float: left;
 }
 
-/* Align fork popup's title style with other popup (GitHub bug) */
-details-dialog h1.Box-title {
-	position: static;
-	font-size: 14px;
-	font-weight: 600;
-	min-height: unset;
+/* Align fork popup's header (GitHub bug) */
+[aria-label^="Fork"] .Box-title {
+	min-height: 0;
+	margin: -5px 0;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -131,3 +131,11 @@ pr-branches
 .subnav .d-flex.flex-md-row.flex-justify-between.flex-md-items-center {
 	float: left;
 }
+
+/* Align fork popup's title style with other popup (GitHub bug) */
+details-dialog h1.Box-title {
+	position: static;
+	font-size: 14px;
+	font-weight: 600;
+	min-height: unset;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -134,6 +134,7 @@ pr-branches
 
 /* Align fork popup's header (GitHub bug) */
 [aria-label^='Fork'] .Box-title {
+	position: static; /* The title wrongly overlaps the Close button, making it impossible to click */
 	min-height: 0;
 	margin: -5px 0;
 }


### PR DESCRIPTION
Code copied from https://github.com/kidonng/cherry/blob/4e6e5e34fa59aed18fc21e155c5ca9067b83db5e/styles/github.user.css#L32-L38
Close #3283

Before: 
![image](https://user-images.githubusercontent.com/44045911/87644599-ea5d2100-c77e-11ea-8c2a-e493d166f293.png)

After: 
![image](https://user-images.githubusercontent.com/44045911/87644633-f34df280-c77e-11ea-9e1c-03b5f5018b6a.png)

Test: here