### PR TITLE
Fix `profile-hotkey` on Gist pages

### DIFF
--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -2,15 +2,9 @@ import select from 'select-dom';
 import onetime from 'onetime';
 
 import features from '.';
-import {getUsername} from '../github-helpers';
 
-function init(): false | void {
+function init(): void {
 	select('a[data-ga-click$="text:your profile"]')!.dataset.hotkey = 'g m';
-	if (!menuItem) {
-		return false;
-	}
-
-	menuItem.dataset.hotkey = 'g m';
 }
 
 void features.add({

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -5,7 +5,7 @@ import features from '.';
 import {getUsername} from '../github-helpers';
 
 function init(): false | void {
-	const menuItem = select.last(`[aria-label="View profile and more"] ~ details-menu a[href$="/${getUsername()}"]`);
+	select('a[data-ga-click$="text:your profile"]')!.dataset.hotkey = 'g m';
 	if (!menuItem) {
 		return false;
 	}

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -5,7 +5,7 @@ import features from '.';
 import {getUsername} from '../github-helpers';
 
 function init(): false | void {
-	const menuItem = select(`a[href="/${getUsername()}"]`);
+	const menuItem = select.last(`[aria-label="View profile and more"] ~ details-menu a[href$="/${getUsername()}"]`);
 	if (!menuItem) {
 		return false;
 	}


### PR DESCRIPTION
1. LINKED ISSUES:
   None

2. TEST URLS:
   https://gist.github.com/yakov116

3. SCREENSHOT:
   None

It did not work there since `/${getUsername()` leads to the `Your gists` button