### PR TITLE
Fix `comment-fields-keyboard-shortcuts`

### DIFF
--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import onCommentFieldKeydown from '../github-events/on-comment-field-keydown';
 
-async function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): Promise<void> {
+function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): void {
 	const field = event.delegateTarget;
 
 	if (event.key === 'Escape') {

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -4,8 +4,9 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onCommentFieldKeydown from '../github-events/on-comment-field-keydown';
+import elementReady from 'element-ready';
 
-function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): void {
+async function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): Promise<void> {
 	const field = event.delegateTarget;
 
 	if (event.key === 'Escape') {
@@ -39,7 +40,8 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>)
 			});
 
 		if (lastOwnComment) {
-			select<HTMLButtonElement>('.js-comment-edit-button', lastOwnComment)!.click();
+			select('details[id]', lastOwnComment)!.dispatchEvent(new MouseEvent('mouseover'));
+			(await elementReady('.js-comment-edit-button', {target: lastOwnComment, stopOnDomReady: false}) as HTMLButtonElement).click();
 			field
 				.closest('form')!
 				.querySelector<HTMLButtonElement>('.js-hide-inline-comment-form')

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -40,6 +40,7 @@ async function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaEle
 			});
 
 		if (lastOwnComment) {
+			// Make edit comment button appear
 			select('details[id]', lastOwnComment)!.dispatchEvent(new MouseEvent('mouseover'));
 			(await elementReady('.js-comment-edit-button', {target: lastOwnComment, stopOnDomReady: false}) as HTMLButtonElement).click();
 			field

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -41,7 +41,7 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>)
 
 		if (lastOwnComment) {
 			// Make the comment editable (the native edit button might not be available yet)
-			const editButton = <button className="js-comment-edit-button" hidden/>;
+			const editButton = <button hidden type="button" className="js-comment-edit-button"/>;
 			lastOwnComment.append(editButton);
 			editButton.click();
 			editButton.remove();

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -1,6 +1,6 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
-import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -40,9 +40,11 @@ async function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaEle
 			});
 
 		if (lastOwnComment) {
-			// Make edit comment button appear
-			select('details[id]', lastOwnComment)!.dispatchEvent(new MouseEvent('mouseover'));
-			(await elementReady('.js-comment-edit-button', {target: lastOwnComment, stopOnDomReady: false}) as HTMLButtonElement).click();
+			// Make the comment editable (the native edit button might not be available yet)
+			const editButton = <button className="js-comment-edit-button" hidden/>;
+			lastOwnComment.append(editButton);
+			editButton.click();
+			editButton.remove();
 			field
 				.closest('form')!
 				.querySelector<HTMLButtonElement>('.js-hide-inline-comment-form')

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -1,10 +1,10 @@
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onCommentFieldKeydown from '../github-events/on-comment-field-keydown';
-import elementReady from 'element-ready';
 
 async function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>): Promise<void> {
 	const field = event.delegateTarget;


### PR DESCRIPTION
Fix #3388

GitHub has some kind of lazy load logic for the edit comment button, ~~so we need to dispatch a `mouseover` event to make the button "appear" (though not visible, unless `edit-comments-faster` is also enabled).~~

~~The first trigger will be slow (about 2-3 seconds on my machine) but following triggers will be instant.~~

I think the same method can be used to make `edit-comments-faster` more reliable (or can it?)