### PR TITLE
Improve detection in `hide-useless-comments`

### DIFF
--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -19,7 +19,7 @@ function init(): void {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
 		// Find useless comments
-		if (!/^([+-]\d+!*|👍|🙏|👎|👌|)+$/.test(commentText.textContent!.trim())) {
+		if (!/^([+-]\d+|⬆️|(👍|👎|👌|🙏)[\u{1F3FB}-\u{1F3FF}]*|ditto|metoo|same(here)?(-?\w+)?|(same)?pleaseupdate(thanks)?.{0,2}|)+$/ui.test(commentText.textContent!.replace(/[\s.,!]+/g, ''))) {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -18,8 +18,8 @@ function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 function init(): void {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
-		// Find useless comments
-		if (!/^([+-]\d+|⬆️|(👍|👎|👌|🙏)[\u{1F3FB}-\u{1F3FF}]*|ditto|metoo|same(here)?(-?\w+)?|(same)?pleaseupdate(thanks)?.{0,2}|)+$/ui.test(commentText.textContent!.replace(/[\s.,!]+/g, ''))) {
+		// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
+		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏⬆️\u{1F3FB}-\u{1F3FF}]+|[+-]\d+|ditto|me|too|same|here|please|update|thanks?/gui, '').length > 20) {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -19,7 +19,7 @@ function init(): void {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
 		// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
-		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me|too|same|here|please|update|thanks?/gui, '').length > 20) {
+		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me too|same|here|please|update|thanks?/gui, '') !== '') {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -5,6 +5,7 @@ import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import isUselessComment from '../helpers/useless-comments';
 
 function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	for (const comment of select.all('.rgh-hidden-comment')) {
@@ -18,8 +19,7 @@ function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 function init(): void {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
-		// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
-		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me too|same|here|please|update|thanks?/gui, '') !== '') {
+		if (!isUselessComment(commentText.textContent!)) {
 			continue;
 		}
 

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -19,7 +19,7 @@ function init(): void {
 	let uselessCount = 0;
 	for (const commentText of select.all('.comment-body > p:only-child')) {
 		// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
-		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏⬆️\u{1F3FB}-\u{1F3FF}]+|[+-]\d+|ditto|me|too|same|here|please|update|thanks?/gui, '').length > 20) {
+		if (commentText.textContent!.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me|too|same|here|please|update|thanks?/gui, '').length > 20) {
 			continue;
 		}
 

--- a/source/helpers/useless-comments.ts
+++ b/source/helpers/useless-comments.ts
@@ -1,0 +1,4 @@
+export default function isUselessComment(text: string): boolean {
+	// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
+	return text.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me too|same|here|please|update|thanks?( you)?/gui, '') === '';
+}

--- a/source/helpers/useless-comments.ts
+++ b/source/helpers/useless-comments.ts
@@ -1,4 +1,4 @@
 export default function isUselessComment(text: string): boolean {
 	// Find useless comments (note: the unicode range targets skin color modifiers for the hand emojis)
-	return text.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me too|same|here|please|update|thanks?( you)?/gui, '') === '';
+	return text.replace(/[\s,.!?👍👎👌🙏]+|[\u{1F3FB}-\u{1F3FF}]|[+-]\d+|⬆️|ditto|me too|same here|please update|thanks?( you)?/gui, '') === '';
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -15,6 +15,7 @@ import {
 	prCompareUrlRegex
 } from '../source/github-helpers';
 import {getParsedBackticksParts} from '../source/github-helpers/parse-backticks';
+import isUselessComment from '../source/helpers/useless-comments';
 
 test('getConversationNumber', t => {
 	const pairs = new Map<string, string | undefined>([
@@ -258,4 +259,22 @@ test('parseBackticks', t => {
 		parseBackticks('backtick-delimited string in a code span: `` `foo` ``'),
 		'backtick-delimited string in a code span: <code>`foo`</code>'
 	);
+});
+
+test('isUselessComment', t => {
+	t.true(isUselessComment('+1'));
+	t.true(isUselessComment('+1!'));
+	t.true(isUselessComment('+10'));
+	t.true(isUselessComment('+9000'));
+	t.true(isUselessComment('-1'));
+	t.true(isUselessComment('👍'));
+	t.true(isUselessComment('👍🏾'));
+	t.true(isUselessComment('me too'));
+	t.true(isUselessComment('please update!'));
+	t.true(isUselessComment('please update 🙏🏻'));
+	t.true(isUselessComment('Same here, please update, thanks'));
+	t.true(isUselessComment('Same here! Please update, thank you.'));
+
+	t.false(isUselessComment('+1\n<some useful information>'));
+	t.false(isUselessComment('Same here. <some useul information>'));
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -276,5 +276,5 @@ test('isUselessComment', t => {
 	t.true(isUselessComment('Same here! Please update, thank you.'));
 
 	t.false(isUselessComment('+1\n<some useful information>'));
-	t.false(isUselessComment('Same here. <some useul information>'));
+	t.false(isUselessComment('Same here. <some useful information>'));
 });


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3822 

2. TEST URLS:
  - ["Please update" and variations](https://github.com/justinfrankel/licecap/issues/97)
  - ["+1" and variations](https://github.com/hayaku/hayaku/issues/303)
  - ["+1" and thumbs-ups](https://github.com/isaacs/github/issues/215)

This PR:
 * removes spaces and basic punctuation from the comments before testing them — it makes it easier to match small sentences like "Please update, thanks" and all their possible variations
 * adds several keywords and their variations
 * adds support for skin tone modifiers on hand-related emojis (it's relatively rare but I've seen them used a few times)

TODO:
- [x] Rewrite using `text.replace()`
- [x] Add tests