### PR TITLE
Added a hotkey to go to the home page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -289,6 +289,7 @@ Thanks for contributing! 🦋🙌
 - [](# "format-conversation-titles") [Makes issue/PR references in issue/PR titles clickable and renders `` `text in backticks` ``.](https://user-images.githubusercontent.com/22439276/58927232-71ae2780-876b-11e9-941e-bb56a7389123.png)
 - [](# "trending-menu-item") Adds a `Trending` link to the global navbar and a keyboard shortcut: <kbd>g</kbd> <kbd>t</kbd>.
 - [](# "navigate-pages-with-arrow-keys") Adds shortcuts to navigate through pages with pagination: <kbd>←</kbd> and <kbd>→</kbd>.
+- [](# "home-hotkey") Adds a keyboard shortcut to visit the GitHub home page: <kbd>g</kbd> <kbd>h</kbd>.
 - [](# "open-all-notifications") [Adds button to open all your unread notifications at once.](https://user-images.githubusercontent.com/1402241/80861295-fbad8b80-8c6d-11ea-87a4-8025fbc3a3f4.png)
 - [](# "action-used-by-link") [Lets you see how others are using the current Action in the Marketplace.](https://user-images.githubusercontent.com/8360597/80250140-86d9c080-8673-11ea-9d28-f62faf9fd3d4.png)
 - [](# "improve-shortcut-help") [Shows all of Refined GitHub’s new keyboard shortcuts in the help modal (<kbd>?</kbd> hotkey).](https://user-images.githubusercontent.com/29176678/36999174-9f07d33e-20bf-11e8-83e3-b3a9908a4b5f.png)

--- a/source/features/home-hotkey.tsx
+++ b/source/features/home-hotkey.tsx
@@ -1,0 +1,18 @@
+import React from 'dom-chef';
+import onetime from 'onetime';
+import {isEnterprise} from 'github-url-detection';
+
+import features from '.';
+
+function init(): void {
+	const homepageLink = (isEnterprise() ? location.origin : 'https://github.com');
+	document.body.append(<a hidden data-hotkey="g h" href={homepageLink}/>);
+}
+
+void features.add(__filebasename, {
+	shortcuts: {
+		'g h': 'Go to home page'
+	},
+	awaitDomReady: false,
+	init: onetime(init)
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -44,6 +44,7 @@ import './features/edit-comments-faster';
 import './features/open-all-notifications';
 import './features/copy-on-y';
 import './features/profile-hotkey';
+import './features/home-hotkey';
 import './features/close-out-of-view-modals';
 import './features/improve-shortcut-help';
 import './features/deprioritize-marketplace-link';


### PR DESCRIPTION
1. LINKED ISSUES:
None

2. TEST URLS:
None

3. SCREENSHOT:
None

Added a `g` `h` shortcut to go to the homepage of GitHub.

Copied most of it from the `profile-hotkey` feature.

Having `g` `h` as a keyboard shortcut to go to the homepage appears to be quite common:
- One of my extensions does it (not sure which) on Stack Overflow
- Twitter does it natively

I got used to it and felt like GitHub should have it too.