### PR TITLE
Add tooltip to `table-input` button

### DIFF
--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -37,13 +37,11 @@ function init(): void {
 
 	for (const anchor of select.all('md-task-list')) {
 		anchor.after(
-			<details
-				className="toolbar-item tooltipped tooltipped-n mx-1 details-reset details-overlay flex-auto select-menu select-menu-modal-right hx_rsm"
-				aria-label="Add a table"
-			>
+			<details className="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right hx_rsm">
 				<summary
-					className="text-center menu-target py-2 p-md-1 hx_rsm-trigger"
+					className="text-center menu-target py-2 p-md-1 hx_rsm-trigger tooltipped tooltipped-n mx-1"
 					role="button"
+					aria-label="Add a table"
 					aria-haspopup="menu"
 				>
 					<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" className="octicon">

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -37,11 +37,13 @@ function init(): void {
 
 	for (const anchor of select.all('md-task-list')) {
 		anchor.after(
-			<details className="details-reset details-overlay flex-auto toolbar-item select-menu select-menu-modal-right hx_rsm">
+			<details
+				className="toolbar-item tooltipped tooltipped-n mx-1 details-reset details-overlay flex-auto select-menu select-menu-modal-right hx_rsm"
+				aria-label="Add a table"
+			>
 				<summary
-					className="text-center menu-target py-2 p-md-1 hx_rsm-trigger ml-1"
+					className="text-center menu-target py-2 p-md-1 hx_rsm-trigger"
 					role="button"
-					aria-label="Add a table"
 					aria-haspopup="menu"
 				>
 					<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" className="octicon">


### PR DESCRIPTION
First of all, congratulations on this one of the most elegant features in Refined GitHub 🎉

- Add (possibly) missing tooltip classes
- ~~Sorted the classes to match GitHub's order~~
- ~~Move `aria-label` attribute one level up to avoid the popup arrow being cut off~~

1. LINKED ISSUES:
   None

2. TEST URLS:
   This PR

3. SCREENSHOT:
   ![chrome_n9aSmzYqQ3](https://user-images.githubusercontent.com/44045911/94989042-49734a80-05a4-11eb-9343-058c500b94ec.png)
  
   Note the tooltip persists when creating a table 🤷‍♀️:

   ![chrome_9KXRCbD5rN](https://user-images.githubusercontent.com/44045911/94989052-555f0c80-05a4-11eb-8d49-bdd8d364dbbe.png)
