### PR TITLE
Don't show next scheduled time of disabled workflows

### DIFF
--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -54,7 +54,7 @@ async function init(): Promise<false | void> {
 	}
 
 	for (const workflowListItem of select.all('[href*="?query"]', await elementReady('.hx_actions-sidebar'))) {
-		if (select.exists('.octicon-stop')) {
+		if (select.exists('.octicon-stop', workflowListItem)) {
 			continue;
 		}
 

--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -54,6 +54,10 @@ async function init(): Promise<false | void> {
 	}
 
 	for (const workflowListItem of select.all('[href*="?query"]', await elementReady('.hx_actions-sidebar'))) {
+		if (select('svg', workflowListItem)?.classList.contains('octicon-stop')) {
+			continue;
+		}
+
 		const workflowName = workflowListItem.textContent!.trim();
 		if (!(workflowName in workflows)) {
 			continue;

--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -54,7 +54,7 @@ async function init(): Promise<false | void> {
 	}
 
 	for (const workflowListItem of select.all('[href*="?query"]', await elementReady('.hx_actions-sidebar'))) {
-		if (select('svg', workflowListItem)?.classList.contains('octicon-stop')) {
+		if (select.exists('.octicon-stop')) {
 			continue;
 		}
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: None (PR #3604)

2. TEST URLS: https://github.com/sindresorhus/refined-github/actions

3. SCREENSHOT:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/46634000/95301758-554f5d00-0881-11eb-934c-052dd5289b01.png) | ![image](https://user-images.githubusercontent.com/46634000/95301818-68622d00-0881-11eb-9362-c7e142393379.png)

This is a pretty flaky fix since it depends on the SVG icon next to the workflow name, but I couldn't find another way to do this.