### PR TITLE
Support `bot` label in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -13,7 +13,7 @@ export const botSelectors = [
 
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
-	'.labels [href$="bot"]'
+	'.labels [href$="/bot"]'
 ];
 
 function init(): void {

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -12,7 +12,8 @@ export const botSelectors = [
 	'.commit-author[href$="scala-steward"]:first-child',
 
 	/* Issues/PRs */
-	'.opened-by [href*="author%3Aapp%2F"]'
+	'.opened-by [href*="author%3Aapp%2F"]',
+	'.labels [href$="bot"]',
 ];
 
 function init(): void {

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -13,7 +13,7 @@ export const botSelectors = [
 
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
-	'.labels [href$="bot"]',
+	'.labels [href$="bot"]'
 ];
 
 function init(): void {


### PR DESCRIPTION
# Problem

There is a use case where a bot like `renovate` could be self-hosted using an author username does not match the `app/` pattern. 
Ex: our renovate PRs are created by a bot user matching `author:XXX-renovate`

Initially, I thought about supporting this use case by adding a specific selector for that use case: 

```
	/* Support self-hosted renovate contribution comming from a git user ending with *-renovate */
	'.commit-author[href$="-renovate"]:first-child',
	'.opened-by [href$="-renovate+sort%3Aupdated-desc"]'
```
The problem now is that this does not scale with how people might name their bot or if they use renovate locally with their credentials

# Solution

Bots like `renovate` usually allows us to add custom labels upon PR creation.

A user of `dim-bots` feature could benefit from the feature by setting up his self-hosted or local instance to add the `bot` label. 

# Tested 
Given the structure of the HTML, this works if there is any number of labels on a given PR

# Limitation
I don't have the `dim-bots` working for commits only for PRs with labels but I think it's good enough