### PR TITLE
Fix `first-commit-message-for-new-prs`

### DIFF
--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -8,7 +8,6 @@ import looseParseInt from '../helpers/loose-parse-int';
 
 async function init(): Promise<void | false> {
 	const commitCount = (await elementReady<HTMLElement>('div.Box.mb-3 .octicon-git-commit'))?.nextElementSibling;
-	console.log(commitCount);
 	if (!commitCount || looseParseInt(commitCount.textContent!) < 2 || !select.exists('#new_pull_request')) {
 		return false;
 	}

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -7,14 +7,13 @@ import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
 async function init(): Promise<void | false> {
-	const commitsBucket = await elementReady<HTMLElement>('#commits_bucket');
-	const commitCount = commitsBucket?.previousElementSibling?.querySelector('ul > li:nth-child(1) .text-emphasized');
-
+	const commitCount = (await elementReady<HTMLElement>('div.Box.mb-3 .octicon-git-commit'))?.nextElementSibling;
+	console.log(commitCount);
 	if (!commitCount || looseParseInt(commitCount.textContent!) < 2 || !select.exists('#new_pull_request')) {
 		return false;
 	}
 
-	const [prTitle, ...prMessage] = select('[data-url$="compare/commit"] a[title]', commitsBucket)!.title.split(/\n\n/);
+	const [prTitle, ...prMessage] = select('#commits_bucket [data-url$="compare/commit"] a[title]')!.title.split(/\n\n/);
 
 	textFieldEdit.set(
 		select<HTMLInputElement>('.discussion-topic-header input')!,

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -8,7 +8,7 @@ import looseParseInt from '../helpers/loose-parse-int';
 
 async function init(): Promise<void | false> {
 	const commitCount = (await elementReady<HTMLElement>('div.Box.mb-3 .octicon-git-commit'))?.nextElementSibling;
-	if (!commitCount || looseParseInt(commitCount.textContent!) < 2 || !select.exists('#new_pull_request')) {
+	if (!commitCount || looseParseInt(commitCount) < 2 || !select.exists('#new_pull_request')) {
 		return false;
 	}
 

--- a/source/features/use-first-commit-message-for-new-prs.tsx
+++ b/source/features/use-first-commit-message-for-new-prs.tsx
@@ -7,16 +7,14 @@ import features from '.';
 import looseParseInt from '../helpers/loose-parse-int';
 
 async function init(): Promise<void | false> {
-	const commitCount = await elementReady<HTMLElement>([
-		'.overall-summary > ul > li:nth-child(1) .text-emphasized', // Cross fork
-		'[href="#commits_bucket"] .Counter' // Same repository
-	].join());
+	const commitsBucket = await elementReady<HTMLElement>('#commits_bucket');
+	const commitCount = commitsBucket?.previousElementSibling?.querySelector('ul > li:nth-child(1) .text-emphasized');
 
 	if (!commitCount || looseParseInt(commitCount.textContent!) < 2 || !select.exists('#new_pull_request')) {
 		return false;
 	}
 
-	const [prTitle, ...prMessage] = select('#commits_bucket .commit-message code a')!.title.split(/\n\n/);
+	const [prTitle, ...prMessage] = select('[data-url$="compare/commit"] a[title]', commitsBucket)!.title.split(/\n\n/);
 
 	textFieldEdit.set(
 		select<HTMLInputElement>('.discussion-topic-header input')!,


### PR DESCRIPTION
GitHub is going to give us a very hard time. There are almost no more class specific selectors

Test on: 
https://github.com/sindresorhus/refined-github/compare/master...yakov116:text?expand=1 (Cross-fork)
https://github.com/sindresorhus/refined-github/compare/master...sindresorhus:lint?expand=1 (Same-repo)