### PR TITLE
Persist `toggle-files-button` state

### DIFF
--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -12,9 +12,9 @@ import UnfoldIcon from 'octicon/unfold.svg';
 import features from '.';
 import observeElement from '../helpers/simplified-element-observer';
 
-function addButton(): void {
-	console.log('will add');
+const cacheKey = 'files-hidden';
 
+function addButton(): void {
 	// `div` excludes `include-fragment`, which means the list is still loading. #2160
 	const filesHeader = select([
 		'div.commit-tease',
@@ -36,19 +36,21 @@ function addButton(): void {
 	);
 }
 
+async function toggleHandler(): Promise<void> {
+	const isHidden = select('.repository-content')!.classList.toggle('rgh-files-hidden');
+	if (isHidden) {
+		await cache.set(cacheKey, true);
+	} else {
+		await cache.delete(cacheKey);
+	}
+}
+
 async function init(): Promise<void> {
-	const cacheKey = 'hide-file-list';
 	const repoContent = (await elementReady('.repository-content'))!;
 	observeElement(repoContent, addButton);
+	delegate(document, '.rgh-toggle-files', 'click', toggleHandler);
 
-	delegate(document, '.rgh-toggle-files', 'click', async () => {
-		console.log('will toggle');
-		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
-	});
-
-	console.log('check closed');
 	if (await cache.get<boolean>(cacheKey)) {
-		console.log('was closed');
 		repoContent.classList.add('rgh-files-hidden');
 	}
 }

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -42,8 +42,9 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-toggle-files', 'click', async () => {
 		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
 	});
+
 	if (await cache.get<boolean>(cacheKey)) {
-		select('.rgh-toggle-files')!.click();
+		repoContent.classList.toggle('rgh-files-hidden');
 	}
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -40,16 +40,14 @@ async function init(): Promise<void> {
 	observeElement(repoContent, addButton);
 
 	const cacheKey = 'files-list-toggled-off';
-	if (await cache.get<boolean>(cacheKey)) {
-		repoContent.classList.toggle('rgh-files-hidden', true);
-		select('.rgh-toggle-files')!.setAttribute('aria-expanded', 'false');
-	}
-
 	delegate(document, '.rgh-toggle-files', 'click', async ({delegateTarget}) => {
 		const toggleState = repoContent.classList.toggle('rgh-files-hidden');
 		delegateTarget.setAttribute('aria-expanded', String(!toggleState));
 		await cache.set(cacheKey, toggleState);
 	});
+	if (await cache.get<boolean>(cacheKey)) {
+		select('.rgh-toggle-files')!.click();
+	}
 }
 
 void features.add({

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -60,5 +60,6 @@ void features.add({
 	include: [
 		pageDetect.isRepoTree
 	],
+	awaitDomReady: false,
 	init
 });

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -40,12 +40,11 @@ async function init(): Promise<void> {
 	observeElement(repoContent, addButton);
 
 	delegate(document, '.rgh-toggle-files', 'click', async () => {
-		// Persist a closed list or remove from cache
-		await cache.set(cacheKey, (repoContent.classList.toggle('rgh-files-hidden') || undefined)!);
+		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
 	});
 
 	if (await cache.get<boolean>(cacheKey)) {
-		repoContent.classList.toggle('rgh-files-hidden');
+		select('.rgh-toggle-files')!.click();
 	}
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -58,5 +58,6 @@ void features.add({
 		pageDetect.isRepoTree
 	],
 	awaitDomReady: false,
+	repeatOnBackButton: true,
 	init
 });

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -35,12 +35,13 @@ function addButton(): void {
 }
 
 async function init(): Promise<void> {
-	const cacheKey = 'files-list-toggled-off';
+	const cacheKey = 'hide-file-list';
 	const repoContent = (await elementReady('.repository-content'))!;
 	observeElement(repoContent, addButton);
 
 	delegate(document, '.rgh-toggle-files', 'click', async () => {
-		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
+		// Persist a closed list or remove from cache
+		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden') || undefined);
 	});
 
 	if (await cache.get<boolean>(cacheKey)) {

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -13,6 +13,8 @@ import features from '.';
 import observeElement from '../helpers/simplified-element-observer';
 
 function addButton(): void {
+	console.log('will add');
+
 	// `div` excludes `include-fragment`, which means the list is still loading. #2160
 	const filesHeader = select([
 		'div.commit-tease',
@@ -40,11 +42,14 @@ async function init(): Promise<void> {
 	observeElement(repoContent, addButton);
 
 	delegate(document, '.rgh-toggle-files', 'click', async () => {
+		console.log('will toggle');
 		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
 	});
 
+	console.log('check closed');
 	if (await cache.get<boolean>(cacheKey)) {
-		select('.rgh-toggle-files')!.click();
+		console.log('was closed');
+		repoContent.classList.add('rgh-files-hidden');
 	}
 }
 

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -41,7 +41,7 @@ async function init(): Promise<void> {
 
 	delegate(document, '.rgh-toggle-files', 'click', async () => {
 		// Persist a closed list or remove from cache
-		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden') || undefined);
+		await cache.set(cacheKey, (repoContent.classList.toggle('rgh-files-hidden') || undefined)!);
 	});
 
 	if (await cache.get<boolean>(cacheKey)) {

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -27,7 +27,6 @@ function addButton(): void {
 			type="button"
 			className="btn-octicon rgh-toggle-files"
 			aria-label="Toggle files section"
-			aria-expanded="true"
 		>
 			<FoldIcon/>
 			<UnfoldIcon/>
@@ -36,14 +35,12 @@ function addButton(): void {
 }
 
 async function init(): Promise<void> {
+	const cacheKey = 'files-list-toggled-off';
 	const repoContent = (await elementReady('.repository-content'))!;
 	observeElement(repoContent, addButton);
 
-	const cacheKey = 'files-list-toggled-off';
-	delegate(document, '.rgh-toggle-files', 'click', async ({delegateTarget}) => {
-		const toggleState = repoContent.classList.toggle('rgh-files-hidden');
-		delegateTarget.setAttribute('aria-expanded', String(!toggleState));
-		await cache.set(cacheKey, toggleState);
+	delegate(document, '.rgh-toggle-files', 'click', async () => {
+		await cache.set(cacheKey, repoContent.classList.toggle('rgh-files-hidden'));
 	});
 	if (await cache.get<boolean>(cacheKey)) {
 		select('.rgh-toggle-files')!.click();


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3588 

2. TEST URLS: https://github.com/sindresorhus/refined-github

3. SCREENSHOT:
![Peek 2020-09-22 20-00](https://user-images.githubusercontent.com/46634000/93921004-42307f00-fd10-11ea-9b80-278070e87838.gif)

As you can see in the GIF above, I couldn't totally get rid of the content flash. I don't find it too distracting though, so I could live with it. But it's probably possible to do better, given that "Hide Files on GitHub" modifies the file list on load without any noticeable jitters.