### PR TITLE
Make `clean-pinned-issues` more visible

### DIFF
--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -11,15 +11,16 @@
 		margin-bottom: 20px;
 
 		/* Rounded table border https://stackoverflow.com/a/2586780/288906 */
-		box-shadow: 0 0 0 2px #d1d5da;
+		box-shadow: 0 0 0 1px #c0d3eb;
 		border-collapse: collapse;
 		border-radius: 6px;
 		border-style: hidden;
+		background-color: #f1f8ff;
 	}
 
 	:root .pinned-issue-item {
 		display: table-row !important;
-		border-color: #e1e4e8 !important;
+		border-color: #c0d3eb !important;
 	}
 
 	.pinned-issue-item > * {


### PR DESCRIPTION
Update pinned issues style to be more accurate with the GitHub theme. 💅 

<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:
   Continue the discussion https://github.com/sindresorhus/refined-github/pull/3491

2. TEST URLS:
    https://github.com/sindresorhus/refined-github/issues

3. SCREENSHOT:
   

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="1246" alt="Captura de pantalla 2020-10-16 a las 0 41 20" src="https://user-images.githubusercontent.com/11599942/96194030-c6f66d80-0f49-11eb-91d2-8e8a7353e856.png">
	<td><img width="1241" alt="Captura de pantalla 2020-10-16 a las 0 43 26" src="https://user-images.githubusercontent.com/11599942/96194041-cfe73f00-0f49-11eb-910c-aae6fa6f7d42.png">
</table>
