### PR TITLE
`link-to-github-io` improvements

### DIFF
--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -31,6 +31,7 @@ async function initRepo(): Promise<void> {
 	const repoTitle = await elementReady('[itemprop="name"]')!;
 	repoTitle!.after(
 		<a
+			className="mr-2"
 			href={`https://${getRepositoryInfo().name!}`}
 			target="_blank"
 			rel="noopener noreferrer"
@@ -54,7 +55,8 @@ void features.add({
 	init: initRepo
 }, {
 	include: [
-		pageDetect.isUserProfileRepoTab
+		pageDetect.isUserProfileRepoTab,
+		pageDetect.isOrganizationProfile
 	],
 	init: onetime(initRepoList)
 });

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -197,7 +197,7 @@ import './features/linkify-full-profile-readme-title';
 import './features/same-page-definition-jump';
 import './features/new-repo-disable-projects-and-wikis';
 import './features/table-input';
-import './features/link-to-gihub-io';
+import './features/link-to-github-io';
 import './features/next-scheduled-github-action';
 
 // Add global for easier debugging


### PR DESCRIPTION

   - Fix filename typo
   - Add padding: https://github.com/Qv2ray/qv2ray.github.io
	![image](https://user-images.githubusercontent.com/44045911/94993574-8a7b5700-05c4-11eb-8090-42b3324407cc.png)
    ![image](https://user-images.githubusercontent.com/44045911/94993577-90713800-05c4-11eb-8619-42d57e2c0aa8.png)
   - Enable on orgs: https://github.com/Qv2ray
	![image](https://user-images.githubusercontent.com/44045911/94993595-ada60680-05c4-11eb-9d64-700e2e58d8e3.png)
