### PR TITLE
Focus field after using `collapsible-content-button`

### DIFF
--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -46,6 +46,7 @@ function addContentToDetails(event: delegate.Event<MouseEvent, HTMLButtonElement
 
 	// Restore selection.
 	// `selectionStart` will be right after the newly-inserted text
+	field.focus();
 	field.setSelectionRange(
 		field.value.lastIndexOf('</summary>', field.selectionStart) + '</summary>'.length + 2,
 		field.value.lastIndexOf('</details>', field.selectionStart) - 2

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -42,11 +42,11 @@ function addContentToDetails(event: delegate.Event<MouseEvent, HTMLButtonElement
 		</details>
 	`.replace(/(\n|\b)\t+/g, '$1').trim();
 
+	field.focus();
 	textFieldEdit.insert(field, smartBlockWrap(newContent, field));
 
 	// Restore selection.
 	// `selectionStart` will be right after the newly-inserted text
-	field.focus();
 	field.setSelectionRange(
 		field.value.lastIndexOf('</summary>', field.selectionStart) + '</summary>'.length + 2,
 		field.value.lastIndexOf('</details>', field.selectionStart) - 2


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: none

2. TEST URLS: https://github.com/sindresorhus/refined-github/issues/new

While working on #3598 I noticed a small bug in `collapsible-content-button.tsx`: there was a few lines of code to restore the selection after wrapping it in a `<details>` tag, but it had no effect (at least on latest Firefox):
![without-focus](https://user-images.githubusercontent.com/46634000/94562048-2293dc00-0265-11eb-971e-ab1909435f38.gif)

This can be fixed by focusing the textarea before restoring the selection:
![with-focus](https://user-images.githubusercontent.com/46634000/94562096-30e1f800-0265-11eb-8026-5b7f14d448ed.gif)