### PR TITLE
Fix `sync-pr-commit-title` to work with GitHub's auto-merge

### DIFF
--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -8,11 +8,12 @@ import * as textFieldEdit from 'text-field-edit';
 import features from '.';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
+const mergeFormSelector = '.is-squashing form:not([hidden])';
 const prTitleFieldSelector = '.js-issue-update [name="issue[title]"]';
 const prTitleSubmitSelector = '.js-issue-update [type="submit"]';
 
 function getCommitTitleField(): HTMLInputElement | undefined {
-	return select<HTMLInputElement>('.is-squashing #merge_title_field') ?? undefined;
+	return select<HTMLInputElement>(`${mergeFormSelector} #merge_title_field`) ?? undefined;
 }
 
 function getPRNumber(): string {
@@ -40,7 +41,7 @@ function needsSubmission(): boolean {
 }
 
 function getUI(): HTMLElement {
-	return select('.note.rgh-sync-pr-commit-title-note') ?? (
+	return select(`${mergeFormSelector} .rgh-sync-pr-commit-title-note`) ?? (
 		<p className="note rgh-sync-pr-commit-title-note">
 			The title of this PR will be updated to match this title. <button type="button" className="btn-link muted-link text-underline rgh-sync-pr-commit-title">Cancel</button>
 		</p>


### PR DESCRIPTION
Closes #3829.

Test URLs are quite specific… A PR that you can merge, where some branch restrictions are not met, and where auto-merge is enabled.

Please test both cases:

1. Auto-merge
   ![grafik](https://user-images.githubusercontent.com/202916/102809988-3b72e000-43c3-11eb-8846-3781e40979d2.png)

2. Override restrictions and merge immediately
    ![grafik](https://user-images.githubusercontent.com/202916/102810057-580f1800-43c3-11eb-9792-09c6b86387cd.png)

You don't need to actually merge the PR, just verify that this note appears when changing the commit title:

> The title of this PR will be updated to match this title. <ins>Cancel</ins>