### PR TITLE
Fix `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -84,7 +84,7 @@ async function init(): Promise<false | void> {
 		return false;
 	}
 
-	const breadcrumb = await elementReady('.breadcrumb');
+	const breadcrumb = await elementReady('#branch-select-menu');
 	if (!breadcrumb) {
 		return;
 	}
@@ -102,7 +102,7 @@ async function init(): Promise<false | void> {
 		</a>
 	);
 
-	breadcrumb.before(link);
+	breadcrumb.after(link);
 	if (currentBranch !== latestTag) {
 		link.append(' ', <span className="css-truncate-target">{latestTag}</span>);
 	}


### PR DESCRIPTION
Fix https://github.com/sindresorhus/refined-github/issues/3277#issuecomment-655173202

This is a placeholder, once the feature goes into production (likely) we can fix it (or make other changes).

Screenshot with the fix:
![image](https://user-images.githubusercontent.com/44045911/86869237-cd827700-c108-11ea-9ef5-edc73b650ff8.png)
