### PR TITLE
Restore counter on `profile-gists-link`

### DIFF
--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -20,7 +20,8 @@ const getGistCount = cache.function(async (username: string): Promise<number> =>
 	`);
 	return user.gists.totalCount;
 }, {
-	cacheKey: ([username]) => 'gist-count:' + username
+	cacheKey: ([username]) => 'gist-count:' + username,
+	maxAge: 3
 });
 
 async function init(): Promise<void> {

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -1,23 +1,46 @@
 import './profile-gists-link.css';
 import React from 'dom-chef';
+import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 import CodeSquareIcon from 'octicon/code-square.svg';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import * as api from '../github-helpers/api';
 import {getCleanPathname} from '../github-helpers';
+
+const getGistCount = cache.function(async (username: string): Promise<number> => {
+	const {user} = await api.v4(`
+		user(login: "${username}") {
+			gists(first: 0) {
+				totalCount
+			}
+		}
+	`);
+	return user.gists.totalCount;
+}, {
+	cacheKey: ([username]) => 'gist-count:' + username
+});
 
 async function init(): Promise<void> {
 	await elementReady('.UnderlineNav-body + *');
 
 	const username = getCleanPathname();
 	const href = pageDetect.isEnterprise() ? `/gist/${username}` : `https://gist.github.com/${username}`;
-	select('.UnderlineNav-body')!.append(
+	const link = (
 		<a href={href} className="UnderlineNav-item" role="tab" aria-selected="false">
 			<CodeSquareIcon className="UnderlineNav-octicon hide-sm"/> Gists
 		</a>
 	);
+
+	select('.UnderlineNav-body')!.append(link);
+
+	const count = await getGistCount(username);
+
+	if (count > 0) {
+		link.append(<span className="Counter">{count}</span>);
+	}
 }
 
 void features.add({

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -38,7 +38,6 @@ async function init(): Promise<void> {
 	select('.UnderlineNav-body')!.append(link);
 
 	const count = await getGistCount(username);
-
 	if (count > 0) {
 		link.append(<span className="Counter">{count}</span>);
 	}

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -46,7 +46,7 @@ async function init(): Promise<void> {
 void features.add({
 	id: __filebasename,
 	description: 'Adds a link to the user’s public gists on their profile.',
-	screenshot: 'https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png'
+	screenshot: 'https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png'
 }, {
 	include: [
 		pageDetect.isUserProfile


### PR DESCRIPTION
The counters on user profiles were missing in the initial GitHub redesign, so we removed the Gists counter in #3272.

GitHub later added back counters for repositories, packages (see https://github.com/kidonng), and projects (see https://github.com/ouuan).

To be consistent with the design, and recover the usage mentioned in https://github.com/sindresorhus/refined-github/pull/3286#issuecomment-660881989, I suggest adding back the Gists counter.

The logic is the same as GitHub's (and https://github.com/sindresorhus/refined-github/pull/3272#issuecomment-648577062), the counter will only be added if the user has gists.