### PR TITLE
Fixes and improvements to `useful-not-found-page`

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -68,7 +68,7 @@ async function addDefaultBranchLink(bar: Element): Promise<void> {
 
 	bar.after(
 		<p className="container mt-4 text-center">
-			See also the file on the <a href={url}>default branch</a>
+			See also the object on the <a href={url}>default branch</a>
 		</p>
 	);
 }
@@ -82,8 +82,8 @@ function init(): false | void {
 	const bar = <h2 className="container mt-4 text-center"/>;
 
 	for (const [i, part] of parts.entries()) {
-		if (i === 2 && part === 'tree') {
-			// `/tree/` is not a real part of the URL
+		if (i === 2 && ['tree', 'blob', 'edit'].includes(part)) {
+			// Exclude parts that don't exist as standalones
 			continue;
 		}
 
@@ -103,8 +103,14 @@ function init(): false | void {
 		void checkAnchor(bar.children[i] as HTMLAnchorElement);
 	}
 
-	if (parts[2] === 'tree') {
+	if (parts[2] === 'tree' || parts[2] === 'blob') {
+		// Object might be 410 Gone
 		void addCommitHistoryLink(bar);
+	}
+
+	if (parts[2] === 'edit') {
+		// File might not be available on the current branch
+		// GitHub already redirects /tree/ and /blob/ natively
 		void addDefaultBranchLink(bar);
 	}
 }


### PR DESCRIPTION
GitHub seems to have finally started automatically redirecting URLs to old branches:

<img width="693" alt="Screen Shot 2020-08-03 at 19 24 49" src="https://user-images.githubusercontent.com/1402241/89216258-fdb31d80-d5c1-11ea-8892-a90586fd4e12.png">

Demo:

- 404 branch, file: https://github.com/sindresorhus/refined-github/blob/404/package.json
- 404 branch, folder: https://github.com/sindresorhus/refined-github/blob/404/source

So I'm removing this behavior from `blob` and `tree`

---

However, they don't apply this behavior to `edit` URLs, so I'm leaving the logic just for that:


- 404 branch, **edit** file: https://github.com/sindresorhus/refined-github/edit/404/package.json


---

Bugfixes:

- `/user/repo/edit/` URLs should not be queried in the loop:
	https://github.com/sindresorhus/refined-github/edit/master/wrong-file
	<img width="655" alt="" src="https://user-images.githubusercontent.com/1402241/89216825-048e6000-d5c3-11ea-8fce-7a7f65ee94ed.png">

---

Original feature tests in https://github.com/sindresorhus/refined-github/pull/1558
