### PR TITLE
Make `releases-tab` non dependent of `more-dropdown`

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -71,7 +71,7 @@ async function init(): Promise<false | void> {
 		const releasesTab = (
 			<a
 				href={`/${repoUrl}/releases`}
-				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item"
+				className="js-selected-navigation-item UnderlineNav-item no-wrap"
 				data-hotkey="g r"
 				data-selected-links="repo_releases"
 				data-tab-item="rgh-releases-item"
@@ -103,11 +103,16 @@ async function init(): Promise<false | void> {
 			releasesTab.setAttribute('aria-current', 'page');
 		}
 
-		select('.dropdown-divider', repoNavigationBar)!.before(
-			createDropdownItem('Releases', `/${repoUrl}/releases`, {
-				'data-menu-item': 'rgh-releases-item'
-			})
-		);
+		const moreDropdown = select('.dropdown-divider', repoNavigationBar);
+
+		if (moreDropdown) {
+			releasesTab.classList.add('hx_underlinenav-item', 'js-responsive-underlinenav-item');
+			moreDropdown.before(
+				createDropdownItem('Releases', `/${repoUrl}/releases`, {
+					'data-menu-item': 'rgh-releases-item'
+				})
+			);
+		}
 
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -71,7 +71,7 @@ async function init(): Promise<false | void> {
 		const releasesTab = (
 			<a
 				href={`/${repoUrl}/releases`}
-				className="js-selected-navigation-item UnderlineNav-item no-wrap"
+				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item"
 				data-hotkey="g r"
 				data-selected-links="repo_releases"
 				data-tab-item="rgh-releases-item"
@@ -103,16 +103,11 @@ async function init(): Promise<false | void> {
 			releasesTab.setAttribute('aria-current', 'page');
 		}
 
-		const moreDropdown = select('.dropdown-divider', repoNavigationBar);
-
-		if (moreDropdown) {
-			releasesTab.classList.add('hx_underlinenav-item', 'js-responsive-underlinenav-item');
-			moreDropdown.before(
-				createDropdownItem('Releases', `/${repoUrl}/releases`, {
-					'data-menu-item': 'rgh-releases-item'
-				})
-			);
-		}
+		select('.dropdown-divider', repoNavigationBar)!.before(
+			createDropdownItem('Releases', `/${repoUrl}/releases`, {
+				'data-menu-item': 'rgh-releases-item'
+			})
+		);
 
 		// Hide redundant 'Releases' section from repo sidebar
 		if (pageDetect.isRepoRoot()) {

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -103,7 +103,9 @@ async function init(): Promise<false | void> {
 			releasesTab.setAttribute('aria-current', 'page');
 		}
 
-		select('.dropdown-divider', repoNavigationBar)!.before(
+		appendBefore(
+			select('.js-responsive-underlinenav .dropdown-menu ul')!,
+			'.dropdown-divider', // Won't exist if `more-dropdown` is disabled
 			createDropdownItem('Releases', `/${repoUrl}/releases`, {
 				'data-menu-item': 'rgh-releases-item'
 			})


### PR DESCRIPTION
1. LINKED ISSUES:
   Resolves #3652 

2. TEST URLS:
   None

3. SCREENSHOT:
   None
