### PR TITLE
Correctly hide more information in `dim-bots` 

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -7,11 +7,9 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 .rgh-dim-bot .commit-meta, /* Pre "Repository refresh" layout */
 .rgh-dim-bot .mb-1,
 .rgh-dim-bot .mb-1 + .d-flex,
-.rgh-dim-bot .signed-commit-badge, /* `Verified` badge */
+.rgh-dim-bot > .d-md-block,
 .rgh-dim-bot .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
 .rgh-dim-bot .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
-.rgh-dim-bot .BtnGroup, /* Hash and Copy hash buttons */
-.rgh-dim-bot .BtnGroup + .btn, /* Browse repository button */
 .rgh-dim-bot .Box-row--drag-hide, /* PR row */
 .rgh-dim-bot .labels, /* PR labels */
 .rgh-dim-bot .labels + .text-small /* PR meta */ {
@@ -34,11 +32,9 @@ ALL the following rules define the non-focused state
 
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-meta, /* Pre "Repository refresh" layout */
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .mb-1 + .d-flex,
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .signed-commit-badge, /* `Verified` badge */
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .BtnGroup, /* Hash and Copy hash buttons */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .BtnGroup + .btn /* Browse repository button */ {
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) > .d-md-block {
 	opacity: 0%;
 	margin-bottom: -1.6em;
 	transition-delay: 0s;

--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -6,7 +6,7 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 .rgh-dim-bot .commit-title, /* Pre "Repository refresh" layout */
 .rgh-dim-bot .commit-meta, /* Pre "Repository refresh" layout */
 .rgh-dim-bot .mb-1,
-.rgh-dim-bot .mb-1 + .d-flex,
+.rgh-dim-bot .mb-1 ~ .d-flex,
 .rgh-dim-bot > .d-md-block,
 .rgh-dim-bot .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
 .rgh-dim-bot .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
@@ -31,7 +31,7 @@ ALL the following rules define the non-focused state
 }
 
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-meta, /* Pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .mb-1 + .d-flex,
+.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .mb-1 ~ .d-flex,
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
 .rgh-dim-bot:not(.navigation-focus):not(.Details--on) > .d-md-block {


### PR DESCRIPTION
- The selectors added in #2864 are a mess now
- They didn't hide the comment link
- They didn't correctly hide the meta if there is commit message (added in #3389)

1. LINKED ISSUES:
   See above

2. TEST URLS:
   - https://github.com/kidonng/readhub/commits/master
   - https://github.com/bors-ng/bors-ng/commits/master

3. SCREENSHOT:
   Before: 
![image](https://user-images.githubusercontent.com/44045911/91545215-65575100-e953-11ea-9fd7-f92c80548d09.png)
![image](https://user-images.githubusercontent.com/44045911/91546621-54a7da80-e955-11ea-90e1-2ee0feadda12.png)

   After: 
![image](https://user-images.githubusercontent.com/44045911/91545310-7607c700-e953-11ea-8fd0-d6b1cda0740f.png)
  (Also note the height difference)
![image](https://user-images.githubusercontent.com/44045911/91546600-4ce83600-e955-11ea-9096-723d18f59e40.png)