### PR TITLE
Enable `warn-pr-from-master` on cross fork pr's

### DIFF
--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -4,15 +4,23 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import getDefaultBranch from '../github-helpers/get-default-branch';
+import {getRepositoryInfo} from '../github-helpers';
 
 async function init(): Promise<false | void> {
-	const defaultBranch = await getDefaultBranch();
+	let defaultBranch;
+	if (select.exists('.is-cross-repo')) {
+		const forkedRepository = getRepositoryInfo(select('[title^="head: "]')!.textContent!);
+		defaultBranch = await getDefaultBranch(forkedRepository);
+	} else {
+		defaultBranch = await getDefaultBranch();
+	}
+
 	// Expected: /user/repo/compare/master...user:master
 	if (!location.pathname.endsWith(':' + defaultBranch)) {
 		return false;
 	}
 
-	select('.gh-header-new-pr')!.append(
+	select('.js-compare-pr')!.before(
 		<div className="flash flash-error my-3">
 			<strong>Note:</strong> Creating a PR from the default branch is an <a href="https://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/" target="_blank" rel="noopener noreferrer">anti-pattern</a>.
 		</div>
@@ -26,6 +34,9 @@ void features.add({
 }, {
 	include: [
 		pageDetect.isCompare
+	],
+	exclude: [
+		() => select.exists('.blankslate')
 	],
 	init
 });


### PR DESCRIPTION
1. LINKED ISSUES:
   None but it fixes the feature too, the selector changed.

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/compare/incremental-tag-changelog-link...yakov116:upstream

3. SCREENSHOT:
	**There should be no visible changes**

   Before
![image](https://user-images.githubusercontent.com/16872793/91509357-fffa5600-e8a7-11ea-9029-94eae771ed1e.png)

	After

	![image](https://user-images.githubusercontent.com/16872793/91509423-2e783100-e8a8-11ea-9974-8913c5de560b.png)


@busches can you check if `.is-cross-repo` and `.js-compare-pr` exist on GHE?


