### PR TITLE
Fix `add-tag-to-commits` selector

### DIFF
--- a/source/features/add-tag-to-commits.tsx
+++ b/source/features/add-tag-to-commits.tsx
@@ -142,7 +142,7 @@ async function init(): Promise<void | false> {
 		} else if (targetTags.length > 0) {
 			select([
 				'.commit-meta', // Pre "Repository refresh" layout
-				'p + div.d-flex'
+				'.flex-auto .d-flex.mt-1'
 			], commit)!.append(
 				<div className="ml-2">
 					<TagIcon/>


### PR DESCRIPTION
It would fail if the commit had expanded details

Test on https://github.com/sindresorhus/refined-github/commits/master