### PR TITLE
Faster & Simplify `close-out-of-view-modals`

### DIFF
--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -5,7 +5,7 @@ import features from '.';
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
 		observer.unobserve(target);
-		target.closest('details')!.removeAttribute('open');
+		target.closest('details')!.open = false;
 	}
 });
 

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -5,13 +5,13 @@ import features from '.';
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
 		observer.unobserve(target);
-		target.removeAttribute('open');
+		target.closest('details')!.removeAttribute('open');
 	}
 });
 
 function init(): void {
 	document.addEventListener('menu:activated', ((event: CustomEvent) => {
-		observer.observe((event.target as HTMLElement));
+		observer.observe((event.target as HTMLElement).querySelector('details-menu')!);
 	}) as EventListener);
 }
 

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -13,10 +13,10 @@ function init(): void {
 	document.addEventListener('menu:activated', ((event: CustomEvent) => {
 		const target = (event.target as HTMLElement);
 		const modalBox = target.querySelector('details-menu')!;
-		// it prevents the feature silently breaking the interface: #2701
-		if (modalBox.getBoundingClientRect().width === 0) {	
-			features.error(__filebasename, 'Modal element was not correctly detected for', target);	
-			return;	
+		// It prevents the feature silently breaking the interface: #2701
+		if (modalBox.getBoundingClientRect().width === 0) {
+			features.error(__filebasename, 'Modal element was not correctly detected for', target);
+			return;
 		}
 
 		observer.observe(modalBox);

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -11,7 +11,15 @@ const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 
 function init(): void {
 	document.addEventListener('menu:activated', ((event: CustomEvent) => {
-		observer.observe((event.target as HTMLElement).querySelector('details-menu')!);
+		const target = (event.target as HTMLElement);
+		const modalBox = target.querySelector('details-menu')!;
+		// it prevents the feature silently breaking the interface: #2701
+		if (modalBox.getBoundingClientRect().width === 0) {	
+			features.error(__filebasename, 'Modal element was not correctly detected for', target);	
+			return;	
+		}
+
+		observer.observe(modalBox);
 	}) as EventListener);
 }
 

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -1,5 +1,3 @@
-import onetime from 'onetime';
-
 import features from '.';
 
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
@@ -9,18 +7,20 @@ const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	}
 });
 
-function init(): void {
-	document.addEventListener('menu:activated', (event: CustomEvent) => {
-		const details = event.target as HTMLElement;
-		const modalBox = details.querySelector('details-menu')!;
+function menuActivatedHandler(event: CustomEvent): void {
+	const details = event.target as HTMLElement;
+	const modalBox = details.querySelector('details-menu')!;
 
-		// Avoid silently breaking the interface: #2701
-		if (modalBox.getBoundingClientRect().width === 0) {
-			features.error(__filebasename, 'Modal element was not correctly detected for', details);
-		} else {
-			observer.observe(modalBox);
-		}
-	});
+	// Avoid silently breaking the interface: #2701
+	if (modalBox.getBoundingClientRect().width === 0) {
+		features.error(__filebasename, 'Modal element was not correctly detected for', details);
+	} else {
+		observer.observe(modalBox);
+	}
+}
+
+function init(): void {
+	document.addEventListener('menu:activated', menuActivatedHandler);
 }
 
 void features.add({
@@ -29,5 +29,5 @@ void features.add({
 	screenshot: 'https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif'
 }, {
 	waitForDomReady: false,
-	init: onetime(init)
+	init
 });

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -1,29 +1,18 @@
 import onetime from 'onetime';
-import delegate from 'delegate-it';
 
 import features from '.';
 
 const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 	if (intersectionRatio === 0) {
 		observer.unobserve(target);
-		target.closest('details')!.open = false;
+		target.removeAttribute('open');
 	}
 });
 
 function init(): void {
-	// The `open` attribute is added after this handler is run, so the selector is inverted
-	delegate(document, '.details-overlay:not([open]) > summary[aria-haspopup="menu"]', 'click', ({delegateTarget: summary}) => {
-		// The timeout gives the element time to "open"
-		setTimeout(() => {
-			const modalBox = summary.parentElement!.querySelector('details-menu')!;
-			if (modalBox.getBoundingClientRect().width === 0) {
-				features.error(__filebasename, 'Modal element was not correctly detected for', summary);
-				return;
-			}
-
-			observer.observe(modalBox);
-		}, 100);
-	});
+	document.addEventListener('menu:activated', ((event: CustomEvent) => {
+		observer.observe((event.target as HTMLElement));
+	}) as EventListener);
 }
 
 void features.add({

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -10,17 +10,17 @@ const observer = new IntersectionObserver(([{intersectionRatio, target}]) => {
 });
 
 function init(): void {
-	document.addEventListener('menu:activated', ((event: CustomEvent) => {
-		const target = (event.target as HTMLElement);
-		const modalBox = target.querySelector('details-menu')!;
-		// It prevents the feature silently breaking the interface: #2701
-		if (modalBox.getBoundingClientRect().width === 0) {
-			features.error(__filebasename, 'Modal element was not correctly detected for', target);
-			return;
-		}
+	document.addEventListener('menu:activated', (event: CustomEvent) => {
+		const details = event.target as HTMLElement;
+		const modalBox = details.querySelector('details-menu')!;
 
-		observer.observe(modalBox);
-	}) as EventListener);
+		// Avoid silently breaking the interface: #2701
+		if (modalBox.getBoundingClientRect().width === 0) {
+			features.error(__filebasename, 'Modal element was not correctly detected for', details);
+		} else {
+			observer.observe(modalBox);
+		}
+	});
 }
 
 void features.add({

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -36,6 +36,7 @@ declare module 'deep-weak-map' {
 
 // Custom UI events specific to RGH
 interface GlobalEventHandlersEventMap {
+	'menu:activated': CustomEvent;
 	'details:toggled': CustomEvent;
 	'rgh:view-markdown-source': CustomEvent;
 	'rgh:view-markdown-rendered': CustomEvent;


### PR DESCRIPTION
1. LINKED ISSUES:
-

2. TEST URLS:
-

3. SCREENSHOT
-

We can listen for `menu:activated` (CutomEvent) instead of click.