### PR TITLE
Meta: remove no-longer-necessary alignment CSS

### DIFF
--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -17,11 +17,6 @@
 	border-bottom-right-radius: 5px;
 }
 
-/* Align author name on PR sticky header #3660 */
-.sticky-content .author.css-truncate-target {
-	vertical-align: -4px;
-}
-
 /* Align dropdown button on file page #3660 */
 #blob-more-options-details {
 	margin-top: 5.6px;

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -10,16 +10,19 @@
 	margin: -5px 0;
 }
 
-/* Reposition committer's avatar on PR commits #3444 */
-.pull-request-tab-content .commit .AvatarStack {
-	display: inline-block;
-	margin-bottom: -4px;
-	margin-right: -4px;
-}
-
 /* Add missing border radius to collapsed PR files #3444 */
 .js-blob-wrapper,
 .file:not(.open) .file-header.file-header--expandable {
 	border-bottom-left-radius: 5px;
 	border-bottom-right-radius: 5px;
+}
+
+/* Align author name on PR sticky header */
+.sticky-content .author.css-truncate-target {
+	vertical-align: -4px;
+}
+
+/* Align dropdown button on file page */
+#blob-more-options-details {
+	margin-top: 5.6px;
 }

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -16,8 +16,3 @@
 	border-bottom-left-radius: 5px;
 	border-bottom-right-radius: 5px;
 }
-
-/* Align dropdown button on file page #3660 */
-#blob-more-options-details {
-	margin-top: 5.6px;
-}

--- a/source/features/github-bugs.css
+++ b/source/features/github-bugs.css
@@ -17,12 +17,12 @@
 	border-bottom-right-radius: 5px;
 }
 
-/* Align author name on PR sticky header */
+/* Align author name on PR sticky header #3660 */
 .sticky-content .author.css-truncate-target {
 	vertical-align: -4px;
 }
 
-/* Align dropdown button on file page */
+/* Align dropdown button on file page #3660 */
 #blob-more-options-details {
 	margin-top: 5.6px;
 }


### PR DESCRIPTION
- Add first fix from #3444 again (details on https://github.com/sindresorhus/refined-github/pull/3444#discussion_r468017909)
- Remove second fix from #3444 since it has been fixed by GitHub
- Added a new fix

<table>
<tr>
	<td> Test
	<td> Before
	<td> After
<tr>
	<td> This PR
	<td> <img src="https://user-images.githubusercontent.com/44045911/89752707-0d71bb00-db08-11ea-9f50-e625c956bf11.png">
	<td> <img src="https://user-images.githubusercontent.com/44045911/89752675-e9ae7500-db07-11ea-9989-f518c2542643.png">
<tr>
	<td> <a href="https://github.com/sindresorhus/refined-github/pull/3660/commits/ad3b3d20d36c017dcbc06a46277aa0ed595b309a">Link</a>
	<td> <img src="https://user-images.githubusercontent.com/44045911/96263039-2067a680-0ff5-11eb-8c67-746b9826549c.png">
	<td> <img src="https://user-images.githubusercontent.com/44045911/96263068-29587800-0ff5-11eb-9b6f-b3596a681773.png">

<tr>
	<td> <a href="https://github.com/sindresorhus/refined-github/blob/master/package.json">Link</a>
	<td> <img src="https://user-images.githubusercontent.com/44045911/96262395-4fc9e380-0ff4-11eb-8db5-2e8a8a398b41.png">
	<td> <img src="https://user-images.githubusercontent.com/44045911/96262419-59ebe200-0ff4-11eb-8178-7c3ed90521d1.png">
</table>
