### PR TITLE
Add `unfinished-comments` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ Thanks for contributing! 🦋🙌
 - [](# "monospace-textareas") Uses a monospace font for all textareas.
 - [](# "quick-mention") [Adds a button to `@mention` a user in conversations.](https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif)
 - [](# "table-input") [Adds a button in the text editor to quickly insert a simplified HTML table.](https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif)
-- [](# "unfinished-comments") [Notifies the user of unfinished comments in hidden tabs.](https://user-images.githubusercontent.com/46634000/97785800-a2d09880-1ba7-11eb-9529-aad077fd13d1.gif)
+- [](# "unfinished-comments") [Notifies the user of unfinished comments in hidden tabs.](https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ Thanks for contributing! 🦋🙌
 - [](# "monospace-textareas") Uses a monospace font for all textareas.
 - [](# "quick-mention") [Adds a button to `@mention` a user in conversations.](https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif)
 - [](# "table-input") [Adds a button in the text editor to quickly insert a simplified HTML table.](https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif)
+- [](# "unfinished-comments") [Notifies the user of unfinished comments in a hidden tab]()
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -140,7 +140,7 @@ Thanks for contributing! 🦋🙌
 - [](# "monospace-textareas") Uses a monospace font for all textareas.
 - [](# "quick-mention") [Adds a button to `@mention` a user in conversations.](https://user-images.githubusercontent.com/1402241/70406615-f445d580-1a73-11ea-9ab1-bf6bd9aa70a3.gif)
 - [](# "table-input") [Adds a button in the text editor to quickly insert a simplified HTML table.](https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif)
-- [](# "unfinished-comments") [Notifies the user of unfinished comments in a hidden tab]()
+- [](# "unfinished-comments") [Notifies the user of unfinished comments in hidden tabs.](https://user-images.githubusercontent.com/46634000/97785800-a2d09880-1ba7-11eb-9529-aad077fd13d1.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -3,28 +3,23 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-let documentTitle = document.title;
+let documentTitle = '';
+
+async function updateDocumentTitle(): Promise<void> {
+	if (document.visibilityState === 'hidden') {
+		if (select.all('textarea').some(textarea => textarea.value.length > 0 && (textarea.offsetWidth > 0 || textarea.offsetHeight > 0))) {
+			console.log('changing title');
+			documentTitle = document.title;
+			document.title = '(Draft comment) ' + document.title;
+		}
+	} else {
+		document.title = documentTitle;
+	}
+}
 
 function init(): void {
-	if (document.body.dataset.visibilityListenerAdded) {
-		return;
-	}
-
-	const textareas = select.all('textarea');
-
-	document.addEventListener('visibilitychange', async () => {
-		if (document.visibilityState === 'hidden') {
-			if (textareas.some(textarea => (textarea.offsetWidth > 0 || textarea.offsetHeight > 0) && textarea.value.length > 0)) {
-				documentTitle = document.title;
-				document.title = '(Draft comment) ' + document.title;
-			}
-
-			return;
-		}
-
-		document.title = documentTitle;
-	});
-	document.body.dataset.visibilityListenerAdded = String(true);
+	documentTitle = document.title;
+	document.addEventListener('visibilitychange', updateDocumentTitle);
 }
 
 void features.add(__filebasename, {

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -1,10 +1,9 @@
 import select from 'select-dom';
-import cache from 'webext-storage-cache';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-const cacheKey = __filebasename + ':' + window.location.href;
+let documentTitle = document.title;
 
 function init(): void {
 	if (document.body.dataset.visibilityListenerAdded) {
@@ -16,17 +15,14 @@ function init(): void {
 	document.addEventListener('visibilitychange', async () => {
 		if (document.visibilityState === 'hidden') {
 			if (textareas.some(textarea => (textarea.offsetWidth > 0 || textarea.offsetHeight > 0) && textarea.value.length > 0)) {
-				await cache.set(cacheKey, document.title);
+				documentTitle = document.title;
 				document.title = '(Draft comment) ' + document.title;
 			}
 
 			return;
 		}
 
-		if (await cache.has(cacheKey)) {
-			document.title = String(await cache.get(cacheKey));
-			await cache.delete(cacheKey);
-		}
+		document.title = documentTitle;
 	});
 	document.body.dataset.visibilityListenerAdded = String(true);
 }

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -3,17 +3,19 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-let documentTitle: string | null = null;
+let documentTitle: string | undefined = undefined;
+
+function hasDraftComments(): boolean {
+	return select.all('textarea').some(textarea => textarea.value.length > 0 && textarea.offsetWidth > 0);
+}
 
 async function updateDocumentTitle(): Promise<void> {
-	if (document.visibilityState === 'hidden') {
-		if (select.all('textarea').some(textarea => textarea.value.length > 0 && textarea.offsetWidth > 0) {
-			documentTitle = document.title;
-			document.title = '(Draft comment) ' + document.title;
-		}
-	} else if (documentTitle) {
+	if (documentTitle) {
 		document.title = documentTitle;
-		documentTitle = null;
+		documentTitle = undefined;
+	} else if (document.visibilityState === 'hidden' && hasDraftComments()) {
+		documentTitle = document.title;
+		document.title = '(Draft comment) ' + document.title;
 	}
 }
 

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -7,7 +7,7 @@ let documentTitle: string | null = null;
 
 async function updateDocumentTitle(): Promise<void> {
 	if (document.visibilityState === 'hidden') {
-		if (select.all('textarea').some(textarea => textarea.value.length > 0 && (textarea.offsetWidth > 0 || textarea.offsetHeight > 0))) {
+		if (select.all('textarea').some(textarea => textarea.value.length > 0 && textarea.offsetWidth > 0) {
 			documentTitle = document.title;
 			document.title = '(Draft comment) ' + document.title;
 		}
@@ -18,7 +18,6 @@ async function updateDocumentTitle(): Promise<void> {
 }
 
 function init(): void {
-	documentTitle = document.title;
 	document.addEventListener('visibilitychange', updateDocumentTitle);
 }
 

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -3,7 +3,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-let documentTitle: string | undefined = undefined;
+let documentTitle: string | undefined;
 
 function hasDraftComments(): boolean {
 	return select.all('textarea').some(textarea => textarea.value.length > 0 && textarea.offsetWidth > 0);

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -1,0 +1,39 @@
+import select from 'select-dom';
+import cache from 'webext-storage-cache';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+const cacheKey = __filebasename + ':' + window.location.href;
+
+function init(): void {
+	if (document.body.dataset.visibilityListenerAdded) {
+		return;
+	}
+
+	const textareas = select.all('textarea');
+
+	document.addEventListener('visibilitychange', async () => {
+		if (document.visibilityState === 'hidden') {
+			if (textareas.some(textarea => (textarea.offsetWidth > 0 || textarea.offsetHeight > 0) && textarea.value.length > 0)) {
+				await cache.set(cacheKey, document.title);
+				document.title = '(Draft comment) ' + document.title;
+			}
+
+			return;
+		}
+
+		if (await cache.has(cacheKey)) {
+			document.title = String(await cache.get(cacheKey));
+			await cache.delete(cacheKey);
+		}
+	});
+	document.body.dataset.visibilityListenerAdded = String(true);
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.hasComments
+	],
+	init
+});

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -3,17 +3,17 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-let documentTitle = '';
+let documentTitle: string | null = null;
 
 async function updateDocumentTitle(): Promise<void> {
 	if (document.visibilityState === 'hidden') {
 		if (select.all('textarea').some(textarea => textarea.value.length > 0 && (textarea.offsetWidth > 0 || textarea.offsetHeight > 0))) {
-			console.log('changing title');
 			documentTitle = document.title;
 			document.title = '(Draft comment) ' + document.title;
 		}
-	} else {
+	} else if (documentTitle) {
 		document.title = documentTitle;
+		documentTitle = null;
 	}
 }
 

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -198,6 +198,7 @@ import './features/table-input';
 import './features/link-to-github-io';
 import './features/next-scheduled-github-action';
 import './features/convert-pr-to-draft-improvements';
+import './features/unfinished-comments';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3680 

2. TEST URLS:
- https://github.com/sindresorhus/refined-github/issues/3680
- https://github.com/sindresorhus/refined-github/pull/3596 (hidden textareas)

3. SCREENSHOT:
![Peek 2020-10-31 18-24](https://user-images.githubusercontent.com/46634000/97785800-a2d09880-1ba7-11eb-9529-aad077fd13d1.gif)

Notes:
- I used the `visibilitychange` event instead of `pageshow`/`pagehide` as the latter weren't working for me in Firefox. As an added bonus, it also works when hiding/minifying the whole browser window.
- I followed the suggestion of the issue for the notification text, but imho something shorter would be better, e.g. `(+)` or `[*]` (akin to what editors show when a file has been modified but not saved).