### PR TITLE
Add `isRepoSearch` into `parse-backticks`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -96,7 +96,7 @@ async function init(): Promise<false | void> {
 	});
 
 	const link = (
-		<a className="btn btn-sm btn-outline ml-2 flex-self-center" href={String(url)}>
+		<a className="btn btn-sm btn-outline ml-2 flex-self-center rgh-latest-tag-button" href={String(url)}>
 			<TagIcon/>
 		</a>
 	);
@@ -138,7 +138,7 @@ async function init(): Promise<false | void> {
 		link.setAttribute('aria-label', 'Visit the latest release');
 	}
 
-	link.classList.add('tooltipped', 'tooltipped-ne', 'rgh-latest-tag-button');
+	link.classList.add('tooltipped', 'tooltipped-ne');
 }
 
 void features.add({

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -47,7 +47,6 @@ function init(): void {
 	// `isRepoSearch`
 	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
-			// Prepare
 			const child = element.firstElementChild!;
 			const keywords = [...child.querySelectorAll('em')].map(element => element.textContent);
 			// Combine text content to enable backticks parsing

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -5,6 +5,7 @@ import zipTextNodes from 'zip-text-nodes';
 
 import features from '.';
 import {parseBackticks} from '../github-helpers/dom-formatters';
+import parseBackticksCore from '../github-helpers/parse-backticks';
 
 function init(): void {
 	const selectors = [
@@ -46,15 +47,8 @@ function init(): void {
 	// `isRepoSearch`
 	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
-			const child = element.firstElementChild!;
-			const clone = element.cloneNode(true);
-			// Combine text content to enable backticks parsing
-			child.textContent = `${child.textContent!}`;
-
 			element.classList.add('rgh-backticks-already-parsed');
-			parseBackticks(element);
-
-			zipTextNodes(element, clone);
+			zipTextNodes(element, parseBackticksCore(element.textContent!););
 		}
 	});
 }

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -44,7 +44,7 @@ function init(): void {
 		}
 	});
 
-	// `isRepoSearch`
+	// `isRepoSearch` might highlight keywords inside backticks, breaking the regular dom-formatter #3509
 	observe('.codesearch-results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
 			element.classList.add('rgh-backticks-already-parsed');

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -44,6 +44,7 @@ function init(): void {
 		}
 	});
 
+	// `isRepoSearch`
 	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
 			// Prepare

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,11 +1,10 @@
 import './parse-backticks.css';
-import React from 'dom-chef';
 import onetime from 'onetime';
 import {observe} from 'selector-observer';
+import zipTextNodes from 'zip-text-nodes'
 
 import features from '.';
 import {parseBackticks} from '../github-helpers/dom-formatters';
-import getTextNodes from '../helpers/get-text-nodes';
 
 function init(): void {
 	const selectors = [
@@ -48,33 +47,14 @@ function init(): void {
 	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
 			const child = element.firstElementChild!;
-			const keywords = [...child.querySelectorAll('em')].map(element => element.textContent);
+			const clone = element.cloneNode(true);
 			// Combine text content to enable backticks parsing
 			child.textContent = `${child.textContent!}`;
 
-			// Parse backticks
 			element.classList.add('rgh-backticks-already-parsed');
 			parseBackticks(element);
 
-			// Rehighlight search keywords
-			for (const keyword of keywords) {
-				const splittingRegex = new RegExp(`(${keyword!})`);
-
-				for (const node of getTextNodes(child)) {
-					const fragment = new DocumentFragment();
-					for (const [index, text] of node.textContent!.split(splittingRegex).entries()) {
-						if (index % 2 && text.length >= 1) {
-							fragment.append(
-								<em>{text}</em>
-							);
-						} else if (text.length > 0) {
-							fragment.append(text);
-						}
-					}
-
-					node.replaceWith(fragment);
-				}
-			}
+			zipTextNodes(element, clone);
 		}
 	});
 }

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,7 +1,7 @@
 import './parse-backticks.css';
 import onetime from 'onetime';
 import {observe} from 'selector-observer';
-import zipTextNodes from 'zip-text-nodes'
+import zipTextNodes from 'zip-text-nodes';
 
 import features from '.';
 import {parseBackticks} from '../github-helpers/dom-formatters';

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -45,7 +45,7 @@ function init(): void {
 	});
 
 	// `isRepoSearch`
-	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
+	observe('.codesearch-results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
 			element.classList.add('rgh-backticks-already-parsed');
 			zipTextNodes(element, parseBackticksCore(element.textContent!));

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -48,7 +48,7 @@ function init(): void {
 	observe('#issue_search_results .f4:not(.rgh-backticks-already-parsed)', {
 		add(element) {
 			element.classList.add('rgh-backticks-already-parsed');
-			zipTextNodes(element, parseBackticksCore(element.textContent!););
+			zipTextNodes(element, parseBackticksCore(element.textContent!));
 		}
 	});
 }


### PR DESCRIPTION
This is tougher than I previously thought (*just add a selector is fine*) because existing functions won't handle elements inside, while the keyword should remain highlighted on the search page. I end up with:

- ~~Adding a workaround (`child.textContent = child.textContent`)~~
- ~~Rehighlight the search keywords~~

~~The code may not look pretty but it works, though only for **issues/PRs**. **Commits** has a deeper level of elements to couple with, which I may come up with an idea later.~~

Suggestions/testing welcome.

1. LINKED ISSUES:
   None

2. TEST URLS:
- Commit search: https://github.com/sindresorhus/refined-github/search?q=latest+button&type=Commits
- Issue search: https://github.com/sindresorhus/refined-github/search?q=latest+button+is%3Aissue&type=Issues
- PR search: https://github.com/sindresorhus/refined-github/search?q=latest+button+is%3Aissue+is%3Apr&type=Issues

3. SCREENSHOT:
Before:
![image](https://user-images.githubusercontent.com/44045911/91477810-7fe8e600-e8d1-11ea-857f-5a28643e549d.png)
After:
![image](https://user-images.githubusercontent.com/44045911/91477863-92631f80-e8d1-11ea-98d4-e489a9390576.png)
