### PR TITLE
Append `ci-link` icon after private label

### DIFF
--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -5,3 +5,7 @@
 .rgh-ci-link summary .octicon {
 	vertical-align: 0;
 }
+
+.Label + .rgh-ci-link {
+	margin-left: 8px;
+}

--- a/source/features/ci-link.css
+++ b/source/features/ci-link.css
@@ -6,6 +6,7 @@
 	vertical-align: 0;
 }
 
+/* Adds space between `ci-link` and "Private" label, if present */
 .Label + .rgh-ci-link {
 	margin-left: 8px;
 }

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -27,11 +27,7 @@ async function init(): Promise<false | void> {
 	}
 
 	// Append to title (aware of forks and private repos)
-	const privateLabel = select('[itemprop="name"] + .Label');
-	(privateLabel ?? select('[itemprop="name"]'))!.after(icon);
-	if (privateLabel) {
-		icon.classList.add('ml-2');
-	}
+	select('[itemprop="name"]')!.parentElement!.append(icon);
 }
 
 void features.add({

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -27,7 +27,11 @@ async function init(): Promise<false | void> {
 	}
 
 	// Append to title (aware of forks and private repos)
-	select('[itemprop="name"]')!.after(icon);
+	const privateLabel = select('[itemprop="name"] + .Label');
+	if (privateLabel) {
+		icon.classList.add('ml-2');
+	}
+	(privateLabel ?? select('[itemprop="name"]'))!.after(icon);
 }
 
 void features.add({

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -28,10 +28,10 @@ async function init(): Promise<false | void> {
 
 	// Append to title (aware of forks and private repos)
 	const privateLabel = select('[itemprop="name"] + .Label');
+	(privateLabel ?? select('[itemprop="name"]'))!.after(icon);
 	if (privateLabel) {
 		icon.classList.add('ml-2');
 	}
-	(privateLabel ?? select('[itemprop="name"]'))!.after(icon);
 }
 
 void features.add({


### PR DESCRIPTION
Test URL: a private repo

Before: 
![image](https://user-images.githubusercontent.com/44045911/89138057-d847f480-d56c-11ea-89a0-bfa753d379cf.png)

After:
![image](https://user-images.githubusercontent.com/44045911/89178051-5c2acc80-d5bf-11ea-9a4c-9a69b49caca6.png)


<details>
<summary>No longer apply <s>The extra margin also pairs nicely with other extensions like Octotree.</s>
</summary>

Before:
![image](https://user-images.githubusercontent.com/44045911/89138141-28bf5200-d56d-11ea-85dd-08c5b5dd9646.png)

After:
![image](https://user-images.githubusercontent.com/44045911/89138165-3d9be580-d56d-11ea-993c-5635607792bb.png)

Before:
![image](https://user-images.githubusercontent.com/44045911/89138175-50aeb580-d56d-11ea-892a-c3eded9dee83.png)

After:
![image](https://user-images.githubusercontent.com/44045911/89138190-5ad0b400-d56d-11ea-8b11-4e9998783b99.png)

</details>