### PR TITLE
Add feature that toggles square user avatars

### DIFF
--- a/source/features/avatar-user-squared.css
+++ b/source/features/avatar-user-squared.css
@@ -1,0 +1,17 @@
+.avatar-user {
+  border-radius: inherit !important;
+}
+
+img.avatar-user, img.d-block {
+  border-radius: 4px !important;
+}
+
+.user-status-circle-badge-container {
+  left: 1px;
+  margin-left: 0;
+  margin-bottom: 0;
+}
+
+.user-status-circle-badge {
+  border-radius: 4px;
+}

--- a/source/features/avatar-user-squared.tsx
+++ b/source/features/avatar-user-squared.tsx
@@ -1,0 +1,24 @@
+import * as pageDetect from 'github-url-detection';
+import features from '.';
+
+function init(): void {
+  document.querySelectorAll('.avatar-user').forEach(el => el.classList.remove('avatar-user'));
+}
+
+features.add({
+  id: __filebasename,
+  description: 'Restores the squared format of user avatars.',
+  screenshot: 'https://user-images.githubusercontent.com/23259585/94072057-3ec2f380-fdf5-11ea-8bfc-31b9cff2f898.png',
+}, {
+  include: [
+    pageDetect.isDashboard,
+    pageDetect.isIssue,
+    pageDetect.isPR,
+    pageDetect.isPRConversation,
+    pageDetect.isRepoHome,
+    pageDetect.isRepoCommitList,
+    pageDetect.isRepoSettings,
+    pageDetect.isUserProfile,
+  ],
+  init,
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -22,6 +22,7 @@ import './features/clean-notifications.css';
 import './features/clean-pinned-issues.css';
 import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';
+import './features/avatar-user-squared.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.
@@ -197,6 +198,7 @@ import './features/convert-release-to-draft';
 import './features/linkify-full-profile-readme-title';
 import './features/same-page-definition-jump';
 import './features/new-repo-disable-projects-and-wikis';
+import './features/avatar-user-squared';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
I previously put some simple CSS rules for this [here](https://github.com/sindrekjr/github-avatar-user-squared) but realized it might make a very suitable addition to refined-github. :) 

1. LINKED ISSUES:

2. TEST URLS:
https://github.com
https://github.com/sindrekjr
https://github.com/sindresorhus/refined-github

3. SCREENSHOTS:
![avatar-user-squared-commits](https://user-images.githubusercontent.com/23259585/94072971-f7d5fd80-fdf6-11ea-9b3e-3fac0dd60e2c.png)
![avatar-user-squared-sindre](https://user-images.githubusercontent.com/23259585/94072982-fe647500-fdf6-11ea-9b17-c3ddb0e6954b.png)