### PR TITLE
Use `@octokit/rest`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,6 +1467,113 @@
 				"mkdirp": "^1.0.4"
 			}
 		},
+		"@octokit/auth-token": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+			"integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
+			"requires": {
+				"@octokit/types": "^5.0.0"
+			}
+		},
+		"@octokit/core": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.1.2.tgz",
+			"integrity": "sha512-AInOFULmwOa7+NFi9F8DlDkm5qtZVmDQayi7TUgChE3yeIGPq0Y+6cAEXPexQ3Ea+uZy66hKEazR7DJyU+4wfw==",
+			"requires": {
+				"@octokit/auth-token": "^2.4.0",
+				"@octokit/graphql": "^4.3.1",
+				"@octokit/request": "^5.4.0",
+				"@octokit/types": "^5.0.0",
+				"before-after-hook": "^2.1.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/endpoint": {
+			"version": "6.0.8",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.8.tgz",
+			"integrity": "sha512-MuRrgv+bM4Q+e9uEvxAB/Kf+Sj0O2JAOBA131uo1o6lgdq1iS8ejKwtqHgdfY91V3rN9R/hdGKFiQYMzVzVBEQ==",
+			"requires": {
+				"@octokit/types": "^5.0.0",
+				"is-plain-object": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/graphql": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.5.6.tgz",
+			"integrity": "sha512-Rry+unqKTa3svswT2ZAuqenpLrzJd+JTv89LTeVa5UM/5OX8o4KTkPL7/1ABq4f/ZkELb0XEK/2IEoYwykcLXg==",
+			"requires": {
+				"@octokit/request": "^5.3.0",
+				"@octokit/types": "^5.0.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.4.0.tgz",
+			"integrity": "sha512-YT6Klz3LLH6/nNgi0pheJnUmTFW4kVnxGft+v8Itc41IIcjl7y1C8TatmKQBbCSuTSNFXO5pCENnqg6sjwpJhg==",
+			"requires": {
+				"@octokit/types": "^5.5.0"
+			}
+		},
+		"@octokit/plugin-request-log": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+			"integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw=="
+		},
+		"@octokit/plugin-rest-endpoint-methods": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.2.0.tgz",
+			"integrity": "sha512-1/qn1q1C1hGz6W/iEDm9DoyNoG/xdFDt78E3eZ5hHeUfJTLJgyAMdj9chL/cNBHjcjd+FH5aO1x0VCqR2RE0mw==",
+			"requires": {
+				"@octokit/types": "^5.5.0",
+				"deprecation": "^2.3.1"
+			}
+		},
+		"@octokit/request": {
+			"version": "5.4.9",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.9.tgz",
+			"integrity": "sha512-CzwVvRyimIM1h2n9pLVYfTDmX9m+KHSgCpqPsY8F1NdEK8IaWqXhSBXsdjOBFZSpEcxNEeg4p0UO9cQ8EnOCLA==",
+			"requires": {
+				"@octokit/endpoint": "^6.0.1",
+				"@octokit/request-error": "^2.0.0",
+				"@octokit/types": "^5.0.0",
+				"deprecation": "^2.0.0",
+				"is-plain-object": "^5.0.0",
+				"node-fetch": "^2.6.1",
+				"once": "^1.4.0",
+				"universal-user-agent": "^6.0.0"
+			}
+		},
+		"@octokit/request-error": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+			"integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
+			"requires": {
+				"@octokit/types": "^5.0.1",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			}
+		},
+		"@octokit/rest": {
+			"version": "18.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.0.6.tgz",
+			"integrity": "sha512-ES4lZBKPJMX/yUoQjAZiyFjei9pJ4lTTfb9k7OtYoUzKPDLl/M8jiHqt6qeSauyU4eZGLw0sgP1WiQl9FYeM5w==",
+			"requires": {
+				"@octokit/core": "^3.0.0",
+				"@octokit/plugin-paginate-rest": "^2.2.0",
+				"@octokit/plugin-request-log": "^1.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "4.2.0"
+			}
+		},
+		"@octokit/types": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.5.0.tgz",
+			"integrity": "sha512-UZ1pErDue6bZNjYOotCNveTXArOMZQFG6hKJfOnGnulVCMcVVi7YIIuuR4WfBhjo7zgpmzn/BkPDnUXtNx+PcQ==",
+			"requires": {
+				"@types/node": ">= 8"
+			}
+		},
 		"@primer/octicons": {
 			"version": "9.6.0",
 			"resolved": "https://registry.npmjs.org/@primer/octicons/-/octicons-9.6.0.tgz",
@@ -3241,6 +3348,11 @@
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
+		},
+		"before-after-hook": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+			"integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -5174,6 +5286,11 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/delegate-it/-/delegate-it-2.0.1.tgz",
 			"integrity": "sha512-a+5+Zc15Ds3hrKik+FmuewO+FiK5bYjesAhTuPx1Dt0IVMqoGnVkMCh1Jue7weh5WnT8d2VnSjW5mftQDHkSPQ=="
