### PR TITLE
Expand `quick-fork-deletion` to empty repos

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Thanks for contributing! 🦋🙌
 - [](# "sticky-sidebar") [Makes conversation sidebars and repository sidebars sticky, if they fit the viewport.](https://user-images.githubusercontent.com/10238474/62276723-5a2eaa80-b44d-11e9-810b-ff598d1c5c6a.gif)
 - [](# "link-to-github-io") [Adds a link to visit the user’s github.io website from its repo.](https://user-images.githubusercontent.com/31387795/94045261-dbcd5e80-fdec-11ea-83fa-30bb673cc26e.jpg)
 - [](# "next-scheduled-github-action") [Shows the next scheduled time of relevant GitHub Actions in the workflows sidebar.](https://user-images.githubusercontent.com/46634000/94690232-2476a180-0330-11eb-99d7-e174bb762cea.png)
-- [](# "quick-fork-deletion") [Lets you delete your forks in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
+- [](# "quick-repo-deletion") [Lets you delete your repos in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/quick-repo-deletion.css
+++ b/source/features/quick-repo-deletion.css
@@ -1,10 +1,10 @@
-:root .rgh-quick-fork-deletion[open] span {
+:root .rgh-quick-repo-deletion[open] span {
 	position: relative;
 	z-index: 81;
 	transform-origin: top;
 }
 
-:root .rgh-quick-fork-deletion[open] summary::before {
+:root .rgh-quick-repo-deletion[open] summary::before {
 	background-color: var(--color-scale-red-6);
 	opacity: 30%;
 }

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -1,4 +1,4 @@
-import './quick-fork-deletion.css';
+import './quick-repo-deletion.css';
 import delay from 'delay';
 import React from 'dom-chef';
 import select from 'select-dom';
@@ -21,7 +21,7 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 		'.rgh-open-prs-of-forks' // PRs opened in the source repo
 	]);
 
-	if (hasContent && !confirm('This fork has open issues/PRs, are you sure you want to delete everything?')) {
+	if (hasContent && !confirm('This repo has open issues/PRs, are you sure you want to delete everything?')) {
 		// Close the <details> element again
 		event.delegateTarget.open = false;
 	} else {
@@ -58,11 +58,11 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 	try {
 		do {
 			button.style.transform = `scale(${1.2 - ((secondsLeft - 5) / 3)})`; // Dividend is zoom speed
-			button.textContent = `Deleting fork in ${pluralize(secondsLeft, '$$ second')}. Cancel?`;
+			button.textContent = `Deleting repo in ${pluralize(secondsLeft, '$$ second')}. Cancel?`;
 			await delay(1000, {signal: abortController.signal}); // eslint-disable-line no-await-in-loop
 		} while (--secondsLeft);
 	} catch {
-		button.textContent = 'Delete fork';
+		button.textContent = 'Delete repo';
 		button.style.transform = '';
 	}
 
@@ -74,7 +74,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 		return;
 	}
 
-	select('.btn', buttonContainer)!.textContent = 'Deleting fork…';
+	select('.btn', buttonContainer)!.textContent = 'Deleting repo…';
 
 	try {
 		const {nameWithOwner} = getRepo()!;
@@ -117,16 +117,16 @@ async function init(): Promise<void | false> {
 	// (Ab)use the details element as state and an accessible "click-anywhere-to-cancel" utility
 	select('.pagehead-actions')!.prepend(
 		<li>
-			<details className="details-reset details-overlay select-menu rgh-quick-fork-deletion">
+			<details className="details-reset details-overlay select-menu rgh-quick-repo-deletion">
 				<summary aria-haspopup="menu" role="button">
 					{/* This extra element is needed to keep the button above the <summary>’s lightbox */}
-					<span className="btn btn-sm btn-danger">Delete fork</span>
+					<span className="btn btn-sm btn-danger">Delete repo</span>
 				</summary>
 			</details>
 		</li>
 	);
 
-	delegate(document, '.rgh-quick-fork-deletion[open]', 'toggle', handleToggle, true);
+	delegate(document, '.rgh-quick-repo-deletion[open]', 'toggle', handleToggle, true);
 }
 
 void features.add(__filebasename, {

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -25,6 +25,10 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 		// Close the <details> element again
 		event.delegateTarget.open = false;
 	} else {
+		if (!pageDetect.isForkedRepo() && !confirm('⚠️ ⚠️ ARE YOU TOTALLY SURE YOU WANT TO DELETE THIS REPOSITORY? ⚠️ ⚠️')) {
+			event.delegateTarget.open = false;
+		}
+
 		// Without the timeout, the same toggle event will also trigger the AbortController
 		setTimeout(start, 1, event.delegateTarget);
 	}

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -104,7 +104,7 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 async function init(): Promise<void | false> {
 	if (
 		// Only if the user can delete the repository
-		!await elementReady('[data-tab-item="settings-tab"]') ||
+		!await elementReady('nav [data-content="Settings"]') ||
 
 		// Only if the repository hasn't been starred
 		looseParseInt(select('.starring-container .social-count')!) > 0

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -24,14 +24,16 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 	if (hasContent && !confirm('This repo has open issues/PRs, are you sure you want to delete everything?')) {
 		// Close the <details> element again
 		event.delegateTarget.open = false;
-	} else {
-		if (!pageDetect.isForkedRepo() && !confirm('⚠️ ⚠️ ARE YOU TOTALLY SURE YOU WANT TO DELETE THIS REPOSITORY? ⚠️ ⚠️')) {
-			event.delegateTarget.open = false;
-		}
-
-		// Without the timeout, the same toggle event will also trigger the AbortController
-		setTimeout(start, 1, event.delegateTarget);
+		return;
 	}
+
+	if (!pageDetect.isForkedRepo() && !confirm('⚠️ ⚠️ ARE YOU TOTALLY SURE YOU WANT TO DELETE THIS REPOSITORY? ⚠️ ⚠️')) {
+		event.delegateTarget.open = false;
+		return;
+	}
+
+	// Without the timeout, the same toggle event will also trigger the AbortController
+	setTimeout(start, 1, event.delegateTarget);
 }
 
 async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boolean> {

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -131,7 +131,7 @@ async function init(): Promise<void | false> {
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.isForkedRepo
+		pageDetect.isRepo
 	],
 	awaitDomReady: false,
 	init

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -27,7 +27,7 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 		return;
 	}
 
-	if (!pageDetect.isForkedRepo() && !confirm('⚠️ ⚠️ ARE YOU TOTALLY SURE YOU WANT TO DELETE THIS REPOSITORY? ⚠️ ⚠️')) {
+	if (!pageDetect.isForkedRepo() && !confirm('⚠️ This action cannot be undone. This will permanently delete the repository, wiki, issues, comments, packages, secrets, workflow runs, and remove all collaborator associations.')) {
 		event.delegateTarget.open = false;
 		return;
 	}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -201,7 +201,7 @@ import './features/unfinished-comments';
 import './features/single-diff-column-selection';
 import './features/jump-to-change-requested-comment';
 import './features/esc-to-cancel';
-import './features/quick-fork-deletion';
+import './features/quick-repo-deletion';
 import './features/pr-easy-toggle-files';
 
 // Add global for easier debugging


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3779 

2. TEST URLS: see https://github.com/sindresorhus/refined-github/pull/3734#issue-523513983

3. SCREENSHOT: **TODO**

* Renamed the feature to `quick-repo-deletion`
* Fixed an incorrect selector that broke the feature
* Enabled the feature on every repo and added an additional confirmation step for non-forks