### PR TITLE
Fix `parse-backticks` in PR commit list and Compare page

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -15,7 +15,9 @@ function init(): void {
 		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message
 		'.commit-title', // `isCommit` commit message
 		'.commit-desc', // `isCommit` commit description
-		'.js-commit .pr-1 > code', // `isPRConversation`, `isCompare`, `isReleasesOrTags` pushed commits
+		'.js-commit .pr-1 > code', // `isPRConversation` pushed commits
+		'.js-details-container .pr-1 > code', // `isCompare` pushed commits
+		'.Box-row .mb-1 a', // `isCompare` open Pull Request title
 		'.blame-commit-message', // `isBlame` commit message
 		'a[id^="issue_"]', // `isConversationList` issue and PR title
 		'.TimelineItem-body > del', // `isIssue`, `isPRConversation` title edits

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -13,7 +13,7 @@ function init(): void {
 		'.js-commits-list-item .mb-1, .js-commits-list-item pre', // `isCommitList` commit message and description
 		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message
 		'.commit-title, .commit-desc', // `isCommit` commit message and description
-		'.commit-message', // `isPRConversation`, `isCompare`, `isReleasesOrTags` pushed commits
+		'.js-commit .pr-1 > code', // `isPRConversation`, `isCompare`, `isReleasesOrTags` pushed commits
 		'.blame-commit-message', // `isBlame` commit message
 		'a[id^="issue_"]', // `isConversationList` issue and PR title
 		'.TimelineItem-body > del, .TimelineItem-body > ins', // `isIssue`, `isPRConversation` title edits

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -10,16 +10,21 @@ import parseBackticksCore from '../github-helpers/parse-backticks';
 function init(): void {
 	const selectors = [
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
-		'.js-commits-list-item .mb-1, .js-commits-list-item pre', // `isCommitList` commit message and description
+		'.js-commits-list-item .mb-1', // `isCommitList` commit message
+		'.js-commits-list-item pre', // `isCommitList` commit description
 		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message
-		'.commit-title, .commit-desc', // `isCommit` commit message and description
+		'.commit-title', // `isCommit` commit message
+		'.commit-desc', // `isCommit` commit description
 		'.js-commit .pr-1 > code', // `isPRConversation`, `isCompare`, `isReleasesOrTags` pushed commits
 		'.blame-commit-message', // `isBlame` commit message
 		'a[id^="issue_"]', // `isConversationList` issue and PR title
-		'.TimelineItem-body > del, .TimelineItem-body > ins', // `isIssue`, `isPRConversation` title edits
-		'[id^=ref-issue-], [id^=ref-pullrequest-]', // `isIssue`, `isPRConversation` issue and PR references
+		'.TimelineItem-body > del', // `isIssue`, `isPRConversation` title edits
+		'.TimelineItem-body > ins', // `isIssue`, `isPRConversation` title edits
+		'[id^=ref-issue-]', // `isIssue` issue and PR references
+		'[id^=ref-pullrequest-]', // `isPRConversation` issue and PR references
 		'[aria-label="Link issues"] a', // `isIssue`, `isPRConversation` linked issue and PR
-		'.Box-header.Details .link-gray, .Box-header.Details pre', // `isSingleFile` commit message and description
+		'.Box-header.Details .link-gray', // `isSingleFile` commit message
+		'.Box-header.Details pre', // `isSingleFile` commit description
 		'.js-pinned-issue-list-item > .d-block', // Pinned Issues
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR


### PR DESCRIPTION
1. LINKED ISSUES:
   None specifically, but these two comments: https://github.com/sindresorhus/refined-github/issues/3798#issuecomment-742561887, https://github.com/sindresorhus/refined-github/pull/3806#issuecomment-742667247.

2. TEST URLS:
   [This PR with many commits](https://github.com/sindresorhus/refined-github/pull/1986).

3. SCREENSHOT:
	<table>
	<tr>
		<td>Before
		<td>After
	<tr>
		<td><img alt="backticks in PR commit list - before" src="https://user-images.githubusercontent.com/1441704/101916737-a5230b00-3bc7-11eb-9f28-e855f9b71186.png">
		<td><img alt="backticks in PR commit list - after" src="https://user-images.githubusercontent.com/1441704/101916823-bff57f80-3bc7-11eb-91da-1a5d9975981a.png">
	</table>

-----

I also fixed the way the `:not(.rgh-backticks-already-parsed)` pseudo-class is added to the selectors, in the case where multiple selectors are grouped in a single array item (see commit 2).