+		},
+		"deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
 		},
 		"des.js": {
 			"version": "1.0.1",
@@ -8513,8 +8630,7 @@
 		"is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.0",
@@ -10452,6 +10568,11 @@
 				"minimatch": "^3.0.2"
 			}
 		},
+		"node-fetch": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+			"integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+		},
 		"node-forge": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -10985,7 +11106,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -14739,6 +14859,11 @@
 				"unist-util-is": "^4.0.0"
 			}
 		},
+		"universal-user-agent": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+			"integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -15914,8 +16039,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	},
 	"dependencies": {
 		"@cheap-glitch/mi-cron": "^1.0.1",
+		"@octokit/rest": "^18.0.6",
 		"@primer/octicons": "^9.6.0",
 		"@primer/octicons-v2": "0.0.0-60ee16f",
 		"@types/webpack": "^4.41.22",
@@ -74,6 +75,7 @@
 	},
 	"devDependencies": {
 		"@ava/typescript": "^1.1.1",
+		"@octokit/types": "^5.5.0",
 		"@rollup/plugin-typescript": "^6.0.0",
 		"@sindresorhus/tsconfig": "^0.7.0",
 		"@types/chrome": "0.0.124",

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -6,14 +6,14 @@ import EyeClosedIcon from 'octicon/eye-closed.svg';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import * as api from '../github-helpers/api';
 import {getUsername} from '../github-helpers';
+import octokit from '../github-helpers/octokit';
 
 const getPublicOrganizationsNames = cache.function(async (username: string): Promise<string[]> => {
 	// API v4 seems to *require* `org:read` permission AND it includes private organizations as well, which defeats the purpose. There's no way to filter them.
 	// GitHub's API explorer inexplicably only includes public organizations.
-	const response = await api.v3(`users/${username}/orgs`);
-	return response.map((organization: AnyObject) => organization.login);
+	const {data} = await octokit.orgs.listForUser({username});
+	return data.map(org => org.login);
 }, {
 	maxAge: {days: 10},
 	cacheKey: ([username]) => __filebasename + ':' + username

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -6,17 +6,22 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import {getRepoURL} from '../github-helpers';
+import {getRepositoryInfo} from '../github-helpers';
+import octokit from '../github-helpers/octokit';
 
 async function disableWikiAndProjects(): Promise<void> {
 	delete sessionStorage.rghNewRepo;
 
-	await api.v3(`repos/${getRepoURL()}`, {
-		method: 'PATCH',
-		body: {
-			has_projects: false,
-			has_wiki: false
-		}
+	const {owner, name: repo} = getRepositoryInfo();
+	if (!owner || !repo) {
+		return;
+	}
+
+	await octokit.repos.update({
+		owner,
+		repo,
+		has_projects: false,
+		has_wiki: false
 	});
 	await domLoaded;
 	select('[data-content="Wiki"]')?.closest('.d-flex')!.remove();

--- a/source/github-helpers/octokit.ts
+++ b/source/github-helpers/octokit.ts
@@ -1,0 +1,55 @@
+import {Octokit} from '@octokit/rest';
+import {
+	StrategyInterface,
+	RequestInterface,
+	Route,
+	EndpointOptions,
+	RequestParameters,
+	EndpointDefaults,
+	OctokitResponse
+} from '@octokit/types';
+
+import optionsStorage from '../options-storage';
+
+type AnyResponse = OctokitResponse<any>;
+interface TokenAuthentication {
+	type: 'token';
+	token: string;
+}
+interface Unauthenticated {
+	type: 'unauthenticated';
+}
+
+type Authentication = TokenAuthentication | Unauthenticated;
+type AuhtStrategyInterface = StrategyInterface<[], [], Authentication>;
+
+const authStrategy: AuhtStrategyInterface = function () {
+	const auth = async (): Promise<Authentication> => {
+		const {personalToken} = await optionsStorage.getAll();
+		return personalToken ? {type: 'token', token: personalToken} : {type: 'unauthenticated'};
+	};
+
+	auth.hook = async function (
+		request: RequestInterface,
+		route: Route | EndpointOptions,
+		parameters?: RequestParameters
+	): Promise<AnyResponse> {
+		const endpoint: EndpointDefaults = request.endpoint.merge(
+			route as string,
+			parameters
+		);
+
+		const authentication = await auth();
+		if (authentication.type === 'token') {
+			endpoint.headers.authorization = `bearer ${authentication.token}`;
+		}
+
+		return request(endpoint as EndpointOptions);
+	};
+
+	return auth;
+};
+
+const octokit = new Octokit({authStrategy});
+
+export default octokit;


### PR DESCRIPTION
This PR converts some `api.v3` features to `@octokit/rest` as mentioned in #3599.

The main thing was to get octokit working with an async `token`.
For that I implemented something similar to [`@octokit/auth-token`](https://github.com/octokit/auth-token.js).
_(The main challenge for me was typescript here :sweat_smile:)_

Regarding size of the built `refined-github.js`
Before: `98.9 kB`
After: `113 kB`

The [documentation](https://octokit.github.io/rest.js) is okay and always links to the actual rest api.
Found it hard to find the right function first, but then I saw that the search on the top is actually quite powerful, that made it way easier.