### PR TITLE
Add `convert-pr-to-draft-improvements` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -355,6 +355,7 @@ Thanks for contributing! 🦋🙌
 - [](# "stop-pjax-loading-with-esc") [After you click on an ajaxed link, this lets you stop loading a page by pressing the <kbd>esc</kbd> key, like the browser does for regular page loads.](https://user-images.githubusercontent.com/36174850/90323385-3c08ef00-df69-11ea-8c0e-c85241888a7b.gif)
 - [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png)
 - [](# "linkify-full-profile-readme-title") [Linkify the readme text on profile pages.](https://user-images.githubusercontent.com/16872793/90910173-ebe4bf00-e3a4-11ea-8fc5-aea3d1a2e5e5.png)
+- [](# "convert-pr-to-draft-improvements") [Moves the "Convert PR to Draft" button to the mergeability box and adds visual feedback to its confirm button.](https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -36,6 +36,8 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
+	description: 'Moves the "Convert PR to Draft" button to the mergeability box and adds visual feedback to its confirm button.',
+	screenshot: 'https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif'
 }, {
 	include: [
 		pageDetect.isPRConversation

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -1,0 +1,33 @@
+import select from 'select-dom';
+import onetime from 'onetime';
+import {observe} from 'selector-observer';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function init(): void {
+	console.log(112);
+	observe('.alt-merge-options:not(.rgh-convert-pr-draft-position)', {
+		add(alternativeActions) {
+			const existingButton = select('[data-url$="/convert_to_draft"]');
+			// Needs to check the existence of both to guarantee the non-draft state
+			if (!existingButton || select.exists('[action$="/ready_for_review"]')) {
+				return;
+			}
+
+			alternativeActions.classList.add('rgh-convert-pr-draft-position');
+			const convertToDraft = existingButton.closest('details')!.cloneNode(true);
+			select('.muted-link', convertToDraft)!.classList.remove('muted-link');
+			alternativeActions.prepend(convertToDraft);
+		}
+	});
+}
+
+void features.add({
+	id: __filebasename,
+}, {
+	include: [
+		pageDetect.isPRConversation
+	],
+	init: onetime(init)
+});

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -1,12 +1,23 @@
+import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
+import delegate from 'delegate-it';
 import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import IconLoading from '../github-helpers/icon-loading';
+
+function closeModal({delegateTarget: button}: delegate.Event<MouseEvent, HTMLButtonElement>): void {
+	button.append(' ', <IconLoading className="v-align-middle"/>);
+	button.disabled = true;
+}
 
 function init(): void {
-	console.log(112);
+	// Immediately close lightbox after click instead of waiting for the ajaxed widget to refresh
+	delegate(document, '.js-convert-to-draft', 'click', closeModal);
+
+	// Copy button to mergeability box
 	observe('.alt-merge-options:not(.rgh-convert-pr-draft-position)', {
 		add(alternativeActions) {
 			const existingButton = select('[data-url$="/convert_to_draft"]');

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -199,6 +199,7 @@ import './features/new-repo-disable-projects-and-wikis';
 import './features/table-input';
 import './features/link-to-github-io';
 import './features/next-scheduled-github-action';
+import './features/convert-pr-to-draft-improvements';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/3213

Some people will keep using the button in the sidebar, so I opted to _copy it_ instead of _moving it._

Also I added a "clicked" state because the modal does not give any feedback after you click it, only closing a few seconds later.

![](https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif)

Gif note for reviewers: the loading icon alignment has already been fixed.

Gif note for contributors: notice how clean the gif is; it's because I move/delete every other element around it. If you can sometimes, try to do the same.