### PR TITLE
fix repo filelist actions

### DIFF
--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -18,10 +18,8 @@ function init(): void {
 		addButtonWrapper.setAttribute('aria-label', 'Add file');
 
 		const addIcon = select('.btn span', addButtonWrapper)!;
-		addIcon.classList.remove('d-md-flex');
-		addIcon.classList.add('d-md-block');
-		addIcon.textContent = '';
-		addIcon.append(<PlusIcon/>);
+		addIcon.classList.replace('d-md-flex', 'd-md-block');
+		addIcon.firstChild!.replaceWith(<PlusIcon/>);
 	}
 
 	const downloadButton = select('get-repo details');

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -17,7 +17,7 @@ function init(): void {
 		addButtonWrapper.classList.add('tooltipped', 'tooltipped-ne');
 		addButtonWrapper.setAttribute('aria-label', 'Add file');
 
-		const addIcon = select('.btn span', addButtonWrapper)!
+		const addIcon = select('.btn span', addButtonWrapper)!;
 		addIcon.classList.remove('d-md-flex');
 		addIcon.classList.add('d-md-block');
 		addIcon.textContent = '';

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -5,7 +5,6 @@ import SearchIcon from 'octicon/search.svg';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {groupButtons} from '../github-helpers/group-buttons';
 
 function init(): void {
 	const searchButton = select('.btn[data-hotkey="t"]')!;
@@ -14,16 +13,15 @@ function init(): void {
 	searchButton.firstChild!.replaceWith(<SearchIcon/>);
 
 	const addButtonWrapper = searchButton.nextElementSibling!;
-	const addButton = select('.btn', addButtonWrapper);
-	if (addButton) {
-		addButton.classList.add('d-md-block', 'tooltipped', 'tooltipped-ne');
-		addButton.classList.remove('d-md-flex', 'ml-2');
-		addButton.setAttribute('aria-label', 'Add file');
-		addButton.textContent = '';
-		addButton.append(<PlusIcon/>);
+	if (addButtonWrapper.nodeName === 'DETAILS') {
+		addButtonWrapper.classList.add('tooltipped', 'tooltipped-ne');
+		addButtonWrapper.setAttribute('aria-label', 'Add file');
 
-		searchButton.classList.remove('mr-2');
-		groupButtons([searchButton, addButtonWrapper]);
+		const addIcon = select('.btn span', addButtonWrapper)!
+		addIcon.classList.remove('d-md-flex');
+		addIcon.classList.add('d-md-block');
+		addIcon.textContent = '';
+		addIcon.append(<PlusIcon/>);
 	}
 
 	const downloadButton = select('get-repo details');


### PR DESCRIPTION
- fix "add file" details overlay broken by `.tooltipped`
- fix nextElementSibling when the user is logged out
- add compatibility with mobile styles
- remove BtnGroup in favor of mobile style improvements

<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:
   Does this PR close/fix an existing issue? Write something like `Closes #10`

2. TEST URLS:
https://github.com/sindresorhus/refined-github

3. SCREENSHOT:

<table>
<tr>
    <th>
    <th> GitHub
    <th> Before
    <th> After
<tr>
   <td> Desktop
	<td><img width="1009" alt="Captura de pantalla 2020-10-13 a las 22 55 54" src="https://user-images.githubusercontent.com/11599942/95917095-fe2e1880-0da9-11eb-8dc5-150c881d4a87.png">
    <td><img width="1267" alt="Captura de pantalla 2020-10-13 a las 23 09 48" src="https://user-images.githubusercontent.com/11599942/95917141-0ede8e80-0daa-11eb-97d0-95203761e038.png">
    <td><img width="1009" alt="Captura de pantalla 2020-10-13 a las 22 53 37" src="https://user-images.githubusercontent.com/11599942/95917183-2158c800-0daa-11eb-9142-58e8d04b3d7b.png">
 
<tr>
    <td> Mobile
	<td><img width="747" alt="Captura de pantalla 2020-10-13 a las 22 56 03" src="https://user-images.githubusercontent.com/11599942/95917361-6b41ae00-0daa-11eb-89d2-43ee4490afda.png">
	<td><img width="736" alt="Captura de pantalla 2020-10-13 a las 23 09 56" src="https://user-images.githubusercontent.com/11599942/95917504-a80da500-0daa-11eb-87f1-7465142e3ed2.png">
	<td><img width="745" alt="Captura de pantalla 2020-10-13 a las 22 56 18" src="https://user-images.githubusercontent.com/11599942/95917419-86142280-0daa-11eb-8abf-2c2491acb117.png">
<tr>
    <td>Desktop logged out
	<td><img width="760" alt="Captura de pantalla 2020-10-13 a las 23 04 41" src="https://user-images.githubusercontent.com/11599942/95917721-fde24d00-0daa-11eb-8439-7ef1ccb227c5.png">
    <td><img width="1219" alt="Captura de pantalla 2020-10-13 a las 23 08 36" src="https://user-images.githubusercontent.com/11599942/95917877-35e99000-0dab-11eb-8cba-bc90dd5180fd.png">
    <td><img width="1225" alt="Captura de pantalla 2020-10-13 a las 23 07 44" src="https://user-images.githubusercontent.com/11599942/95917786-1488a400-0dab-11eb-8473-5da81c16b1ef.png">
<tr>
    <td>Mobile logged out
    <td><img width="751" alt="Captura de pantalla 2020-10-13 a las 23 26 20" src="https://user-images.githubusercontent.com/11599942/95918254-c45e1180-0dab-11eb-91fd-5df470389585.png">
    <td><img width="750" alt="Captura de pantalla 2020-10-13 a las 23 08 46" src="https://user-images.githubusercontent.com/11599942/95918272-cb851f80-0dab-11eb-8dbd-1e474dcbdcfa.png">
    <td><img width="750" alt="Captura de pantalla 2020-10-13 a las 23 08 13" src="https://user-images.githubusercontent.com/11599942/95918310-da6bd200-0dab-11eb-8c4a-dfb34e2a2f8a.png">
</table>
