### PR TITLE
Enable `fork-source-link-same-view` on editing pages

### DIFF
--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -27,7 +27,8 @@ void features.add({
 }, {
 	include: [
 		pageDetect.isSingleFile,
-		pageDetect.isRepoTree
+		pageDetect.isRepoTree,
+		pageDetect.isEditingFile
 	],
 	exclude: [
 		() => !pageDetect.isForkedRepo(),


### PR DESCRIPTION
1. LINKED ISSUES:
https://github.com/sindresorhus/refined-github/pull/3230#issuecomment-671308585

2. TEST URLS:
   https://github.com/yakov116/refined-github/edit/upstream/package.json

3. SCREENSHOT:
   None

Sorry about 
>Send it just to blob?
>
>_Originally posted by @yakov116 in https://github.com/sindresorhus/refined-github/pull/3230#issuecomment-671309723_

I made a mistake and thought that `doesFileExist` looks at route. ([For the second time!](https://github.com/sindresorhus/refined-github/pull/3420#discussion_r463870882))