### PR TITLE
Fix permalink detection in 3 features

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import GitHubURL from '../github-helpers/github-url';
-import {getRepoURL} from '../github-helpers';
+import {getRepoURL, isPermalinkAsync} from '../github-helpers';
 import {appendBefore} from '../helpers/dom-utils';
 
 function addInlineLinks(comment: HTMLElement, timestamp: string): void {
@@ -65,9 +65,7 @@ async function showTimemachineBar(): Promise<void | false> {
 		url.pathname = pathnameParts.join('/');
 	} else {
 		// This feature only makes sense if the URL points to a non-permalink
-		const branchSelector = await elementReady('[data-hotkey="w"] i');
-		const isPermalink = /Tag|Tree/.test(branchSelector!.textContent!);
-		if (isPermalink) {
+		if (await isPermalinkAsync()) {
 			return false;
 		}
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import GitHubURL from '../github-helpers/github-url';
-import {getRepoURL, isPermalinkAsync} from '../github-helpers';
+import {getRepoURL, isPermalink} from '../github-helpers';
 import {appendBefore} from '../helpers/dom-utils';
 
 function addInlineLinks(comment: HTMLElement, timestamp: string): void {
@@ -65,7 +65,7 @@ async function showTimemachineBar(): Promise<void | false> {
 		url.pathname = pathnameParts.join('/');
 	} else {
 		// This feature only makes sense if the URL points to a non-permalink
-		if (await isPermalinkAsync()) {
+		if (await isPermalink()) {
 			return false;
 		}
 

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -12,7 +12,7 @@ import getDefaultBranch from '../github-helpers/get-default-branch';
 import onFileListUpdate from '../github-events/on-file-list-update';
 
 async function init(): Promise<void> {
-	const isPermalink_ = isPermalink();
+	const isPermalink_ = await isPermalink();
 	for (const fileIcon of select.all('.js-navigation-container .octicon-file')) {
 		const fileLink = fileIcon.closest('.js-navigation-item')!.querySelector<HTMLAnchorElement>('.js-navigation-open')!;
 		const url = new GitHubURL(fileLink.href).assign({

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -7,18 +7,19 @@ import * as pageDetect from 'github-url-detection';
 import {wrap} from '../helpers/dom-utils';
 import features from '.';
 import GitHubURL from '../github-helpers/github-url';
+import {isPermalink} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import onFileListUpdate from '../github-events/on-file-list-update';
 
 async function init(): Promise<void> {
-	const isPermalink = /Tag|Tree/.test(select('[data-hotkey="w"] i')!.textContent!);
+	const isPermalink_ = isPermalink();
 	for (const fileIcon of select.all('.js-navigation-container .octicon-file')) {
 		const fileLink = fileIcon.closest('.js-navigation-item')!.querySelector<HTMLAnchorElement>('.js-navigation-open')!;
 		const url = new GitHubURL(fileLink.href).assign({
 			route: 'edit'
 		});
 
-		if (isPermalink) {
+		if (isPermalink_) {
 			// eslint-disable-next-line no-await-in-loop
 			url.branch = await getDefaultBranch(); // Permalinks can't be edited
 		}

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -5,6 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import GitHubURL from '../github-helpers/github-url';
+import {isPermalink} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 
 async function init(): Promise<void | false> {
@@ -13,7 +14,7 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const isPermalink = /Tag|Tree/.test(select('[data-hotkey="w"] i')!.textContent!);
+	const isPermalink_ = isPermalink();
 	const filename = readmeHeader.textContent!.trim();
 	const fileLink = select<HTMLAnchorElement>(`.js-navigation-open[title="${filename}"]`)!;
 
@@ -21,14 +22,14 @@ async function init(): Promise<void | false> {
 		route: 'edit'
 	});
 
-	if (isPermalink) {
+	if (isPermalink_) {
 		url.branch = await getDefaultBranch(); // Permalinks can't be edited
 	}
 
 	// The button already exists on repos you can push to.
 	const existingButton = select<HTMLAnchorElement>('a[aria-label="Edit this file"]');
 	if (existingButton) {
-		if (isPermalink) {
+		if (isPermalink_) {
 			// GitHub has a broken link in this case #2997
 			existingButton.href = String(url);
 		}

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -14,7 +14,7 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const isPermalink_ = isPermalink();
+	const isPermalink_ = await isPermalink();
 	const filename = readmeHeader.textContent!.trim();
 	const fileLink = select<HTMLAnchorElement>(`.js-navigation-open[title="${filename}"]`)!;
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -2,6 +2,7 @@ import select from 'select-dom';
 import oneTime from 'onetime';
 import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection/esm/index.js'; // eslint-disable-line import/extensions -- Required for Node tests compatibility
+import elementReady from 'element-ready';
 
 // This never changes, so it can be cached here
 export const getUsername = oneTime(pageDetect.utils.getUsername);
@@ -109,4 +110,22 @@ export function preventPrCommitLinkLoss(url: string, pr: string, commit: string,
 // https://github.com/idimetrix/text-case/blob/master/packages/upper-case-first/src/index.ts
 export function upperCaseFirst(input: string): string {
 	return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
+}
+
+/** Is tag or commit */
+export function isPermalink(): boolean {
+	return (
+		// Pre "Latest commit design updates"
+		/Tag|Tree/.test(select('[data-hotkey="w"] i')?.textContent!) || // Text appears in the branch selector
+
+		// "Latest commit design updates"
+		select.exists('[data-hotkey="w"] .octicon-tag') || // Tags have an icon
+		!select.exists('[data-menu-item="code-tab"] [href*="/tree/"]') // Commits don't change the "Code" tab address
+	);
+}
+
+/** Is tag or commit, with elementReady */
+export async function isPermalinkAsync(): Promise<boolean> {
+	await elementReady('[data-hotkey="w"]');
+	return isPermalink();
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -112,20 +112,20 @@ export function upperCaseFirst(input: string): string {
 	return input.charAt(0).toUpperCase() + input.slice(1).toLowerCase();
 }
 
-/** Is tag or commit */
-export function isPermalink(): boolean {
+/** Is tag or commit, with elementReady */
+export async function isPermalink(): Promise<boolean> {
+	debugger
+	if (/^[\da-f]{40}$/.test(getCurrentBranch())) {
+		// It's a commit
+		return true;
+	}
+
+	await elementReady('[data-hotkey="w"]');
 	return (
 		// Pre "Latest commit design updates"
 		/Tag|Tree/.test(select('[data-hotkey="w"] i')?.textContent!) || // Text appears in the branch selector
 
 		// "Latest commit design updates"
-		select.exists('[data-hotkey="w"] .octicon-tag') || // Tags have an icon
-		!select.exists('[data-menu-item="code-tab"] [href*="/tree/"]') // Commits don't change the "Code" tab address
+		select.exists('[data-hotkey="w"] .octicon-tag') // Tags have an icon
 	);
-}
-
-/** Is tag or commit, with elementReady */
-export async function isPermalinkAsync(): Promise<boolean> {
-	await elementReady('[data-hotkey="w"]');
-	return isPermalink();
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -114,7 +114,6 @@ export function upperCaseFirst(input: string): string {
 
 /** Is tag or commit, with elementReady */
 export async function isPermalink(): Promise<boolean> {
-	debugger
 	if (/^[\da-f]{40}$/.test(getCurrentBranch())) {
 		// It's a commit
 		return true;


### PR DESCRIPTION
They removed the text we were using:
<img width="186" alt="Screen Shot 2020-07-19 at 12 15 46" align=middle src="https://user-images.githubusercontent.com/1402241/87872512-9be79680-c9b9-11ea-972a-8e3743f04d62.png"> ➡️ <img align=middle width="136" alt="Screen Shot 2020-07-19 at 12 15 36" src="https://user-images.githubusercontent.com/1402241/87872515-9db15a00-c9b9-11ea-9c88-21fbaf97a099.png">

Causing

```
❌ Refined GitHub → edit-files-faster → TypeError: The element wasn’t found, the selector needs to be updated.
```
```
❌ Refined GitHub → edit-readme → TypeError: The element wasn’t found, the selector needs to be updated.
```

cc @yakov116 I think you mentioned this first

# Test

https://github.com/sindresorhus/refined-github/tree/20.7.16 (`edit-readme` and `edit-files-faster`)


```
`comments-time-machine-links` bar at the top: https://github.com/sindresorhus/refined-github/blob/master/source/features/comments-time-machine-links.tsx?rgh-link-date=2019-12-11T10%3A12%3A11Z
```