### PR TITLE
Meta: Fix typo in the description of `show-associated-branch-prs-on-fork`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Thanks for contributing! 🦋🙌
 - [](# "repo-wide-file-finder") Enables the File Finder keyboard shortcut (<kbd>t</kbd>) on Issues and Pull Request pages as well.
 - [](# "file-finder-buffer") [Lets you start typing your search immediately after invoking the File Finder (<kbd>t</kbd>), instead of having you wait for it to load first.](https://user-images.githubusercontent.com/1402241/75542106-1c811700-5a5a-11ea-8aa5-bea0472c59e2.gif)
 - [](# "preserve-file-finder-term") Preserves the search terms when navigating back and forth between the File Finder and the files.
-- [](# "show-associated-branch-prs-on-fork") [Shows the associated pull requests on branches for forked repository’s.](https://user-images.githubusercontent.com/16872793/81504659-7e5ec800-92b8-11ea-9ee6-924110e8cca1.png)
+- [](# "show-associated-branch-prs-on-fork") [Shows the associated pull requests on branches for forked repositories.](https://user-images.githubusercontent.com/16872793/81504659-7e5ec800-92b8-11ea-9ee6-924110e8cca1.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 


### PR DESCRIPTION
Apostrophe abuse is a crime!

<!-- Please follow the template -->

1. LINKED ISSUES:
   N/A

2. TEST URLS:
   N/A

3. SCREENSHOT:
   N/A, this is just copy-editing.
