### PR TITLE
Enable `batch-open-conversations` on repos without write access

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Thanks for contributing! 🦋🙌
 
 ### Conversations
 
-- [](# "batch-open-conversations") 🔥 [Adds a button to open multiple conversations at once in your repos.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- [](# "batch-open-conversations") 🔥 [Adds a button to open multiple conversations at once.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
 - [](# "split-issue-pr-search-results") [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
 - [](# "sticky-conversation-sidebar") [Makes the conversation sidebar sticky.](https://user-images.githubusercontent.com/10238474/62276723-5a2eaa80-b44d-11e9-810b-ff598d1c5c6a.gif)
 - [](# "sticky-conversation-list-toolbar") [Makes the conversation list’s filters toolbar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)

--- a/readme.md
+++ b/readme.md
@@ -195,7 +195,7 @@ Thanks for contributing! 🦋🙌
 
 ### Conversations
 
-- [](# "batch-open-conversations") 🔥 [Adds a button to open multiple conversations at once.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
+- [](# "batch-open-conversations") 🔥 [Lets you open multiple conversations at once via checkboxes.](https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif)
 - [](# "split-issue-pr-search-results") [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
 - [](# "sticky-conversation-sidebar") [Makes the conversation sidebar sticky.](https://user-images.githubusercontent.com/10238474/62276723-5a2eaa80-b44d-11e9-810b-ff598d1c5c6a.gif)
 - [](# "sticky-conversation-list-toolbar") [Makes the conversation list’s filters toolbar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -68,7 +68,7 @@ async function init(): Promise<void | false> {
 		const issuesToolbar = select('#js-issues-toolbar')!;
 		issuesToolbar.prepend(
 			<div className="mr-3 d-none d-md-block">
-				<input type="checkbox" data-check-all="" aria-label="Select all issues" autoComplete="off"/>
+				<input data-check-all type="checkbox" aria-label="Select all issues" autoComplete="off"/>
 			</div>
 		);
 		issuesToolbar.append(
@@ -86,8 +86,8 @@ async function init(): Promise<void | false> {
 			conversation.firstElementChild!.prepend(
 				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
 					<input
+						data-check-all-item
 						type="checkbox"
-						data-check-all-item=""
 						className="js-issues-list-check"
 						name="issues[]"
 						value={number}

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -95,9 +95,8 @@ async function init(): Promise<void | false> {
 		);
 
 		const prRows = select.all('.js-issue-row');
-		const prs = prRows.map(getIssueConfig);
-
-		for (const pr of prs) {
+		for (const prRow of prRows) {
+			const pr = getIssueConfig(prRow);
 			pr.prependAt.prepend(
 				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
 					<input

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -34,6 +34,21 @@ function openIssues(): void {
 	});
 }
 
+interface IssueConfig {
+	number: string;
+	prependAt: Element;
+}
+
+function getIssueConfig(prRow: Element): IssueConfig {
+	let match = prRow.id.match(/^issue_(\d*)$/);
+	const number: string = match?.[1] ?? '';
+	return {
+		number,
+		prependAt: prRow.children[0]!,
+	};
+}
+
+
 async function init(): Promise<void | false> {
 	if (!await elementReady('.js-issue-row + .js-issue-row')) {
 		return false;
@@ -63,12 +78,44 @@ async function init(): Promise<void | false> {
 				Open selected
 			</button>
 		);
+	} else {
+		select('#js-issues-toolbar')?.prepend(
+			<div className="mr-3 d-none d-md-block">
+  			<input type="checkbox" data-check-all="" aria-label="Select all issues" autoComplete="off"/>
+		  </div>
+		);
+		select('#js-issues-toolbar')?.append(
+			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
+				<span className="text-gray table-list-header-toggle">
+					<span data-check-all-count="">1</span> selected
+					<button type="button" className="btn-link rgh-batch-open-issues pl-3">Open selected</button>
+				</span>
+			</div>
+		);
+
+		const prElements = select.all('.js-issue-row');
+		const prs = prElements.map(getIssueConfig);
+
+		for (const pr of prs) {
+			pr.prependAt.prepend(
+				<label class="flex-shrink-0 py-2 pl-3  d-none d-md-block">
+					<input
+						type="checkbox"
+						data-check-all-item=""
+						className="js-issues-list-check"
+						name="issues[]"
+						value={pr.number}
+						aria-labelledby={`issue_${pr.number}_link`}
+						autoComplete="off" />
+				</label>
+			);
+		}
 	}
 }
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a button to open multiple conversations at once in your repos.',
+	description: 'Adds a button to open multiple conversations at once.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif'
 }, {
 	include: [

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -40,14 +40,13 @@ interface IssueConfig {
 }
 
 function getIssueConfig(prRow: Element): IssueConfig {
-	let match = prRow.id.match(/^issue_(\d*)$/);
+	const match = /^issue_(\d*)$/.exec(prRow.id);
 	const number: string = match?.[1] ?? '';
 	return {
 		number,
-		prependAt: prRow.children[0]!,
+		prependAt: prRow.children[0]!
 	};
 }
-
 
 async function init(): Promise<void | false> {
 	if (!await elementReady('.js-issue-row + .js-issue-row')) {
@@ -81,13 +80,14 @@ async function init(): Promise<void | false> {
 	} else {
 		select('#js-issues-toolbar')?.prepend(
 			<div className="mr-3 d-none d-md-block">
-  			<input type="checkbox" data-check-all="" aria-label="Select all issues" autoComplete="off"/>
-		  </div>
+				<input type="checkbox" data-check-all="" aria-label="Select all issues" autoComplete="off"/>
+			</div>
 		);
 		select('#js-issues-toolbar')?.append(
 			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
 				<span className="text-gray table-list-header-toggle">
 					<span data-check-all-count="">1</span> selected
+					{' '} { /*   89:44  Ambiguous spacing after previous element span react/jsx-child-element-spacing */ }
 					<button type="button" className="btn-link rgh-batch-open-issues pl-3">Open selected</button>
 				</span>
 			</div>
@@ -98,7 +98,7 @@ async function init(): Promise<void | false> {
 
 		for (const pr of prs) {
 			pr.prependAt.prepend(
-				<label class="flex-shrink-0 py-2 pl-3  d-none d-md-block">
+				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
 					<input
 						type="checkbox"
 						data-check-all-item=""
@@ -106,7 +106,8 @@ async function init(): Promise<void | false> {
 						name="issues[]"
 						value={pr.number}
 						aria-labelledby={`issue_${pr.number}_link`}
-						autoComplete="off" />
+						autoComplete="off"
+					/>
 				</label>
 			);
 		}

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -93,8 +93,8 @@ async function init(): Promise<void | false> {
 			</div>
 		);
 
-		const prElements = select.all('.js-issue-row');
-		const prs = prElements.map(getIssueConfig);
+		const prRows = select.all('.js-issue-row');
+		const prs = prRows.map(getIssueConfig);
 
 		for (const pr of prs) {
 			pr.prependAt.prepend(

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -80,10 +80,11 @@ async function init(): Promise<void | false> {
 			</div>
 		);
 
+		const regExpPrNumber = /^issue_(\d*)$/;
+
 		const prRows = select.all('.js-issue-row');
 		for (const prRow of prRows) {
-			const match = /^issue_(\d*)$/.exec(prRow.id);
-			const prNumber: string = match?.[1] ?? '';
+			const prNumber = regExpPrNumber.exec(prRow.id)?.[1] ?? '';
 			const prependAt = prRow.children[0]!;
 			prependAt.prepend(
 				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -88,7 +88,7 @@ async function init(): Promise<void | false> {
 			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
 				<span className="text-gray table-list-header-toggle">
 					<span data-check-all-count="">1</span> selected
-					{' '} { /*   89:44  Ambiguous spacing after previous element span react/jsx-child-element-spacing */ }
+					{' '}
 					<button type="button" className="btn-link rgh-batch-open-issues pl-3">Open selected</button>
 				</span>
 			</div>

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -34,20 +34,6 @@ function openIssues(): void {
 	});
 }
 
-interface IssueConfig {
-	number: string;
-	prependAt: Element;
-}
-
-function getIssueConfig(prRow: Element): IssueConfig {
-	const match = /^issue_(\d*)$/.exec(prRow.id);
-	const number: string = match?.[1] ?? '';
-	return {
-		number,
-		prependAt: prRow.children[0]!
-	};
-}
-
 async function init(): Promise<void | false> {
 	if (!await elementReady('.js-issue-row + .js-issue-row')) {
 		return false;
@@ -96,16 +82,18 @@ async function init(): Promise<void | false> {
 
 		const prRows = select.all('.js-issue-row');
 		for (const prRow of prRows) {
-			const pr = getIssueConfig(prRow);
-			pr.prependAt.prepend(
+			const match = /^issue_(\d*)$/.exec(prRow.id);
+			const prNumber: string = match?.[1] ?? '';
+			const prependAt = prRow.children[0]!;
+			prependAt.prepend(
 				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
 					<input
 						type="checkbox"
 						data-check-all-item=""
 						className="js-issues-list-check"
 						name="issues[]"
-						value={pr.number}
-						aria-labelledby={`issue_${pr.number}_link`}
+						value={prNumber}
+						aria-labelledby={`issue_${prNumber}_link`}
 						autoComplete="off"
 					/>
 				</label>

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -5,6 +5,7 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import looseParseInt from '../helpers/loose-parse-int';
 
 const confirmationRequiredCount = 10;
 
@@ -73,28 +74,24 @@ async function init(): Promise<void | false> {
 		issuesToolbar.append(
 			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
 				<span className="text-gray table-list-header-toggle">
-					<span data-check-all-count="">1</span> selected
-					{' '}
+					<span data-check-all-count="">1</span>
+					{' selected '}
 					<button type="button" className="btn-link rgh-batch-open-issues pl-3">Open selected</button>
 				</span>
 			</div>
 		);
 
-		const regExpPrNumber = /^issue_(\d*)$/;
-
-		const prRows = select.all('.js-issue-row');
-		for (const prRow of prRows) {
-			const prNumber = regExpPrNumber.exec(prRow.id)?.[1] ?? '';
-			const prependAt = prRow.children[0]!;
-			prependAt.prepend(
+		for (const conversation of select.all('.js-issue-row')) {
+			const number = looseParseInt(conversation.id);
+			conversation.firstElementChild!.prepend(
 				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
 					<input
 						type="checkbox"
 						data-check-all-item=""
 						className="js-issues-list-check"
 						name="issues[]"
-						value={prNumber}
-						aria-labelledby={`issue_${prNumber}_link`}
+						value={number}
+						aria-labelledby={`issue_${number}_link`}
 						autoComplete="off"
 					/>
 				</label>
@@ -105,7 +102,7 @@ async function init(): Promise<void | false> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a button to open multiple conversations at once.',
+	description: 'Lets you open multiple conversations at once via checkboxes.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif'
 }, {
 	include: [

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -78,12 +78,13 @@ async function init(): Promise<void | false> {
 			</button>
 		);
 	} else {
-		select('#js-issues-toolbar')?.prepend(
+		const issuesToolbar = select('#js-issues-toolbar')!;
+		issuesToolbar.prepend(
 			<div className="mr-3 d-none d-md-block">
 				<input type="checkbox" data-check-all="" aria-label="Select all issues" autoComplete="off"/>
 			</div>
 		);
-		select('#js-issues-toolbar')?.append(
+		issuesToolbar.append(
 			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
 				<span className="text-gray table-list-header-toggle">
 					<span data-check-all-count="">1</span> selected


### PR DESCRIPTION
### Description

Add checkboxes to issues for batch-open-conversations when i don't have write access to the repo.

### 1. LINKED ISSUES:

closes #3487

### 2. TEST URLS:

*Note: an repo i don't have write access:*
https://github.com/gatsbyjs/gatsby/pulls?page=2&q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+is%3Aunread

### 3. SCREENSHOT:

*Note: an repo i don't have write access:*
<img width="825" alt="Bildschirmfoto 2020-08-20 um 00 50 52" src="https://user-images.githubusercontent.com/184316/90697823-8ea31d80-e27f-11ea-9d62-ac736265f6cf.png">
<img width="828" alt="Bildschirmfoto 2020-08-20 um 00 53 08" src="https://user-images.githubusercontent.com/184316/90697837-9236a480-e27f-11ea-8254-0a5cdc79721e.png">
