### PR TITLE
Fetch widget for `view-markdown-source` instead of maintaining a copy of it

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -45,9 +45,8 @@ addDomainPermissionToggle();
 
 // `background` fetch required to avoid avoid CORB introduced in Chrome 73 https://chromestatus.com/feature/5629709824032768
 // Don’t turn this into an `async` function https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#addListener_syntax
-browser.runtime.onMessage.addListener(({request, json}): Promise<Response> | void => {
-	return fetch(request).then(async response => {
-		const textContent = await response.text();
-		return json ? JSON.parse(textContent) : textContent;
-	});
+browser.runtime.onMessage.addListener((message): Promise<string> | void => {
+	if (message?.request) {
+		return fetch(request).then(async response => response.text());
+	}
 });

--- a/source/background.ts
+++ b/source/background.ts
@@ -47,6 +47,6 @@ addDomainPermissionToggle();
 // Don’t turn this into an `async` function https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#addListener_syntax
 browser.runtime.onMessage.addListener((message): Promise<string> | void => {
 	if (message?.request) {
-		return fetch(request).then(async response => response.text());
+		return fetch(message.request).then(async response => response.text());
 	}
 });

--- a/source/background.ts
+++ b/source/background.ts
@@ -45,6 +45,9 @@ addDomainPermissionToggle();
 
 // `background` fetch required to avoid avoid CORB introduced in Chrome 73 https://chromestatus.com/feature/5629709824032768
 // Don’t turn this into an `async` function https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage#addListener_syntax
-browser.runtime.onMessage.addListener(({request}): Promise<Response> | void => {
-	return fetch(request).then(async response => response.json());
+browser.runtime.onMessage.addListener(({request, json}): Promise<Response> | void => {
+	return fetch(request).then(async response => {
+		const textContent = await response.text();
+		return json ? JSON.parse(textContent) : textContent;
+	});
 });

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -20,7 +20,7 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 
 	try {
 		// Get the gist via background.js due to CORB policies introduced in Chrome 73
-		const gistData = await browser.runtime.sendMessage({request: `${link.href}.json`});
+		const gistData = await browser.runtime.sendMessage({request: `${link.href}.json`, json: true});
 
 		const files = domify.one(gistData.div)!;
 		const fileCount = files.children.length;

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -20,9 +20,9 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 
 	try {
 		// Get the gist via background.js due to CORB policies introduced in Chrome 73
-		const gistData = await browser.runtime.sendMessage({request: `${link.href}.json`, json: true});
+		const gistData = await browser.runtime.sendMessage({request: `${link.href}.json`});
 
-		const files = domify.one(gistData.div)!;
+		const files = domify.one(JSON.parse(gistData).div)!;
 		const fileCount = files.children.length;
 
 		if (fileCount > 1) {

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -7,73 +7,19 @@ import * as pageDetect from 'github-url-detection';
 
 import FileIcon from 'octicon/file.svg';
 import CodeIcon from 'octicon/code.svg';
-import KebabHorizontalIcon from 'octicon/kebab-horizontal.svg';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 import GitHubURL from '../github-helpers/github-url';
 import {buildRepoURL} from '../github-helpers';
 
-const lineActions = onetime(() => (
-	<details
-		className="details-reset details-overlay BlobToolbar position-absolute js-file-line-actions dropdown d-none"
-		aria-hidden="true"
-	>
-		<summary
-			className="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1"
-			aria-label="Inline file action toolbar"
-			aria-haspopup="menu"
-			role="button"
-		>
-			<KebabHorizontalIcon/>
-		</summary>
-		<details-menu role="menu">
-			<ul
-				className="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2"
-				style={{width: '185px'}}
-			>
-				<li>
-					<clipboard-copy
-						role="menuitem"
-						className="dropdown-item zeroclipboard-link"
-						id="js-copy-lines"
-					>
-						Copy line
-					</clipboard-copy>
-				</li>
-				<li>
-					<clipboard-copy
-						role="menuitem"
-						className="dropdown-item zeroclipboard-link"
-						id="js-copy-permalink"
-					>
-						Copy permalink
-					</clipboard-copy>
-				</li>
-				<li>
-					<a
-						className="dropdown-item js-update-url-with-hash"
-						id="js-view-git-blame"
-						role="menuitem"
-						href={new GitHubURL(location.href).assign({route: 'blame'}).href}
-					>
-						View git blame
-					</a>
-				</li>
-				<li>
-					<a
-						className="dropdown-item"
-						id="js-new-issue"
-						role="menuitem"
-						href={buildRepoURL('issues/new')}
-					>
-						Reference in new issue
-					</a>
-				</li>
-			</ul>
-		</details-menu>
-	</details>
-));
+const lineActions = onetime(async () => {
+	// Avoid having to create the entire 70 lines of JSX. The URL is hardcoded to support enterprise
+	const blobToolbar = await fetchDom('https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig', '.BlobToolbar');
+	select<HTMLAnchorElement>('#js-view-git-blame', blobToolbar)!.href = new GitHubURL(location.href).assign({route: 'blame'}).href;
+	select<HTMLAnchorElement>('#js-new-issue', blobToolbar)!.href = buildRepoURL('issues/new');
+	return blobToolbar;
+});
 
 const buttonBodyMap = new WeakMap<Element, Element | Promise<Element>>();
 
@@ -119,7 +65,7 @@ async function showSource(): Promise<void> {
 	sourceButton.classList.add('selected');
 	renderedButton.classList.remove('selected');
 	blurButton(sourceButton);
-	(await source).before(lineActions());
+	(await source).before(await lineActions() as unknown as HTMLDetailsElement);
 
 	dispatchEvent(sourceButton, 'rgh:view-markdown-source');
 }
@@ -137,7 +83,7 @@ async function showRendered(): Promise<void> {
 	sourceButton.classList.remove('selected');
 	renderedButton.classList.add('selected');
 	blurButton(renderedButton);
-	lineActions().remove();
+	(lineActions() as unknown as HTMLDetailsElement).remove();
 
 	dispatchEvent(sourceButton, 'rgh:view-markdown-rendered');
 }

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -15,7 +15,9 @@ import {buildRepoURL} from '../github-helpers';
 
 const lineActions = onetime(async () => {
 	// Avoid having to create the entire 60 lines of JSX. The URL is hardcoded to a file we know the DOM exists.
-	const blobToolbar = await fetchDom('https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig', '.BlobToolbar', true);
+	const randomKnownFile = 'https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig';
+	const html = await browser.runtime.sendMessage({request: randomKnownFile});
+	const blobToolbar = domify(html).querySelector('.BlobToolbar');
 	select<HTMLAnchorElement>('#js-view-git-blame', blobToolbar)!.href = new GitHubURL(location.href).assign({route: 'blame'}).href;
 	select<HTMLAnchorElement>('#js-new-issue', blobToolbar)!.href = buildRepoURL('issues/new');
 	return blobToolbar!;

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -14,8 +14,8 @@ import GitHubURL from '../github-helpers/github-url';
 import {buildRepoURL} from '../github-helpers';
 
 const lineActions = onetime(async () => {
-	// Avoid having to create the entire 70 lines of JSX. The URL is hardcoded to support enterprise
-	const blobToolbar = await fetchDom('https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig', '.BlobToolbar');
+	// Avoid having to create the entire 60 lines of JSX. The URL is hardcoded to a file we know the DOM exists.
+	const blobToolbar = await fetchDom('https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig', '.BlobToolbar', true);
 	select<HTMLAnchorElement>('#js-view-git-blame', blobToolbar)!.href = new GitHubURL(location.href).assign({route: 'blame'}).href;
 	select<HTMLAnchorElement>('#js-new-issue', blobToolbar)!.href = buildRepoURL('issues/new');
 	return blobToolbar;

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -86,9 +86,9 @@ async function showRendered(): Promise<void> {
 	sourceButton.classList.remove('selected');
 	renderedButton.classList.add('selected');
 	blurButton(renderedButton);
-	(await lineActions()).remove();
-
 	dispatchEvent(sourceButton, 'rgh:view-markdown-rendered');
+
+	(await lineActions()).remove();
 }
 
 async function init(): Promise<void> {

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -1,5 +1,6 @@
 import './view-markdown-source.css';
 import React from 'dom-chef';
+import domify from 'doma';
 import select from 'select-dom';
 import onetime from 'onetime';
 import delegate from 'delegate-it';
@@ -17,10 +18,10 @@ const lineActions = onetime(async () => {
 	// Avoid having to create the entire 60 lines of JSX. The URL is hardcoded to a file we know the DOM exists.
 	const randomKnownFile = 'https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig';
 	const html = await browser.runtime.sendMessage({request: randomKnownFile});
-	const blobToolbar = domify(html).querySelector('.BlobToolbar');
+	const blobToolbar = domify(html).querySelector('.BlobToolbar')!;
 	select<HTMLAnchorElement>('#js-view-git-blame', blobToolbar)!.href = new GitHubURL(location.href).assign({route: 'blame'}).href;
 	select<HTMLAnchorElement>('#js-new-issue', blobToolbar)!.href = buildRepoURL('issues/new');
-	return blobToolbar!;
+	return blobToolbar;
 });
 
 const buttonBodyMap = new WeakMap<Element, Element | Promise<Element>>();

--- a/source/helpers/fetch-dom.ts
+++ b/source/helpers/fetch-dom.ts
@@ -2,11 +2,17 @@ import mem from 'mem';
 import domify from 'doma';
 
 async function fetchDom(url: string): Promise<DocumentFragment>;
-async function fetchDom<TElement extends Element>(url: string, selector: string): Promise<TElement | undefined>;
-async function fetchDom(url: string, selector?: string): Promise<Node | undefined> {
+async function fetchDom<TElement extends Element>(url: string, selector: string, backgroundRequest?: boolean): Promise<TElement | undefined>;
+async function fetchDom(url: string, selector?: string, backgroundRequest?: boolean): Promise<Node | undefined> {
 	const absoluteURL = new URL(url, location.origin).toString(); // Firefox `fetch`es from the content script, so relative URLs fail
-	const response = await fetch(absoluteURL);
-	const dom = domify(await response.text());
+	let dom;
+	if (backgroundRequest) {
+		dom = domify(await browser.runtime.sendMessage({request: absoluteURL}));
+	} else {
+		const response = await fetch(absoluteURL);
+		dom = domify(await response.text());
+	}
+
 	if (selector) {
 		return dom.querySelector(selector) ?? undefined;
 	}

--- a/source/helpers/fetch-dom.ts
+++ b/source/helpers/fetch-dom.ts
@@ -7,7 +7,6 @@ async function fetchDom(url: string, selector?: string, backgroundRequest?: bool
 	const absoluteURL = new URL(url, location.origin).toString(); // Firefox `fetch`es from the content script, so relative URLs fail
 	const response = backgroundRequest ? await browser.runtime.sendMessage({request: absoluteURL}) : await fetch(absoluteURL);
 	const dom = domify(await response.text?.() ?? response);
-	console.log(dom);
 	if (selector) {
 		return dom.querySelector(selector) ?? undefined;
 	}

--- a/source/helpers/fetch-dom.ts
+++ b/source/helpers/fetch-dom.ts
@@ -2,11 +2,11 @@ import mem from 'mem';
 import domify from 'doma';
 
 async function fetchDom(url: string): Promise<DocumentFragment>;
-async function fetchDom<TElement extends Element>(url: string, selector: string, backgroundRequest?: boolean): Promise<TElement | undefined>;
-async function fetchDom(url: string, selector?: string, backgroundRequest?: boolean): Promise<Node | undefined> {
+async function fetchDom<TElement extends Element>(url: string, selector: string): Promise<TElement | undefined>;
+async function fetchDom(url: string, selector?: string): Promise<Node | undefined> {
 	const absoluteURL = new URL(url, location.origin).toString(); // Firefox `fetch`es from the content script, so relative URLs fail
-	const response = backgroundRequest ? await browser.runtime.sendMessage({request: absoluteURL}) : await fetch(absoluteURL);
-	const dom = domify(await response.text?.() ?? response);
+	const response = await fetch(absoluteURL);
+	const dom = domify(await response.text());
 	if (selector) {
 		return dom.querySelector(selector) ?? undefined;
 	}

--- a/source/helpers/fetch-dom.ts
+++ b/source/helpers/fetch-dom.ts
@@ -5,14 +5,9 @@ async function fetchDom(url: string): Promise<DocumentFragment>;
 async function fetchDom<TElement extends Element>(url: string, selector: string, backgroundRequest?: boolean): Promise<TElement | undefined>;
 async function fetchDom(url: string, selector?: string, backgroundRequest?: boolean): Promise<Node | undefined> {
 	const absoluteURL = new URL(url, location.origin).toString(); // Firefox `fetch`es from the content script, so relative URLs fail
-	let dom;
-	if (backgroundRequest) {
-		dom = domify(await browser.runtime.sendMessage({request: absoluteURL}));
-	} else {
-		const response = await fetch(absoluteURL);
-		dom = domify(await response.text());
-	}
-
+	const response = backgroundRequest ? await browser.runtime.sendMessage({request: absoluteURL}) : await fetch(absoluteURL);
+	const dom = domify(await response.text?.() ?? response);
+	console.log(dom);
 	if (selector) {
 		return dom.querySelector(selector) ?? undefined;
 	}


### PR DESCRIPTION
1. LINKED ISSUES:
   https://github.com/sindresorhus/refined-github/pull/3594#issuecomment-711839565

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/blob/3d517d6cd00e83a51973808c7ff03cae2b692d2b/contributing.md#L3-L5

3. SCREENSHOT:
   None

@fregante why do you say we need to exclude enterprise?
