### PR TITLE
Meta: Update Sourcegraph Readme link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,5 +386,5 @@ Read the [contribution guide](contributing.md) and join the [contributors](https
 - [Show All GitHub Issues](https://github.com/sindresorhus/show-all-github-issues) - Shows both Issues and Pull Requests in the Issues tab
 - [Refined Twitter](https://github.com/sindresorhus/refined-twitter) - Improves Twitter
 - [Friendly GitHub](https://github.com/Hermanya/friendly-github) - Make GitHub more social
-- [Sourcegraph](https://github.com/sourcegraph/sourcegraph/tree/master/browser) - Code search and navigation tool
+- [Sourcegraph](https://github.com/sourcegraph/sourcegraph/tree/main/client/browser) - Code search and navigation tool
 - [PR Monitor](https://github.com/fwouts/prmonitor) - Notifies you about incoming and outgoing PRs


### PR DESCRIPTION
The old link is now broken. Thanks for including us in your list of related extensions!