### PR TITLE
Make `clean-pinned-issues` slightly more visible

### DIFF
--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -11,7 +11,7 @@
 		margin-bottom: 20px;
 
 		/* Rounded table border https://stackoverflow.com/a/2586780/288906 */
-		box-shadow: 0 0 0 1px #d1d5da;
+		box-shadow: 0 0 0 2px #d1d5da;
 		border-collapse: collapse;
 		border-radius: 6px;
 		border-style: hidden;


### PR DESCRIPTION
I feel that with `clean-pinned-issues`, the pinned issues have become _less visible_, which was not the intent. Here I just make the border thicker. Alternative suggestions welcome.

## Before / after

<img width="45%" alt="" src="https://user-images.githubusercontent.com/1402241/90811123-fc9d2280-e31b-11ea-8568-a5dea3eb724f.png"><img width="45%" align=right alt="" src="https://user-images.githubusercontent.com/1402241/90811126-fdce4f80-e31b-11ea-837d-0a8ba33867e7.png">
