### PR TITLE
Use more precise `parse-backticks` selectors on `isSingleFile`

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -27,8 +27,8 @@ function initRepo(): void {
 		'[id^=ref-issue-]', // Issue references in `isIssue`, `isPRConversation`
 		'[id^=ref-pullrequest-]', // PR references in `isIssue`, `isPRConversation`
 		'[aria-label="Link issues"] a', // "Linked issues" in `isIssue`, `isPRConversation`
-		'.repository-content .js-details-container .link-gray[href*="/commit/"]', // `isSingleFile`
-		'.repository-content .js-details-container pre', // `isSingleFile`
+		'.Box-header.Details .link-gray', // `isSingleFile`
+		'.Box-header.Details pre', // `isSingleFile`
 		'.js-pinned-issue-list-item > .d-block', // Pinned Issues
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -16,8 +16,7 @@ function parse(selectors: string[]): void {
 function initRepo(): void {
 	parse([
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
-		'.Details[data-issue-and-pr-hovercards-enabled] .Details-content--hidden a.link-gray-dark', // `isRepoRoot`
-		'.Details[data-issue-and-pr-hovercards-enabled] .Details-content--hidden pre', // `isRepoRoot`
+		'.js-commits-list-item .mb-1', // `isCommitList` commit message
 		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot`
 		'.commit-title', // `isCommit`
 		'.commit-desc', // `isCommit`, `isCommitList`, `isRepoTree`


### PR DESCRIPTION
Fix #3385 

The bug is caused by 

https://github.com/sindresorhus/refined-github/blob/a82f849bd4a745542642b9453c12a6ec18c381aa/source/features/parse-backticks.tsx#L31

After this PR:

![image](https://user-images.githubusercontent.com/44045911/88288402-4cd99280-cd26-11ea-8e77-91e1cf5a42aa.png)

To prevent possible problems, I updated another selector which uses `.repository-content .js-details-container` as well.
