### PR TITLE
Lint

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -33,7 +33,7 @@ features.add({
 	include: [
 		pageDetect.isPR
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });
 ```
@@ -66,7 +66,7 @@ features.add({
 	},
 }, {
 	/** Whether to wait for DOM ready before runnin `init`. `false` makes `init` run right as soon as `body` is found. @default true */
-	waitForDomReady: false,
+	awaitDomReady: false,
 
 	/** Rarely needed: When pressing the back button, the DOM and listeners are still there, so normally `init` isn’t called again. If this is true, it’s called anyway. @default false */
 	repeatOnBackButton: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6320,9 +6320,9 @@
 			}
 		},
 		"github-url-detection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-2.1.0.tgz",
-			"integrity": "sha512-7vDtCqLmjamKtFI5526Ro51/GHstMC9PodNDW7Kri+AUtWpnzW9JqvnTGREJzBxzmEjYYdFSMSEKNPp/VLtMQA=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-2.2.0.tgz",
+			"integrity": "sha512-WcZMoNGs7eu4PK9hRZH57ajXhSrtKaoe4drAJ6R2AmqqAkRX5F/188pPFyl+AlIOG+DbmoS+vU43kxq/G6lUCw=="
 		},
 		"glob": {
 			"version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
 		"github-reserved-names": "^1.1.10",
-		"github-url-detection": "^2.1.0",
+		"github-url-detection": "^2.2.0",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.0.2",
 		"linkify-issues": "^2.0.0",

--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -12,7 +12,7 @@ void features.add({
 	description: 'Aligns labels in lists to the left.',
 	screenshot: 'https://user-images.githubusercontent.com/37769974/85866472-11aa7900-b7e5-11ea-80aa-d84e3aee2551.png'
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -53,7 +53,7 @@ void features.add({
 	description: 'Mark/unmark multiple files as “Viewed” in the PR Files tab. Click on the first checkbox you want to mark/unmark and then `shift`-click another one; all the files between the two checkboxes will be marked/unmarked as “Viewed”.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/79343285-854f2080-7f2e-11ea-8d4c-a9dc163be9be.gif'
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	include: [
 		pageDetect.isPRFiles
 	],

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -111,6 +111,6 @@ void features.add({
 	include: [
 		pageDetect.isConversationList
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -111,6 +111,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -39,7 +39,7 @@ void features.add({
 		pageDetect.isRepo
 	],
 	exclude: [
-		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
+		pageDetect.isEmptyRepo
 	],
 	awaitDomReady: false,
 	init

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -38,6 +38,9 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
+	exclude: [
+		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
+	],
 	waitForDomReady: false,
 	init
 });

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -41,6 +41,6 @@ void features.add({
 	exclude: [
 		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -83,6 +83,6 @@ void features.add({
 	include: [
 		pageDetect.isRepoConversationList
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -60,12 +60,12 @@ void features.add({
 	include: [
 		pageDetect.isIssue
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(initIssue)
 }, {
 	include: [
 		pageDetect.isPR
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(initPR)
 });

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -28,6 +28,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(hideButtons)
 });

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -44,7 +44,7 @@ void features.add({
 		pageDetect.isSingleFile
 	],
 	exclude: [
-		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
+		pageDetect.isEmptyRepo
 	],
 	init
 });

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -43,5 +43,8 @@ void features.add({
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile
 	],
+	exclude: [
+		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
+	],
 	init
 });

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -33,6 +33,6 @@ void features.add({
 		onPrMergePanelOpen
 	],
 	onlyAdditionalListeners: true,
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -28,6 +28,6 @@ void features.add({
 	description: 'Automatically closes dropdown menus when they’re no longer visible.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif'
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -75,6 +75,6 @@ void features.add({
 	include: [
 		pageDetect.hasRichTextEditor
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -151,6 +151,6 @@ void features.add({
 	exclude: [
 		() => !new URLSearchParams(location.search).has('rgh-link-date')
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: showTimemachineBar
 });

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -28,7 +28,7 @@ void features.add({
 	include: [
 		pageDetect.isSingleFile
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	repeatOnBackButton: true,
 	init,
 	deinit

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -66,6 +66,6 @@ void features.add({
 	exclude: [
 		pageDetect.isRepoHome
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -30,6 +30,6 @@ void features.add({
 	exclude: [
 		pageDetect.isGist
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -57,6 +57,6 @@ void features.add({
 	include: [
 		pageDetect.isRepoTree
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -31,6 +31,6 @@ void features.add({
 	include: [
 		pageDetect.hasCode
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -69,6 +69,6 @@ void features.add({
 	include: [
 		pageDetect.isConversationList
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -53,12 +53,12 @@ void features.add({
 	additionalListeners: [
 		() => void onReplacedElement('#partial-discussion-sidebar', addSidebarReviewButton)
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: addSidebarReviewButton
 }, {
 	include: [
 		pageDetect.isPRFiles
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: initReviewButtonEnhancements
 });

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -56,6 +56,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -123,6 +123,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -17,6 +17,6 @@ void features.add({
 	description: 'Removes the file hover effect in the repo file browser. Some lists like notifications, file lists, and issue lists, are highlighted as you move the mouse over them. This highlight is useful when navigating via the keyboard (j/k), but annoying when just moving the mouse around.',
 	screenshot: false
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -16,6 +16,6 @@ void features.add({
 	include: [
 		pageDetect.isDashboard
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -16,6 +16,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -1,6 +1,7 @@
 import './highlight-collaborators-and-own-conversations.css';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
+import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -22,15 +23,10 @@ const getCollaborators = cache.function(async (): Promise<string[]> => {
 	cacheKey: () => 'repo-collaborators:' + getRepoURL()
 });
 
-async function highlightCollaborators(): Promise<false | void> {
-	const authors = select.all('.js-issue-row [data-hovercard-type="user"]');
-	if (authors.length === 0) {
-		return false;
-	}
-
+async function highlightCollaborators(): Promise<void> {
 	const collaborators = await getCollaborators();
-
-	for (const author of authors) {
+	await domLoaded;
+	for (const author of select.all('.js-issue-row [data-hovercard-type="user"]')) {
 		if (collaborators.includes(author.textContent!.trim())) {
 			author.classList.add('rgh-collaborator');
 		}
@@ -53,6 +49,10 @@ void features.add({
 	include: [
 		pageDetect.isRepoConversationList
 	],
+	exclude: [
+		() => select.exists('.blankslate')
+	],
+	awaitDomReady: false,
 	init: highlightCollaborators
 }, {
 	include: [

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -1,7 +1,6 @@
 import './highlight-collaborators-and-own-conversations.css';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import domLoaded from 'dom-loaded';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -23,10 +22,15 @@ const getCollaborators = cache.function(async (): Promise<string[]> => {
 	cacheKey: () => 'repo-collaborators:' + getRepoURL()
 });
 
-async function highlightCollaborators(): Promise<void> {
+async function highlightCollaborators(): Promise<false | void> {
+	const authors = select.all('.js-issue-row [data-hovercard-type="user"]');
+	if (authors.length === 0) {
+		return false;
+	}
+
 	const collaborators = await getCollaborators();
-	await domLoaded;
-	for (const author of select.all('.js-issue-row [data-hovercard-type="user"]')) {
+
+	for (const author of authors) {
 		if (collaborators.includes(author.textContent!.trim())) {
 			author.classList.add('rgh-collaborator');
 		}
@@ -49,10 +53,6 @@ void features.add({
 	include: [
 		pageDetect.isRepoConversationList
 	],
-	exclude: [
-		() => select.exists('.blankslate')
-	],
-	awaitDomReady: false,
 	init: highlightCollaborators
 }, {
 	include: [

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -69,5 +69,5 @@ void features.add({
 	],
 	init,
 	deinit: () => observer.abort(),
-	waitForDomReady: false
+	awaitDomReady: false
 });

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -66,6 +66,6 @@ void features.add({
 	description: 'Show Refined GitHub’s keyboard shortcuts in the help modal (`?` hotkey)',
 	screenshot: 'https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png'
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -28,7 +28,7 @@ interface FeatureMeta {
 
 interface FeatureLoader extends Partial<InternalRunConfig> {
 	/** Whether to wait for DOM ready before runnin `init`. `false` makes `init` run right as soon as `body` is found. @default true */
-	waitForDomReady?: false;
+	awaitDomReady?: false;
 
 	/** When pressing the back button, the DOM and listeners are still there, so normally `init` isn’t called again. If this is true, it’s called anyway.  @default false */
 	repeatOnBackButton?: true;
@@ -203,7 +203,7 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 			exclude = [], // Default: nothing
 			init,
 			deinit,
-			waitForDomReady = true,
+			awaitDomReady = true,
 			repeatOnBackButton = false,
 			onlyAdditionalListeners = false,
 			additionalListeners = []
@@ -217,7 +217,7 @@ const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<voi
 		enforceDefaults(id, include, additionalListeners);
 
 		const details = {include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners};
-		if (waitForDomReady) {
+		if (awaitDomReady) {
 			(async () => {
 				await domLoaded;
 				await setupPageLoad(id, details);

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -173,7 +173,9 @@ const checkForHotfixes = cache.function(async () => {
 
 	return hotfixes;
 }, {
-	maxAge: {hours: 6},
+	maxAge: {
+		hours: 6
+	},
 	cacheKey: () => 'hotfix'
 });
 

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -150,6 +150,6 @@ void features.add({
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/monospace-textareas.tsx
+++ b/source/features/monospace-textareas.tsx
@@ -12,6 +12,6 @@ void features.add({
 	description: 'Use a monospace font for all textareas.',
 	screenshot: false
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -116,6 +116,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -65,6 +65,6 @@ void features.add({
 	include: [
 		() => Boolean(sessionStorage.rghNewRepo)
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: disableWikiAndProjects
 });

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -42,6 +42,6 @@ void features.add({
 	include: [
 		pageDetect.hasCode
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -51,6 +51,6 @@ void features.add({
 	include: [
 		pageDetect.isPRCommit
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -127,6 +127,6 @@ void features.add({
 	include: [
 		pageDetect.isPRList
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -56,6 +56,6 @@ void features.add({
 	include: [
 		pageDetect.isUserProfile
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -151,6 +151,6 @@ void features.add({
 	include: [
 		pageDetect.isRepo
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/remove-diff-signs.tsx
+++ b/source/features/remove-diff-signs.tsx
@@ -15,6 +15,6 @@ void features.add({
 	include: [
 		pageDetect.hasCode
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -76,13 +76,13 @@ void features.add({
 		pageDetect.canUserEditRepo,
 		pageDetect.canUserEditOrganization
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: removeProjectsTab
 }, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isOrganizationProfile
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(addNewProjectLink)
 });

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -123,7 +123,7 @@ void features.add({
 		pageDetect.isRepoRoot
 	],
 	exclude: [
-		pageDetect.isEmptyRepoRoot
+		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
 	],
 	waitForDomReady: false,
 	init

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -123,9 +123,9 @@ void features.add({
 		pageDetect.isRepoRoot
 	],
 	exclude: [
-		// Excludes empty repos, compatible with `waitForDomReady: false`
+		// Excludes empty repos, compatible with `awaitDomReady: false`
 		() => !select.exists('link[rel="canonical"]')
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -123,8 +123,7 @@ void features.add({
 		pageDetect.isRepoRoot
 	],
 	exclude: [
-		// Excludes empty repos, compatible with `awaitDomReady: false`
-		() => !select.exists('link[rel="canonical"]')
+		pageDetect.isEmptyRepoRoot
 	],
 	awaitDomReady: false,
 	init

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -123,7 +123,7 @@ void features.add({
 		pageDetect.isRepoRoot
 	],
 	exclude: [
-		() => select.exists('[aria-label="Cannot fork because repository is empty."]')
+		() => !select.exists('link[rel="canonical"]')
 	],
 	waitForDomReady: false,
 	init

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -123,6 +123,7 @@ void features.add({
 		pageDetect.isRepoRoot
 	],
 	exclude: [
+		// Excludes empty repos, compatible with `waitForDomReady: false`
 		() => !select.exists('link[rel="canonical"]')
 	],
 	waitForDomReady: false,

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -28,6 +28,6 @@ void features.add({
 		'shift o': 'Open selection in new tab'
 	}
 }, {
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -115,5 +115,6 @@ void features.add({
 	exclude: [
 		() => !pageDetect.isForkedRepo()
 	],
+	waitForDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -115,6 +115,6 @@ void features.add({
 	exclude: [
 		() => !pageDetect.isForkedRepo()
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -104,7 +104,7 @@ void features.add({
 	exclude: [
 		() => !pageDetect.isForkedRepo()
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: initHeadHint
 }, {
 	include: [
@@ -113,6 +113,6 @@ void features.add({
 	exclude: [
 		() => !pageDetect.isForkedRepo()
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: initDeleteHint
 });

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -40,6 +40,6 @@ void features.add({
 	include: [
 		pageDetect.isGlobalConversationList
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(cleanBar)
 });

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -28,6 +28,6 @@ void features.add({
 	include: [
 		hasNotificationBar
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -17,6 +17,6 @@ void features.add({
 	include: [
 		pageDetect.hasRichTextEditor
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -27,6 +27,6 @@ void features.add({
 	exclude: [
 		pageDetect.isGist
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/unwrap-useless-dropdowns.tsx
+++ b/source/features/unwrap-useless-dropdowns.tsx
@@ -66,12 +66,12 @@ void features.add({
 	include: [
 		pageDetect.isNotifications
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: unwrapNotifications
 }, {
 	include: [
 		pageDetect.isActionJobRun
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: unwrapActionJobRun
 });

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -36,6 +36,6 @@ void features.add({
 	include: [
 		pageDetect.isCompare
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -141,6 +141,6 @@ void features.add({
 	include: [
 		pageDetect.isPRCommit404
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init: onetime(initPRCommit)
 });

--- a/source/github-helpers/dom-formatters.ts
+++ b/source/github-helpers/dom-formatters.ts
@@ -3,8 +3,8 @@ import linkifyURLsCore from 'linkify-urls';
 import linkifyIssuesCore from 'linkify-issues';
 
 import getTextNodes from '../helpers/get-text-nodes';
-import {getRepositoryInfo} from '.';
 import parseBackticksCore from './parse-backticks';
+import {getRepositoryInfo} from '.';
 
 // Shared class necessary to avoid also shortening the links
 export const linkifiedURLClass = 'rgh-linkified-code';

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -1,8 +1,8 @@
 import select from 'select-dom';
 import onetime from 'onetime';
+import elementReady from 'element-ready';
 import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection/esm/index.js'; // eslint-disable-line import/extensions -- Required for Node tests compatibility
-import elementReady from 'element-ready';
 
 // This never changes, so it can be cached here
 export const getUsername = onetime(pageDetect.utils.getUsername);

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -124,8 +124,8 @@ function addEventListeners(): void {
 	});
 
 	// Refresh page when permissions are changed (because the dropdown selector needs to be regenerated)
-	browser.permissions.onRemoved!.addListener(() => location.reload());
-	browser.permissions.onAdded!.addListener(() => location.reload());
+	browser.permissions.onRemoved.addListener(() => location.reload());
+	browser.permissions.onAdded.addListener(() => location.reload());
 
 	// Improve textareas editing
 	fitTextarea.watch('textarea');


### PR DESCRIPTION
- Faster `show-associated-branch-prs-on-fork`, Request before dom ready
- Sort From
- **`isEmptyRepoRoot` does not work**
- Lint


@fregante 
> https://github.com/fregante/github-url-detection/commit/0c36c4c08636174cc039b077680ff90acb3b5d37

I followed https://github.com/sindresorhus/refined-github/pull/3505/files/92330f5ca0627ce23adb5ef216c7007008e844dc#diff-7988466746fb3fcac77295b4dd4038d1 (npm deprecate *) but that gave me an error. (I can provide a stack trace if needed 😉 )

'.blankState' does not exist on repo root. 

Direction needed.