### PR TITLE
Further improvements to Dark mode

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -17,7 +17,7 @@
 /* Add background and border Whole list */
 .rgh-clean-dashboard .dashboard .js-all-activity-header + div {
 	background-color: var(--color-bg-canvas, #fff);
-	border: 1px solid var(--color-border-primary, var(--github-border-color));
+	border: 1px solid var(--github-border-color);
 	border-radius: 6px;
 	margin-top: 8px !important;
 }

--- a/source/features/conflict-marker.css
+++ b/source/features/conflict-marker.css
@@ -2,3 +2,7 @@
 	vertical-align: middle;
 	color: #c0c0c0;
 }
+
+[data-color-mode='dark'] .rgh-conflict-marker svg {
+	color: #505050;
+}

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,7 +1,7 @@
 .js-issue-row [aria-label='Open draft pull request'] svg {
-	stroke: #586069;
+	stroke: var(--color-text-secondary, #586069);
 	stroke-width: 1.2px;
-	color: #fff !important;
+	color: var(--color-bg-canvas, #fff) !important;
 	paint-order: stroke;
 	overflow: visible !important;
 }

--- a/source/features/highlight-collaborators-and-own-conversations.css
+++ b/source/features/highlight-collaborators-and-own-conversations.css
@@ -1,5 +1,5 @@
 .rgh-collaborator {
-	border: 1px solid #c0d3eb;
+	border: 1px solid var(--color-border-tertiary, #c0d3eb);
 	border-radius: 2em;
 	padding: 2px 5px;
 }

--- a/source/features/parse-backticks.css
+++ b/source/features/parse-backticks.css
@@ -1,6 +1,6 @@
 /* Style copied from GitHub's <code> */
 .rgh-parse-backticks {
-	background-color: rgb(27 31 35 / 5%);
+	background-color: var(--color-markdown-code-bg, rgb(27 31 35 / 5%));
 	border-radius: 6px;
 	font-size: 85%;
 	margin: 0;

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -4,8 +4,8 @@
 }
 
 button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
-	border-top: 1px solid var(--color-border-primary, #e1e4e8); /* Required when the second line is longer than the first line */
-	border-bottom: 1px solid var(--color-border-primary, #e1e4e8); /* Required when the first line is longer than the second line */
+	border-top: 1px solid var(--github-border-color); /* Required when the second line is longer than the first line */
+	border-bottom: 1px solid var(--github-border-color); /* Required when the first line is longer than the second line */
 	margin-bottom: -1px; /* Makes up for `order-bottom` */
 }
 

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -28,13 +28,9 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-top: -0.3em;
 	margin-left: -0.5em;
 	vertical-align: middle;
-	background: #efefef; /* Placeholder before the images load */
+	background: var(--color-bg-canvas-inset, #efefef); /* Placeholder before the images load */
 	box-shadow: 0 0 0 2px var(--background, var(--color-bg-primary, #fff));
 	font-size: 10px; /* Base sizer */
-}
-
-[data-color-mode='dark'] .reaction-summary-item a {
-	background: #101010; /* Placeholder before the images load */
 }
 
 .reaction-summary-item a:first-of-type {

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -17,6 +17,10 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	--background: #f2f8fa;
 }
 
+[data-color-mode='dark'] .reaction-summary-item.user-has-reacted {
+	--background: #111d2f;
+}
+
 .reaction-summary-item a {
 	display: inline-block;
 	width: 2em;
@@ -25,8 +29,12 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-left: -0.5em;
 	vertical-align: middle;
 	background: #efefef; /* Placeholder before the images load */
-	box-shadow: 0 0 0 2px var(--background, #fff);
+	box-shadow: 0 0 0 2px var(--background, var(--color-bg-primary, #fff));
 	font-size: 10px; /* Base sizer */
+}
+
+[data-color-mode='dark'] .reaction-summary-item a {
+	background: #101010; /* Placeholder before the images load */
 }
 
 .reaction-summary-item a:first-of-type {

--- a/source/features/resolve-conflicts.css
+++ b/source/features/resolve-conflicts.css
@@ -1,4 +1,4 @@
 /* Fix bug caused by feature https://user-images.githubusercontent.com/1402241/54978279-d6663c80-4fda-11e9-9638-af25480fb988.png */
 .rgh-resolve-conflicts .CodeMirror-linenumber {
-	background-color: var(--github-faint-yellow);
+	background-color: var(--color-auto-yellow-1, #fffbdd);
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -15,3 +15,11 @@
 	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(36,41,46,25%)"/%3E%3C/svg%3E');
 	background-size: 1ch 1.25em;
 }
+
+[data-color-mode='dark'] [data-rgh-whitespace='tab'] {
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
+}
+
+[data-color-mode='dark'] [data-rgh-whitespace='space'] {
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
+}

--- a/source/features/split-issue-pr-search-results.css
+++ b/source/features/split-issue-pr-search-results.css
@@ -1,4 +1,8 @@
-.rgh-split-issue-pr-combined.selected:hover {
-	background-color: #f6f8fa;
+.menu-item.selected.rgh-split-issue-pr-combined {
+	background-color: initial;
+}
+
+.menu-item.selected.rgh-split-issue-pr-combined:hover {
+	background-color: var(--color-menu-bg-active, #f6f8fa);
 	cursor: pointer;
 }

--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -19,5 +19,5 @@
 
 .rgh-table-input:hover .selected div {
 	border-color: #79b8ff;
-	background-color: #dbedff;
+	background-color: var(--color-diff-blob-hunk-num-bg, #dbedff);
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -3,7 +3,6 @@
 	--github-red: #cb2431;
 	--github-gray-background: #fafbfc;
 	--github-gray-text: #6a737d;
-	--github-faint-yellow: #fffbdd;
 	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -4,7 +4,7 @@
 	--github-gray-background: #fafbfc;
 	--github-gray-text: #6a737d;
 	--github-faint-yellow: #fffbdd;
-	--github-border-color: #e1e4e8;
+	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 
 /* Fade out the file icons */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,8 +1,7 @@
 :root {
-	--github-green: #28a745;
-	--github-red: #cb2431;
-	--github-gray-background: #fafbfc;
-	--github-gray-text: #6a737d;
+	/* 2020-12-15: these variables only exist for GHE. Remove in the future. */
+	--github-green: var(--color-text-success, #28a745);
+	--github-red: var(--color-text-danger, #cb2431);
 	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 


### PR DESCRIPTION
I believe this PR fixes all Dark mode issues, so close issue #3798 once this is merged if you agree.

-----
1. LINKED ISSUES:
   Fix border issues in #3798:
   - [Pinned issues border](https://github.com/sindresorhus/refined-github/issues/3798#issuecomment-741568995).
   - [Divider line in grouped events in Activity list](https://github.com/sindresorhus/refined-github/issues/3798#issuecomment-741604005).

2. TEST URLS:
   - [Pinned issues example](https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc).
   - [Activity list example](https://github.com/) (see while logged in).

3. SCREENSHOTS:

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img alt="pinned issues - before" src="https://user-images.githubusercontent.com/1441704/101666452-864d3900-3a4e-11eb-8b9d-97717301fcc3.png">
	<td><img alt="pinned issues - after" src="https://user-images.githubusercontent.com/1441704/101666047-03c47980-3a4e-11eb-9268-d04af97f2359.png">
</table>

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img alt="grouped events divider line - before" src="https://user-images.githubusercontent.com/1441704/101666533-a0871700-3a4e-11eb-8dd0-b8a802f5a07b.png">
	<td><img alt="grouped events divider line - after" src="https://user-images.githubusercontent.com/1441704/101666295-530aaa00-3a4e-11eb-8358-017f0f09ef73.png">
</table>

Since this PR uses the `--github-border-color` CSS variable already present in the codebase, this automatically fixes other border colors that use this variable. This includes table-input cell borders in comments:

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img alt="table-input cells - before" src="https://user-images.githubusercontent.com/1441704/101667248-636f5480-3a4f-11eb-82cc-dc215b78c3a5.png">
	<td><img alt="table-input cells - after" src="https://user-images.githubusercontent.com/1441704/101667138-4175d200-3a4f-11eb-8c1e-487cbaf32cc6.png">
</table>

This is a better approach than making `--github-border-color` a fallback like I did in the previous PR since it requires less changes.

---

## More fixes

1. Feature: `parse-backticks`. Use the `--color-markdown-code-bg` CSS variable to color the background in backticks parsed by the `parse-backticks` feature. To find the appropriate CSS variable I inspected the CSS of code elements in Markdown content (you can do it yourself with this very comment). [First reported here](https://github.com/sindresorhus/refined-github/issues/3798#issuecomment-742444029).

	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102022936-4659bf00-3d8a-11eb-9e4a-911ab084c090.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102022896-15798a00-3d8a-11eb-9aea-b5f6ddbec757.png">
	</table>

2. Feature: `split-issue-pr-search-results`. In a [GitHub search](https://github.com/search?q=asdfasdf&type=Issues), remove the background color in split Issues and PRs, then fix the color when hovering by using the `--color-menu-bg-active` CSS variable. I had to use `.menu-item` to add specificity to the selector, otherwise it could be done with `!important`.

	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102022836-af8d0280-3d89-11eb-92a3-5c499d6aa41c.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102022858-d9462980-3d89-11eb-9294-a67578ace46f.png">
	</table>

3. Feature: `resolve-conflicts`. When resolving a conflict, the first line number background uses the light color. We use `--color-auto-yellow-1` instead which is the coloring used by GitHub, and since `--github-faint-yellow` isn't used in any other place of the codebase, I removed it from `:root` and replaced its value.

	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102023778-1f04f100-3d8e-11eb-9cef-903dd480eff4.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102023796-347a1b00-3d8e-11eb-82ca-36423d233d34.png">
	</table>

4. Feature: many. Some features that use `--github-green` and `--github-red` appeared darker than the colors that GitHub uses now (`--color-text-success` and `--color-text-danger`).

	Red color:
	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102025247-f6cdc000-3d96-11eb-826c-81f924872888.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102025319-53c97600-3d97-11eb-8f62-a48fe62ba1ff.png">
	</table>
	
	Green color:
	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102025256-0947f980-3d97-11eb-91ea-170f07a1a153.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102025306-4c09d180-3d97-11eb-97b4-83114791d17f.png">
	</table>

5. Feature: `show-whitespace`. Fix the color of whitespace glyphs (fixes #3772).

	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="before" src="https://user-images.githubusercontent.com/1441704/102115794-5336eb00-3e3c-11eb-8e5f-81f1bbc36bf0.png">
		<td><img alt="after" src="https://user-images.githubusercontent.com/1441704/102115891-72ce1380-3e3c-11eb-8cf1-8acdd208ea57.png">
	</table>

6. Feature: `table-input`. Soften the blue background color of cells.

	![image](https://user-images.githubusercontent.com/1441704/102227005-59cf6c00-3ee9-11eb-8704-23982c45e57e.png) ![image](https://user-images.githubusercontent.com/1441704/102227822-4b358480-3eea-11eb-8b07-2af71b8fb59b.png)

7. Feature: `conflict-marker`. Use a darker color for Dark mode (`#505050`).

    ![before](https://user-images.githubusercontent.com/1441704/102625121-4e787c80-4145-11eb-9a44-2fdae9f6980d.png) ![after](https://user-images.githubusercontent.com/1441704/102624980-14a77600-4145-11eb-98bc-1dcaf8ebe43f.png)

8. Feature: `emphasize-draft-pr-label`. Make it less bright on dark mode.

    ![before](https://user-images.githubusercontent.com/1441704/102625257-7cf65780-4145-11eb-8684-080fbd12f8d3.png) ![after](https://user-images.githubusercontent.com/1441704/102625374-afa05000-4145-11eb-960e-393e5db96b5e.png)

9. Feature: `highlight-collaborators-and-own-conversations`. Dim collaborator/own indicator border in PR lists

    ![before](https://user-images.githubusercontent.com/1441704/102625496-dfe7ee80-4145-11eb-97cb-7d0e7bf7cb51.png) ![after](https://user-images.githubusercontent.com/1441704/102625445-ccd51e80-4145-11eb-99d9-6518c591b200.png)

10. Feature: `reactions-avatars`. Fix reaction avatars in dark mode: (1) make the box-shadow color match the background, and (2) use a darker background color in avatars for when the image didn't load.

    ![before](https://user-images.githubusercontent.com/1441704/102624773-c98d6300-4144-11eb-80ea-d3f6ada4acc2.png) ![after](https://user-images.githubusercontent.com/1441704/102624898-f5104d80-4144-11eb-8961-9c7d3a06600f.png)

