### PR TITLE
Fix `hide-zero-packages` on repo roots

### DIFF
--- a/source/features/hide-zero-packages.tsx
+++ b/source/features/hide-zero-packages.tsx
@@ -6,7 +6,7 @@ import getTabCount from './remove-projects-tab';
 
 async function init(): Promise<void | false> {
 	const packagesTab = await elementReady([
-		'.BorderGrid-cell a[href$="/packages"]', // `isRepoRoot`
+		'.BorderGrid-cell a[href*="/packages"]', // `isRepoRoot`
 		'.UnderlineNav-item[href$="?tab=packages"]:not(.selected)' // `isUserProfile`
 	].join());
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: None

2. TEST URLS: https://github.com/sindresorhus/refined-github

This feature broke because the URL of the "Packages" links now ends with some query parameters (e.g. `https://github.com/users/sindresorhus/packages?repo_name=refined-github`)