### PR TITLE
Fix `new-repo-disable-projects-and-wiki` feature

### DIFF
--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -114,7 +114,7 @@ export const v3 = mem(async (
 	const {personalToken} = await settings;
 
 	if (!query.startsWith('https')) {
-		query = query.startsWith('/') ? query.slice(1) : 'repos/' + getRepo()!.nameWithOwner + (query.length > 0 ? '/' + query : '');
+		query = query.startsWith('/') ? query.slice(1) : ['repos', getRepo()!.nameWithOwner, query].filter(Boolean).join('/');
 	}
 
 	const url = new URL(query, api3);

--- a/source/github-helpers/api.ts
+++ b/source/github-helpers/api.ts
@@ -114,7 +114,7 @@ export const v3 = mem(async (
 	const {personalToken} = await settings;
 
 	if (!query.startsWith('https')) {
-		query = query.startsWith('/') ? query.slice(1) : 'repos/' + getRepo()!.nameWithOwner + '/' + query;
+		query = query.startsWith('/') ? query.slice(1) : 'repos/' + getRepo()!.nameWithOwner + (query.length > 0 ? '/' + query : '');
 	}
 
 	const url = new URL(query, api3);


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: none

2. TEST URLS: https://github.com/new

The `new-repo-disable-projects-and-wiki` feature was the only one passing an empty query string to `api.v3()`, which caused a trailing slash to appear at the end of the URL and resulted in a 404 error.