### PR TITLE
Fix "Cookie Preferences" link color in `clean-footer`

### DIFF
--- a/source/features/clean-footer.css
+++ b/source/features/clean-footer.css
@@ -14,6 +14,7 @@ body > .footer > div > ul:first-of-type li:first-of-type { /* The `© 2017 GitHu
 	display: none;
 }
 
-body > .footer li a {
+body > .footer li a,
+body > .footer li .btn-link {
 	color: #666;
 }


### PR DESCRIPTION
Sets the color to the button recently added to the footer.

<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:
   No issue

2. TEST URLS:
   Any url

3. SCREENSHOT:
   

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="435" alt="Captura de pantalla 2020-10-16 a las 0 24 13" src="https://user-images.githubusercontent.com/11599942/96192634-b690c380-0f46-11eb-9d97-baf52a5f2259.png">
	<td><img width="447" alt="Captura de pantalla 2020-10-16 a las 0 23 27" src="https://user-images.githubusercontent.com/11599942/96192649-bc86a480-0f46-11eb-88e8-53f2b544522e.png">
</table>
