### PR TITLE
Fix `z-index` conflict between `sticky-sidebar` and the footer

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -5,6 +5,7 @@
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 0;
+	z-index: 1; /* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
 }
 
 #partial-discussion-sidebar.rgh-sticky-sidebar {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3732

This shouldn't make it any worse than `sticky` already does since, at most, it just brings the whole sidebar a little higher than the rest of the page, which is expected since it floats. Its contents and their z-index were also already trapped by `sticky` so they won't be affected by this.

All that this does is bring it above the regular `z-index` of the elements that _follow_ the sidebar, like the footer.

If it causes issues, the alternative to #3732 would be to detect an "overlay details" opening/closing and toggling the "sticky-sidebar" class instead.