### PR TITLE
Apply `shorten-links` after editing comments

### DIFF
--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -11,7 +11,7 @@ function init(): void {
 		add(element) {
 			applyToLink(element as HTMLAnchorElement, location.href);
 		}
-	})
+	});
 }
 
 void features.add({

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -1,15 +1,16 @@
 import onetime from 'onetime';
+import {observe} from 'selector-observer';
 import {applyToLink} from 'shorten-repo-url';
 import * as pageDetect from 'github-url-detection';
-import {observe} from 'selector-observer';
 
 import features from '.';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters';
 
 function init(): void {
 	observe(`a[href]:not(.${linkifiedURLClass})`, {
-		add(element) {
-			applyToLink(element as HTMLAnchorElement, location.href);
+		constructor: HTMLAnchorElement,
+		add(link) {
+			applyToLink(link, location.href);
 		}
 	});
 }

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -1,14 +1,17 @@
-import select from 'select-dom';
+import onetime from 'onetime';
 import {applyToLink} from 'shorten-repo-url';
 import * as pageDetect from 'github-url-detection';
+import {observe} from 'selector-observer';
 
 import features from '.';
 import {linkifiedURLClass} from '../github-helpers/dom-formatters';
 
 function init(): void {
-	for (const a of select.all<HTMLAnchorElement>(`a[href]:not(.${linkifiedURLClass})`)) {
-		applyToLink(a, location.href);
-	}
+	observe(`a[href]:not(.${linkifiedURLClass})`, {
+		add(element) {
+			applyToLink(element as HTMLAnchorElement, location.href);
+		}
+	})
 }
 
 void features.add({
@@ -20,5 +23,5 @@ void features.add({
 		// Due to GitHub’s bug: #2828
 		pageDetect.isGlobalSearchResults
 	],
-	init
+	init: onetime(init)
 });


### PR DESCRIPTION
Resolves #2264
Test: https://github.com/sindresorhus/refined-github/pull/636/files (edit this comment and observe the link)
Screenshot: 
![image](https://user-images.githubusercontent.com/44045911/89768020-99e2a480-db2d-11ea-9ac0-68e7124a36da.png)
