### PR TITLE
Fix `keyboard-navigation` issues

### DIFF
--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -4,6 +4,22 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import {isEditable} from '../helpers/dom-utils';
 
+function isCommentGroupMinimized(comment: HTMLElement): boolean {
+	if (select.exists('.minimized-comment:not(.d-none)', comment)) {
+		return true;
+	}
+
+	if (comment.closest('.js-resolvable-thread-contents.d-none')) {
+		return true;
+	}
+
+	if (comment.closest('.js-resolvable-timeline-thread-container:not([open])')) {
+		return true;
+	}
+
+	return false;
+}
+
 function runShortcuts(event: KeyboardEvent): void {
 	if (isEditable(event.target)) {
 		return;
@@ -15,7 +31,14 @@ function runShortcuts(event: KeyboardEvent): void {
 		event.preventDefault();
 
 		const items = select.all('.js-targetable-element:not([id^="pullrequestreview"]')
-			.filter(comment => !comment.querySelector('.minimized-comment:not(.d-none)'));
+			.filter(element => {
+				if (element.classList.contains('js-minimizable-comment-group')) {
+					return !isCommentGroupMinimized(element);
+				}
+
+				return true;
+			});
+
 		// `j` goes to the next comment, `k` goes back a comment
 		const direction = event.key === 'j' ? 1 : -1;
 

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -29,8 +29,9 @@ function runShortcuts(event: KeyboardEvent): void {
 				'.js-minimizable-comment-group'
 			])
 			.filter(element =>
-				!element.classList.contains('js-minimizable-comment-group') ||
-				!isCommentGroupMinimized(element)
+				element.classList.contains('js-minimizable-comment-group') ?
+					!isCommentGroupMinimized(element) :
+					true
 			);
 
 		// `j` goes to the next comment, `k` goes back a comment

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -20,6 +20,14 @@ function isCommentGroupMinimized(comment: HTMLElement): boolean {
 	return false;
 }
 
+function pullRequestReviewHasComment(review: HTMLElement): boolean {
+	if (review.id.endsWith('-body-html')) {
+		return false;
+	}
+
+	return select.exists(`#${review.id}-body-html`, review);
+}
+
 function runShortcuts(event: KeyboardEvent): void {
 	if (isEditable(event.target)) {
 		return;
@@ -30,8 +38,12 @@ function runShortcuts(event: KeyboardEvent): void {
 	if (['j', 'k'].includes(event.key)) {
 		event.preventDefault();
 
-		const items = select.all('.js-targetable-element:not([id^="pullrequestreview"]')
+		const items = select.all('.js-targetable-element')
 			.filter(element => {
+				if (element.id.startsWith('pullrequestreview-')) {
+					return pullRequestReviewHasComment(element);
+				}
+
 				if (element.classList.contains('js-minimizable-comment-group')) {
 					return !isCommentGroupMinimized(element);
 				}


### PR DESCRIPTION
Fixes #3319 

Instead of making complex query selectors this approach just filters out elements that shouldn't be *targetable*.

I mainly tested this code with use cases described in the [issue](https://github.com/sindresorhus/refined-github/issues/3319#issue-651357203), so if there are any other edge case I didn't consider please let me know.

> Hidden conversations in Files tabs are "focused"

For this now any `.js-minimizable-comment-group` is ignored if if it is *minimized*.
I tested this with in [#3242 (files)](https://github.com/sindresorhus/refined-github/pull/3242/files), now only the files are targeted.
For me the comments also where hidden *(and not visible when targeted)* without pressing `i` first, so I handled both scenarios.

> PR reviews are skipped

Targetable `#pullrequestreview-{id}` elements are now only *targetable* if they contain a message.
PR reviews with a message also contain a targetable element with `#pullrequestreview-{id}-body-html`.

So now pressing `j` on [this issue comment](https://github.com/sindresorhus/refined-github/pull/3242#issuecomment-652709634) skips the two messageless review comments and goes to the next [review with a message](https://github.com/sindresorhus/refined-github/pull/3242#pullrequestreview-442052008) below.

---

I noticed some problems with the `.filter()` approach because we might filtered out the current targeted element.
So e.g. if a [messageless review](https://github.com/sindresorhus/refined-github/pull/3242#pullrequestreview-441470147) is targeted, pressing `j` will jump to the first *targetable* element.
A better approach might be to target the next/previous *targetable* element instead.

Happy for any feedback on this, or if there are any other issues/use cases where this code doesn't work 😄 