### PR TITLE
Apply `clean-notifications` to Notifications V2 Beta

### DIFF
--- a/source/features/clean-notifications.css
+++ b/source/features/clean-notifications.css
@@ -1,12 +1,15 @@
 /* Place conversation number before the title */
+.js-notifications-list [id^='notification'],
 .js-notifications-group [id^='notification'] {
 	flex-direction: row !important;
 }
 /* Hide duplicate repository URL */
+.js-notifications-list [id^='notification'] > .d-flex > .f6,
 .js-notifications-group [id^='notification'] > .d-flex > .f6 {
 	font-size: 0 !important;
 }
 /* Size and position the conversation number */
+.js-notifications-list [id^='notification'] > .d-flex > .f6 > span,
 .js-notifications-group [id^='notification'] > .d-flex > .f6 > span {
 	display: block;
 	font-size: 12px;


### PR DESCRIPTION
The current `clean-notifications` css selector only applied to the old layout, which resulted in a inconsistent behavior in V2 notifications because the selector would match only sometimes (more specifically, the selector only matched when grouping by repository). Changing the selector applies `clean-notifications` to all notifications pages.

### Old behavior

#### Grouping by date
![Screenshot from 2020-07-21 14-04-05](https://user-images.githubusercontent.com/4048656/88107053-519e1b00-cb5b-11ea-99b9-c8a4235be4bc.png)

#### Grouping by repo
![Screenshot from 2020-07-21 14-04-13](https://user-images.githubusercontent.com/4048656/88107052-519e1b00-cb5b-11ea-9f31-563c2158c16d.png)

#### Using filters
![Screenshot from 2020-07-21 14-04-27](https://user-images.githubusercontent.com/4048656/88107047-51058480-cb5b-11ea-86e3-5b38ab99bd92.png)

### New behavior

#### Grouping by date
![Screenshot from 2020-07-21 14-04-37](https://user-images.githubusercontent.com/4048656/88107187-88743100-cb5b-11ea-8fc4-d1cbd02df477.png)

#### Grouping by repo
![Screenshot from 2020-07-21 14-04-48](https://user-images.githubusercontent.com/4048656/88107202-8dd17b80-cb5b-11ea-9a59-3ba91ce0756e.png)

#### Using filters
![Screenshot from 2020-07-21 14-04-54](https://user-images.githubusercontent.com/4048656/88107212-91fd9900-cb5b-11ea-9a4e-b419b725f3b4.png)