### PR TITLE
Restore `hide-zero-packages`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,7 +122,7 @@ Thanks for contributing! 🦋🙌
 - [](# "star-repo-hotkey") Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
 - [](# "default-branch-button") 🔥 [Adds link the default branch on directory listings and files.](https://user-images.githubusercontent.com/1402241/71886648-2891dc00-316f-11ea-98d8-c5bf6c24d85c.png)
 - [](# "swap-branches-on-compare") [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
-- [](# "hide-zero-packages") [Hides the `Packages` tab in repositories if it’s empty.](https://user-images.githubusercontent.com/44045911/93541991-80354800-f98a-11ea-8347-a571abbbd318.png)
+- [](# "hide-zero-packages") [Hides the `Packages` tab in repositories if it’s empty.](https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png)
 - [](# "forked-to") [Adds a shortcut to your forks next to the `Fork` button on the current repo.](https://user-images.githubusercontent.com/55841/64077281-17bbf000-cccf-11e9-9123-092063f65357.png)
 - [](# "repo-age") [Adds the age of the repository to the statistics bar.](https://user-images.githubusercontent.com/3848317/69494069-7d2b1180-0eb7-11ea-9aa1-d4194e566340.png)
 - [](# "show-open-prs-of-forks") [In your forked repos, shows number of your open PRs to the original repo.](https://user-images.githubusercontent.com/1922624/76398271-e0648500-637c-11ea-8210-53dda1be9d51.png)

--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,7 @@ Thanks for contributing! 🦋🙌
 - [](# "star-repo-hotkey") Adds a keyboard shortcut to star/unstar the current repo: <kbd>g</kbd> <kbd>s</kbd>.
 - [](# "default-branch-button") 🔥 [Adds link the default branch on directory listings and files.](https://user-images.githubusercontent.com/1402241/71886648-2891dc00-316f-11ea-98d8-c5bf6c24d85c.png)
 - [](# "swap-branches-on-compare") [Adds link to swap branches in the branch compare view.](https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png)
+- [](# "hide-zero-packages") [Hides the `Packages` tab in repositories if it’s empty.](https://user-images.githubusercontent.com/44045911/93541991-80354800-f98a-11ea-8347-a571abbbd318.png)
 - [](# "forked-to") [Adds a shortcut to your forks next to the `Fork` button on the current repo.](https://user-images.githubusercontent.com/55841/64077281-17bbf000-cccf-11e9-9123-092063f65357.png)
 - [](# "repo-age") [Adds the age of the repository to the statistics bar.](https://user-images.githubusercontent.com/3848317/69494069-7d2b1180-0eb7-11ea-9aa1-d4194e566340.png)
 - [](# "show-open-prs-of-forks") [In your forked repos, shows number of your open PRs to the original repo.](https://user-images.githubusercontent.com/1922624/76398271-e0648500-637c-11ea-8210-53dda1be9d51.png)
@@ -384,7 +385,6 @@ GitHub implemented dozens of features that used to be part of Refined GitHub �
 - [Blog post](https://github.blog/changelog/2019-12-19-improved-attribution-when-squashing-commits/): [Adds `co-authored-by` to the commit when merging PRs with multiple committers.](https://user-images.githubusercontent.com/1402241/51468821-71a42100-1da2-11e9-86aa-fc2a6a29da84.png)
 - [Blog post](https://github.com/sindresorhus/refined-github/pull/3015): [Makes it easier to tell apart commits added to the current PR versus plain commits that reference the PR.](https://user-images.githubusercontent.com/1402241/64478939-398b0a80-d1da-11e9-8c6a-bb98668cb78c.gif)
 - [Blog post](https://github.blog/changelog/2020-06-23-design-updates-to-repositories-and-github-ui/): [Widens the discussion search box.](https://user-images.githubusercontent.com/1402241/55069759-bceaf080-50bf-11e9-84d0-7707de2eb9e9.png)
-- [Blog post](https://github.blog/changelog/2020-06-23-design-updates-to-repositories-and-github-ui/): [Hides the `Packages` tab in repositories and user profiles if it’s empty.](https://user-images.githubusercontent.com/35382021/62426530-688ef780-b6d5-11e9-93f2-515110aed1eb.jpg)
 
 </details>
 

--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -26,6 +26,6 @@ void features.add({
 		pageDetect.isRepoRoot,
 		pageDetect.isUserProfile
 	],
-	waitForDomReady: false,
+	awaitDomReady: false,
 	init
 });

--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -20,7 +20,7 @@ async function init(): Promise<void | false> {
 void features.add({
 	id: __filebasename,
 	description: 'Hides the `Packages` tab if it’s empty (in repositories and user profiles).',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/93541991-80354800-f98a-11ea-8347-a571abbbd318.png'
+	screenshot: 'https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png'
 }, {
 	include: [
 		pageDetect.isRepoRoot,

--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -1,0 +1,31 @@
+import elementReady from 'element-ready';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import getTabCount from './remove-projects-tab';
+
+async function init(): Promise<void | false> {
+	const packagesTab = await elementReady([
+		'.BorderGrid-cell a[href$="/packages"]', // `isRepoRoot`
+		'.UnderlineNav-item[href$="?tab=packages"]:not(.selected)' // `isUserProfile`
+	].join());
+
+	if (!packagesTab || await getTabCount(packagesTab) > 0) {
+		return false;
+	}
+
+	packagesTab.closest('.BorderGrid-row, .UnderlineNav-item')!.remove();
+}
+
+void features.add({
+	id: __filebasename,
+	description: 'Hides the `Packages` tab if it’s empty (in repositories and user profiles).',
+	screenshot: 'https://user-images.githubusercontent.com/44045911/93541991-80354800-f98a-11ea-8347-a571abbbd318.png'
+}, {
+	include: [
+		pageDetect.isRepoRoot,
+		pageDetect.isUserProfile
+	],
+	waitForDomReady: false,
+	init
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -141,6 +141,7 @@ import './features/list-prs-for-file';
 import './features/pr-branch-auto-delete';
 import './features/linkify-symbolic-links'; // Must be before show-whitespace
 import './features/show-whitespace';
+import './features/hide-zero-packages';
 import './features/restore-file';
 import './features/hidden-review-comments-indicator';
 import './features/reload-failed-proxied-images';


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:
   Close #3572

   > [Just to mention that if we want to hide “Packages” tab on organization, we need to query the API.](https://github.com/sindresorhus/refined-github/pull/3297#issuecomment-650671415)

2. TEST URLS:
   https://github.com/sindresorhus/refined-github (no packages)
   https://github.com/yarnpkg/berry (with packages)
   https://github.com/sindresorhus (no packages)
   https://github.com/kidonng (with packages)

3. SCREENSHOT:
   ![](https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png)
