### PR TITLE
Correctly dim `bot` label in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -13,7 +13,7 @@ export const botSelectors = [
 
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
-	'.labels [href$="/bot"]'
+	'.labels [href$="%3Abot"]'
 ];
 
 function init(): void {

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -13,7 +13,7 @@ export const botSelectors = [
 
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
-	'.labels [href$="%3Abot"]'
+	'.labels [href$="label%3Abot"]'
 ];
 
 function init(): void {


### PR DESCRIPTION
Fix: #3520 
@fregante I went a bit fast by approving the change you propose. 
This will work a lot better, since there is not `/` in the URL.