### PR TITLE
Prevent `linkify-urls` from running multiple times

### DIFF
--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -9,8 +9,8 @@ import {linkifiedURLClass, linkifyURLs, linkifyIssues} from '../github-helpers/d
 function init(): void {
 	const selectors = [
 		'.js-blob-wrapper',
-		':not(.js-suggested-changes-blob) > .blob-wrapper',
-		'.comment-body',
+		'.blob-wrapper',
+		'.comment-body.d-block',
 		'.blob-expanded'
 	].map(selector => selector + `:not(.${linkifiedURLClass})`).join();
 

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -9,7 +9,7 @@ import {linkifiedURLClass, linkifyURLs, linkifyIssues} from '../github-helpers/d
 function init(): void {
 	const selectors = [
 		'.js-blob-wrapper',
-		'.blob-wrapper',
+		':not(.js-suggested-changes-blob) > .blob-wrapper',
 		'.comment-body',
 		'.blob-expanded'
 	].map(selector => selector + `:not(.${linkifiedURLClass})`).join();


### PR DESCRIPTION
Both `.blob-wrapper` and `.comment-body` matches a code block in review comments, so the linkify functions got run for multiple times.

1. LINKED ISSUES:
   Fix #3226

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/pull/3225#discussion_r439535538

3. SCREENSHOT:
   Before: ![image](https://user-images.githubusercontent.com/1402241/84527576-71316080-acde-11ea-856e-db9f72915a36.png)
   After: 
![image](https://user-images.githubusercontent.com/44045911/91534177-af383b00-e943-11ea-9ee1-fa1a9a471ff1.png)
