### PR TITLE
Reduce `pr-branches` to `highlight-non-default-base-branch`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,7 +228,7 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-commit-sha") [Adds link to non-PR commit when visiting a PR commit.](https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png)
 - [](# "pr-filters") [Adds Checks and Draft PR dropdown filters in PR lists.](https://user-images.githubusercontent.com/202916/74453250-6d9de200-4e82-11ea-8fd4-7c0de57e001a.png)
 - [](# "pr-approvals-count") [Shows color-coded review counts in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
-- [](# "pr-branches") [Shows head and base branches in PR lists if they’re significant.](https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png)
+- [](# "highlight-non-default-base-branch") [Shows the base branch in PR lists if it’s not the default branch.](https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png)
 - [](# "remove-checks-tab") Hides the `Checks` tab if it’s empty, unless you’re the owner.
 - [](# "hide-inactive-deployments") [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
 - [](# "previous-next-commit-buttons") [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -66,8 +66,8 @@ async function init(): Promise<false | void> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Shows the base in PR lists if they’re not the default branch.',
-	screenshot: '#TODO'
+	description: 'Shows the base branch in PR lists if it’s not the default branch.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png'
 }, {
 	include: [
 		pageDetect.isRepoConversationList

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -41,7 +41,7 @@ async function init(): Promise<false | void> {
 
 	for (const prLink of prLinks) {
 		const pr: BranchInfo = data.repository[prLink.id];
-		if (pr.baseRefName === defaultBranch ) {
+		if (pr.baseRefName === defaultBranch) {
 			continue;
 		}
 

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -8,6 +8,11 @@ import * as api from '../github-helpers/api';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getRepositoryInfo, getRepoGQL} from '../github-helpers';
 
+type BranchInfo = {
+	baseRef: string;
+	baseRefName: string;
+};
+
 function buildQuery(issueIds: string[]): string {
 	return `
 		repository(${getRepoGQL()}) {
@@ -35,12 +40,12 @@ async function init(): Promise<false | void> {
 	]);
 
 	for (const prLink of prLinks) {
-		if (data.baseRefName === defaultBranch || !data.repository[prLink.id].headOwner) { // 👻 @ghost user
+		const pr: BranchInfo = data.repository[prLink.id];
+		if (pr.baseRefName === defaultBranch || !pr.headOwner) { // 👻 @ghost user
 			continue;
 		}
 
-		const name = data.baseRefName;
-		const branch = data.baseRef && `/${currentRepository.owner!}/${currentRepository.name!}/tree/${data.baseRefName}`;
+		const branch = pr.baseRef && `/${currentRepository.owner!}/${currentRepository.name!}/tree/${pr.baseRefName}`;
 
 		prLink.parentElement!.querySelector('.text-small.text-gray')!.append(
 			<span className="issue-meta-section d-inline-block">
@@ -50,9 +55,9 @@ async function init(): Promise<false | void> {
 					className="commit-ref css-truncate user-select-contain mb-n1"
 					style={(branch ? {} : {textDecoration: 'line-through'})}
 				>
-					<a title={branch ? name : 'Deleted'} href={branch}>
-						{name}
-					</a> 
+					<a title={branch ? pr.baseRefName : 'Deleted'} href={branch}>
+						{pr.baseRefName}
+					</a>
 				</span>
 			</span>
 		);

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -5,60 +5,8 @@ import PullRequestIcon from 'octicon/git-pull-request.svg';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {botSelectors} from './dim-bots';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getRepositoryInfo, getRepoGQL} from '../github-helpers';
-
-type RepositoryReference = {
-	owner: string;
-	branchExists: boolean;
-	url?: string;
-	label: string;
-};
-
-type BranchInfo = {
-	baseRef: string;
-	baseRefName: string;
-	headRef: string;
-	headOwner: {
-		login: string;
-	};
-	headRefName: string;
-	headRepository?: {
-		url: string;
-	};
-};
-
-function normalizeBranchInfo(data: BranchInfo): {
-	base?: RepositoryReference;
-	head?: RepositoryReference;
-} {
-	const currentRepository = getRepositoryInfo();
-
-	const base = {} as RepositoryReference; // eslint-disable-line @typescript-eslint/consistent-type-assertions
-	base.branchExists = Boolean(data.baseRef);
-	base.label = data.baseRefName;
-	if (base.branchExists) {
-		base.url = `/${currentRepository.owner!}/${currentRepository.name!}/tree/${data.baseRefName}`;
-	}
-
-	const head = {} as RepositoryReference; // eslint-disable-line @typescript-eslint/consistent-type-assertions
-	head.branchExists = Boolean(data.headRef);
-	head.owner = data.headOwner.login;
-	if (data.headOwner.login === currentRepository.owner) {
-		head.label = data.headRefName;
-	} else {
-		head.label = `${data.headOwner.login}:${data.headRefName}`;
-	}
-
-	if (head.branchExists) { // If the branch hasn't been deleted
-		head.url = `${data.headRepository!.url}/tree/${data.headRefName}`;
-	} else if (data.headRepository) { // If the repo hasn't been deleted
-		head.url = data.headRepository.url;
-	}
-
-	return {base, head};
-}
 
 function buildQuery(issueIds: string[]): string {
 	return `
@@ -66,38 +14,15 @@ function buildQuery(issueIds: string[]): string {
 			${issueIds.map(id => `
 				${id}: pullRequest(number: ${id.replace(/\D/g, '')}) {
 					baseRef {id}
-					headRef {id}
 					baseRefName
-					headRefName
-					headRepository {url}
-					headOwner: headRepositoryOwner {login}
 				}
 			`).join('\n')}
 		}
 	`;
 }
 
-function createLink(reference: RepositoryReference): HTMLSpanElement {
-	return (
-		<span
-			className="commit-ref css-truncate user-select-contain mb-n1"
-			style={(reference.branchExists ? {} : {textDecoration: 'line-through'})}
-		>
-			{
-				reference.url ?
-					<a title={(reference.branchExists ? reference.label : 'Deleted')} href={reference.url}>
-						{reference.label}
-					</a> :
-					<span className="unknown-repo">unknown repository</span>
-			}
-		</span>
-	);
-}
-
 async function init(): Promise<false | void> {
-	const prLinks = select.all('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]')
-		// Exclude bots
-		.filter(link => !link.parentElement?.querySelector(botSelectors.join()));
+	const prLinks = select.all('.js-issue-row .js-navigation-open[data-hovercard-type="pull_request"]');
 	if (prLinks.length === 0) {
 		return false;
 	}
@@ -110,34 +35,25 @@ async function init(): Promise<false | void> {
 	]);
 
 	for (const prLink of prLinks) {
-		if (!data.repository[prLink.id].headOwner) { // 👻 @ghost user
-			return;
-		}
-
-		let branches;
-		let {base, head} = normalizeBranchInfo(data.repository[prLink.id]);
-
-		if (base!.label === defaultBranch) {
-			base = undefined;
-		}
-
-		if (head!.owner !== currentRepository.owner) {
-			head = undefined;
-		}
-
-		if (base && head) {
-			branches = <>From {createLink(head)} into {createLink(base)}</>;
-		} else if (head) {
-			branches = <>From {createLink(head)}</>;
-		} else if (base) {
-			branches = <>To {createLink(base)}</>;
-		} else {
+		if (data.baseRefName === defaultBranch || !data.repository[prLink.id].headOwner) { // 👻 @ghost user
 			continue;
 		}
 
+		const name = data.baseRefName;
+		const branch = data.baseRef && `/${currentRepository.owner!}/${currentRepository.name!}/tree/${data.baseRefName}`;
+
 		prLink.parentElement!.querySelector('.text-small.text-gray')!.append(
 			<span className="issue-meta-section d-inline-block">
-				<PullRequestIcon/> {branches}
+				<PullRequestIcon/>
+				{' To '}
+				<span
+					className="commit-ref css-truncate user-select-contain mb-n1"
+					style={(branch ? {} : {textDecoration: 'line-through'})}
+				>
+					<a title={branch ? name : 'Deleted'} href={branch}>
+						{name}
+					</a> 
+				</span>
 			</span>
 		);
 	}

--- a/source/features/pr-branches.tsx
+++ b/source/features/pr-branches.tsx
@@ -41,7 +41,7 @@ async function init(): Promise<false | void> {
 
 	for (const prLink of prLinks) {
 		const pr: BranchInfo = data.repository[prLink.id];
-		if (pr.baseRefName === defaultBranch || !pr.headOwner) { // 👻 @ghost user
+		if (pr.baseRefName === defaultBranch ) {
 			continue;
 		}
 
@@ -66,8 +66,8 @@ async function init(): Promise<false | void> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Shows head and base branches in PR lists if they’re significant: The base branch is added when it’s not the repo’s default branch; The head branch is added when it’s from the same repo or the PR is by the current user.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/51428391-ae9ed500-1c35-11e9-8e54-6b6a424fede4.png'
+	description: 'Shows the base in PR lists if they’re not the default branch.',
+	screenshot: '#TODO'
 }, {
 	include: [
 		pageDetect.isRepoConversationList

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -100,7 +100,7 @@ import './features/show-followers-you-know';
 import './features/show-user-top-repositories';
 import './features/set-default-repositories-type-to-sources';
 import './features/user-profile-follower-badge';
-import './features/pr-branches';
+import './features/highlight-non-default-base-branch';
 import './features/mark-private-orgs';
 import './features/linkify-commit-sha';
 import './features/bypass-checks';


### PR DESCRIPTION
~_Draft: I just edited the feature on the fly_~

This brings the feature in line with https://github.com/sindresorhus/refined-github/pull/455

IMHO the feature is noisy and doesn't show all the branches to begin with. If anyone finds this useful, they'll probably find it more useful to show _all_ the branches _all_ the time.

Resolves https://github.com/sindresorhus/refined-github/issues/2943, which asked for more branches to appear