### PR TITLE
Restore `ci-link`

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -9,8 +9,10 @@ import {getRepoURL} from '../github-helpers';
 
 // Look for the CI icon in the latest 2 days of commits #2990
 const getIcon = oneTime(fetchDom.bind(null,
-	`/${getRepoURL()}/commits`,
-	'.commit-group:nth-of-type(-n+2) .commit-build-statuses'
+	`/${getRepoURL()}/commits`, [
+		'.commit-group:nth-of-type(-n+2) .commit-build-statuses', // Pre "Repository refresh" layout
+		'.TimelineItem--condensed:nth-of-type(-n+2) .commit-build-statuses'
+	].join()
 ));
 
 async function init(): Promise<false | void> {


### PR DESCRIPTION
Selector update