### PR TITLE
Don't add `restore-file` action on new files in PRs

### DIFF
--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -112,8 +112,8 @@ function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): void {
 	}
 
 	if (editFile.closest('.file-header')!.querySelector('[aria-label="File added"]')) {
-		// There's already a "Delete file" action.
-		// Depends on `highlight-deleted-and-added-files-in-diffs`
+		// The file is new. "Restoring" it means deleting it, which is already possible.
+		// Depends on `highlight-deleted-and-added-files-in-diffs`.
 		return;
 	}
 

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -45,14 +45,6 @@ async function getFile(filePath: string): Promise<{isTruncated: boolean; text: s
 	return repository.file;
 }
 
-async function deleteFile(menuItem: Element): Promise<void> {
-	menuItem.textContent = 'Deleting…';
-
-	const deleteFileLink = select<HTMLAnchorElement>('a[aria-label^="Delete this"]', menuItem.parentElement!)!;
-	const form = await fetchDom<HTMLFormElement>(deleteFileLink.href, '#new_blob');
-	await postForm(form!);
-}
-
 async function commitFileContent(menuItem: Element, content: string, filePath: string): Promise<void> {
 	let {pathname} = menuItem.previousElementSibling as HTMLAnchorElement;
 	// Check if file was deleted by PR
@@ -93,8 +85,8 @@ async function handleRestoreFileClick(event: delegate.Event<MouseEvent, HTMLButt
 
 		if (!file) {
 			// The file was created by this PR. Restore === Delete.
-			// If there was a way to tell if a file was created by the PR, we could skip `getFile`
-			await deleteFile(menuItem);
+			// This shouldn't happen unless `highlight-deleted-and-added-files-in-diffs` is broken
+			showError(menuItem, 'Nothing to restore. Delete file instead');
 			return;
 		}
 
@@ -116,6 +108,12 @@ async function handleRestoreFileClick(event: delegate.Event<MouseEvent, HTMLButt
 function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): void {
 	const editFile = select<HTMLAnchorElement>('[aria-label^="Change this"]', dropdown);
 	if (!editFile || select.exists('.rgh-restore-file', dropdown)) {
+		return;
+	}
+
+	if (editFile.closest('.file-header')!.querySelector('[aria-label="File added"]')) {
+		// There's already a "Delete file" action.
+		// Depends on `highlight-deleted-and-added-files-in-diffs`
 		return;
 	}
 

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -84,8 +84,8 @@ async function handleRestoreFileClick(event: delegate.Event<MouseEvent, HTMLButt
 		const file = await getFile(filePath);
 
 		if (!file) {
-			// The file was created by this PR. Restore === Delete.
-			// This shouldn't happen unless `highlight-deleted-and-added-files-in-diffs` is broken
+			// The file was created by this PR.
+			// This code won’t be reached if `highlight-deleted-and-added-files-in-diffs` works.
 			showError(menuItem, 'Nothing to restore. Delete file instead');
 			return;
 		}


### PR DESCRIPTION
1. New files can be "reverted" by deleting them.
2. PRs already have a button to delete the files
3. Thanks to `highlight-deleted-and-added-files-in-diffs` now we also know which files are new as I had hoped in the JS comment.

![](https://user-images.githubusercontent.com/1402241/96306707-ce5b5c80-0fc5-11eb-9acd-187b59c02b7c.gif)

Test on https://github.com/sindresorhus/refined-github/pull/3650/files?file-filters%5B%5D=.json&file-filters%5B%5D=.tsx#diff-793b39887195dc240846c30af909a5a6ef55a7fc329979225fecbebea653047f