### PR TITLE
Move Security and Insights tabs to `more-dropdown`

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -42,6 +42,13 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 	);
 }
 
+function onlyShowInDropdown(id: string): void {
+	select(`[data-tab-item="${id}"]`)!.parentElement!.remove();
+	const menuItem = select(`[data-menu-item="${id}"]`)!;
+	menuItem.hidden = false;
+	select('.js-responsive-underlinenav-overflow ul')!.append(menuItem);
+}
+
 async function init(): Promise<void> {
 	// Wait for the tab bar to be loaded
 	await elementReady([
@@ -65,6 +72,9 @@ async function init(): Promise<void> {
 			createDropdownItem('Commits', commitsUrl),
 			createDropdownItem('Branches', `/${repoUrl}/branches`)
 		);
+
+		onlyShowInDropdown('security-tab');
+		onlyShowInDropdown('insights-tab');
 		return;
 	}
 

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -45,7 +45,10 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 function onlyShowInDropdown(id: string): void {
 	select(`[data-tab-item="${id}"]`)!.parentElement!.remove();
 	const menuItem = select(`[data-menu-item="${id}"]`)!;
+	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;
+
+	// The item has to be moved somewhere else because the overflow nav is order-dependent
 	select('.js-responsive-underlinenav-overflow ul')!.append(menuItem);
 }
 

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -104,7 +104,7 @@ async function init(): Promise<false | void> {
 			releasesTab.setAttribute('aria-current', 'page');
 		}
 
-		select('[data-menu-item="insights-tab"]', repoNavigationBar)!.after(
+		select('.dropdown-divider', repoNavigationBar)!.before(
 			createDropdownItem('Releases', `/${repoUrl}/releases`, {
 				'data-menu-item': 'rgh-releases-item'
 			})


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/3354 (this issue wasn't a "good first issue" after all 😅)
Replaces and closes https://github.com/sindresorhus/refined-github/pull/3482

This seems to work, but https://github.com/sindresorhus/refined-github/issues/3347 still exists, complicating things a bit.

![](https://user-images.githubusercontent.com/1402241/93028729-a3b86580-f60d-11ea-81aa-6b33a67febae.gif)
