### PR TITLE
Add `same-page-definition-jump` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ Thanks for contributing! 🦋🙌
 - [](# "esc-to-deselect-line") [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 - [](# "html-preview-link") [Adds a link to preview HTML files.](https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png)
 - [](# "vertical-front-matter") [Show Markdown front matter as vertical table.](https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png)
+- [](# "follow-local-link") [Stay on the local page while jumping to the definition of a function or method within the same file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -348,7 +348,7 @@ Thanks for contributing! 🦋🙌
 - [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
 - [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png)
 - [](# "prevent-duplicate-pr-submission") [Avoids creating duplicate PRs when mistakenly clicking "Create pull request" more than once.](https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif)
-- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
+- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/1402241/90641702-70aace00-e229-11ea-946c-3a76697b9184.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -348,7 +348,7 @@ Thanks for contributing! 🦋🙌
 - [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
 - [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png)
 - [](# "prevent-duplicate-pr-submission") [Avoids creating duplicate PRs when mistakenly clicking "Create pull request" more than once.](https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif)
-- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/1402241/90641702-70aace00-e229-11ea-946c-3a76697b9184.png)
+- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,6 @@ Thanks for contributing! 🦋🙌
 - [](# "esc-to-deselect-line") [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 - [](# "html-preview-link") [Adds a link to preview HTML files.](https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png)
 - [](# "vertical-front-matter") [Show Markdown front matter as vertical table.](https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png)
-- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 
@@ -349,6 +348,7 @@ Thanks for contributing! 🦋🙌
 - [](# "align-repository-header") [Aligns the repository header to the repository content on wide screens.](https://user-images.githubusercontent.com/1402241/86574587-587f3800-bf76-11ea-9961-5c25cdb6e357.gif)
 - [](# "linkify-user-edit-history-popup") [Linkifies the username in the edit history popup.](https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png)
 - [](# "prevent-duplicate-pr-submission") [Avoids creating duplicate PRs when mistakenly clicking "Create pull request" more than once.](https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif)
+- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -157,7 +157,7 @@ Thanks for contributing! 🦋🙌
 - [](# "esc-to-deselect-line") [Adds a keyboard shortcut to deselect the current line: <kbd>esc</kbd>.](https://github.com/sindresorhus/refined-github/issues/1590)
 - [](# "html-preview-link") [Adds a link to preview HTML files.](https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png)
 - [](# "vertical-front-matter") [Show Markdown front matter as vertical table.](https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png)
-- [](# "follow-local-link") [Stay on the local page while jumping to the definition of a function or method within the same file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
+- [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/follow-local-link.tsx
+++ b/source/features/follow-local-link.tsx
@@ -1,0 +1,27 @@
+import delegate from 'delegate-it';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import GitHubURL from '../github-helpers/github-url';
+
+function followLocalLink(event: delegate.Event<MouseEvent, HTMLAnchorElement>) {
+	if (new GitHubURL(event.delegateTarget.href).filePath === new GitHubURL(location.href).filePath) {
+		location.hash = event.delegateTarget.hash;
+		event.preventDefault();
+	}
+}
+
+function init(): void {
+	delegate(document, '.TagsearchPopover-item', 'click', followLocalLink);
+}
+
+void features.add({
+	id: __filebasename,
+	description: 'Stay on the local page while jumping to the definition of a function or method within the same file.',
+	screenshot: 'https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png'
+}, {
+	include: [
+		pageDetect.isSingleFile
+	],
+	init
+});

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -18,7 +18,7 @@ function init(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Avoids re-loading the page when jumping to function definition in the current file.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png'
+	screenshot: 'https://user-images.githubusercontent.com/1402241/90641702-70aace00-e229-11ea-946c-3a76697b9184.png'
 }, {
 	include: [
 		pageDetect.isSingleFile

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -18,7 +18,7 @@ function init(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Avoids re-loading the page when jumping to function definition in the current file.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/90641702-70aace00-e229-11ea-946c-3a76697b9184.png'
+	screenshot: 'https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png'
 }, {
 	include: [
 		pageDetect.isSingleFile

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -17,7 +17,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Stay on the local page while jumping to the definition of a function or method within the same file.',
+	description: 'Avoids re-loading the page when jumping to function definition in the current file.',
 	screenshot: 'https://user-images.githubusercontent.com/16872793/90635640-7091da80-e1f7-11ea-9d79-eb340f9d2c61.png'
 }, {
 	include: [

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -192,6 +192,7 @@ import './features/remove-label-faster';
 import './features/clean-conversation-headers';
 import './features/highlight-deleted-and-added-files-in-diffs';
 import './features/convert-release-to-draft';
+import './features/follow-local-link';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -192,7 +192,7 @@ import './features/remove-label-faster';
 import './features/clean-conversation-headers';
 import './features/highlight-deleted-and-added-files-in-diffs';
 import './features/convert-release-to-draft';
-import './features/follow-local-link';
+import './features/same-page-definition-jump';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
1. LINKED ISSUES:
   Closes #3337 

2. TEST URLS:
   (Same Page) https://github.com/sindresorhus/refined-github/blob/master/source/github-helpers/api.ts#L50
	(External Page) https://github.com/sindresorhus/refined-github/blob/master/source/features/add-tag-to-commits.tsx#L127

3. SCREENSHOT:
![image](https://user-images.githubusercontent.com/1402241/90641702-70aace00-e229-11ea-946c-3a76697b9184.png)
