### PR TITLE
Enable `highlight-deleted-and-added-files-in-diffs` on Compare pages

### DIFF
--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -18,11 +18,17 @@ async function loadDeferred(jumpList: Element): Promise<void> {
 	clearInterval(retrier);
 }
 
-async function init(): Promise<void> {
+async function init(): Promise<void | false> {
 	const fileList = await elementReady([
 		'.toc-select details-menu', // `isPR`
-		'.toc-diff-stats + .content' // `isSingleCommit`
+		'.toc-diff-stats + .content' // `isSingleCommit` and `isCompare`
 	].join());
+
+	// The file list does not exist if the diff is too large
+	if (pageDetect.isCompare() && !fileList) {
+		return false;
+	}
+
 	if (pageDetect.isPR()) {
 		await loadDeferred(fileList!);
 	}
@@ -61,7 +67,8 @@ void features.add({
 }, {
 	include: [
 		pageDetect.isPRFiles,
-		pageDetect.isCommit
+		pageDetect.isCommit,
+		pageDetect.isCompare
 	],
 	exclude: [
 		pageDetect.isPRFile404,


### PR DESCRIPTION
1. LINKED ISSUES:
   https://github.com/sindresorhus/refined-github/pull/3439

2. TEST URLS:
[20.9.11...master](https://github.com/sindresorhus/refined-github/compare/20.9.11...master#diff-67ba01fa3e792891b585fa43e92c78ea) (Showing the change)
   https://github.com/sindresorhus/refined-github/compare/incremental-tag-changelog-link...20.9.11 (Too large)
	https://github.com/sindresorhus/refined-github/compare/master...20.9.11 (Nothing to compare)

3. SCREENSHOT:
   None
