### PR TITLE
Enable `unfinished-comments` on temporarily-hidden text fields

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -9,7 +9,7 @@ function hasDraftComments(): boolean {
 	// `[disabled]` excludes the PR description field that `wait-for-build` disables while it waits
 	return select.all<HTMLTextAreaElement>('textarea:not([disabled])').some(textarea =>
 		textarea.value !== textarea.textContent && // Exclude comments being edited but not yet changed (and empty comment fields)
-		textarea.offsetWidth > 0 && // Exclude invisible fields
+		(textarea.offsetWidth > 0 || select('.js-preview-body', textarea.form!)!.textContent !== 'Nothing to preview') && // Exclude invisible fields that aren't being previewed
 		!select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
 	);
 }

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -9,7 +9,6 @@ function hasDraftComments(): boolean {
 	// `[disabled]` excludes the PR description field that `wait-for-build` disables while it waits
 	return select.all<HTMLTextAreaElement>('textarea:not([disabled])').some(textarea =>
 		textarea.value !== textarea.textContent && // Exclude comments being edited but not yet changed (and empty comment fields)
-		(textarea.offsetWidth > 0 || select('.js-preview-body', textarea.form!)!.textContent !== 'Nothing to preview') && // Exclude invisible fields that aren't being previewed
 		!select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
 	);
 }


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3765 

2. TEST URLS:
- issue: https://github.com/sindresorhus/refined-github/issues/3765
- PR: https://github.com/sindresorhus/refined-github/pull/3767

Tested on Firefox and Chromium in all possible cases (issue comment, PR comment, PR review comment). Side note: it also works on the "New issue"/"New PR" pages now, but we get the same "switching tabs right after posting" problem as we had for the comments (at least on Firefox).