### PR TITLE
Move backtick parsing in `format-conversation-titles`  test

### DIFF
--- a/source/features/format-conversation-titles.tsx
+++ b/source/features/format-conversation-titles.tsx
@@ -9,7 +9,6 @@ function init(): void {
 	for (const title of select.all('.js-issue-title:not(.rgh-formatted-title)')) {
 		title.classList.add('rgh-formatted-title');
 		domFormatters.linkifyIssues(title);
-		domFormatters.parseBackticks(title);
 	}
 }
 

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -15,6 +15,7 @@ function init(): void {
 		'a[id^="issue_"]', // `isConversationList` issue and PR title
 		'.TimelineItem-body > del, .TimelineItem-body > ins', // `isIssue`, `isPRConversation` title edits
 		'[id^=ref-issue-], [id^=ref-pullrequest-]', // `isIssue`, `isPRConversation` issue and PR references
+		'.js-issue-title', // `isIssue`, `isPR` titles
 		'[aria-label="Link issues"] a', // `isIssue`, `isPRConversation` linked issue and PR
 		'.Box-header.Details .link-gray, .Box-header.Details pre', // `isSingleFile` commit message and description
 		'.js-pinned-issue-list-item > .d-block', // Pinned Issues


### PR DESCRIPTION
Note `format-conversation-titles` will be removed in #3409