### PR TITLE
Add `linkify-user-edit-history-popup` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,7 @@ Thanks for contributing! 🦋🙌
 - [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
 - [](# "pinned-issue-update-time") [Adds the updated time to pinned issues.](https://user-images.githubusercontent.com/1402241/75525936-bb524700-5a4b-11ea-9225-466bda58b7de.png)
 - [](# "clean-pinned-issues") [Changes the layout of pinned issues from side-by-side to a standard list.](https://user-images.githubusercontent.com/1402241/84509958-c82a3c00-acc4-11ea-8399-eaf06a59e9e4.png)
+- [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -336,7 +336,7 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png)
 - [](# "prevent-pr-commit-link-loss") [Suggests fixing your PR Commit links before commenting. GitHub has a bug that causes these link to appear as plain commit links, without association to the PR.](https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif)
 - [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
-- [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png)
+- [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -220,7 +220,6 @@ Thanks for contributing! 🦋🙌
 - [](# "bugs-tab") [Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.](https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png)
 - [](# "pinned-issue-update-time") [Adds the updated time to pinned issues.](https://user-images.githubusercontent.com/1402241/75525936-bb524700-5a4b-11ea-9225-466bda58b7de.png)
 - [](# "clean-pinned-issues") [Changes the layout of pinned issues from side-by-side to a standard list.](https://user-images.githubusercontent.com/1402241/84509958-c82a3c00-acc4-11ea-8399-eaf06a59e9e4.png)
-- [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -337,6 +336,7 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-notification-repository-header") [Linkifies the header of each notification group (when grouped by repository).](https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png)
 - [](# "prevent-pr-commit-link-loss") [Suggests fixing your PR Commit links before commenting. GitHub has a bug that causes these link to appear as plain commit links, without association to the PR.](https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif)
 - [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
+- [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -3,20 +3,13 @@ import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {wrap} from '../helpers/dom-utils';
 
 function init(): void {
 	observe('details-dialog .Box-header .mr-3 img:not([alt*="[bot]"])', {
-		add(element) {
-			const userName = (element as HTMLImageElement).alt.slice(1);
-
-			element.nextElementSibling!.replaceWith(
-				<a
-					className="link-gray-dark css-truncate-target v-align-middle text-bold text-small"
-					href={`/${userName}`}
-				>
-					{userName}
-				</a>
-			);
+		add(avatar) {
+			const userName = (avatar as HTMLImageElement).alt.slice(1);
+			wrap(avatar.nextElementSibling!, <a className="link-gray-dark" href={`/${userName}`}/>);
 		}
 	});
 }

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -21,12 +21,12 @@ function init(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Linkifies the username in the edit history popup.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png'
+	screenshot: 'https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png'
 }, {
 	init,
 	include: [
 		pageDetect.isIssue,
 		pageDetect.isPRConversation
 	],
-	once: true
+	repeatOnAjax: false
 });

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -28,5 +28,5 @@ void features.add({
 		pageDetect.isIssue,
 		pageDetect.isPRConversation
 	],
-	repeatOnAjax: false
+	once: true
 });

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -5,9 +5,9 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function init(): void {
-	observe<HTMLImageElement>('details-dialog .Box-header .mr-3 img:not([alt*="[bot]"])', {
+	observe('details-dialog .Box-header .mr-3 img:not([alt*="[bot]"])', {
 		add(element) {
-			const userName = element.alt.slice(1);
+			const userName = (element as HTMLImageElement).alt.slice(1);
 
 			element.nextElementSibling!.replaceWith(
 				<a

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -6,10 +6,14 @@ import features from '.';
 import {wrap} from '../helpers/dom-utils';
 
 function init(): void {
-	observe('details-dialog .Box-header .mr-3 img:not([alt*="[bot]"])', {
+	observe('details-dialog .Box-header .mr-3 > img:not([alt*="[bot]"])', {
 		add(avatar) {
 			const userName = (avatar as HTMLImageElement).alt.slice(1);
+			// Linkify name first
 			wrap(avatar.nextElementSibling!, <a className="link-gray-dark" href={`/${userName}`}/>);
+
+			// Then linkify avatar
+			wrap(avatar, <a href={`/${userName}`}/>);
 		}
 	});
 }

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -1,0 +1,38 @@
+import React from 'dom-chef';
+import {observe} from 'selector-observer';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function init(): void {
+	observe('details-dialog .Box-header .mr-3 img', {
+		add(element) {
+			const userName = (element as HTMLImageElement).alt.slice(1);
+			if (userName.includes('[bot]')) {
+				return;
+			}
+
+			element.nextElementSibling!.replaceWith(
+				<a
+					className="link-gray-dark css-truncate-target v-align-middle text-bold text-small"
+					href={`/${userName}`}
+				>
+					{userName}
+				</a>
+			);
+		}
+	});
+}
+
+void features.add({
+	id: __filebasename,
+	description: 'Linkifies the username in the edit history popup.',
+	screenshot: 'https://user-images.githubusercontent.com/16872793/88803491-85d89380-d17a-11ea-9aad-53635ad7b699.png'
+}, {
+	init,
+	include: [
+		pageDetect.isIssue,
+		pageDetect.isPRConversation
+	],
+	repeatOnAjax: false
+});

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -5,12 +5,9 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function init(): void {
-	observe('details-dialog .Box-header .mr-3 img', {
+	observe<HTMLImageElement>('details-dialog .Box-header .mr-3 img:not([alt*="[bot]"])', {
 		add(element) {
-			const userName = (element as HTMLImageElement).alt.slice(1);
-			if (userName.includes('[bot]')) {
-				return;
-			}
+			const userName = element.alt.slice(1);
 
 			element.nextElementSibling!.replaceWith(
 				<a

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -184,6 +184,7 @@ import './features/pr-jump-to-first-non-viewed-file';
 import './features/keyboard-navigation';
 import './features/vertical-front-matter';
 import './features/use-first-commit-message-for-new-prs';
+import './features/linkify-user-edit-history-popup';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
1. LINKED ISSUES:
   Closes #2161

2. TEST URLS:
	https://github.com/Mottie/GitHub-userscripts/issues/88#issuecomment-502933879 (with bot and should not be linkified)
	https://github.com/sindresorhus/refined-github/pull/1766#issue-251741293
	This pull request

3. SCREENSHOT:
![image](https://user-images.githubusercontent.com/16872793/88804746-5b87d580-d17c-11ea-8867-02b6a7ae83bb.png)
