### PR TITLE
Add `theme-switch` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ The Chrome version also works in Opera (using [this](https://addons.opera.com/en
 			<p><a title="linkify-code"></a> Linkifies issue/PR references and URLs in code
 			<p><img src="https://cloud.githubusercontent.com/assets/170270/25370217/61718820-29b3-11e7-89c5-2959eaf8cac8.png">
 		<th width="50%">
-			<p><a title="restore-file"></a> Adds button to revert all the changes to a file in a PR
+			<p><a title="restore-file"></a> Adds a button to revert all the changes to a file in a PR
 			<p><img src="https://user-images.githubusercontent.com/1402241/62826118-73b7bb00-bbe0-11e9-9449-2dd64c469bb9.gif">
 </table>
 
@@ -213,7 +213,7 @@ Thanks for contributing! 🦋🙌
 ### Editing pull requests
 
 - [](# "sync-pr-commit-title") 🔥 [Uses the PR’s title as the default squash commit title](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
-- [](# "update-pr-from-base-branch") [Adds button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
+- [](# "update-pr-from-base-branch") [Adds a button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
 - [](# "quick-review-buttons") [Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
 - [](# "warn-pr-from-master") [Warns you when creating a pull request from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)
@@ -289,11 +289,12 @@ Thanks for contributing! 🦋🙌
 - [](# "format-conversation-titles") [Makes issue/PR references in issue/PR titles clickable and renders `` `text in backticks` ``.](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
-- [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)
+- [](# "open-all-notifications") [Adds a button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
 - [](# "stop-redirecting-in-notification-bar") [Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.](https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png)
 - [](# "hide-zero-packages") [Hides the `Packages` tab if it’s empty (in repositories and user profiles).](https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png)
+- [](# "theme-switch") Adds a button to switch theme preferences from the profile dropdown.
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ Thanks for contributing! 🦋🙌
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)
 - [](# "stop-redirecting-in-notification-bar") [Stops redirecting to notification inbox from notification bar actions while holding <kbd>Alt</kbd>.](https://user-images.githubusercontent.com/202916/80318782-c38cef80-880c-11ea-9226-72c585f42a51.png)
 - [](# "hide-zero-packages") [Hides the `Packages` tab if it’s empty (in repositories and user profiles).](https://user-images.githubusercontent.com/44045911/93543684-d1473b00-f98e-11ea-9957-e4464400f81b.png)
-- [](# "theme-switch") Adds a button to switch theme preferences from the profile dropdown.
+- [](# "theme-switch") [Adds a button to switch theme preferences from the profile dropdown.](https://user-images.githubusercontent.com/44045911/101625949-2a3ae280-3a57-11eb-9298-d1dde71806fc.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/theme-switch.css
+++ b/source/features/theme-switch.css
@@ -1,7 +1,3 @@
-.rgh-theme-switch-form.js-color-mode-settings img {
-	display: none !important;
-}
-
 .rgh-theme-switch-form .hx_theme-toggle {
 	border: none;
 	font-weight: normal;

--- a/source/features/theme-switch.css
+++ b/source/features/theme-switch.css
@@ -1,8 +1,8 @@
-.rgh-theme-switch.js-color-mode-settings img {
+.rgh-theme-switch-form.js-color-mode-settings img {
 	display: none !important;
 }
 
-.rgh-theme-switch .hx_theme-toggle {
+.rgh-theme-switch-form .hx_theme-toggle {
 	border: none;
 	font-weight: normal;
 }

--- a/source/features/theme-switch.css
+++ b/source/features/theme-switch.css
@@ -1,0 +1,13 @@
+.rgh-theme-switch.js-color-mode-settings img {
+	display: none !important;
+}
+
+.rgh-theme-switch .hx_theme-toggle {
+	border: none;
+	font-weight: normal;
+}
+
+.rgh-theme-switch-title.dropdown-item:hover {
+	color: var(--color-text-primary);
+	background-color: var(--color-bg-overlay);
+}

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -1,0 +1,36 @@
+import './theme-switch.css';
+import React from 'dom-chef';
+import select from 'select-dom';
+import onetime from 'onetime';
+import {observe} from 'selector-observer';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import fetchDom from '../helpers/fetch-dom';
+
+async function init(): Promise<void> {
+	const dom = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
+	dom.classList.add('rgh-theme-switch', 'mt-1', 'ml-1');
+	select('.flex-column', dom)!.classList.remove('flex-lg-row');
+	for (const radio of select.all('.position-relative', dom)) {
+		radio.classList.remove('mb-4');
+	}
+
+	observe('.dropdown-item[href="https://gist.github.com/mine"]', {
+		add(item) {
+			item.after(
+				<>
+					<span role="menuitem" className="dropdown-item rgh-theme-switch-title">Theme preference</span>
+					{dom}
+				</>
+			);
+		}
+	});
+}
+
+void features.add(__filebasename, {
+	exclude: [
+		pageDetect.isGist
+	],
+	init: onetime(init)
+});

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -9,19 +9,20 @@ import features from '.';
 import fetchDom from '../helpers/fetch-dom';
 
 async function init(): Promise<void> {
-	const dom = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
-	dom.classList.add('rgh-theme-switch', 'mt-1', 'ml-1');
-	select('.flex-column', dom)!.classList.remove('flex-lg-row');
-	for (const radio of select.all('.position-relative', dom)) {
+	const form = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
+	form.classList.add('rgh-theme-switch-form', 'mt-1', 'ml-1');
+	select('.flex-column', form)!.classList.remove('flex-lg-row');
+	for (const radio of select.all('.position-relative', form)) {
 		radio.classList.remove('mb-4');
 	}
 
-	observe('.dropdown-item[href="https://gist.github.com/mine"]', {
+	observe('.dropdown-item[href="https://gist.github.com/mine"]:not(.rgh-theme-switch)', {
 		add(item) {
+			item.classList.add('rgh-theme-switch');
 			item.after(
 				<>
 					<span role="menuitem" className="dropdown-item rgh-theme-switch-title">Theme preference</span>
-					{dom}
+					{form}
 				</>
 			);
 		}

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -12,6 +12,9 @@ async function init(): Promise<void> {
 	const form = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
 	form.classList.add('rgh-theme-switch-form', 'mt-1', 'ml-1');
 	select('.flex-column', form)!.classList.remove('flex-lg-row');
+	for (const image of select.all('img', form)) {
+		image.remove();
+	}
 	for (const radio of select.all('.position-relative', form)) {
 		radio.classList.remove('mb-4');
 	}

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -12,9 +12,11 @@ async function init(): Promise<void> {
 	const form = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
 	form.classList.add('rgh-theme-switch-form', 'mt-1', 'ml-1');
 	select('.flex-column', form)!.classList.remove('flex-lg-row');
+
 	for (const image of select.all('img', form)) {
 		image.remove();
 	}
+
 	for (const radio of select.all('.position-relative', form)) {
 		radio.classList.remove('mb-4');
 	}

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -12,8 +12,9 @@ async function init(): Promise<void> {
 	const form = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
 	form.classList.add('rgh-theme-switch-form', 'mt-1', 'ml-1');
 	select('.flex-column', form)!.classList.remove('flex-lg-row');
-	for (const radio of select.all('.position-relative', form)) {
-		radio.classList.remove('mb-4');
+	for (const radio of select.all('[name="color_mode"]', form)) {
+		radio.style.bottom = '11px';
+		radio.parentElement!.classList.remove('mb-4');
 	}
 
 	observe('.dropdown-item[href="https://gist.github.com/mine"]:not(.rgh-theme-switch)', {

--- a/source/features/theme-switch.tsx
+++ b/source/features/theme-switch.tsx
@@ -12,9 +12,8 @@ async function init(): Promise<void> {
 	const form = (await fetchDom('https://github.com/settings/appearance', '.js-color-mode-settings'))!;
 	form.classList.add('rgh-theme-switch-form', 'mt-1', 'ml-1');
 	select('.flex-column', form)!.classList.remove('flex-lg-row');
-	for (const radio of select.all('[name="color_mode"]', form)) {
-		radio.style.bottom = '11px';
-		radio.parentElement!.classList.remove('mb-4');
+	for (const radio of select.all('.position-relative', form)) {
+		radio.classList.remove('mb-4');
 	}
 
 	observe('.dropdown-item[href="https://gist.github.com/mine"]:not(.rgh-theme-switch)', {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -203,6 +203,7 @@ import './features/jump-to-change-requested-comment';
 import './features/esc-to-cancel';
 import './features/quick-fork-deletion';
 import './features/pr-easy-toggle-files';
+import './features/theme-switch';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:
   Resolves #3802

2. TEST URLS:
   Anywhere except Gists (which doesn't have a dark theme yet)

3. SCREENSHOT:

  ![image](https://user-images.githubusercontent.com/44045911/101625949-2a3ae280-3a57-11eb-9298-d1dde71806fc.png)

P.S. I was expecting some headache before I accidentally found that we can just put the form into the dropdown directly. I love this implementation 😄 

---

I just realized GitHub has a toggle on your own profile page:

![image](https://user-images.githubusercontent.com/44045911/101629002-9f101b80-3a5b-11eb-9b30-2872e8969588.png)

But it doesn't support "auto" (follow system) so sticking to the settings one.