### PR TITLE
Meta: Use the Readme as the only source of feature descriptions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -53,7 +53,7 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	/** Whether to wait for DOM ready before runnin `init`. `false` makes `init` run right as soon as `body` is found. @default true */
+	/** Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady: false,
 
 	/** Rarely needed: When pressing the back button, the DOM and listeners are still there, so normally `init` isn’t called again. If this is true, it’s called anyway. @default false */

--- a/contributing.md
+++ b/contributing.md
@@ -10,7 +10,7 @@ Suggestions and pull requests are highly encouraged! Have a look at the [open is
 - All the [latest DOM APIs](https://github.com/WebReflection/dom4#features) and JavaScript features are available because the extension only has to work in the latest Chrome and Firefox. 🎉
 - Each JavaScript feature lives in its own file under [`source/features`](https://github.com/sindresorhus/refined-github/tree/master/source/features) and it's imported in [`source/refined-github.ts`](https://github.com/sindresorhus/refined-github/blob/master/source/refined-github.ts).
 - See what a _feature_ [looks like](https://github.com/sindresorhus/refined-github/blob/master/source/features/user-profile-follower-badge.tsx).
-- Follow [the styleguide](https://github.com/sindresorhus/refined-github/blob/master/readme.md#L100) that appears in the Readme's source to write readable descriptions.
+- Follow [the styleguide](https://github.com/sindresorhus/refined-github/blob/master/readme.md#L62) that appears in the Readme's source to write readable descriptions.
 - Refined GitHub tries to integrate as best as possible, so [GitHub's own styleguide](https://primer.style/css) might come in useful.
 
 ## `features.add`

--- a/contributing.md
+++ b/contributing.md
@@ -53,6 +53,11 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	/** This only adds the shortcut to the help screen, it doesn't enable it. */
+	shortcuts: {
+		'↑': 'Edit your last comment'
+	},
+
 	/** Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady: false,
 
@@ -65,12 +70,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isOwnUserProfile
 	],
-
-	/** This only adds the shortcut to the help screen, it doesn't enable it. */
-	shortcuts: {
-		'↑': 'Edit your last comment'
-	},
-
 	init
 }, {
 	include: [

--- a/contributing.md
+++ b/contributing.md
@@ -25,7 +25,7 @@ function init () {
 	console.log('✨');
 }
 
-features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR // Find which one you need on https://fregante.github.io/github-url-detection/
 	],
@@ -52,11 +52,7 @@ function init(): void {
 	delegate(document, '.btn', 'click', append);
 }
 
-features.add(__filebasename, {
-	shortcuts: { // This only adds the shortcut to the help screen, it doesn't enable it
-		'↑': 'Edit your last comment'
-	},
-}, {
+void features.add(__filebasename, {
 	/** Whether to wait for DOM ready before runnin `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady: false,
 
@@ -69,6 +65,12 @@ features.add(__filebasename, {
 	exclude: [
 		pageDetect.isOwnUserProfile
 	],
+
+	/** This only adds the shortcut to the help screen, it doesn't enable it. */
+	shortcuts: {
+		'↑': 'Edit your last comment'
+	},
+
 	init
 }, {
 	include: [

--- a/contributing.md
+++ b/contributing.md
@@ -25,11 +25,7 @@ function init () {
 	console.log('✨');
 }
 
-features.add({
-	id: __filebasename,
-	description: 'Simplify the GitHub interface and adds useful features.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/58238638-3cbcd080-7d7a-11e9-80f6-be6c0520cfed.jpg',
-}, {
+features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPR // Find which one you need on https://fregante.github.io/github-url-detection/
 	],
@@ -56,10 +52,7 @@ function init(): void {
 	delegate(document, '.btn', 'click', append);
 }
 
-features.add({
-	id: __filebasename,
-	description: 'Simplify the GitHub interface and adds useful features.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/58238638-3cbcd080-7d7a-11e9-80f6-be6c0520cfed.jpg',
+features.add(__filebasename, {
 	shortcuts: { // This only adds the shortcut to the help screen, it doesn't enable it
 		'↑': 'Edit your last comment'
 	},

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,6 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 - Keyboard shortcuts must follow:
 	- "Adds a keyboard shortcut to ...: <kbd>key1</kbd> <kbd>key2</kbd>"
 	- "Adds keyboard shortcuts to ...: <kbd>a</kbd> and <kbd>alt</kbd> <kbd>a</kbd>"
-- You should try to use the same description and screenshot in the feature’s file (inside `features.add`)
 - Use smart apostrophes: ’ instead of '
 - Keep it concise.
 

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 <table>
 	<tr>
 		<th width="50%">
-			<a title="show-whitespace"></a> Makes whitespace characters visible
+			Makes whitespace characters visible
 		</th>
 		<th width="50%">
 			Adds one-click merge conflict fixers
@@ -44,10 +44,10 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 	<tr><!-- Prevent zebra stripes --></tr>
 	<tr>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png">
+			<img id="show-whitespace" alt="Makes whitespace characters visible." src="https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png">
 		</td>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png">
+			<img id="resolve-conflicts" alt="Adds one-click merge conflict fixers." src="https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png">
 		</td>
 	</tr>
 </table>
@@ -64,10 +64,10 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 	<tr><!-- Prevent zebra stripes --></tr>
 	<tr>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png">
+			<img id="reactions-avatars" alt="Adds reaction avatars showing *who* reacted to a comment." src="https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png">
 		</td>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">
+			<img id="wait-for-build" alt="Adds the option to wait for checks when merging a PR." src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">
 		</td>
 	</tr>
 </table>
@@ -78,16 +78,16 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 			Linkifies issue/PR references and URLs in code
 		</th>
 		<th width="50%">
-			<a title="restore-file"></a> Adds button to revert all the changes to a file in a PR.
+			Adds button to revert all the changes to a file in a PR
 		</th>
 	</tr>
 	<tr><!-- Prevent zebra stripes --></tr>
 	<tr>
 		<td>
-			<img src="https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png">
+			<img id="linkify-code" alt="Linkifies issue/PR references and URLs in code." src="https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png">
 		</td>
 		<td>
-			<img src="https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif">
+			<img id="restore-file" alt="Adds button to revert all the changes to a file in a PR." src="https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif">
 		</td>
 	</tr>
 </table>
@@ -138,7 +138,7 @@ Thanks for contributing! 🦋🙌
 
 ### File management
 
-- [](# "download-folder-button") [Adds a button to download entire folders.](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png) *Uses [download-directory.github.io](https://download-directory.github.io)*
+- [](# "download-folder-button") [Adds a button to download entire folders](https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png), via https://download-directory.github.io.
 - [](# "toggle-files-button") [Adds a button to toggle the repo file list.](https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif)
 - [](# "edit-files-faster") [Adds a button to edit files from the repo file list.](https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png)
 - [](# "edit-readme") [Ensures that the “Edit readme” button always appears (even when you have to make a fork) and works (GitHub’s link does’t work on git tags).](https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png)
@@ -165,7 +165,7 @@ Thanks for contributing! 🦋🙌
 
 ### Writing comments
 
-- [](# "tab-to-indent") 🔥 [Enables <kbd>tab</kbd> and <kbd>shift+tab</kbd> for indentation in comment fields.](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)
+- [](# "tab-to-indent") 🔥 [Enables <kbd>tab</kbd> and <kbd>shift</kbd> <kbd>tab</kbd> for indentation in comment fields.](https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif)
 - [](# "submit-review-as-single-comment") [Adds a button to submit a single PR comment if you mistakenly started a new review.](https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif)
 - [](# "collapsible-content-button") [Adds a button to insert collapsible content (via `<details>`).](https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png)
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
@@ -182,7 +182,7 @@ Thanks for contributing! 🦋🙌
 
 ### Reading comments
 
-- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
+- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG) Not supported by Firefox.
 - [](# "comments-time-machine-links") Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
 - [](# "show-names") [Adds the real name of users by their usernames.](https://user-images.githubusercontent.com/1402241/62075835-5f82ce00-b270-11e9-91eb-4680b70cb3cb.png)
 - [](# "shorten-links") [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
@@ -203,7 +203,7 @@ Thanks for contributing! 🦋🙌
 - [](# "split-issue-pr-search-results") [Separates issues from PRs in the global search.](https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png)
 - [](# "sticky-conversation-list-toolbar") [Makes the conversation list’s filters toolbar sticky.](https://user-images.githubusercontent.com/380914/39878141-7632e61a-542c-11e8-9c66-74fcd3a134aa.gif)
 - [](# "highlight-collaborators-and-own-conversations") [Highlights conversations opened by you or the current repo’s collaborators.](https://user-images.githubusercontent.com/1402241/65013882-03225d80-d947-11e9-8eb8-5507bc1fc14b.png)
-- [](# "align-issue-labels") [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/1402241/28006237-070b8214-6581-11e7-94bc-2b01a007d00b.png)
+- [](# "align-issue-labels") [Aligns labels in lists to the left.](https://user-images.githubusercontent.com/37769974/85866472-11aa7900-b7e5-11ea-80aa-d84e3aee2551.png)
 - [](# "sort-conversations-by-update-time") 🔥 Changes the default sort order of conversations to `Recently updated`.
 - [](# "conversation-filters") [Adds `Everything commented by you` and `Everything you subscribed to` filters in the search box dropdown.](https://user-images.githubusercontent.com/202916/84156153-72a62300-aa69-11ea-8592-3094292fde3c.png)
 - [](# "global-conversation-list-filters") [Adds filters for conversations _in your repos_ and _commented on by you_ in the global conversation search.](https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png)
@@ -227,7 +227,7 @@ Thanks for contributing! 🦋🙌
 - [](# "pr-filters") [Adds Checks and Draft PR dropdown filters in PR lists.](https://user-images.githubusercontent.com/202916/74453250-6d9de200-4e82-11ea-8fd4-7c0de57e001a.png)
 - [](# "pr-approvals-count") [Shows color-coded review counts in PR lists.](https://user-images.githubusercontent.com/1402241/33474535-a814ee78-d6ad-11e7-8f08-a8b72799e376.png)
 - [](# "highlight-non-default-base-branch") [Shows the base branch in PR lists if it’s not the default branch.](https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png)
-- [](# "hide-inactive-deployments") [Hides inactive deployments.](https://github.com/sindresorhus/refined-github/issues/1144)
+- [](# "hide-inactive-deployments") [Hides inactive deployments in PRs.](https://github.com/sindresorhus/refined-github/issues/1144)
 - [](# "previous-next-commit-buttons") [Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.](https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png)
 - [](# "preserve-whitespace-option-in-nav") Preserves the "ignore whitespace" setting when navigating with Next/Previous in PR review mode.
 - [](# "bypass-checks") [Bypasses the "Checks" interstitial when clicking the "Details" links on a PR Checks added by third-party services like Travis.](https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png)
@@ -235,7 +235,7 @@ Thanks for contributing! 🦋🙌
 - [](# "hidden-review-comments-indicator") [Adds comment indicators when comments are hidden in PR review.](https://user-images.githubusercontent.com/1402241/63112671-011d5580-bfbb-11e9-9e19-53e11641990e.gif)
 - [](# "conflict-marker") [Shows which PRs have conflicts in PR lists.](https://user-images.githubusercontent.com/9092510/62777551-2affe500-baae-11e9-8ba4-67f078347913.png)
 - [](# "pr-commit-lines-changed") [Adds diff stats on PR commits.](https://user-images.githubusercontent.com/16872793/76107253-48deeb00-5fa6-11ea-9931-721cde553bdf.png)
-- [](# "cross-deleted-pr-branches") [Adds a line-through to the deleted branches.](https://user-images.githubusercontent.com/16872793/75619638-9bef1300-5b4c-11ea-850e-3a8f95c86d83.png)
+- [](# "cross-deleted-pr-branches") [Adds a line-through to the deleted branches in PRs.](https://user-images.githubusercontent.com/16872793/75619638-9bef1300-5b4c-11ea-850e-3a8f95c86d83.png)
 - [](# "batch-mark-files-as-viewed") [Mark/unmark multiple files as “Viewed” in the PR Files tab. Click on the first checkbox you want to mark/unmark and then `shift`-click another one; all the files between the two checkboxes will be marked/unmarked as “Viewed”.](https://user-images.githubusercontent.com/1402241/79343285-854f2080-7f2e-11ea-8d4c-a9dc163be9be.gif)
 - [](# "first-published-tag-for-merged-pr") 🔥 [Shows the first Git tag a merged PR was included in.](https://user-images.githubusercontent.com/16872793/81943321-38ac4300-95c9-11ea-8543-0f4858174e1e.png)
 - [](# "pr-jump-to-first-non-viewed-file") [Jumps to first non-viewed file in a pull request when clicking on the progress bar.](https://user-images.githubusercontent.com/16872793/85226580-3bf3d500-b3a6-11ea-8494-3d9b6280d033.gif)
@@ -266,9 +266,9 @@ Thanks for contributing! 🦋🙌
 - [](# "follow-file-renames") 🔥 [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
 - [](# "link-to-file-in-file-history") [Adds links to the file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
-- [](# "remove-diff-signs") [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (since diffs are color coded already.)
+- [](# "remove-diff-signs") [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (+-) since diffs are color coded already.
 - [](# "suggest-commit-title-limit") [Suggests limiting commit titles to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
-- [](# "expand-all-collapsed-code") [Expands the entire file when you <kbd>alt</kbd> <kbd>click</kbd> on any "Expand code" button in diffs.](https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif)
+- [](# "expand-all-collapsed-code") [Expands the entire file when you <kbd>alt</kbd>-click on any "Expand code" button in diffs.](https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif)
 - [](# "tags-on-commits-list") [Displays the corresponding tags next to commits.](https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png)
 - [](# "mark-merge-commits-in-list") [Marks merge commits in commit lists.](https://user-images.githubusercontent.com/16872793/75561016-457eb900-5a14-11ea-95e1-a89e81ee7390.png)
 - [](# "deep-reblame") [When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit a single change.](https://user-images.githubusercontent.com/16872793/77248541-8e3f2180-6c10-11ea-91d4-221ccc0ecebb.png)
@@ -291,7 +291,7 @@ Thanks for contributing! 🦋🙌
 ### Profiles
 
 - [](# "user-profile-follower-badge") [On profiles, it shows whether the user follows you.](https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif)
-- [](# "profile-gists-link") [Adds a link to the user’s public gists.](https://user-images.githubusercontent.com/11544418/34268306-1c974fd2-e678-11e7-9e82-861dfe7add22.png)
+- [](# "profile-gists-link") [Adds a link to the user’s public gists on their profile.](https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png)
 - [](# "mark-private-orgs") [Marks private organizations on your own profile.](https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png)
 - [](# "profile-hotkey") Adds a keyboard shortcut to visit your own profile: <kbd>g</kbd> <kbd>m</kbd>.
 - [](# "show-user-top-repositories") [Adds a link to the user’s most starred repositories.](https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png)
@@ -305,8 +305,8 @@ Thanks for contributing! 🦋🙌
 ### Newsfeed
 
 - [](# "clean-dashboard") 🔥 [Condenses the events to take up less space and uncollapses "User starred X repos" groups.](https://user-images.githubusercontent.com/1402241/54401114-39192780-4701-11e9-9934-7c71f01e957f.png)
-- [](# "hide-own-stars") Hides "starred" events for your own repos.
-- [](# "hide-useless-newsfeed-events") Hides other inutile events (commits, forks, new followers).
+- [](# "hide-own-stars") Hides "starred" events for your own repos on the newsfeed.
+- [](# "hide-useless-newsfeed-events") Hides other inutile newsfeed events (commits, forks, new followers).
 - [](# "infinite-scroll") Automagically expands the newsfeed when you scroll down.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
@@ -317,12 +317,13 @@ Thanks for contributing! 🦋🙌
 - [](# "selection-in-new-tab") [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
 - [](# "close-out-of-view-modals") [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
 - [](# "deprioritize-marketplace-link") Moves the "Marketplace" link from the black header bar to the profile dropdown.
-- [](# "parse-backticks") [Renders text in <code>\`backticks\`</code> in issue titles, commit titles and more places.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [](# "parse-backticks") [Renders <code>\`text in backticks\`</code> in issue titles, commit titles and more places.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [](# "format-conversation-titles") [Makes issue/PR references in issue/PR titles clickable and renders <code>\`text in backticks\`</code>.](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
 - [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
-- [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal.](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png) *(<kbd>?</kbd> hotkey)*
+- [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
 - [](# "stop-redirecting-in-notification-bar") [Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.](https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png)
 - [](# "hide-zero-packages") [Hides the `Packages` tab if it’s empty (in repositories and user profiles).](https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png)
 

--- a/readme.md
+++ b/readme.md
@@ -135,7 +135,7 @@ Thanks for contributing! 🦋🙌
 - [](# "fit-textareas") 🔥 [Auto-resizes comment fields to fit their content and no longer show scroll bars.](https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif)
 - [](# "edit-comments-faster") [Lets you edit any comment with one click instead of having to open a dropdown.](https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png)
 - [](# "comment-fields-keyboard-shortcuts") [Adds a shortcut to edit your last comment: <kbd>↑</kbd>.](https://github.com/sindresorhus/refined-github/pull/961) (Only works in the following comment field, if it’s empty.)
-- [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif) `[` <code>\`</code> `'` `"` `*` `~` `_`
+- [](# "one-key-formatting") [Wraps selected text when pressing one of Markdown symbols instead of replacing it:](https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif) `[` `` ` `` `'` `"` `*` `~` `_`
 - [](# "minimize-upload-bar") [Reduces the upload bar to a small button.](https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png)
 - [](# "clean-rich-text-editor") [Hides unnecessary comment field tooltips and toolbar items](https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png) (each one has a keyboard shortcut.)
 - [](# "monospace-textareas") Uses a monospace font for all textareas.
@@ -281,8 +281,8 @@ Thanks for contributing! 🦋🙌
 - [](# "selection-in-new-tab") [Adds a keyboard shortcut to open selection in new tab when navigating via <kbd>j</kbd> and <kbd>k</kbd>: <kbd>shift</kbd> <kbd>o</kbd>.](https://github.com/sindresorhus/refined-github/issues/1110)
 - [](# "close-out-of-view-modals") [Automatically closes dropdown menus when they’re no longer visible.](https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif)
 - [](# "deprioritize-marketplace-link") Moves the "Marketplace" link from the black header bar to the profile dropdown.
-- [](# "parse-backticks") [Renders <code>\`text in backticks\`</code> in issue titles, commit titles and more places.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
-- [](# "format-conversation-titles") [Makes issue/PR references in issue/PR titles clickable and renders <code>\`text in backticks\`</code>.](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
+- [](# "parse-backticks") [Renders `` `text in backticks` `` in issue titles, commit titles and more places.](https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png)
+- [](# "format-conversation-titles") [Makes issue/PR references in issue/PR titles clickable and renders `` `text in backticks` ``.](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
 - [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)

--- a/readme.md
+++ b/readme.md
@@ -182,7 +182,7 @@ Thanks for contributing! 🦋🙌
 
 ### Reading comments
 
-- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG) Not supported by Firefox.
+- [](# "embed-gist-inline") [Embeds linked gists.](https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG)
 - [](# "comments-time-machine-links") Adds links to [browse the repository](https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png) and [linked files](https://user-images.githubusercontent.com/1402241/56450895-68076680-635b-11e9-86b4-b6c2f3745d51.png) at the time of each comment.
 - [](# "show-names") [Adds the real name of users by their usernames.](https://user-images.githubusercontent.com/1402241/62075835-5f82ce00-b270-11e9-91eb-4680b70cb3cb.png)
 - [](# "shorten-links") [Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".](https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png)
@@ -266,7 +266,7 @@ Thanks for contributing! 🦋🙌
 - [](# "follow-file-renames") 🔥 [Enhances files’ commit lists navigation to follow file renames.](https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png)
 - [](# "link-to-file-in-file-history") [Adds links to the file itself in a file’s commit list.](https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png)
 - [](# "extend-diff-expander") [Widens the `Expand diff` button to be clickable across the screen.](https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG)
-- [](# "remove-diff-signs") [Hides diff signs](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png) (+-) since diffs are color coded already.
+- [](# "remove-diff-signs") [Hides diff signs since diffs are color coded already.](https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png)
 - [](# "suggest-commit-title-limit") [Suggests limiting commit titles to 72 characters.](https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif)
 - [](# "expand-all-collapsed-code") [Expands the entire file when you <kbd>alt</kbd>-click on any "Expand code" button in diffs.](https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif)
 - [](# "tags-on-commits-list") [Displays the corresponding tags next to commits.](https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png)

--- a/readme.md
+++ b/readme.md
@@ -35,61 +35,25 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 <table>
 	<tr>
 		<th width="50%">
-			Makes whitespace characters visible
-		</th>
+			<p><a title="show-whitespace"></a> Makes whitespace characters visible
+			<p><img src="https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png">
 		<th width="50%">
-			Adds one-click merge conflict fixers
-		</th>
-	</tr>
-	<tr><!-- Prevent zebra stripes --></tr>
-	<tr>
-		<td>
-			<img id="show-whitespace" alt="Makes whitespace characters visible." src="https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png">
-		</td>
-		<td>
-			<img id="resolve-conflicts" alt="Adds one-click merge conflict fixers." src="https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png">
-		</td>
-	</tr>
-</table>
-
-<table>
+			<p><a title="resolve-conflicts"></a> Adds one-click merge conflict fixers
+			<p><img src="https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png">
 	<tr>
 		<th width="50%">
-			Adds reaction avatars showing <i>who</i> reacted to a comment
-		</th>
+			<p><a title="reactions-avatars"></a> Adds reaction avatars showing <i>who</i> reacted to a comment
+			<p><img src="https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png">
 		<th width="50%">
-			Adds the option to wait for checks when merging a PR
-		</th>
-	</tr>
-	<tr><!-- Prevent zebra stripes --></tr>
-	<tr>
-		<td>
-			<img id="reactions-avatars" alt="Adds reaction avatars showing *who* reacted to a comment." src="https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png">
-		</td>
-		<td>
-			<img id="wait-for-build" alt="Adds the option to wait for checks when merging a PR." src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">
-		</td>
-	</tr>
-</table>
-
-<table>
+			<p><a title="wait-for-build"></a> Adds the option to wait for checks when merging a PR
+			<p><img src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">
 	<tr>
 		<th width="50%">
-			Linkifies issue/PR references and URLs in code
-		</th>
+			<p><a title="linkify-code"></a> Linkifies issue/PR references and URLs in code
+			<p><img src="https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png">
 		<th width="50%">
-			Adds button to revert all the changes to a file in a PR
-		</th>
-	</tr>
-	<tr><!-- Prevent zebra stripes --></tr>
-	<tr>
-		<td>
-			<img id="linkify-code" alt="Linkifies issue/PR references and URLs in code." src="https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png">
-		</td>
-		<td>
-			<img id="restore-file" alt="Adds button to revert all the changes to a file in a PR." src="https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif">
-		</td>
-	</tr>
+			<p><a title="restore-file"></a> Adds button to revert all the changes to a file in a PR
+			<p><img src="https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif">
 </table>
 
 <!--

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -24,11 +24,7 @@ function init(): void {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you see how others are using the current Action in the Marketplace.',
-	screenshot: 'https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isMarketplaceAction
 	],

--- a/source/features/action-used-by-link.tsx
+++ b/source/features/action-used-by-link.tsx
@@ -24,7 +24,7 @@ function init(): void {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isMarketplaceAction
 	],

--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-align-issue-labels');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	include: [
 		pageDetect.isConversationList

--- a/source/features/align-issue-labels.tsx
+++ b/source/features/align-issue-labels.tsx
@@ -7,11 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-align-issue-labels');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Aligns labels in lists to the left.',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/85866472-11aa7900-b7e5-11ea-80aa-d84e3aee2551.png'
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	include: [
 		pageDetect.isConversationList

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -48,11 +48,7 @@ function deinit(): void {
 	previousFile = undefined;
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Mark/unmark multiple files as “Viewed” in the PR Files tab. Click on the first checkbox you want to mark/unmark and then `shift`-click another one; all the files between the two checkboxes will be marked/unmarked as “Viewed”.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/79343285-854f2080-7f2e-11ea-8d4c-a9dc163be9be.gif'
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	include: [
 		pageDetect.isPRFiles

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -48,7 +48,7 @@ function deinit(): void {
 	previousFile = undefined;
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	include: [
 		pageDetect.isPRFiles

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -103,11 +103,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you open multiple conversations at once via checkboxes.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/38084752-4820b0d8-3378-11e8-868c-a1582b16f915.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -103,7 +103,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -100,7 +100,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -100,11 +100,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a "Bugs" tab to repos, if there are any open issues with the "bug" label.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/73720910-a688d900-4755-11ea-9c8d-70e5ddb3bfe5.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -35,7 +35,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -35,11 +35,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Bypasses the "Checks" interstitial when clicking the "Details" links on a PR Checks added by third-party services like Travis.',
-	screenshot: 'https://user-images.githubusercontent.com/2103975/49071220-c6596e80-f22d-11e8-8a1e-bdcd62aa6ece.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -30,7 +30,7 @@ async function init(): Promise<false | void> {
 	select('[itemprop="name"]')!.parentElement!.append(icon);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -32,7 +32,7 @@ async function init(): Promise<false | void> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Add build status and link to CI after the repo’s title.',
+	description: 'Adds a build/CI status icon next to the repo’s name.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png'
 }, {
 	include: [

--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -30,11 +30,7 @@ async function init(): Promise<false | void> {
 	select('[itemprop="name"]')!.parentElement!.append(icon);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a build/CI status icon next to the repo’s name.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/32562120-d65166e4-c4e8-11e7-90fb-cbaf36e2709f.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -71,11 +71,7 @@ async function init(): Promise<void | false> {
 	]);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides `Projects` and `Milestones` filters in conversation lists if they are empty.',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/59083449-0ef88f80-8915-11e9-8296-68af1ddcf191.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -71,7 +71,7 @@ async function init(): Promise<void | false> {
 	]);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -52,11 +52,7 @@ function initPR(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Removes duplicate information in conversation headers.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/89736767-686ec800-da9e-11ea-81c3-252e9813140b.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -52,7 +52,7 @@ function initPR(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -15,11 +15,7 @@ function hideTextareaTooltip(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides unnecessary comment field tooltips and toolbar items (each one has a keyboard shortcut.)',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -17,7 +17,7 @@ function hideTextareaTooltip(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Hides unnecessary comment field tooltips and toolbar items.',
+	description: 'Hides unnecessary comment field tooltips and toolbar items (each one has a keyboard shortcut.)',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/53629083-a4fe8900-3c47-11e9-8211-bfe2d254ffcb.png'
 }, {
 	include: [

--- a/source/features/clean-rich-text-editor.tsx
+++ b/source/features/clean-rich-text-editor.tsx
@@ -15,7 +15,7 @@ function hideTextareaTooltip(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -109,7 +109,7 @@ async function clean(): Promise<void> {
 	cleanSection('[aria-label="Select milestones"]');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/clean-sidebar.tsx
+++ b/source/features/clean-sidebar.tsx
@@ -109,11 +109,7 @@ async function clean(): Promise<void> {
 	cleanSection('[aria-label="Select milestones"]');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides empty sections (or just their "empty" label) in the conversation sidebar.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/57199809-20691780-6fb6-11e9-9672-1ad3f9e1b827.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -30,7 +30,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile

--- a/source/features/cleanup-repo-filelist-actions.tsx
+++ b/source/features/cleanup-repo-filelist-actions.tsx
@@ -30,11 +30,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Replaces the labels of some simple buttons on repository filelists with icons, making them take less space.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/88551471-7a3f7c80-d055-11ea-82f1-c558b7871824.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -17,7 +17,7 @@ function init(): void {
 	messageField.value = [...deduplicatedAuthors].join('\n');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -17,11 +17,7 @@ function init(): void {
 	messageField.value = [...deduplicatedAuthors].join('\n');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Clears the PR merge commit message of clutter, leaving only deduplicated co-authors.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/79257078-62b6fc00-7e89-11ea-8798-c06f33baa94b.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/clone-branch.tsx
+++ b/source/features/clone-branch.tsx
@@ -95,7 +95,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-clone-branch', 'click', cloneBranch);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isBranches
 	],

--- a/source/features/clone-branch.tsx
+++ b/source/features/clone-branch.tsx
@@ -95,11 +95,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-clone-branch', 'click', cloneBranch);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Clone a branch from the branches list.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/76802029-2a020500-67ad-11ea-95dc-bee1b1352976.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isBranches
 	],

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -23,7 +23,7 @@ function init(): void {
 	document.addEventListener('menu:activated', menuActivatedHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	init
 });

--- a/source/features/close-out-of-view-modals.tsx
+++ b/source/features/close-out-of-view-modals.tsx
@@ -23,11 +23,7 @@ function init(): void {
 	document.addEventListener('menu:activated', menuActivatedHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Automatically closes dropdown menus when they’re no longer visible.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/37022353-531c676e-2155-11e8-96cc-80d934bb22e0.gif'
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	init
 });

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -44,11 +44,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to insert collapsible content (via `<details>`).',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/53678019-0c721280-3cf4-11e9-9c24-4d11a697f67c.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -44,7 +44,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -63,7 +63,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -64,13 +64,13 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	include: [
-		pageDetect.hasRichTextEditor
-	],
-	awaitDomReady: false,
 	shortcuts: {
 		'↑': 'Edit your last comment',
 		esc: 'Unfocuses comment field'
 	},
+	include: [
+		pageDetect.hasRichTextEditor
+	],
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -63,10 +63,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a shortcut to edit your last comment: `↑`. (Only works in the following comment field, if it’s empty.)',
-	screenshot: 'https://github.com/sindresorhus/refined-github/pull/961',
+void features.add(__filebasename, {
 	shortcuts: {
 		'↑': 'Edit your last comment',
 		esc: 'Unfocuses comment field'

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -63,15 +63,14 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		'↑': 'Edit your last comment',
-		esc: 'Unfocuses comment field'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],
 	awaitDomReady: false,
+	shortcuts: {
+		'↑': 'Edit your last comment',
+		esc: 'Unfocuses comment field'
+	},
 	init: onetime(init)
 });

--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -65,8 +65,8 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds shortcuts to comment fields: `↑` to edit your previous comment; `esc` to blur field or cancel comment.',
-	screenshot: false,
+	description: 'Adds a shortcut to edit your last comment: `↑`. (Only works in the following comment field, if it’s empty.)',
+	screenshot: 'https://github.com/sindresorhus/refined-github/pull/961',
 	shortcuts: {
 		'↑': 'Edit your last comment',
 		esc: 'Unfocuses comment field'

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -133,7 +133,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -133,11 +133,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds links to browse the repository and linked files at the time of each comment.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/56450896-68076680-635b-11e9-8b24-ebd11cc4e655.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -65,7 +65,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -65,11 +65,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows which PRs have conflicts in PR lists.',
-	screenshot: 'https://user-images.githubusercontent.com/9092510/62777551-2affe500-baae-11e9-8ba4-67f078347913.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/conversation-filters.tsx
+++ b/source/features/conversation-filters.tsx
@@ -34,11 +34,7 @@ function init(): void {
 	commentsMenuItem.after(subscriptionsMenuItem);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds `Everything commented by you` and `Everything you subscribed to` filters in the search box dropdown.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/84156153-72a62300-aa69-11ea-8592-3094292fde3c.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/conversation-filters.tsx
+++ b/source/features/conversation-filters.tsx
@@ -34,7 +34,7 @@ function init(): void {
 	commentsMenuItem.after(subscriptionsMenuItem);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -40,7 +40,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isUserProfileRepoTab,
 		pageDetect.isGlobalSearchResults

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -40,11 +40,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the issues and pulls on the user profile repository tab and global search.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isUserProfileRepoTab,
 		pageDetect.isGlobalSearchResults

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -34,7 +34,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -34,11 +34,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Moves the "Convert PR to Draft" button to the mergeability box and adds visual feedback to its confirm button.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -40,7 +40,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-convert-draft', 'click', convertToDraft);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleTag
 	],

--- a/source/features/convert-release-to-draft.tsx
+++ b/source/features/convert-release-to-draft.tsx
@@ -40,11 +40,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-convert-draft', 'click', convertToDraft);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to convert a release to draft.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/90017455-8e03f900-dc79-11ea-95c5-377e0a82d4ea.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleTag
 	],

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -60,7 +60,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isGist

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -60,11 +60,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to copy a file’s content.',
-	screenshot: 'https://cloud.githubusercontent.com/assets/170270/14453865/8abeaefe-00c1-11e6-8718-9406cee1dc0d.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isGist

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -20,11 +20,7 @@ function deinit(): void {
 	window.removeEventListener('keyup', handler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Enhances the `y` hotkey to also copy the permalink.',
-	screenshot: 'https://help.github.com/articles/getting-permanent-links-to-files/'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -23,7 +23,7 @@ function deinit(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Enhances the `y` hotkey to also copy the permalink.',
-	screenshot: false
+	screenshot: 'https://help.github.com/articles/getting-permanent-links-to-files/'
 }, {
 	include: [
 		pageDetect.isSingleFile

--- a/source/features/copy-on-y.tsx
+++ b/source/features/copy-on-y.tsx
@@ -20,7 +20,7 @@ function deinit(): void {
 	window.removeEventListener('keyup', handler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -17,7 +17,7 @@ function init(): void {
 void features.add(__filebasename, {
 	shortcuts: {
 		c: 'Create a new release',
-		'control enter': 'Publish a release'
+		'ctrl enter': 'Publish a release'
 	},
 	include: [
 		pageDetect.isReleasesOrTags

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -14,7 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -14,10 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a keyboard shortcut to create a new release while on the Releases page: `c`.',
-	screenshot: false,
+void features.add(__filebasename, {
 	shortcuts: {
 		c: 'Create a new release',
 		'control enter': 'Publish a release'

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -15,13 +15,13 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	include: [
-		pageDetect.isReleasesOrTags
-	],
 	shortcuts: {
 		c: 'Create a new release',
 		'control enter': 'Publish a release'
 	},
+	include: [
+		pageDetect.isReleasesOrTags
+	],
 	init
 }, {
 	include: [

--- a/source/features/create-release-shortcut.tsx
+++ b/source/features/create-release-shortcut.tsx
@@ -14,15 +14,14 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		c: 'Create a new release',
-		'control enter': 'Publish a release'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],
+	shortcuts: {
+		c: 'Create a new release',
+		'control enter': 'Publish a release'
+	},
 	init
 }, {
 	include: [

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -38,11 +38,7 @@ function init(): void | false {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a line-through to the deleted branches in PRs.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/75619638-9bef1300-5b4c-11ea-850e-3a8f95c86d83.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -38,7 +38,7 @@ function init(): void | false {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -52,7 +52,7 @@ function init(): void {
 	delegate(document, '.js-filterable-field', 'keydown', handleKeyDown);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isIssue,

--- a/source/features/cycle-lists-with-keyboard-shortcuts.tsx
+++ b/source/features/cycle-lists-with-keyboard-shortcuts.tsx
@@ -52,11 +52,7 @@ function init(): void {
 	delegate(document, '.js-filterable-field', 'keydown', handleKeyDown);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Allows the `↑` and `↓` keys to cycle "popover lists" (labels, milestones, etc).',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/59158786-6fd2c400-8add-11e9-9db1-db80186fa6ea.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isIssue,

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -109,7 +109,7 @@ function init(): void | false {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isBlame
 	],

--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -109,11 +109,7 @@ function init(): void | false {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'When exploring blames, `Alt`-clicking the “Reblame” buttons will extract the associated PR’s commits first, instead of treating the commit a single change.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/77248541-8e3f2180-6c10-11ea-91d4-221ccc0ecebb.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isBlame
 	],

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -53,11 +53,7 @@ async function init(): Promise<false | void> {
 	branchSelector.style.float = 'none'; // Pre "Repository refresh" layout
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the default branch on directory listings and files.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/71886648-2891dc00-316f-11ea-98d8-c5bf6c24d85c.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile,

--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -53,7 +53,7 @@ async function init(): Promise<false | void> {
 	branchSelector.style.float = 'none'; // Pre "Repository refresh" layout
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile,

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -22,7 +22,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isGist
 	],

--- a/source/features/deprioritize-marketplace-link.tsx
+++ b/source/features/deprioritize-marketplace-link.tsx
@@ -22,11 +22,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Moves the "Marketplace" link from the black header bar to the profile dropdown.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	exclude: [
 		pageDetect.isGist
 	],

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -22,7 +22,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommitList,
 		pageDetect.isConversationList

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -22,11 +22,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Dims commits and PRs by bots to reduce noise.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCommitList,
 		pageDetect.isConversationList

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -35,7 +35,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a button to a download button entire folders, via https://download-directory.github.io.',
+	description: 'Adds a button to download entire folders, via https://download-directory.github.io.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png'
 }, {
 	include: [

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -33,11 +33,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to download entire folders, via https://download-directory.github.io.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/35044451-fd3e2326-fbc2-11e7-82e1-61ec7bee612b.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -33,7 +33,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -26,11 +26,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you edit any comment with one click instead of having to open a dropdown.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54864831-92372a00-4d97-11e9-8c29-efba2dde1baa.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -26,7 +26,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -29,7 +29,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/edit-files-faster.tsx
+++ b/source/features/edit-files-faster.tsx
@@ -29,11 +29,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to edit files from the repo file list.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/56370462-d51cde00-622d-11e9-8cd3-8a173bd3dc08.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -49,7 +49,7 @@ async function init(): Promise<void | false> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/edit-readme.tsx
+++ b/source/features/edit-readme.tsx
@@ -49,11 +49,7 @@ async function init(): Promise<void | false> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Ensures that the “Edit readme” button always appears (even when you have to make a fork) and works (GitHub’s link does’t work on git tags).',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/62073307-a8378880-b26a-11e9-9e31-be6525d989d2.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -51,7 +51,7 @@ function init(): void {
 		.forEach(embedGist);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -51,11 +51,7 @@ function init(): void {
 		.forEach(embedGist);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Embeds linked gists. Not supported by Firefox.',
-	screenshot: 'https://user-images.githubusercontent.com/6978877/33911900-c62ee968-df8b-11e7-8685-506ffafc60b4.PNG'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -25,7 +25,7 @@ function init(): void {
 	embedViaScript.after(embedViaIframe);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleGist
 	],

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -25,11 +25,7 @@ function init(): void {
 	embedViaScript.after(embedViaIframe);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a menu item to embed a gist via `<iframe>`.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleGist
 	],

--- a/source/features/embed-gist-via-iframe.tsx
+++ b/source/features/embed-gist-via-iframe.tsx
@@ -27,7 +27,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a menu item to embed a gist via <iframe>.',
+	description: 'Adds a menu item to embed a gist via `<iframe>`.',
 	screenshot: 'https://user-images.githubusercontent.com/44045911/63633382-6a1b6200-c67a-11e9-9038-aedd62e4f6a8.png'
 }, {
 	include: [

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -55,7 +55,7 @@ function init(): void {
 	delegate(document, '.file-header:not([data-file-deleted="true"]) .js-file-header-dropdown:not(.rgh-actionable-link)', 'toggle', handleMenuOpening, true);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -55,11 +55,7 @@ function init(): void {
 	delegate(document, '.file-header:not([data-file-deleted="true"]) .js-file-header-dropdown:not(.rgh-actionable-link)', 'toggle', handleMenuOpening, true);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Points the "View file" on compare view pages to the branch instead of the commit, so the Edit/Delete buttons will be enabled on the "View file" page, if needed.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/69044026-c5b17d80-0a26-11ea-86ae-c95f89d3669a.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -23,7 +23,7 @@ function init(): void {
 	document.body.addEventListener('keyup', listener);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -23,11 +23,7 @@ function init(): void {
 	document.body.addEventListener('keyup', listener);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a keyboard shortcut to deselect the current line: `esc`.',
-	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1590'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -26,7 +26,7 @@ function init(): void {
 void features.add({
 	id: __filebasename,
 	description: 'Adds a keyboard shortcut to deselect the current line: `esc`.',
-	screenshot: false
+	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1590'
 }, {
 	include: [
 		pageDetect.hasCode

--- a/source/features/expand-all-collapsed-code.tsx
+++ b/source/features/expand-all-collapsed-code.tsx
@@ -41,11 +41,7 @@ function init(): void {
 	delegate(document, expanderSelector, 'click', handleAltClick);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Expands the entire file when you `alt`-click on any "Expand code" button in diffs.',
-	screenshot: 'https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRCommit,
 		pageDetect.isPRFiles,

--- a/source/features/expand-all-collapsed-code.tsx
+++ b/source/features/expand-all-collapsed-code.tsx
@@ -41,7 +41,7 @@ function init(): void {
 	delegate(document, expanderSelector, 'click', handleAltClick);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRCommit,
 		pageDetect.isPRFiles,

--- a/source/features/expand-all-collapsed-code.tsx
+++ b/source/features/expand-all-collapsed-code.tsx
@@ -43,7 +43,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Expands the entire file when you alt-click on any "Expand code" button in diffs.',
+	description: 'Expands the entire file when you `alt`-click on any "Expand code" button in diffs.',
 	screenshot: 'https://user-images.githubusercontent.com/44227187/64923605-d0138900-d7e3-11e9-9dc2-461aba81c1cb.gif'
 }, {
 	include: [

--- a/source/features/expand-all-hidden-comments.tsx
+++ b/source/features/expand-all-hidden-comments.tsx
@@ -29,7 +29,7 @@ function init(): void {
 	delegate(document, '.ajax-pagination-form button[type="submit"]', 'click', handleAltClick);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/expand-all-hidden-comments.tsx
+++ b/source/features/expand-all-hidden-comments.tsx
@@ -29,11 +29,7 @@ function init(): void {
 	delegate(document, '.ajax-pagination-form button[type="submit"]', 'click', handleAltClick);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'On long conversations where GitHub hides comments under a "Load more...", alt-clicking it will load up to 200 comments at once instead of 60.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/73838332-0c548e00-4846-11ea-935f-28d728b30ae9.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -61,7 +61,7 @@ async function init(): Promise<void | false> {
 	togglableFilters();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -61,11 +61,7 @@ async function init(): Promise<void | false> {
 	togglableFilters();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you toggle between is:open/is:closed/is:merged filters in searches.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/73605061-2125ed00-45cc-11ea-8cbd-41a53ae00cd3.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -16,11 +16,7 @@ function init(): void {
 	delegate(document, '.diff-view .js-expandable-line', 'click', expandDiff);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Widens the `Expand diff` button to be clickable across the screen.',
-	screenshot: 'https://user-images.githubusercontent.com/6978877/34470024-eee4f43e-ef20-11e7-9036-65094bd58960.PNG'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isCommit

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -16,7 +16,7 @@ function init(): void {
 	delegate(document, '.diff-view .js-expandable-line', 'click', expandDiff);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isCommit

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -109,14 +109,13 @@ function init(): false | void {
 	}
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		'd w': 'Show/hide whitespaces in diffs'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		// Disabled because of #2291 // pageDetect.isPRFiles
 		pageDetect.isCommit
 	],
+	shortcuts: {
+		'd w': 'Show/hide whitespaces in diffs'
+	},
 	init
 });

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -109,7 +109,7 @@ function init(): false | void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		// Disabled because of #2291 // pageDetect.isPRFiles
 		pageDetect.isCommit

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -111,7 +111,7 @@ function init(): false | void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: `d` `w`.',
+	description: 'Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: `d` `w`.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png',
 	shortcuts: {
 		'd w': 'Show/hide whitespaces in diffs'

--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -109,10 +109,7 @@ function init(): false | void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds one-click buttons to change diff style and to ignore the whitespace and a keyboard shortcut to ignore the whitespace: `d` `w`.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54178764-d1c96080-44d1-11e9-889c-734ffd2a602d.png',
+void features.add(__filebasename, {
 	shortcuts: {
 		'd w': 'Show/hide whitespaces in diffs'
 	}

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -39,7 +39,7 @@ async function initReviewButtonEnhancements(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -49,12 +49,12 @@ void features.add(__filebasename, {
 	awaitDomReady: false,
 	init: addSidebarReviewButton
 }, {
+	shortcuts: {
+		v: 'Open PR review popup'
+	},
 	include: [
 		pageDetect.isPRFiles
 	],
 	awaitDomReady: false,
-	shortcuts: {
-		v: 'Open PR review popup'
-	},
 	init: initReviewButtonEnhancements
 });

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -39,11 +39,7 @@ async function initReviewButtonEnhancements(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		v: 'Open PR review popup'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],
@@ -57,5 +53,8 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles
 	],
 	awaitDomReady: false,
+	shortcuts: {
+		v: 'Open PR review popup'
+	},
 	init: initReviewButtonEnhancements
 });

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -39,10 +39,7 @@ async function initReviewButtonEnhancements(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a review button to the PR sidebar, autofocuses the review textarea and adds a keyboard shortcut to open the review popup: `v`.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/83269671-bb3b2200-a1c7-11ea-90b3-b9457a454162.png',
+void features.add(__filebasename, {
 	shortcuts: {
 		v: 'Open PR review popup'
 	}

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -51,11 +51,7 @@ function init(): void {
 	window.addEventListener('pjax:complete', pjaxCompleteHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you start typing your search immediately after invoking the File Finder (`t`), instead of having you wait for it to load first.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/75542106-1c811700-5a5a-11ea-8aa5-bea0472c59e2.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/file-finder-buffer.tsx
+++ b/source/features/file-finder-buffer.tsx
@@ -51,7 +51,7 @@ function init(): void {
 	window.addEventListener('pjax:complete', pjaxCompleteHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -46,7 +46,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -46,11 +46,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows the first Git tag a merged PR was included in.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/81943321-38ac4300-95c9-11ea-8543-0f4858174e1e.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -35,7 +35,7 @@ function init(): void {
 	select.all('textarea').forEach(watchTextarea);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -37,7 +37,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Auto-resizes comment fields to fit their content and no longer show scroll bars, rather than have a height limit like GitHub’s native "fit to content" behavior.',
+	description: 'Auto-resizes comment fields to fit their content and no longer show scroll bars.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif'
 }, {
 	include: [

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -35,11 +35,7 @@ function init(): void {
 	select.all('textarea').forEach(watchTextarea);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Auto-resizes comment fields to fit their content and no longer show scroll bars.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54336211-66fd5e00-4666-11e9-9c5e-111fccab004d.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -64,11 +64,7 @@ function init(): false | void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Enhances files’ commit lists navigation to follow file renames.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54799957-7306a280-4c9a-11e9-86de-b9764ed93397.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -64,7 +64,7 @@ function init(): false | void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -20,7 +20,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -20,11 +20,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Points the “Forked from user/repository” link to current folder or file in the upstream repository.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/84795784-3722d000-aff8-11ea-9b34-97c01acf4fd4.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -111,7 +111,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/forked-to.tsx
+++ b/source/features/forked-to.tsx
@@ -111,11 +111,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a shortcut to your forks next to the `Fork` button on the current repo.',
-	screenshot: 'https://user-images.githubusercontent.com/55841/64077281-17bbf000-cccf-11e9-9123-092063f65357.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/format-conversation-titles.tsx
+++ b/source/features/format-conversation-titles.tsx
@@ -14,7 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR,
 		pageDetect.isIssue

--- a/source/features/format-conversation-titles.tsx
+++ b/source/features/format-conversation-titles.tsx
@@ -14,11 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes issue/PR references in issue/PR titles clickable and renders `text in backticks`.',
-	screenshot: 'https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPR,
 		pageDetect.isIssue

--- a/source/features/format-conversation-titles.tsx
+++ b/source/features/format-conversation-titles.tsx
@@ -16,7 +16,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Make issue/PR references in issue/PR titles clickable and parse `code in backticks` that appear as Markdown',
+	description: 'Makes issue/PR references in issue/PR titles clickable and renders `text in backticks`.',
 	screenshot: 'https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png'
 }, {
 	include: [

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -42,11 +42,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds filters for conversations _in your repos_ and _commented on by you_ in the global conversation search.',
-	screenshot: 'https://user-images.githubusercontent.com/8295888/36827126-8bfc79c4-1d37-11e8-8754-992968b082be.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isGlobalConversationList
 	],

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -42,7 +42,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isGlobalConversationList
 	],

--- a/source/features/go-to-action-from-file.tsx
+++ b/source/features/go-to-action-from-file.tsx
@@ -27,11 +27,7 @@ function init(): void {
 		);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to access the past runs of a GitHub Action workflow when seeing the workflow configuration file.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80146153-ab6d6400-85b1-11ea-9f38-e87950692a62.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		isWorkflowFile
 	],

--- a/source/features/go-to-action-from-file.tsx
+++ b/source/features/go-to-action-from-file.tsx
@@ -27,7 +27,7 @@ function init(): void {
 		);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		isWorkflowFile
 	],

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -69,11 +69,7 @@ function init(): void {
 	delegate(document, '.rgh-comments-indicator', 'click', handleIndicatorClick);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds comment indicators when comments are hidden in PR review.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/63112671-011d5580-bfbb-11e9-9e19-53e11641990e.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -69,7 +69,7 @@ function init(): void {
 	delegate(document, '.rgh-comments-indicator', 'click', handleIndicatorClick);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -73,11 +73,7 @@ function init(): void {
 	delegate(document, '.rgh-hide-comments-faster-details', 'toggle', resetDropdowns, true);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Simplifies the UI to hide comments.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/43039221-1ddc91f6-8d29-11e8-9ed4-93459191a510.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -73,7 +73,7 @@ function init(): void {
 	delegate(document, '.rgh-hide-comments-faster-details', 'toggle', resetDropdowns, true);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/hide-disabled-milestone-sorter.tsx
+++ b/source/features/hide-disabled-milestone-sorter.tsx
@@ -12,11 +12,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides the milestone sorter UI if you don’t have permission to use it.',
-	screenshot: 'https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isMilestone
 	],

--- a/source/features/hide-disabled-milestone-sorter.tsx
+++ b/source/features/hide-disabled-milestone-sorter.tsx
@@ -12,7 +12,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isMilestone
 	],

--- a/source/features/hide-empty-meta.tsx
+++ b/source/features/hide-empty-meta.tsx
@@ -10,7 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoRoot
 	],

--- a/source/features/hide-empty-meta.tsx
+++ b/source/features/hide-empty-meta.tsx
@@ -10,11 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides the placeholder text in repos without a description.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoRoot
 	],

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -16,7 +16,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -16,11 +16,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides inactive deployments in PRs.',
-	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1144'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/hide-issue-list-autocomplete.tsx
+++ b/source/features/hide-issue-list-autocomplete.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	select('.subnav-search')!.setAttribute('autocomplete', 'off');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/hide-issue-list-autocomplete.tsx
+++ b/source/features/hide-issue-list-autocomplete.tsx
@@ -7,11 +7,7 @@ function init(): void {
 	select('.subnav-search')!.setAttribute('autocomplete', 'off');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Removes the autocomplete on search fields.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/42991841-1f057e4e-8c07-11e8-909c-b051db7a2a03.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -12,11 +12,7 @@ function init(): void {
 	}, {once: true});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Removes the file hover effect in the repo file browser.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -14,7 +14,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Removes the file hover effect in the repo file browser. Some lists like notifications, file lists, and issue lists, are highlighted as you move the mouse over them. This highlight is useful when navigating via the keyboard (j/k), but annoying when just moving the mouse around.',
+	description: 'Removes the file hover effect in the repo file browser.',
 	screenshot: false
 }, {
 	awaitDomReady: false,

--- a/source/features/hide-navigation-hover-highlight.tsx
+++ b/source/features/hide-navigation-hover-highlight.tsx
@@ -12,7 +12,7 @@ function init(): void {
 	}, {once: true});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -17,7 +17,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/hide-own-stars.tsx
+++ b/source/features/hide-own-stars.tsx
@@ -17,11 +17,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides "starred" events for your own repos on the newsfeed.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -61,7 +61,7 @@ function init(): void {
 
 void void features.add({
 	id: __filebasename,
-	description: 'Hides reaction comments ("+1", "👍", …).',
+	description: 'Hides reaction comments ("+1", "👍", …) (except the maintainers’) but they can still be shown.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png'
 }, {
 	include: [

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -59,7 +59,7 @@ function init(): void {
 	}
 }
 
-void void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -59,11 +59,7 @@ function init(): void {
 	}
 }
 
-void void features.add({
-	id: __filebasename,
-	description: 'Hides reaction comments ("+1", "👍", …) (except the maintainers’) but they can still be shown.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/45543717-d45f3c00-b847-11e8-84a5-8c439d0ad1a5.png'
-}, {
+void void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -8,11 +8,7 @@ function init(): void {
 	document.body.classList.add('rgh-no-useless-events');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides other inutile newsfeed events (commits, forks, new followers).',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -8,7 +8,7 @@ function init(): void {
 	document.body.classList.add('rgh-no-useless-events');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/hide-useless-newsfeed-events.tsx
+++ b/source/features/hide-useless-newsfeed-events.tsx
@@ -10,7 +10,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Hides inutile newsfeed events (commits, forks, new followers).',
+	description: 'Hides other inutile newsfeed events (commits, forks, new followers).',
 	screenshot: false
 }, {
 	include: [

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -8,7 +8,7 @@ function init(): void {
 	document.body.classList.add('rgh-hide-watch-and-fork-count');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/hide-watch-and-fork-count.tsx
+++ b/source/features/hide-watch-and-fork-count.tsx
@@ -8,11 +8,7 @@ function init(): void {
 	document.body.classList.add('rgh-hide-watch-and-fork-count');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides forks and watchers counters.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/53681077-f3328b80-3d1e-11e9-9e29-2cb017141769.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -17,11 +17,7 @@ async function init(): Promise<void | false> {
 	packagesTab.closest('.BorderGrid-row, .UnderlineNav-item')!.remove();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides the `Packages` tab if it’s empty (in repositories and user profiles).',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoRoot,
 		pageDetect.isUserProfile

--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -17,7 +17,7 @@ async function init(): Promise<void | false> {
 	packagesTab.closest('.BorderGrid-row, .UnderlineNav-item')!.remove();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoRoot,
 		pageDetect.isUserProfile

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -107,11 +107,7 @@ function init(): false | void {
 	highlightBestComment(bestComment);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Highlights the most useful comment in conversations.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/58757449-5b238880-853f-11e9-9526-e86c41a32f00.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -107,7 +107,7 @@ function init(): false | void {
 	highlightBestComment(bestComment);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isIssue
 	],

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -37,11 +37,7 @@ function highlightSelf(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Highlights conversations opened by you or the current repo’s collaborators.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/65013882-03225d80-d947-11e9-8eb8-5507bc1fc14b.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/highlight-collaborators-and-own-conversations.tsx
+++ b/source/features/highlight-collaborators-and-own-conversations.tsx
@@ -37,7 +37,7 @@ function highlightSelf(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -60,11 +60,7 @@ async function init(): Promise<void | false> {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Indicates with an icon whether files in commits and pull requests being added or removed.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/90332474-23262b00-dfb5-11ea-9a03-8fd676ea0fdd.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isCommit,

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -60,7 +60,7 @@ async function init(): Promise<void | false> {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isCommit,

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -64,11 +64,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows the base branch in PR lists if it’s not the default branch.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/88480306-39f4d700-cf4d-11ea-9e40-2b36d92d41aa.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -64,7 +64,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList
 	],

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -20,11 +20,7 @@ function init(): void {
 		);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to preview HTML files.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/67634792-48995980-f8fb-11e9-8b6a-7b57d5b12a2f.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		isSingleHTMLFile
 	],

--- a/source/features/html-preview-link.tsx
+++ b/source/features/html-preview-link.tsx
@@ -20,7 +20,7 @@ function init(): void {
 		);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		isSingleHTMLFile
 	],

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -61,11 +61,7 @@ function init(): void {
 	document.addEventListener('keypress', observeShortcutModal);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (`?` hotkey).',
-	screenshot: 'https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png'
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -63,7 +63,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Show Refined GitHub’s keyboard shortcuts in the help modal (`?` hotkey).',
+	description: 'Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (`?` hotkey).',
 	screenshot: 'https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png'
 }, {
 	awaitDomReady: false,

--- a/source/features/improve-shortcut-help.tsx
+++ b/source/features/improve-shortcut-help.tsx
@@ -61,7 +61,7 @@ function init(): void {
 	document.addEventListener('keypress', observeShortcutModal);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -192,7 +192,7 @@ function enforceDefaults(
 }
 
 /** Register a new feature */
-const add = async (id: FeatureID, _settings: any, ...loaders: FeatureLoader[]): Promise<void> => {
+const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> => {
 	/* Feature filtering and running */
 	const options = await globalReady;
 	if (options[`feature:${id}`] === false) {
@@ -250,7 +250,7 @@ This means that the old features will still be on the page and don't need to re-
 
 This marks each as "processed"
 */
-void add(__filebasename, {}, {
+void add(__filebasename, {
 	init: async () => {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -16,6 +16,9 @@ type CallerFunction = (callback: VoidFunction) => void;
 type FeatureInit = () => Promisable<false | void>;
 
 interface FeatureLoader extends Partial<InternalRunConfig> {
+	/** This only adds the shortcut to the help screen, it doesn't enable it. @default {} */
+	shortcuts?: FeatureShortcuts;
+
 	/** Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady?: false;
 
@@ -24,9 +27,6 @@ interface FeatureLoader extends Partial<InternalRunConfig> {
 
 	/** When true, don’t run the `init` on page load but only add the `additionalListeners`. @default false */
 	onlyAdditionalListeners?: true;
-
-	/** This only adds the shortcut to the help screen, it doesn't enable it. @default {} */
-	shortcuts?: FeatureShortcuts;
 
 	init: FeatureInit; // Repeated here because this interface is Partial<>
 }
@@ -203,6 +203,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 	for (const loader of loaders) {
 		// Input defaults and validation
 		const {
+			shortcuts = {},
 			include = [() => true], // Default: every page
 			exclude = [], // Default: nothing
 			init,
@@ -210,8 +211,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 			awaitDomReady = true,
 			repeatOnBackButton = false,
 			onlyAdditionalListeners = false,
-			additionalListeners = [],
-			shortcuts = {}
+			additionalListeners = []
 		} = loader;
 
 		// Register feature shortcuts

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -200,7 +200,7 @@ function enforceDefaults(
 	}
 }
 
-type FeatureSettings = Pick<FeatureMeta, 'disabled'|'shortcuts'>
+type FeatureSettings = Pick<FeatureMeta, 'disabled'|'shortcuts'>;
 
 /** Register a new feature */
 const add = async (id: FeatureID, settings: FeatureSettings, ...loaders: FeatureLoader[]): Promise<void> => {
@@ -208,7 +208,7 @@ const add = async (id: FeatureID, settings: FeatureSettings, ...loaders: Feature
 	const {
 		disabled = false,
 		shortcuts = {}
-	} = settings ?? {};
+	} = settings;
 
 	/* Feature filtering and running */
 	const options = await globalReady;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -200,14 +200,15 @@ function enforceDefaults(
 	}
 }
 
+type FeatureSettings = Pick<FeatureMeta, 'disabled'|'shortcuts'>
+
 /** Register a new feature */
-const add = async (meta?: FeatureMeta, ...loaders: FeatureLoader[]): Promise<void> => {
+const add = async (id: FeatureID, settings: FeatureSettings, ...loaders: FeatureLoader[]): Promise<void> => {
 	/* Input defaults and validation */
 	const {
-		id = __filebasename,
 		disabled = false,
 		shortcuts = {}
-	} = meta ?? {};
+	} = settings ?? {};
 
 	/* Feature filtering and running */
 	const options = await globalReady;
@@ -265,7 +266,7 @@ This means that the old features will still be on the page and don't need to re-
 
 This marks each as "processed"
 */
-void add(undefined, {
+void add(__filebasename, {}, {
 	init: async () => {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -15,17 +15,6 @@ type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;
 type FeatureInit = () => Promisable<false | void>;
 
-interface FeatureMeta {
-	/**
-	If it's disabled, this should be the issue that explains why, as a reference
-	@example '#123'
-	*/
-	disabled?: string;
-	id: FeatureID;
-	description: string;
-	screenshot: string | false;
-}
-
 interface FeatureLoader extends Partial<InternalRunConfig> {
 	/** Whether to wait for DOM ready before running `init`. `false` makes `init` run right as soon as `body` is found. @default true */
 	awaitDomReady?: false;
@@ -202,19 +191,12 @@ function enforceDefaults(
 	}
 }
 
-type FeatureSettings = Pick<FeatureMeta, 'disabled'>;
-
 /** Register a new feature */
-const add = async (id: FeatureID, settings: FeatureSettings, ...loaders: FeatureLoader[]): Promise<void> => {
-	/* Input defaults and validation */
-	const {
-		disabled = false
-	} = settings;
-
+const add = async (id: FeatureID, _settings: any, ...loaders: FeatureLoader[]): Promise<void> => {
 	/* Feature filtering and running */
 	const options = await globalReady;
-	if (disabled || options[`feature:${id}`] === false) {
-		log('↩️', 'Skipping', id, disabled ? `because of ${disabled}` : '');
+	if (options[`feature:${id}`] === false) {
+		log('↩️', 'Skipping', id);
 		return;
 	}
 

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -35,7 +35,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/infinite-scroll.tsx
+++ b/source/features/infinite-scroll.tsx
@@ -35,11 +35,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Automagically expands the newsfeed when you scroll down.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -54,7 +54,7 @@ function init(): void {
 	document.addEventListener('keypress', runShortcuts);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -54,10 +54,7 @@ function init(): void {
 	document.addEventListener('keypress', runShortcuts);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds shortcuts to conversations and PR file lists: `j` focuses the comment/file below; `k` focuses the comment/file above.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/86573176-48665900-bf74-11ea-8996-a5c46cb7bdfd.gif',
+void features.add(__filebasename, {
 	shortcuts: {
 		j: 'Focus the comment/file below',
 		k: 'Focus the comment/file above'

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -55,12 +55,12 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	include: [
-		pageDetect.hasComments
-	],
 	shortcuts: {
 		j: 'Focus the comment/file below',
 		k: 'Focus the comment/file above'
 	},
+	include: [
+		pageDetect.hasComments
+	],
 	init
 });

--- a/source/features/keyboard-navigation.tsx
+++ b/source/features/keyboard-navigation.tsx
@@ -54,14 +54,13 @@ function init(): void {
 	document.addEventListener('keypress', runShortcuts);
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		j: 'Focus the comment/file below',
-		k: 'Focus the comment/file above'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],
+	shortcuts: {
+		j: 'Focus the comment/file below',
+		k: 'Focus the comment/file above'
+	},
 	init
 });

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -137,11 +137,7 @@ async function init(): Promise<false | void> {
 	link.classList.add('tooltipped', 'tooltipped-ne');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the latest version tag on directory listings and files.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/74594998-71df2080-5077-11ea-927c-b484ca656e88.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -137,7 +137,7 @@ async function init(): Promise<false | void> {
 	link.classList.add('tooltipped', 'tooltipped-ne');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree,
 		pageDetect.isSingleFile

--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -29,7 +29,7 @@ function init(): void | false {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/link-to-file-in-file-history.tsx
+++ b/source/features/link-to-file-in-file-history.tsx
@@ -29,11 +29,7 @@ function init(): void | false {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds links to the file itself in a file’s commit list.',
-	screenshot: 'https://user-images.githubusercontent.com/22439276/57195061-b88ddf00-6f6b-11e9-8ad9-13225d09266d.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -41,11 +41,7 @@ async function initRepo(): Promise<void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to visit the user’s github.io website from its repo.',
-	screenshot: 'https://user-images.githubusercontent.com/31387795/94045261-dbcd5e80-fdec-11ea-83fa-30bb673cc26e.jpg'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -41,7 +41,7 @@ async function initRepo(): Promise<void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -10,7 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isBlame
 	],

--- a/source/features/link-to-prior-blame-line.tsx
+++ b/source/features/link-to-prior-blame-line.tsx
@@ -10,11 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Preserves the current line on “View blame prior to this change” links.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/60064482-26b47e00-9733-11e9-803c-c113ea612fbe.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isBlame
 	],

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<void | false> {
 	wrap(element.closest('.branch-name')!, <a href={branchUrl}/>);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isQuickPR
 	],

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -16,11 +16,7 @@ async function init(): Promise<void | false> {
 	wrap(element.closest('.branch-name')!, <a href={branchUrl}/>);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies branch references in "Quick PR" pages.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isQuickPR
 	],

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -36,7 +36,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Linkifies URLs and issue references in code.',
+	description: 'Linkifies issue/PR references and URLs in code.',
 	screenshot: 'https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png'
 }, {
 	include: [

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -34,11 +34,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies issue/PR references and URLs in code.',
-	screenshot: 'https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/linkify-code.tsx
+++ b/source/features/linkify-code.tsx
@@ -34,7 +34,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/linkify-commit-sha.tsx
+++ b/source/features/linkify-commit-sha.tsx
@@ -12,11 +12,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the non-PR commit when visiting a PR commit.',
-	screenshot: 'https://user-images.githubusercontent.com/101152/42968387-606b23f2-8ba3-11e8-8a4b-667bddc8d33c.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRCommit
 	],

--- a/source/features/linkify-commit-sha.tsx
+++ b/source/features/linkify-commit-sha.tsx
@@ -12,7 +12,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRCommit
 	],

--- a/source/features/linkify-full-profile-readme-title.tsx
+++ b/source/features/linkify-full-profile-readme-title.tsx
@@ -10,7 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isUserProfileMainTab
 	],

--- a/source/features/linkify-full-profile-readme-title.tsx
+++ b/source/features/linkify-full-profile-readme-title.tsx
@@ -10,11 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkify the readme text on profile pages.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/90910173-ebe4bf00-e3a4-11ea-8fc5-aea3d1a2e5e5.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isUserProfileMainTab
 	],

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -26,11 +26,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes labels clickable on the dashboard.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/69045444-6ef97300-0a29-11ea-99a3-9a622c395709.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/linkify-labels-on-dashboard.tsx
+++ b/source/features/linkify-labels-on-dashboard.tsx
@@ -26,7 +26,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -14,7 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/linkify-notification-repository-header.tsx
+++ b/source/features/linkify-notification-repository-header.tsx
@@ -14,11 +14,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies the header of each notification group (when grouped by repository).',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80849887-81531c00-8c19-11ea-8777-7294ce318630.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -12,11 +12,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies symbolic links files.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/62036664-6d0e6880-b21c-11e9-9270-4ae30cc10de2.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -12,7 +12,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -20,11 +20,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies the username in the edit history popup.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/88917988-9ebb7480-d260-11ea-8690-0a3440f1ebbc.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -32,10 +32,6 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Linkifies the user location in their hovercard and profile page.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png'
-}, {
+void features.add(__filebasename, {}, {
 	init
 });

--- a/source/features/linkify-user-location.tsx
+++ b/source/features/linkify-user-location.tsx
@@ -32,6 +32,6 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init
 });

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -133,7 +133,7 @@ async function init(): Promise<void> {
 	select('.breadcrumb')!.before(link);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isEditingFile,
 		pageDetect.isSingleFile

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -133,11 +133,7 @@ async function init(): Promise<void> {
 	select('.breadcrumb')!.before(link);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows PRs that touch the current file.',
-	screenshot: 'https://user-images.githubusercontent.com/55841/60622834-879e1f00-9de1-11e9-9a9e-bae5ec0b3728.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isEditingFile,
 		pageDetect.isSingleFile

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -56,11 +56,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Marks merge commits in commit lists.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/75561016-457eb900-5a14-11ea-95e1-a89e81ee7390.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCommitList
 	],

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -56,7 +56,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommitList
 	],

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -34,11 +34,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Marks private organizations on your own profile.',
-	screenshot: 'https://user-images.githubusercontent.com/6775216/44633467-d5dcc900-a959-11e8-9116-e6b0ffef66af.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isOwnUserProfile
 	],

--- a/source/features/mark-private-orgs.tsx
+++ b/source/features/mark-private-orgs.tsx
@@ -34,7 +34,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isOwnUserProfile
 	],

--- a/source/features/minimize-upload-bar.tsx
+++ b/source/features/minimize-upload-bar.tsx
@@ -30,11 +30,7 @@ function init(): void {
 	delegate(document, '.rgh-upload-btn', 'click', triggerUpload);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Reduces the upload bar to a small button.',
-	screenshot: 'https://user-images.githubusercontent.com/55841/59802383-3d994180-92e9-11e9-835d-60de67611c30.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/minimize-upload-bar.tsx
+++ b/source/features/minimize-upload-bar.tsx
@@ -30,7 +30,7 @@ function init(): void {
 	delegate(document, '.rgh-upload-btn', 'click', triggerUpload);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/monospace-textareas.tsx
+++ b/source/features/monospace-textareas.tsx
@@ -7,11 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-monospace-textareas');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Uses a monospace font for all textareas.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/monospace-textareas.tsx
+++ b/source/features/monospace-textareas.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-monospace-textareas');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/monospace-textareas.tsx
+++ b/source/features/monospace-textareas.tsx
@@ -9,7 +9,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Use a monospace font for all textareas.',
+	description: 'Uses a monospace font for all textareas.',
 	screenshot: false
 }, {
 	awaitDomReady: false,

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -121,11 +121,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds useful links to the repository navigation dropdown and moves the "Security" and "Insights" tabs to it as well.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/55089736-d94f5300-50e8-11e9-9095-329ac74c1e9f.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -121,7 +121,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/navigate-pages-with-arrow-keys.tsx
+++ b/source/features/navigate-pages-with-arrow-keys.tsx
@@ -28,10 +28,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds shortcuts to navigate through pages with pagination: `←` and `→`.',
-	screenshot: false,
+void features.add(__filebasename, {
 	shortcuts: {
 		'→': 'Go to the next page',
 		'←': 'Go to the previous page'

--- a/source/features/navigate-pages-with-arrow-keys.tsx
+++ b/source/features/navigate-pages-with-arrow-keys.tsx
@@ -28,11 +28,10 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {
+void features.add(__filebasename, {}, {
 	shortcuts: {
 		'→': 'Go to the next page',
 		'←': 'Go to the previous page'
-	}
-}, {
+	},
 	init
 });

--- a/source/features/navigate-pages-with-arrow-keys.tsx
+++ b/source/features/navigate-pages-with-arrow-keys.tsx
@@ -28,7 +28,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	shortcuts: {
 		'→': 'Go to the next page',
 		'←': 'Go to the previous page'

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -52,11 +52,7 @@ async function init(): Promise<void> {
 	delegate(document, '#new_repository', 'submit', setStorage);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Automatically disables projects and wikis when creating a repository.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/92803886-dc460e00-f385-11ea-8af6-d6b7a0d3bf91.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isNewRepo
 	],

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -52,7 +52,7 @@ async function init(): Promise<void> {
 	delegate(document, '#new_repository', 'submit', setStorage);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isNewRepo
 	],

--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -70,11 +70,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows the next scheduled time of relevant GitHub Actions in the workflows sidebar.',
-	screenshot: 'https://user-images.githubusercontent.com/46634000/94690232-2476a180-0330-11eb-99d7-e174bb762cea.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepositoryActions
 	],

--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -70,7 +70,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepositoryActions
 	],

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -34,11 +34,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Wraps selected text when pressing one of Markdown symbols instead of replacing it: `[` <code>\`</code> `\'` `"` `*` `~` `_`',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -36,7 +36,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Wraps selected text when pressing one of Markdown symbols instead of replacing it: (`[` `’` `"` `(` etc).',
+	description: 'Wraps selected text when pressing one of Markdown symbols instead of replacing it: `[` <code>\`</code> `\'` `"` `*` `~` `_`',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/65020298-1f2dfb00-d957-11e9-9a2a-1c0ceab8d9e0.gif'
 }, {
 	include: [

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -34,7 +34,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -78,11 +78,7 @@ function init(): void {
 	update();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds button to open all your unread notifications at once.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/open-all-notifications.tsx
+++ b/source/features/open-all-notifications.tsx
@@ -78,7 +78,7 @@ function init(): void {
 	update();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/open-ci-details-in-new-tab.tsx
+++ b/source/features/open-ci-details-in-new-tab.tsx
@@ -11,7 +11,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR
 	],

--- a/source/features/open-ci-details-in-new-tab.tsx
+++ b/source/features/open-ci-details-in-new-tab.tsx
@@ -11,11 +11,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Opens the Checks "details" link in a new tab.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPR
 	],

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -23,7 +23,7 @@ function initDashboard(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -23,11 +23,7 @@ function initDashboard(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes the "comment" icon in issue lists link to the latest comment of the issue.',
-	screenshot: 'https://user-images.githubusercontent.com/14323370/57962709-7019de00-78e8-11e9-8398-7e617ba7a96f.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversationList
 	],

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -53,6 +53,6 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init: onetime(init)
 });

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -55,7 +55,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Renders text in `backticks` in issue titles, commit titles and more places.',
+	description: 'Renders `text in backticks` in issue titles, commit titles and more places.',
 	screenshot: 'https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png'
 }, {
 	init: onetime(init)

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -53,10 +53,6 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Renders `text in backticks` in issue titles, commit titles and more places.',
-	screenshot: 'https://user-images.githubusercontent.com/170270/55060505-31179b00-50a4-11e9-99a9-c3691ba38d66.png'
-}, {
+void features.add(__filebasename, {}, {
 	init: onetime(init)
 });

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -21,11 +21,7 @@ function init(): void {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds links to `.patch` and `.diff` files in commits.',
-	screenshot: 'https://cloud.githubusercontent.com/assets/737065/13605562/22faa79e-e516-11e5-80db-2da6aa7965ac.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCommit
 	],

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -21,7 +21,7 @@ function init(): void {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommit
 	],

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -52,11 +52,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds the updated time to pinned issues.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/75525936-bb524700-5a4b-11ea-9225-466bda58b7de.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoIssueList
 	],

--- a/source/features/pinned-issues-update-time.tsx
+++ b/source/features/pinned-issues-update-time.tsx
@@ -52,7 +52,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoIssueList
 	],

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -20,11 +20,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Automatically deletes the branch right after merging a PR, if possible.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -43,7 +43,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRCommit
 	],

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -43,11 +43,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds diff stats on PR commits.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/76107253-48deeb00-5fa6-11ea-9931-721cde553bdf.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRCommit
 	],

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -117,11 +117,7 @@ async function init(): Promise<void> {
 	await addChecksFilter();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds Checks and Draft PR dropdown filters in PR lists.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/74453250-6d9de200-4e82-11ea-8fd4-7c0de57e001a.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRList
 	],

--- a/source/features/pr-filters.tsx
+++ b/source/features/pr-filters.tsx
@@ -117,7 +117,7 @@ async function init(): Promise<void> {
 	await addChecksFilter();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRList
 	],

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	select('.diffbar-item progress-bar')!.style.cursor = 'pointer';
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles
 	],

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -20,11 +20,7 @@ function init(): void {
 	select('.diffbar-item progress-bar')!.style.cursor = 'pointer';
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Jumps to first non-viewed file in a pull request when clicking on the progress bar.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/85226580-3bf3d500-b3a6-11ea-8494-3d9b6280d033.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles
 	],

--- a/source/features/preserve-file-finder-term.tsx
+++ b/source/features/preserve-file-finder-term.tsx
@@ -36,7 +36,7 @@ function deinit(): void {
 	window.removeEventListener('pjax:start', unloadHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isFileFinder
 	],

--- a/source/features/preserve-file-finder-term.tsx
+++ b/source/features/preserve-file-finder-term.tsx
@@ -36,11 +36,7 @@ function deinit(): void {
 	window.removeEventListener('pjax:start', unloadHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Preserves the search terms when navigating back and forth between the File Finder and the files.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isFileFinder
 	],

--- a/source/features/preserve-whitespace-option-in-nav.tsx
+++ b/source/features/preserve-whitespace-option-in-nav.tsx
@@ -11,11 +11,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Preserves the "ignore whitespace" setting when navigating with Next/Previous in PR review mode.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/preserve-whitespace-option-in-nav.tsx
+++ b/source/features/preserve-whitespace-option-in-nav.tsx
@@ -11,7 +11,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/prevent-duplicate-pr-submission.tsx
+++ b/source/features/prevent-duplicate-pr-submission.tsx
@@ -17,7 +17,7 @@ function init(): void {
 	delegate(document, '#new_pull_request', 'submit', preventSubmit);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/prevent-duplicate-pr-submission.tsx
+++ b/source/features/prevent-duplicate-pr-submission.tsx
@@ -17,11 +17,7 @@ function init(): void {
 	delegate(document, '#new_pull_request', 'submit', preventSubmit);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Avoids creating duplicate PRs when mistakenly clicking "Create pull request" more than once.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/prevent-pr-commit-link-loss.tsx
+++ b/source/features/prevent-pr-commit-link-loss.tsx
@@ -45,11 +45,7 @@ function init(): void {
 	delegate(document, '.rgh-fix-pr-commit-links', 'click', handleButtonClick);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Suggests fixing your PR Commit links before commenting. GitHub has a bug that causes these link to appear as plain commit links, without association to the PR.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/82131169-93fd5180-97d2-11ea-9695-97051c55091f.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/prevent-pr-commit-link-loss.tsx
+++ b/source/features/prevent-pr-commit-link-loss.tsx
@@ -45,7 +45,7 @@ function init(): void {
 	delegate(document, '.rgh-fix-pr-commit-links', 'click', handleButtonClick);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -34,7 +34,7 @@ const init = (): void => {
 	}
 };
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -34,11 +34,7 @@ const init = (): void => {
 	}
 };
 
-void features.add({
-	id: __filebasename,
-	description: 'Previews hidden comments inline.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/preview-hidden-comments.tsx
+++ b/source/features/preview-hidden-comments.tsx
@@ -36,7 +36,7 @@ const init = (): void => {
 
 void features.add({
 	id: __filebasename,
-	description: 'Preview hidden comments inline.',
+	description: 'Previews hidden comments inline.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/52545036-6e271700-2def-11e9-8c0c-b5e0fa6f37dd.png'
 }, {
 	include: [

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -15,11 +15,7 @@ function init(): false | void {
 	files.after(previousNext);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds duplicate commit navigation buttons at the bottom of the `Commits` tab page.',
-	screenshot: 'https://user-images.githubusercontent.com/24777/41755271-741773de-75a4-11e8-9181-fcc1c73df633.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -15,7 +15,7 @@ function init(): false | void {
 	files.after(previousNext);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -44,11 +44,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the user’s public gists on their profile.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/87950518-f7a94100-cad9-11ea-8393-609fad70635c.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isUserProfile
 	],

--- a/source/features/profile-gists-link.tsx
+++ b/source/features/profile-gists-link.tsx
@@ -44,7 +44,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isUserProfile
 	],

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	select('a[data-ga-click$="text:your profile"]')!.dataset.hotkey = 'g m';
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	shortcuts: {
 		'g m': 'Go to Profile'
 	},

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -7,10 +7,9 @@ function init(): void {
 	select('a[data-ga-click$="text:your profile"]')!.dataset.hotkey = 'g m';
 }
 
-void features.add(__filebasename, {
+void features.add(__filebasename, {}, {
 	shortcuts: {
 		'g m': 'Go to Profile'
-	}
-}, {
+	},
 	init: onetime(init)
 });

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -7,10 +7,7 @@ function init(): void {
 	select('a[data-ga-click$="text:your profile"]')!.dataset.hotkey = 'g m';
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a keyboard shortcut to visit your own profile: `g` `m`.',
-	screenshot: false,
+void features.add(__filebasename, {
 	shortcuts: {
 		'g m': 'Go to Profile'
 	}

--- a/source/features/pull-request-hotkey.tsx
+++ b/source/features/pull-request-hotkey.tsx
@@ -27,14 +27,14 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	include: [
-		pageDetect.isPR
-	],
 	shortcuts: {
 		'g 1': 'Go to Conversation',
 		'g 2': 'Go to Commits',
 		'g 3': 'Go to Checks',
 		'g 4': 'Go to Files changed'
 	},
+	include: [
+		pageDetect.isPR
+	],
 	init
 });

--- a/source/features/pull-request-hotkey.tsx
+++ b/source/features/pull-request-hotkey.tsx
@@ -26,7 +26,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR
 	],

--- a/source/features/pull-request-hotkey.tsx
+++ b/source/features/pull-request-hotkey.tsx
@@ -26,10 +26,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds keyboard shortcuts to cycle through PR tabs: `g` `←` and `g` `→`, or `g` `1`, `g` `2`, `g` `3` and `g` `4`.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/94634958-7e7b5680-029f-11eb-82ea-1f96cd11e4cd.png',
+void features.add(__filebasename, {
 	shortcuts: {
 		'g 1': 'Go to Conversation',
 		'g 2': 'Go to Commits',

--- a/source/features/pull-request-hotkey.tsx
+++ b/source/features/pull-request-hotkey.tsx
@@ -26,16 +26,15 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {
+void features.add(__filebasename, {}, {
+	include: [
+		pageDetect.isPR
+	],
 	shortcuts: {
 		'g 1': 'Go to Conversation',
 		'g 2': 'Go to Commits',
 		'g 3': 'Go to Checks',
 		'g 4': 'Go to Files changed'
-	}
-}, {
-	include: [
-		pageDetect.isPR
-	],
+	},
 	init
 });

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -48,7 +48,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a button to @mention a user in conversations.',
+	description: 'Adds a button to `@mention` a user in conversations.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif'
 }, {
 	include: [

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -46,7 +46,7 @@ function init(): void {
 	delegate(document, 'button.rgh-quick-mention', 'click', mentionUser);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/quick-mention.tsx
+++ b/source/features/quick-mention.tsx
@@ -46,11 +46,7 @@ function init(): void {
 	delegate(document, 'button.rgh-quick-mention', 'click', mentionUser);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to `@mention` a user in conversations.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -90,11 +90,7 @@ function init(): false | void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPR
 	],

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -90,7 +90,7 @@ function init(): false | void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR
 	],

--- a/source/features/raw-file-link.tsx
+++ b/source/features/raw-file-link.tsx
@@ -24,11 +24,7 @@ function init(): void {
 	delegate(document, '.file-header .js-file-header-dropdown:not(.rgh-raw-file-link)', 'toggle', handleMenuOpening, true);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to view the raw version of files in PRs and commits.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/56484988-b99f2500-6504-11e9-9748-c944e1070cc8.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCommit,
 		pageDetect.isPRFiles,

--- a/source/features/raw-file-link.tsx
+++ b/source/features/raw-file-link.tsx
@@ -24,7 +24,7 @@ function init(): void {
 	delegate(document, '.file-header .js-file-header-dropdown:not(.rgh-raw-file-link)', 'toggle', handleMenuOpening, true);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommit,
 		pageDetect.isPRFiles,

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -91,7 +91,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -91,11 +91,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds reaction avatars showing *who* reacted to a comment.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasComments
 	],

--- a/source/features/recently-pushed-branches-enhancements.tsx
+++ b/source/features/recently-pushed-branches-enhancements.tsx
@@ -52,7 +52,7 @@ async function init(): Promise<false | void> {
 	select.last('.Header-item--full,.HeaderMenu nav')!.after(widget);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/recently-pushed-branches-enhancements.tsx
+++ b/source/features/recently-pushed-branches-enhancements.tsx
@@ -52,11 +52,7 @@ async function init(): Promise<false | void> {
 	select.last('.Header-item--full,.HeaderMenu nav')!.after(widget);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Moves the "Recently-pushed branches" widget to the header to avoid content jumps. Also adds it to more pages in the repo.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/56466173-da517700-643f-11e9-8eb5-9b20017fa613.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -88,11 +88,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a download count next to release assets.',
-	screenshot: 'https://user-images.githubusercontent.com/14323370/58944460-e1aeb480-874f-11e9-8052-2d4dc794ecab.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/release-download-count.tsx
+++ b/source/features/release-download-count.tsx
@@ -88,7 +88,7 @@ async function init(): Promise<void | false> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -146,7 +146,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -146,14 +146,13 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		'g r': 'Go to Releases'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],
 	awaitDomReady: false,
+	shortcuts: {
+		'g r': 'Go to Releases'
+	},
 	init
 });

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -146,10 +146,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a `Releases` tab and a keyboard shortcut: `g` `r`.',
-	screenshot: 'https://cloud.githubusercontent.com/assets/170270/13136797/16d3f0ea-d64f-11e5-8a45-d771c903038f.png',
+void features.add(__filebasename, {
 	shortcuts: {
 		'g r': 'Go to Releases'
 	}

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -147,12 +147,12 @@ async function init(): Promise<false | void> {
 }
 
 void features.add(__filebasename, {
+	shortcuts: {
+		'g r': 'Go to Releases'
+	},
 	include: [
 		pageDetect.isRepo
 	],
 	awaitDomReady: false,
-	shortcuts: {
-		'g r': 'Go to Releases'
-	},
 	init
 });

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -18,6 +18,6 @@ function init(): void {
 	delegate(document, 'img[src^="https://camo.githubusercontent.com/"]', 'error', handleErroredImage, true);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init
 });

--- a/source/features/reload-failed-proxied-images.tsx
+++ b/source/features/reload-failed-proxied-images.tsx
@@ -18,10 +18,6 @@ function init(): void {
 	delegate(document, 'img[src^="https://camo.githubusercontent.com/"]', 'error', handleErroredImage, true);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Retries downloading images that failed downloading due to GitHub limited proxying.',
-	screenshot: 'https://user-images.githubusercontent.com/14858959/64068746-21991100-cc45-11e9-844e-827f5ac9b51e.png'
-}, {
+void features.add(__filebasename, {}, {
 	init
 });

--- a/source/features/remove-diff-signs.tsx
+++ b/source/features/remove-diff-signs.tsx
@@ -7,11 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-remove-diff-signs');
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides diff signs (+-) since diffs are color coded already.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54807718-149cec80-4cb9-11e9-869c-e265863211e3.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/remove-diff-signs.tsx
+++ b/source/features/remove-diff-signs.tsx
@@ -7,7 +7,7 @@ function init(): void {
 	document.body.classList.add('rgh-remove-diff-signs');
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/remove-label-faster.tsx
+++ b/source/features/remove-label-faster.tsx
@@ -60,7 +60,7 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-remove-label-faster:not([disabled])', 'click', removeLabelButtonClickHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/remove-label-faster.tsx
+++ b/source/features/remove-label-faster.tsx
@@ -60,11 +60,7 @@ async function init(): Promise<void> {
 	delegate(document, '.rgh-remove-label-faster:not([disabled])', 'click', removeLabelButtonClickHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds one-click buttons to remove labels in conversations.',
-	screenshot: 'https://user-images.githubusercontent.com/36174850/89980178-0bc80480-dc7a-11ea-8ded-9e25f5f13d1a.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isConversation
 	],

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -61,7 +61,7 @@ async function removeProjectsTab(): Promise<void | false> {
 	projectsTab.remove();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isUserProfile,

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -63,8 +63,8 @@ async function removeProjectsTab(): Promise<void | false> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Hides the `Projects` tab from repositories and profiles when it’s empty. New projects can still be created via the `Create new…` menu.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/34909214-18b6fb2e-f8cf-11e7-8556-bed748596d3b.png'
+	description: 'Hides the `Projects` tab from repositories and profiles when it’s empty.',
+	screenshot: false
 }, {
 	include: [
 		pageDetect.isRepo,

--- a/source/features/remove-projects-tab.tsx
+++ b/source/features/remove-projects-tab.tsx
@@ -61,11 +61,7 @@ async function removeProjectsTab(): Promise<void | false> {
 	projectsTab.remove();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides the `Projects` tab from repositories and profiles when it’s empty.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isUserProfile,

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -117,7 +117,7 @@ async function init(): Promise<void> {
 void features.add({
 	id: __filebasename,
 	description: 'Displays the age of the repository in the sidebar.',
-	screenshot: 'https://user-images.githubusercontent.com/3848317/69256318-95e6af00-0bb9-11ea-84c8-c6996d39da80.png'
+	screenshot: 'https://user-images.githubusercontent.com/3848317/69494069-7d2b1180-0eb7-11ea-9aa1-d4194e566340.png'
 }, {
 	include: [
 		pageDetect.isRepoRoot

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -114,11 +114,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Displays the age of the repository in the sidebar.',
-	screenshot: 'https://user-images.githubusercontent.com/3848317/69494069-7d2b1180-0eb7-11ea-9aa1-d4194e566340.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoRoot
 	],

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -114,7 +114,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoRoot
 	],

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -17,7 +17,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList,
 		pageDetect.isPR,

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -17,11 +17,7 @@ async function init(): Promise<void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Enables the File Finder keyboard shortcut (`t`) on Issues and Pull Request pages as well.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoConversationList,
 		pageDetect.isPR,

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -15,7 +15,7 @@ async function init(): Promise<void> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Fix merge conflicts in a click.',
+	description: 'Adds one-click merge conflict fixers.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png'
 }, {
 	include: [

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -13,7 +13,7 @@ async function init(): Promise<void> {
 	document.head.append(<script src={browser.runtime.getURL('build/resolve-conflicts.js')}/>);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConflicts
 	],

--- a/source/features/resolve-conflicts.tsx
+++ b/source/features/resolve-conflicts.tsx
@@ -13,11 +13,7 @@ async function init(): Promise<void> {
 	document.head.append(<script src={browser.runtime.getURL('build/resolve-conflicts.js')}/>);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds one-click merge conflict fixers.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54978791-45906080-4fdc-11e9-8fe1-45374f8ff636.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConflicts
 	],

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -135,11 +135,7 @@ function init(): void {
 	delegate(document, '.rgh-restore-file', 'click', handleRestoreFileClick, true);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds button to revert all the changes to a file in a PR.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/restore-file.tsx
+++ b/source/features/restore-file.tsx
@@ -135,7 +135,7 @@ function init(): void {
 	delegate(document, '.rgh-restore-file', 'click', handleRestoreFileClick, true);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -15,11 +15,7 @@ function init(): void {
 	delegate(document, '.TagsearchPopover-item', 'click', followLocalLink);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Avoids re-loading the page when jumping to function definition in the current file.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/same-page-definition-jump.tsx
+++ b/source/features/same-page-definition-jump.tsx
@@ -15,7 +15,7 @@ function init(): void {
 	delegate(document, '.TagsearchPopover-item', 'click', followLocalLink);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -20,10 +20,7 @@ function init(): void {
 	document.addEventListener('keypress', openInNewTab);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a keyboard shortcut to open selection in new tab when navigating via `j` and `k`: `shift` `o`.',
-	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1110',
+void features.add(__filebasename, {
 	shortcuts: {
 		'shift o': 'Open selection in new tab'
 	}

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -20,11 +20,10 @@ function init(): void {
 	document.addEventListener('keypress', openInNewTab);
 }
 
-void features.add(__filebasename, {
+void features.add(__filebasename, {}, {
+	awaitDomReady: false,
 	shortcuts: {
 		'shift o': 'Open selection in new tab'
-	}
-}, {
-	awaitDomReady: false,
+	},
 	init: onetime(init)
 });

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -21,9 +21,9 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	awaitDomReady: false,
 	shortcuts: {
 		'shift o': 'Open selection in new tab'
 	},
+	awaitDomReady: false,
 	init: onetime(init)
 });

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	document.addEventListener('keypress', openInNewTab);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	awaitDomReady: false,
 	shortcuts: {
 		'shift o': 'Open selection in new tab'

--- a/source/features/selection-in-new-tab.tsx
+++ b/source/features/selection-in-new-tab.tsx
@@ -22,8 +22,8 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a keyboard shortcut to open selection in new tab when navigating via `j` and `k`: `Shift` `o`.',
-	screenshot: false,
+	description: 'Adds a keyboard shortcut to open selection in new tab when navigating via `j` and `k`: `shift` `o`.',
+	screenshot: 'https://github.com/sindresorhus/refined-github/issues/1110',
 	shortcuts: {
 		'shift o': 'Open selection in new tab'
 	}

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -50,11 +50,7 @@ function init(): void | false {
 	createPrButtonGroup.remove();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Lets you create draft pull requests in one click.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/67269317-cd791300-f4b6-11e9-89d1-392de7ef71e1.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -50,7 +50,7 @@ function init(): void | false {
 	createPrButtonGroup.remove();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -22,6 +22,6 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init
 });

--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -22,10 +22,6 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Hides forks and archived repos from profiles (but they can still be shown).',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/45133648-fe21be80-b1c8-11e8-9052-e38cb443efa9.png'
-}, {
+void features.add(__filebasename, {}, {
 	init
 });

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -15,7 +15,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	exclude: [
 		// Due to GitHub’s bug: #2828
 		pageDetect.isGlobalSearchResults

--- a/source/features/shorten-links.tsx
+++ b/source/features/shorten-links.tsx
@@ -15,11 +15,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shortens URLs and repo URLs to readable references like "_user/repo/.file@`d71718d`".',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/27252232-8fdf8ed0-538b-11e7-8f19-12d317c9cd32.png'
-}, {
+void features.add(__filebasename, {}, {
 	exclude: [
 		// Due to GitHub’s bug: #2828
 		pageDetect.isGlobalSearchResults

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -100,11 +100,7 @@ async function init(): Promise<void> {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows the associated pull requests on branches for forked repository’s.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/81504659-7e5ec800-92b8-11ea-9ee6-924110e8cca1.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isBranches
 	],

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -100,7 +100,7 @@ async function init(): Promise<void> {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isBranches
 	],

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -67,11 +67,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds the real name of users by their usernames.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/62075835-5f82ce00-b270-11e9-91eb-4680b70cb3cb.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/show-names.tsx
+++ b/source/features/show-names.tsx
@@ -67,7 +67,7 @@ async function init(): Promise<false | void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isDashboard
 	],

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -89,7 +89,7 @@ async function initDeleteHint(): Promise<void | false> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -89,11 +89,7 @@ async function initDeleteHint(): Promise<void | false> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'In your forked repos, shows number of your open PRs to the original repo.',
-	screenshot: 'https://user-images.githubusercontent.com/1922624/76398271-e0648500-637c-11ea-8210-53dda1be9d51.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -22,7 +22,7 @@ function init(): void {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isUserProfileMainTab
 	],

--- a/source/features/show-user-top-repositories.tsx
+++ b/source/features/show-user-top-repositories.tsx
@@ -22,11 +22,7 @@ function init(): void {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to the user’s most starred repositories.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/48474026-43e3ae80-e82c-11e8-93de-159ad4c6f283.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isUserProfileMainTab
 	],

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -68,11 +68,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes whitespace characters visible.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/61187598-f9118380-a6a5-11e9-985a-990a7f798805.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -68,7 +68,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasCode
 	],

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -30,11 +30,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Changes the default sort order of conversations to `Recently updated`.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	init
 }, {
 	include: [

--- a/source/features/sort-conversations-by-update-time.tsx
+++ b/source/features/sort-conversations-by-update-time.tsx
@@ -30,7 +30,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init
 }, {
 	include: [

--- a/source/features/sort-milestones-by-closest-due-date.tsx
+++ b/source/features/sort-milestones-by-closest-due-date.tsx
@@ -15,11 +15,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Changes the default sort order of milestones `Closest due date`.',
-	screenshot: false
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/sort-milestones-by-closest-due-date.tsx
+++ b/source/features/sort-milestones-by-closest-due-date.tsx
@@ -15,7 +15,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -65,11 +65,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Separates issues from PRs in the global search.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/52181103-35a09f80-2829-11e9-9c6f-57f2e08fc5b2.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoSearch,
 		pageDetect.isGlobalSearchResults

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -65,7 +65,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoSearch,
 		pageDetect.isGlobalSearchResults

--- a/source/features/star-repo-hotkey.tsx
+++ b/source/features/star-repo-hotkey.tsx
@@ -10,13 +10,12 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		'g s': 'Star and unstar repository'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo
 	],
+	shortcuts: {
+		'g s': 'Star and unstar repository'
+	},
 	init
 });

--- a/source/features/star-repo-hotkey.tsx
+++ b/source/features/star-repo-hotkey.tsx
@@ -10,10 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a keyboard shortcut to star/unstar the current repo: `g` `s`.',
-	screenshot: false,
+void features.add(__filebasename, {
 	shortcuts: {
 		'g s': 'Star and unstar repository'
 	}

--- a/source/features/star-repo-hotkey.tsx
+++ b/source/features/star-repo-hotkey.tsx
@@ -10,7 +10,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],

--- a/source/features/star-repo-hotkey.tsx
+++ b/source/features/star-repo-hotkey.tsx
@@ -11,11 +11,11 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
-	include: [
-		pageDetect.isRepo
-	],
 	shortcuts: {
 		'g s': 'Star and unstar repository'
 	},
+	include: [
+		pageDetect.isRepo
+	],
 	init
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -24,7 +24,7 @@ function deinit(): void {
 	window.removeEventListener('resize', onResize);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoRoot,
 		pageDetect.isConversation

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -24,11 +24,7 @@ function deinit(): void {
 	window.removeEventListener('resize', onResize);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes conversation sidebars and repository sidebars sticky, if they fit the viewport.',
-	screenshot: 'https://user-images.githubusercontent.com/10238474/62276723-5a2eaa80-b44d-11e9-810b-ff598d1c5c6a.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoRoot,
 		pageDetect.isConversation

--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -56,11 +56,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'After you click on an ajaxed link, this lets you stop loading a page by pressing the `esc` key, like the browser does for regular page loads.',
-	screenshot: 'https://user-images.githubusercontent.com/36174850/90323385-3c08ef00-df69-11ea-8c0e-c85241888a7b.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isRepoSearch,

--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -58,7 +58,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'After you click on an ajaxed link, this lets you stop loading a page by pressing the esc key, like the browser does for regular page loads.',
+	description: 'After you click on an ajaxed link, this lets you stop loading a page by pressing the `esc` key, like the browser does for regular page loads.',
 	screenshot: 'https://user-images.githubusercontent.com/36174850/90323385-3c08ef00-df69-11ea-8c0e-c85241888a7b.gif'
 }, {
 	include: [

--- a/source/features/stop-pjax-loading-with-esc.tsx
+++ b/source/features/stop-pjax-loading-with-esc.tsx
@@ -56,7 +56,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isRepoSearch,

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	delegate(document, '.notification-shelf .js-notification-action button', 'click', handleClick);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		hasNotificationBar
 	],

--- a/source/features/stop-redirecting-in-notification-bar.tsx
+++ b/source/features/stop-redirecting-in-notification-bar.tsx
@@ -20,11 +20,7 @@ function init(): void {
 	delegate(document, '.notification-shelf .js-notification-action button', 'click', handleClick);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Stops redirecting to notification inbox from notification bar actions while holding `Alt`.',
-	screenshot: 'https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		hasNotificationBar
 	],

--- a/source/features/submit-review-as-single-comment.tsx
+++ b/source/features/submit-review-as-single-comment.tsx
@@ -108,11 +108,7 @@ function init(): void {
 	updateUI();
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to submit a single PR comment if you mistakenly started a new review.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/60331761-f6394200-99c7-11e9-81c2-c671cba9602a.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRFiles
 	],

--- a/source/features/submit-review-as-single-comment.tsx
+++ b/source/features/submit-review-as-single-comment.tsx
@@ -108,7 +108,7 @@ function init(): void {
 	updateUI();
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles
 	],

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -20,11 +20,7 @@ function init(): void {
 	delegate(document, fieldSelector, 'input', validateInput);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Suggests limiting commit titles to 72 characters.',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/60379478-106b3280-9a51-11e9-88b9-0e3607f214cd.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -20,7 +20,7 @@ function init(): void {
 	delegate(document, fieldSelector, 'input', validateInput);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -22,7 +22,7 @@ function init(): void {
 	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -22,11 +22,7 @@ function init(): void {
 	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to swap branches in the branch compare view.',
-	screenshot: 'https://user-images.githubusercontent.com/857700/42854438-821096f2-8a01-11e8-8752-76f7563b5e18.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -5,8 +5,8 @@ import * as pageDetect from 'github-url-detection';
 import * as textFieldEdit from 'text-field-edit';
 
 import features from '.';
-import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 import concatRegex from '../helpers/concat-regex';
+import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
 const prTitleFieldSelector = '.js-issue-update [name="issue[title]"]';
 const prTitleSubmitSelector = '.js-issue-update [type="submit"]';

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -102,11 +102,7 @@ function deinit(): void {
 	listeners.length = 0;
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Uses the PR’s title as the default squash commit title and updates the PR’s title to the match the commit title, if changed.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -102,7 +102,7 @@ function deinit(): void {
 	listeners.length = 0;
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -6,6 +6,7 @@ import * as textFieldEdit from 'text-field-edit';
 
 import features from '.';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
+import concatRegex from '../helpers/concat-regex';
 
 const prTitleFieldSelector = '.js-issue-update [name="issue[title]"]';
 const prTitleSubmitSelector = '.js-issue-update [type="submit"]';
@@ -61,7 +62,7 @@ function updatePRTitle(): void {
 
 	// Remove PR number from commit title
 	const prTitle = getCommitTitleField()!.value
-		.replace(new RegExp(`\\s*\\(${getPRNumber()}\\)$`), '');
+		.replace(concatRegex(/\s*\(/, getPRNumber(), /\)$/), '');
 
 	// Fill and submit title-change form
 	select<HTMLInputElement>(prTitleFieldSelector)!.value = prTitle;

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -9,11 +9,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Enables `tab` and `shift` `tab` for indentation in comment fields.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -11,7 +11,7 @@ function init(): void {
 
 void features.add({
 	id: __filebasename,
-	description: 'Enables <kbd>tab</kbd> and <kbd>shift+tab</kbd> for indentation in comment fields.',
+	description: 'Enables `tab` and `shift` `tab` for indentation in comment fields.',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/33802977-beb8497c-ddbf-11e7-899c-698d89298de4.gif'
 }, {
 	include: [

--- a/source/features/tab-to-indent.tsx
+++ b/source/features/tab-to-indent.tsx
@@ -9,7 +9,7 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -66,11 +66,7 @@ function init(): void {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button in the text editor to quickly insert a simplified HTML table.',
-	screenshot: 'https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/table-input.tsx
+++ b/source/features/table-input.tsx
@@ -66,7 +66,7 @@ function init(): void {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -112,11 +112,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a link to an automatic changelog for each tag/release.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -112,7 +112,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -50,7 +50,7 @@ function init(): void {
 	select('.rgh-tags-dropdown')!.addEventListener('remote-input-success', updateLinksToTag);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/tags-dropdown.tsx
+++ b/source/features/tags-dropdown.tsx
@@ -50,11 +50,7 @@ function init(): void {
 	select('.rgh-tags-dropdown')!.addEventListener('remote-input-success', updateLinksToTag);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a tags dropdown/search on tag/release pages.',
-	screenshot: 'https://user-images.githubusercontent.com/22439276/56373231-27ee9980-621e-11e9-9b21-601919d3dddf.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isReleasesOrTags
 	],

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -167,11 +167,7 @@ async function init(): Promise<void | false> {
 	await cache.set(cacheKey, cached, {days: 1});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Displays the corresponding tags next to commits.',
-	screenshot: 'https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -167,7 +167,7 @@ async function init(): Promise<void | false> {
 	await cache.set(cacheKey, cached, {days: 1});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoCommitList
 	],

--- a/source/features/tags-on-commits-list.tsx
+++ b/source/features/tags-on-commits-list.tsx
@@ -169,7 +169,7 @@ async function init(): Promise<void | false> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Display the corresponding tags next to commits.',
+	description: 'Displays the corresponding tags next to commits.',
 	screenshot: 'https://user-images.githubusercontent.com/14323370/66400400-64ba7280-e9af-11e9-8d6c-07b35afde91f.png'
 }, {
 	include: [

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -56,11 +56,7 @@ function init(): void {
 	delegate(document, '.js-file .js-resolvable-thread-toggler', 'click', clickAll(resolvedCommentsSelector));
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a shortcut to toggle all similar items (minimized comments, deferred diffs, etc) at once: `alt` `click` on each button or checkbox.',
-	screenshot: 'https://user-images.githubusercontent.com/37769974/62208543-dcb75b80-b3b4-11e9-984f-ddb479ea149d.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -56,7 +56,7 @@ function init(): void {
 	delegate(document, '.js-file .js-resolvable-thread-toggler', 'click', clickAll(resolvedCommentsSelector));
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -55,7 +55,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/toggle-files-button.tsx
+++ b/source/features/toggle-files-button.tsx
@@ -55,11 +55,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to toggle the repo file list.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/35480123-68b9af1a-043a-11e8-8934-3ead3cff8328.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isRepoTree
 	],

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -16,14 +16,13 @@ async function init(): Promise<false | void> {
 	);
 }
 
-void features.add(__filebasename, {
-	shortcuts: {
-		'g t': 'Go to Trending'
-	}
-}, {
+void features.add(__filebasename, {}, {
 	exclude: [
 		pageDetect.isGist
 	],
 	awaitDomReady: false,
+	shortcuts: {
+		'g t': 'Go to Trending'
+	},
 	init: onetime(init)
 });

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -16,7 +16,7 @@ async function init(): Promise<false | void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isGist
 	],

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -16,10 +16,7 @@ async function init(): Promise<false | void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a `Trending` link to the global navbar and a keyboard shortcut: `g` `t`.',
-	screenshot: false,
+void features.add(__filebasename, {
 	shortcuts: {
 		'g t': 'Go to Trending'
 	}

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -17,12 +17,12 @@ async function init(): Promise<false | void> {
 }
 
 void features.add(__filebasename, {
+	shortcuts: {
+		'g t': 'Go to Trending'
+	},
 	exclude: [
 		pageDetect.isGist
 	],
 	awaitDomReady: false,
-	shortcuts: {
-		'g t': 'Go to Trending'
-	},
 	init: onetime(init)
 });

--- a/source/features/trending-menu-item.tsx
+++ b/source/features/trending-menu-item.tsx
@@ -18,7 +18,7 @@ async function init(): Promise<false | void> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds a `Trending` link to the global navbar and a keyboard shortcut: `g` ` t`.',
+	description: 'Adds a `Trending` link to the global navbar and a keyboard shortcut: `g` `t`.',
 	screenshot: false,
 	shortcuts: {
 		'g t': 'Go to Trending'

--- a/source/features/unwrap-useless-dropdowns.tsx
+++ b/source/features/unwrap-useless-dropdowns.tsx
@@ -58,11 +58,7 @@ async function unwrapActionRun(): Promise<void | false> {
 	replaceDropdownInPlace(dropdown, desiredForm);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Makes some dropdowns 1-click instead of unnecessarily 2-click.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/80859624-9bfdb300-8c62-11ea-837f-7b7a28e6fdfc.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/unwrap-useless-dropdowns.tsx
+++ b/source/features/unwrap-useless-dropdowns.tsx
@@ -58,7 +58,7 @@ async function unwrapActionRun(): Promise<void | false> {
 	replaceDropdownInPlace(dropdown, desiredForm);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isNotifications
 	],

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -112,11 +112,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-update-pr-from-base-branch button', 'click', handler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself. GitHub only adds it when the base branch is "protected".',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -114,7 +114,7 @@ async function init(): Promise<void | false> {
 
 void features.add({
 	id: __filebasename,
-	description: 'Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.',
+	description: 'Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself. GitHub only adds it when the base branch is "protected".',
 	screenshot: 'https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png'
 }, {
 	include: [

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -112,7 +112,7 @@ async function init(): Promise<void | false> {
 	delegate(document, '.rgh-update-pr-from-base-branch button', 'click', handler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -28,7 +28,7 @@ async function init(): Promise<void | false> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -28,11 +28,7 @@ async function init(): Promise<void | false> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Uses the first commit for a new PR’s title and description.',
-	screenshot: 'https://user-images.githubusercontent.com/16872793/87246205-ccf42400-c419-11ea-86d5-0e6570d99e6e.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -132,7 +132,7 @@ async function initPRCommit(): Promise<void | false> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.is404
 	],

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -132,11 +132,7 @@ async function initPRCommit(): Promise<void | false> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds possible related pages and alternatives on 404 pages.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/46402857-7bdada80-c733-11e8-91a1-856573078ff5.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.is404
 	],

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -140,10 +140,6 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows the user local time in their hovercard (based on their last commit).',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/69863648-ef449180-12cf-11ea-8f36-7c92fc487f31.gif'
-}, {
+void features.add(__filebasename, {}, {
 	init: onetime(init)
 });

--- a/source/features/user-local-time.tsx
+++ b/source/features/user-local-time.tsx
@@ -140,6 +140,6 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	init: onetime(init)
 });

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -33,11 +33,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'On profiles, it shows whether the user follows you.',
-	screenshot: 'https://user-images.githubusercontent.com/3723666/45190460-03ecc380-b20c-11e8-832b-839959ee2c99.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isUserProfile
 	],

--- a/source/features/user-profile-follower-badge.tsx
+++ b/source/features/user-profile-follower-badge.tsx
@@ -33,7 +33,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isUserProfile
 	],

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -30,7 +30,7 @@ function init(): void | false {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		hasFrontMatter
 	],

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -30,11 +30,7 @@ function init(): void | false {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Shows Markdown front matter as vertical table.',
-	screenshot: 'https://user-images.githubusercontent.com/44045911/87251695-26069b00-c4a0-11ea-9077-53ce366490ed.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		hasFrontMatter
 	],

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -122,7 +122,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -122,11 +122,7 @@ async function init(): Promise<void> {
 	}
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds a button to view the source of Markdown files.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/54814836-7bc39c80-4ccb-11e9-8996-9ecf4f6036cb.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isSingleFile
 	],

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -101,11 +101,7 @@ function init(): void {
 	});
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Adds the option to wait for checks when merging a PR.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -101,7 +101,7 @@ function init(): void {
 	});
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation
 	],

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -27,11 +27,7 @@ async function init(): Promise<false | void> {
 	);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Warns you when creating a pull request from the default branch, as it’s an anti-pattern.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/warn-pr-from-master.tsx
+++ b/source/features/warn-pr-from-master.tsx
@@ -27,7 +27,7 @@ async function init(): Promise<false | void> {
 	);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -37,7 +37,7 @@ function init(): void | false {
 	delegate(document, '[name="collab_privs"]', 'change', toggleHandler);
 }
 
-void features.add(__filebasename, {}, {
+void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare,
 		pageDetect.isPRConversation

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -37,11 +37,7 @@ function init(): void | false {
 	delegate(document, '[name="collab_privs"]', 'change', toggleHandler);
 }
 
-void features.add({
-	id: __filebasename,
-	description: 'Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.',
-	screenshot: 'https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif'
-}, {
+void features.add(__filebasename, {}, {
 	include: [
 		pageDetect.isCompare,
 		pageDetect.isPRConversation

--- a/source/github-helpers/parse-backticks.tsx
+++ b/source/github-helpers/parse-backticks.tsx
@@ -2,11 +2,14 @@ import React from 'dom-chef';
 
 const splittingRegex = /`` (.*?) ``|`(.*?)`/g;
 
+export function getParsedBackticksParts(string: string): string[] {
+	return string.split(splittingRegex)
+		.filter(part => part !== undefined); // Only one of the regexp's capture groups matches
+}
+
 export default function parseBackticks(description: string): DocumentFragment {
 	const fragment = new DocumentFragment();
-	const textParts = description.split(splittingRegex)
-		.filter(part => part !== undefined); // Only one of the regexp's capture groups matches
-	for (const [index, text] of textParts.entries()) {
+	for (const [index, text] of getParsedBackticksParts(description).entries()) {
 		if (index % 2 && text.length >= 1) {
 			// `span.sr-only` keeps the backticks copy-pastable but invisible
 			fragment.append(

--- a/source/github-helpers/parse-backticks.tsx
+++ b/source/github-helpers/parse-backticks.tsx
@@ -1,10 +1,12 @@
 import React from 'dom-chef';
 
-const splittingRegex = /`(.*?)`/g;
+const splittingRegex = /`` (.*?) ``|`(.*?)`/g;
 
 export default function parseBackticks(description: string): DocumentFragment {
 	const fragment = new DocumentFragment();
-	for (const [index, text] of description.split(splittingRegex).entries()) {
+	const textParts = description.split(splittingRegex)
+		.filter(part => part !== undefined); // Only one of the regexp's capture groups matches
+	for (const [index, text] of textParts.entries()) {
 		if (index % 2 && text.length >= 1) {
 			// `span.sr-only` keeps the backticks copy-pastable but invisible
 			fragment.append(

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -13,7 +13,6 @@ interface FeatureMeta {
 	id: FeatureID;
 	description: string;
 	screenshot: string | false;
-	shortcuts?: FeatureShortcuts;
 }
 
 interface FeatureConfig {

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -7,7 +7,7 @@ type FeatureShortcuts = Record<string, string>;
 interface FeatureMeta {
 	id: FeatureID;
 	description: string;
-	screenshot: string | false;
+	screenshot?: string;
 }
 
 interface FeatureConfig {

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -5,11 +5,6 @@ type FeatureID = 'use the __filebasename variable';
 
 type FeatureShortcuts = Record<string, string>;
 interface FeatureMeta {
-	/**
-	If it's disabled, this should be the issue that explains why, as a reference
-	@example '#123'
-	*/
-	disabled?: string;
 	id: FeatureID;
 	description: string;
 	screenshot: string | false;

--- a/source/helpers/concat-regex.ts
+++ b/source/helpers/concat-regex.ts
@@ -1,0 +1,5 @@
+export default function concatRegex(...expressions: Array<RegExp | string>): RegExp {
+	const sources = expressions.map(expression => expression instanceof RegExp ? expression.source : expression);
+	const flags = expressions.map(expression => expression instanceof RegExp ? expression.flags : '');
+	return new RegExp(sources.join(''), flags.join(''));
+}

--- a/source/options.css
+++ b/source/options.css
@@ -61,6 +61,19 @@ p {
 	flex-grow: 1;
 }
 
+.js-features kbd {
+	display: inline-block;
+	padding: 3px 5px;
+	font-size: 0.8em;
+	line-height: 10px;
+	color: #444d56;
+	vertical-align: middle;
+	background-color: #fafbfc;
+	border: 1px solid #d1d5da;
+	border-radius: 6px;
+	box-shadow: inset 0 -1px 0 #d1d5da;
+}
+
 .feature-new .feature-name::after {
 	display: inline-block; /* Avoids the strikethrough on disabled features */
 	content: 'New';

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -12,8 +12,7 @@ import {perDomainOptions} from './options-storage';
 import * as domFormatters from './github-helpers/dom-formatters';
 
 function parseDescription(description: string): DocumentFragment {
-	const descriptionElement = <span/>;
-	descriptionElement.innerHTML = description.replaceAll('\\`', '`').replaceAll('<iframe>', '&lt;iframe&gt;');
+	const descriptionElement = <span>{description}</span>;
 	domFormatters.linkifyIssues(descriptionElement, {
 		baseUrl: 'https://github.com',
 		user: 'sindresorhus',

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -12,7 +12,7 @@ import {perDomainOptions} from './options-storage';
 import * as domFormatters from './github-helpers/dom-formatters';
 
 function parseDescription(description: string): DocumentFragment {
-	const descriptionElement = <span/>
+	const descriptionElement = <span/>;
 	descriptionElement.innerHTML = description.replaceAll('\\`', '`').replaceAll('<iframe>', '&lt;iframe&gt;');
 	domFormatters.linkifyIssues(descriptionElement, {
 		baseUrl: 'https://github.com',

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -12,7 +12,7 @@ import getTextNodes from './helpers/get-text-nodes';
 import {perDomainOptions} from './options-storage';
 import * as domFormatters from './github-helpers/dom-formatters';
 
-export function parseSimpleInlineElement(element: Element, tag: string): void {
+function parseSimpleInlineElement(element: Element, tag: string): void {
 	const splittingRegex = new RegExp(`<${tag}>(.+?)</${tag}>`, 'g');
 
 	for (const node of getTextNodes(element)) {

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -35,11 +35,6 @@ function parseSimpleInlineElement(element: Element, tag: string): void {
 
 function parseDescription(description: string): DocumentFragment {
 	const descriptionElement = <span>{description}</span>;
-	domFormatters.linkifyIssues(descriptionElement, {
-		baseUrl: 'https://github.com',
-		user: 'sindresorhus',
-		repository: 'refined-github'
-	});
 	domFormatters.linkifyURLs(descriptionElement);
 	domFormatters.parseBackticks(descriptionElement);
 	parseSimpleInlineElement(descriptionElement, 'i');

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -12,7 +12,8 @@ import {perDomainOptions} from './options-storage';
 import * as domFormatters from './github-helpers/dom-formatters';
 
 function parseDescription(description: string): DocumentFragment {
-	const descriptionElement = <span>{description}</span>;
+	const descriptionElement = <span/>
+	descriptionElement.innerHTML = description.replaceAll('\\`', '`').replaceAll('<iframe>', '&lt;iframe&gt;');
 	domFormatters.linkifyIssues(descriptionElement, {
 		baseUrl: 'https://github.com',
 		user: 'sindresorhus',

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -55,24 +55,20 @@ function parseDescription(description: string): DocumentFragment {
 
 function moveDisabledFeaturesToTop(): void {
 	const container = select('.js-features')!;
-	for (const unchecked of select.all('.feature--enabled [type=checkbox]:not(:checked)', container).reverse()) {
+	for (const unchecked of select.all('.feature [type=checkbox]:not(:checked)', container).reverse()) {
 		// .reverse() needed to preserve alphabetical order while prepending
 		container.prepend(unchecked.closest('.feature')!);
 	}
 }
 
-function buildFeatureCheckbox({id, description, screenshot, disabled}: FeatureMeta): HTMLElement {
-	// `undefined` disconnects it from the options
-	const key = disabled ? undefined : `feature:${id}`;
-
+function buildFeatureCheckbox({id, description, screenshot}: FeatureMeta): HTMLElement {
 	return (
-		<div className={`feature feature--${disabled ? 'disabled' : 'enabled'}`} data-text={`${id} ${description}`.toLowerCase()}>
-			<input type="checkbox" name={key} id={id} disabled={Boolean(disabled)}/>
+		<div className="feature" data-text={`${id} ${description}`.toLowerCase()}>
+			<input type="checkbox" name={`feature:${id}`} id={id}/>
 			<div className="info">
 				<label htmlFor={id}>
 					<span className="feature-name">{id}</span>
 					{' '}
-					{disabled && <small>{parseDescription(`(Disabled because of ${disabled}) `)}</small>}
 					<a href={`https://github.com/sindresorhus/refined-github/blob/master/source/features/${id}.tsx`}>
 						source
 					</a>

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -15,6 +15,7 @@ import {
 	prCommitUrlRegex,
 	prCompareUrlRegex
 } from '../source/github-helpers';
+import {getParsedBackticksParts} from '../source/github-helpers/parse-backticks';
 
 test('getConversationNumber', t => {
 	const pairs = new Map<string, string | undefined>([
@@ -236,5 +237,34 @@ test('preventPrCommitLinkLoss', t => {
 		replaceCompareLink('I like [turtles](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)'),
 		'I like [turtles](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)',
 		'It should ignore Markdown links'
+	);
+});
+
+function parseBackticks(string: string): string {
+	return getParsedBackticksParts(string).map(
+		(part, index) => index % 2 && part.length >= 1 ? `<code>${part.trim()}</code>` : part
+	).join('');
+}
+
+test('parseBackticks', t => {
+	t.is(
+		parseBackticks('multiple `code spans` between ` other ` text'),
+		'multiple <code>code spans</code> between <code>other</code> text'
+	);
+	t.is(
+		parseBackticks('`code` at the start'),
+		'<code>code</code> at the start'
+	);
+	t.is(
+		parseBackticks('code at the `end`'),
+		'code at the <code>end</code>'
+	);
+	t.is(
+		parseBackticks('single backtick in a code span: `` ` ``'),
+		'single backtick in a code span: <code>`</code>'
+	);
+	t.is(
+		parseBackticks('backtick-delimited string in a code span: `` `foo` ``'),
+		'backtick-delimited string in a code span: <code>`foo`</code>'
 	);
 });

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -41,7 +41,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 
 function getFeatures(): FeatureID[] {
 	return Array.from(
-		readFileSync('source/refined-github.ts', 'utf-8').matchAll(/^import '[.][/]features[/]([^.]+)';/gm),
+		readFileSync('source/refined-github.ts', 'utf-8').matchAll(/^import '\.\/features\/([^.]+)';/gm),
 		match => match[1] as FeatureID
 	).sort();
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,27 +12,18 @@ import webpack, {Configuration} from 'webpack';
 
 const readmeContent = readFileSync('readme.md', 'utf-8');
 
-function stripLinks(markdownText: string): Partial<FeatureMeta> {
-	const urls: string[] = [];
-	const description = markdownText.replace(/\[(.+?)]\((.+?)\)/g, (_match, title, url) => {
-		urls.push(url);
-		return title;
-	});
-
-	return {
-		description,
-		screenshot: urls.find(url => url.startsWith('https://user-images.githubusercontent.com/')) ?? urls[0]
-	};
-}
-
 function parseFeatureDetails(id: FeatureID): FeatureMeta {
 	const feature: Partial<FeatureMeta> = {id};
 
 	const lineRegex = new RegExp(`^- \\[\\]\\(# "${id}"\\)(?: 🔥)? (.+)$`, 'm');
 	const lineMatch = lineRegex.exec(readmeContent);
 	if (lineMatch) {
-		Object.assign(feature, stripLinks(lineMatch[1]));
-		feature.description = feature.description!.replace(/<kbd>(.+?)<\/kbd>/g, '`$1`');
+		const urls: string[] = [];
+		feature.description = lineMatch[1].replace(/\[(.+?)]\((.+?)\)/g, (_match, title, url) => {
+			urls.push(url);
+			return title;
+		}).replace(/<kbd>(.+?)<\/kbd>/g, '`$1`');
+		feature.screenshot = urls.find(url => /\.(png|gif)$/i.test(url));
 	} else {
 		// Feature might be highlighted in the readme
 		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,7 +19,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 	for (const field of fields) {
 		const value = new RegExp(`\n\t${field}: '([^\\n]+)'`).exec(content)?.[1];
 		if (value) {
-			const validValue = value.trim().replace(/\\'/g, '’'); // Catch trailing spaces and incorrect apostrophes
+			const validValue = value.trim().replace(/(?<!`)\\'/g, '’'); // Catch trailing spaces and incorrect apostrophes
 			if (value !== validValue) {
 				throw new Error(stripIndent(`
 					❌ Invalid characters found in \`${id}\`. Apply this patch:
@@ -29,7 +29,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 				`));
 			}
 
-			feature[field] = value.replace(/\\\\/g, '\\');
+			feature[field] = value.replace(/\\'/g, '\'').replace(/\\\\/g, '\\');
 		}
 	}
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,6 +12,8 @@ import webpack, {Configuration} from 'webpack';
 
 import concatRegex from './source/helpers/concat-regex';
 
+let isWatching = false;
+
 function parseFeatureDetails(readmeContent: string, id: FeatureID): FeatureMeta {
 	const lineRegex = concatRegex(/^- \[]\(# "/, id, /"\)(?: 🔥)? (.+)$/m);
 	const lineMatch = lineRegex.exec(readmeContent);
@@ -39,7 +41,17 @@ function parseFeatureDetails(readmeContent: string, id: FeatureID): FeatureMeta 
 		};
 	}
 
-	throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);
+	const error = `
+
+	❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.
+
+	`;
+	if (isWatching) {
+		console.error(error);
+		return {} as any;
+	}
+
+	throw new Error(error);
 }
 
 function getFeatures(): FeatureID[] {
@@ -132,4 +144,9 @@ const config: Configuration = {
 	}
 };
 
-export default config;
+const webpackSetup = (_: string, options: webpack.WebpackOptionsNormalized): Configuration => {
+	isWatching = Boolean(options.watch);
+	return config;
+};
+
+export default webpackSetup;

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -13,30 +13,33 @@ import webpack, {Configuration} from 'webpack';
 const readmeContent = readFileSync(path.join(__dirname, 'readme.md'), 'utf-8');
 
 function parseFeatureDetails(id: FeatureID): FeatureMeta {
-	const feature: Partial<FeatureMeta> = {id};
-
 	const lineRegex = new RegExp(`^- \\[\\]\\(# "${id}"\\)(?: 🔥)? (.+)$`, 'm');
 	const lineMatch = lineRegex.exec(readmeContent);
 	if (lineMatch) {
 		const urls: string[] = [];
-		feature.description = lineMatch[1].replace(/\[(.+?)]\((.+?)\)/g, (_match, title, url) => {
-			urls.push(url);
-			return title;
-		});
-		feature.screenshot = urls.find(url => /\.(png|gif)$/i.test(url));
-	} else {
-		// Feature might be highlighted in the readme
-		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
-		const imageMatch = imageRegex.exec(readmeContent);
-		if (imageMatch) {
-			feature.description = `${imageMatch[1]}.`;
-			feature.screenshot = imageMatch[2];
-		} else {
-			throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);
-		}
+
+		return {
+			id,
+			description: lineMatch[1].replace(/\[(.+?)]\((.+?)\)/g, (_match, title, url) => {
+				urls.push(url);
+				return title;
+			}),
+			screenshot: urls.find(url => /\.(png|gif)$/i.test(url))
+		};
 	}
 
-	return feature as FeatureMeta;
+	// Feature might be highlighted in the readme
+	const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
+	const imageMatch = imageRegex.exec(readmeContent);
+	if (imageMatch) {
+		return {
+			id,
+			description: `${imageMatch[1]}.`,
+			screenshot: imageMatch[2]
+		};
+	}
+
+	throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);
 }
 
 function getFeatures(): FeatureID[] {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -37,10 +37,10 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 			.replace(/<kbd>(.+?)<\/kbd>/g, '`$1`'); // Replace keyboard shortcut tags
 	} else {
 		// Feature might be highlighted in the readme
-		const imageRegex = new RegExp(`<img id="${id}" alt="(.+?)" src="(.+?)">`);
+		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
 		const imageMatch = imageRegex.exec(readmeContent);
 		if (imageMatch) {
-			feature.description = imageMatch[1];
+			feature.description = `${imageMatch[1]}.`;
 			feature.screenshot = imageMatch[2];
 		} else {
 			throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -38,7 +38,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
 		const imageMatch = imageRegex.exec(readmeContent);
 		if (imageMatch) {
-			feature.description = `${imageMatch[1]}.`;
+			feature.description = `${imageMatch[1].replace(/<i>(.*?)<\/i>/g, '$1')}.`;
 			feature.screenshot = imageMatch[2];
 		} else {
 			throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="./source/globals" />
 
 import path from 'path';
-import {readdirSync, readFileSync} from 'fs';
+import {readFileSync} from 'fs';
 
 import SizePlugin from 'size-plugin';
 // @ts-expect-error
@@ -36,19 +36,14 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 		}
 	}
 
-	const featureFileContent = readFileSync(`source/features/${id}.tsx`, {encoding: 'utf-8'});
-	const [, disabledReason] = /\n\tdisabled: '([^\n]+)'/.exec(featureFileContent) ?? [];
-	if (disabledReason) {
-		feature.disabled = disabledReason;
-	}
-
 	return feature as FeatureMeta;
 }
 
 function getFeatures(): FeatureID[] {
-	return readdirSync(path.join(__dirname, 'source/features'))
-		.filter(filename => filename !== 'index.tsx' && filename.endsWith('.tsx'))
-		.map(filename => filename.replace('.tsx', '') as FeatureID);
+	return Array.from(
+		readFileSync('source/refined-github.ts', 'utf-8').matchAll(/^import '[.][/]features[/]([^.]+)';/gm),
+		match => match[1] as FeatureID
+	).sort();
 }
 
 const config: Configuration = {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -32,9 +32,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 	const lineMatch = lineRegex.exec(readmeContent);
 	if (lineMatch) {
 		Object.assign(feature, stripLinks(lineMatch[1]));
-		feature.description = feature.description!
-			.replace(/<code>\\`(.+?)\\`<\/code>/, '`$1`') // Simplify weird Markdown escaping
-			.replace(/<kbd>(.+?)<\/kbd>/g, '`$1`'); // Replace keyboard shortcut tags
+		feature.description = feature.description!.replace(/<kbd>(.+?)<\/kbd>/g, '`$1`');
 	} else {
 		// Feature might be highlighted in the readme
 		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -22,14 +22,14 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 		feature.description = lineMatch[1].replace(/\[(.+?)]\((.+?)\)/g, (_match, title, url) => {
 			urls.push(url);
 			return title;
-		}).replace(/<kbd>(.+?)<\/kbd>/g, '`$1`');
+		});
 		feature.screenshot = urls.find(url => /\.(png|gif)$/i.test(url));
 	} else {
 		// Feature might be highlighted in the readme
 		const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
 		const imageMatch = imageRegex.exec(readmeContent);
 		if (imageMatch) {
-			feature.description = `${imageMatch[1].replace(/<i>(.*?)<\/i>/g, '$1')}.`;
+			feature.description = `${imageMatch[1]}.`;
 			feature.screenshot = imageMatch[2];
 		} else {
 			throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -52,16 +52,6 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 		}
 	}
 
-	const validDescription = feature.description.trim().replace(/(?<!`)\\'/g, '’'); // Catch trailing spaces and incorrect apostrophes
-	if (feature.description !== validDescription) {
-		throw new Error(stripIndent(`
-			❌ Invalid characters found in description for \`${id}\`. Apply this patch:
-
-			- ${feature.description}'
-			+ ${validDescription}'
-		`));
-	}
-
 	const featureFileContent = readFileSync(`source/features/${id}.tsx`, {encoding: 'utf-8'});
 	const [, disabledReason] = /\n\tdisabled: '([^\n]+)'/.exec(featureFileContent) ?? [];
 	if (disabledReason) {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -12,9 +12,7 @@ import webpack, {Configuration} from 'webpack';
 
 import concatRegex from './source/helpers/concat-regex';
 
-const readmeContent = readFileSync(path.join(__dirname, 'readme.md'), 'utf-8');
-
-function parseFeatureDetails(id: FeatureID): FeatureMeta {
+function parseFeatureDetails(readmeContent: string, id: FeatureID): FeatureMeta {
 	const lineRegex = concatRegex(/^- \[]\(# "/, id, /"\)(?: 🔥)? (.+)$/m);
 	const lineMatch = lineRegex.exec(readmeContent);
 	if (lineMatch) {
@@ -102,7 +100,10 @@ const config: Configuration = {
 			),
 
 			__featuresMeta__: webpack.DefinePlugin.runtimeValue(
-				() => JSON.stringify(getFeatures().map(parseFeatureDetails)),
+				() => {
+					const readmeContent = readFileSync(path.join(__dirname, 'readme.md'), 'utf-8');
+					return JSON.stringify(getFeatures().map(id => parseFeatureDetails(readmeContent, id)));
+				},
 				true
 			),
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,7 +10,7 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack, {Configuration} from 'webpack';
 
-const readmeContent = readFileSync('readme.md', 'utf-8');
+const readmeContent = readFileSync(path.join(__dirname, 'readme.md'), 'utf-8');
 
 function parseFeatureDetails(id: FeatureID): FeatureMeta {
 	const feature: Partial<FeatureMeta> = {id};
@@ -41,7 +41,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 
 function getFeatures(): FeatureID[] {
 	return Array.from(
-		readFileSync('source/refined-github.ts', 'utf-8').matchAll(/^import '\.\/features\/([^.]+)';/gm),
+		readFileSync(path.join(__dirname, 'source/refined-github.ts'), 'utf-8').matchAll(/^import '\.\/features\/([^.]+)';/gm),
 		match => match[1] as FeatureID
 	).sort();
 }

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -10,10 +10,12 @@ import CopyWebpackPlugin from 'copy-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import webpack, {Configuration} from 'webpack';
 
+import concatRegex from './source/helpers/concat-regex';
+
 const readmeContent = readFileSync(path.join(__dirname, 'readme.md'), 'utf-8');
 
 function parseFeatureDetails(id: FeatureID): FeatureMeta {
-	const lineRegex = new RegExp(`^- \\[\\]\\(# "${id}"\\)(?: 🔥)? (.+)$`, 'm');
+	const lineRegex = concatRegex(/^- \[]\(# "/, id, /"\)(?: 🔥)? (.+)$/m);
 	const lineMatch = lineRegex.exec(readmeContent);
 	if (lineMatch) {
 		const urls: string[] = [];
@@ -29,7 +31,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 	}
 
 	// Feature might be highlighted in the readme
-	const imageRegex = new RegExp(`<p><a title="${id}"></a> (.+?)\\n\\t+<p><img src="(.+?)">`);
+	const imageRegex = concatRegex(/<p><a title="/, id, /"><\/a> (.+?)\n\t+<p><img src="(.+?)">/);
 	const imageMatch = imageRegex.exec(readmeContent);
 	if (imageMatch) {
 		return {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -4,7 +4,6 @@ import path from 'path';
 import {readdirSync, readFileSync} from 'fs';
 
 import SizePlugin from 'size-plugin';
-import stripIndent from 'strip-indent';
 // @ts-expect-error
 import {ESBuildPlugin} from 'esbuild-loader';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
@@ -44,11 +43,7 @@ function parseFeatureDetails(id: FeatureID): FeatureMeta {
 			feature.description = imageMatch[1];
 			feature.screenshot = imageMatch[2];
 		} else {
-			throw new Error(stripIndent(`
-				❌ Feature \`${id}\` needs a description in readme.md (please refer to the style guide there):
-
-				- [](# "${id}") [feature description](screenshot url)
-			`));
+			throw new Error(`❌ Feature \`${id}\` needs a description in readme.md. Please refer to the style guide there.`);
 		}
 	}
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -34,7 +34,7 @@ function parseFeatureDetails(readmeContent: string, id: FeatureID): FeatureMeta 
 	if (imageMatch) {
 		return {
 			id,
-			description: `${imageMatch[1]}.`,
+			description: imageMatch[1] + '.',
 			screenshot: imageMatch[2]
 		};
 	}


### PR DESCRIPTION
Closes #3672.

~I've left a settings object (that is empty in most features) in `features.add`, because both `disabled` and `shortcuts` need to be defined there.~

The first two commits actually change some of the descriptions/screenshots, so that the later commits don't introduce any changes that are not visible in any diff. I've made those changes manually (with a helper function that generates two files that I could diff).

### Implemented in this PR:

1. Parse features' description and screenshot from readme.
2. Disable features by commenting them out in `refined-github.ts`.
3. Move `shortcuts` from `FeatureMeta` to `FeatureLoader`.
4. Drop the `FeatureMeta` parameter from `features.add`.
5. Render `<i>` and `<kbd>` tags in addon options:
  ![](https://user-images.githubusercontent.com/202916/96859373-ba01de80-1461-11eb-9535-9a3e11ee7641.png)
6. Update `parseBackticks`, so that ``` `` ` `` ``` and ``` `` `bla` `` ``` are also parsed correctly (and add some tests for it).
7. Improve some feature descriptions.
8. Add and use a `concatRegex` helper (suggested by @fregante in https://github.com/sindresorhus/refined-github/pull/3678#discussion_r510277945).