### PR TITLE
Meta: Add more information about the token in the options page

### DIFF
--- a/distribution/options.html
+++ b/distribution/options.html
@@ -5,13 +5,17 @@
 <form id="options-form" class="detail-view-container">
 	<p>
 		<label>
-			<strong>Personal token</strong> <sup>(optional)</sup><br>
-			<a href="https://github.com/sindresorhus/refined-github/search?q=github-helpers/api" target="_blank">Some features</a> may not work without it.
-			<a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">Generate one</a>.
+			<strong>Personal token</strong> (optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">generate one</a>)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" pattern="[\da-f]{40}" placeholder=" ">
 		</label>
 	</p>
+	<ul>
+		<li>The token enables <a href="https://github.com/sindresorhus/refined-github/search?q=github-helpers/api" target="_blank">some features</a> to read data from public repositories
+		<li>The <code>public_repo</code> scope lets them edit your public repositories
+		<li>The <code>repo</code> scope lets them edit private repositories as well
+		<li>The <code>delete_repo</code> scope is only used by the <code>quick-fork-deletion</code> feature
+	</ul>
 
 	<hr>
 

--- a/source/options.css
+++ b/source/options.css
@@ -12,6 +12,10 @@ p {
 	margin-top: 0;
 }
 
+ul {
+	padding-left: 1.5em;
+}
+
 :root [name='customCSS'],
 :root [name='personalToken'] {
 	font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;


### PR DESCRIPTION
Related: #3752

## Firefox 

<img width="654" alt="" src="https://user-images.githubusercontent.com/1402241/99917741-d51d7380-2cd7-11eb-9457-96d1bca81f24.png">

## Chrome

<img width="535" alt="" src="https://user-images.githubusercontent.com/1402241/99917742-d6e73700-2cd7-11eb-950d-9bea7c6b7bac.png">
