### PR TITLE
Re-add top padding removed by `hide-readme-header`

### DIFF
--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -32,5 +32,5 @@
 
 /* re-add top padding to the readme */
 .repository-content #readme:not(.blob) .Box-body {
-  padding-top: 32px;
+	padding-top: 32px;
 }

--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -29,3 +29,8 @@
 .repository-content #readme:not(.blob) .Box-header .btn-octicon:focus {
 	opacity: 100%;
 }
+
+/* re-add top padding to the readme */
+.repository-content #readme:not(.blob) .Box-body {
+  padding-top: 32px;
+}

--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -30,7 +30,7 @@
 	opacity: 100%;
 }
 
-/* re-add top padding to the readme */
+/* Restore spacing #3495 */
 .repository-content #readme:not(.blob) .Box-body {
 	padding-top: 32px;
 }


### PR DESCRIPTION
Closes #3495 

Because `hide-readme-header` hides the readme header, it essentially decreases the top padding. This makes the top padding `32px`, the same as the left/right/bottom padding.

### Old
![old](https://user-images.githubusercontent.com/11315492/91063230-041b3f00-e62e-11ea-93fc-0eaf4414038c.jpg)

### New
![new](https://user-images.githubusercontent.com/11315492/91063244-0a112000-e62e-11ea-83c8-95d6c0968952.jpg)