### PR TITLE
Meta: silence XO warnings

### DIFF
--- a/.xo-config.js
+++ b/.xo-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	quiet: true,
 	envs: [
 		'browser'
 	],


### PR DESCRIPTION
I found lint warnings to be more a nuisance than anything else, mixing with real warnings and making them harder to tell them apart.

Warnings are useful if you're actively looking for something to do; in that case, use:

```
❯ xo --no-quiet

  source/features/submit-review-as-single-comment.tsx:50:2
  ⚠   50:2  Unexpected todo comment.                                                             no-warning-comments

  source/features/repo-age.tsx:84:2
  ⚠   84:2  Unexpected todo comment.                                                             no-warning-comments

  source/features/remove-label-faster.tsx:37:1
  ⚠   37:1  Unexpected todo comment.                                                             no-warning-comments

  source/features/highest-rated-comment.tsx:88:3
  ⚠   88:3  Unexpected todo comment.                                                             no-warning-comments

  source/helpers/post-form.ts:9:3
  ⚠    9:3  Unexpected todo comment.                                                             no-warning-comments

  source/github-helpers/search-query.ts:58:2
  ⚠   58:2  Unexpected todo comment.                                                             no-warning-comments

  source/github-helpers/index.ts:102:8
  ⚠  102:8  Function preventPrCommitLinkLoss has too many parameters (5). Maximum allowed is 4.  max-params

  7 warnings
```