### PR TITLE
Adjust minimized review comment selector

### DIFF
--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -8,7 +8,7 @@ const isCommentGroupMinimized = (comment: HTMLElement): boolean =>
 	select.exists('.minimized-comment:not(.d-none)', comment) ||
 	Boolean(comment.closest([
 		'.js-resolvable-thread-contents.d-none', // Regular comments
-		'.js-resolvable-timeline-thread-container:not([open])' // Review comments
+		'details:not([open]).js-resolvable-timeline-thread-container' // Review comments
 	].join()));
 
 function runShortcuts(event: KeyboardEvent): void {

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -8,7 +8,7 @@ const isCommentGroupMinimized = (comment: HTMLElement): boolean =>
 	select.exists('.minimized-comment:not(.d-none)', comment) ||
 	Boolean(comment.closest([
 		'.js-resolvable-thread-contents.d-none', // Regular comments
-		'details:not([open]).js-resolvable-timeline-thread-container' // Review comments
+		'details.js-resolvable-timeline-thread-container:not([open])' // Review comments
 	].join()));
 
 function runShortcuts(event: KeyboardEvent): void {


### PR DESCRIPTION
Fixes #3457

The not already resolved review comments aren't `<details>` elements, so the also don't have an `[open]` attribute.