### PR TITLE
Hide redundant 'Releases' section from repo sidebar

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -112,7 +112,8 @@ async function init(): Promise<false | void> {
 
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {
-			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.setAttribute('hidden', '');
+			const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]');
+			sidebarReleases!.closest('.BorderGrid-row')!.hidden = true;
 		}
 
 		return;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -112,7 +112,7 @@ async function init(): Promise<false | void> {
 
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {
-			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.removeAttribute('hidden');
+			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.setAttribute('hidden', '');
 		}
 
 		return;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -113,7 +113,7 @@ async function init(): Promise<false | void> {
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {
 			const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]');
-			sidebarReleases!.closest('.BorderGrid-row')!.hidden = true;
+			sidebarReleases!.closest('.BorderGrid-row')!.setAttribute('hidden', '');
 		}
 
 		return;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -112,7 +112,7 @@ async function init(): Promise<false | void> {
 
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {
-			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.setAttribute('hidden', '');
+			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.removeAttribute('hidden');
 		}
 
 		return;

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -110,6 +110,11 @@ async function init(): Promise<false | void> {
 			})
 		);
 
+		// Hide redundant 'Releases' section from repo sidebar
+		if (pageDetect.isRepoRoot()) {
+			select('.BorderGrid-cell a[href$="/releases"]')?.closest('.BorderGrid-row')!.setAttribute('hidden', '');
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
The 'Releases' section in the 'Refreshed Repository' design sidebar is redundant when there is already the releases-tab.

This change removes the 'Releases' section from the sidebar.

I'm not sure whether this has been discussed before ( I did dig through some old issues, but could not find any ), but there is one direct link to the latest release that goes away with the section.

I usually find myself either navigating directly to `/releases/latest` or simply going to the main Releases page and referring to the latest release. I do not know if people use the latest release link as often. But the remaining information is already on the releases-tab.

1. LINKED ISSUES:
   None

2. TEST URLS:
   Any repository root page
	* https://github.com/sindresorhus/refined-github
	* https://github.com/xojs/xo
	* https://github.com/avajs/ava

3. SCREENSHOT:

	Before : 
	![Screenshot_2020-09-17 sindresorhus refined-github](https://user-images.githubusercontent.com/4771718/93393997-19803380-f891-11ea-9c23-041f635883f9.png)

	After : 
	![Screenshot_2020-09-17 sindresorhus refined-github (1)](https://user-images.githubusercontent.com/4771718/93394018-22710500-f891-11ea-8eb4-35291154ff53.png)
