### PR TITLE
Fix and improve `split-issue-pr-search-results`

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -34,7 +34,7 @@ async function init(): Promise<void | false> {
 	// - update the count later
 	// On other pages:
 	// - only show the tab if needed
-	const isBugsPage = new SearchQuery(location).includes('label:bug');
+	const isBugsPage = new SearchQuery(location.search).includes('label:bug');
 	if (!isBugsPage && await countPromise === 0) {
 		return false;
 	}

--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -33,7 +33,7 @@ function addMergeLink(): void {
 		// In this case, `lastLink` is expected to be a "Closed" link
 		const mergeLink = lastLink.cloneNode(true);
 		mergeLink.textContent = 'Merged';
-		mergeLink.classList.toggle('selected', new SearchQuery(location).includes('is:merged'));
+		mergeLink.classList.toggle('selected', new SearchQuery(location.search).includes('is:merged'));
 		new SearchQuery(mergeLink).replace('is:closed', 'is:merged');
 		lastLink.after(' ', mergeLink);
 	}

--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -26,7 +26,7 @@ function init(): void {
 		url.searchParams.set('q', `${typeQuery} ${defaultQuery} ${query}`);
 		const link = <a href={String(url)} title={title} className="subnav-item">{label}</a>;
 
-		const isCurrentPage = new SearchQuery(location).includes(query);
+		const isCurrentPage = new SearchQuery(location.search).includes(query);
 
 		// Highlight it, if that's the current page
 		if (isCurrentPage && !select.exists('.subnav-links .selected')) {

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -25,22 +25,6 @@ function updateLinkElement(link: HTMLAnchorElement, type: GitHubConversationType
 	);
 }
 
-// Only the last is:pr/issue query part is used by github for the filter results so we find the one with the higher index
-function searchQueryIs(searchQuery: SearchQuery): GitHubConversationType | null {
-	const queryParts = searchQuery.getQueryParts();
-	const pr = queryParts.lastIndexOf('is:pr');
-	const issue = queryParts.lastIndexOf('is:issue');
-	if (pr > issue) {
-		return 'pr';
-	}
-
-	if (issue !== -1) {
-		return 'issue';
-	}
-
-	return null;
-}
-
 function init(): void {
 	cleanLinks();
 
@@ -58,12 +42,11 @@ function init(): void {
 	const title = select('.codesearch-results h3')!.firstChild!;
 
 	const searchQuery = new SearchQuery(location.search);
-	const is = searchQueryIs(searchQuery);
-	if (is === 'pr') {
+	if (searchQuery.includes('is:pr')) {
 		// Update UI in PR searches
 		issueLink.classList.remove('selected');
 		title.textContent = title.textContent!.replace('issue', 'pull request');
-	} else if (is !== 'issue' && searchQuery.searchParams.get('type') === 'Issues') {
+	} else if (!searchQuery.includes('is:issue') && searchQuery.searchParams.get('type') === 'Issues') {
 		// Update UI in combined searches (where there's no `is:<type>` query)
 		title.textContent = title.textContent!
 			.replace(/issue\b/, 'issue or pull request')

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -18,7 +18,6 @@ function updateLinkElement(link: HTMLAnchorElement, type: GitHubConversationType
 	link.textContent = type === 'pr' ? 'Pull requests' : 'Issues'; // Drops any possible counter
 
 	const searchQuery = new SearchQuery(link);
-	searchQuery.remove('is:pr', 'is:issue');
 	searchQuery.add(`is:${type}`);
 
 	link.append(

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -27,6 +27,14 @@ function createUrl(type: GitHubConversationType, pathname = location.pathname): 
 	searchQuery.add(`is:${type}`);
 	url.searchParams.set('q', searchQuery.get());
 	url.searchParams.set('type', 'Issues');
+
+	// Copy the language (l) and state (closed/open) search parameters if they are set
+	for (const name of ['l', 'state']) {
+		if (searchQuery.searchParams.has(name)) {
+			url.searchParams.set(name, searchQuery.searchParams.get(name)!);
+		}
+	}
+
 	return String(url);
 }
 

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -57,7 +57,7 @@ function init(): void {
 
 	const title = select('.codesearch-results h3')!.firstChild!;
 
-	const searchQuery = new SearchQuery(location);
+	const searchQuery = new SearchQuery(location.search);
 	const is = searchQueryIs(searchQuery);
 	if (is === 'pr') {
 		// Update UI in PR searches

--- a/source/features/split-issue-pr-search-results.tsx
+++ b/source/features/split-issue-pr-search-results.tsx
@@ -46,7 +46,7 @@ function init(): void {
 		// Update UI in PR searches
 		issueLink.classList.remove('selected');
 		title.textContent = title.textContent!.replace('issue', 'pull request');
-	} else if (!searchQuery.includes('is:issue') && searchQuery.searchParams.get('type') === 'Issues') {
+	} else if (!searchQuery.includes('is:issue') && searchQuery.searchParams.get('type')?.toLowerCase() === 'issues') {
 		// Update UI in combined searches (where there's no `is:<type>` query)
 		title.textContent = title.textContent!
 			.replace(/issue\b/, 'issue or pull request')

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -25,6 +25,9 @@ export default class SearchQuery {
 		} else {
 			this.searchParams = new URLSearchParams(link);
 		}
+
+		// Ensure the query string is set and cleaned up
+		this.set(this.get());
 	}
 
 	get(): string {

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,6 +1,6 @@
 import {getUsername} from '.';
 
-type Source = HTMLAnchorElement | URL | URLSearchParams | string;
+type Source = HTMLAnchorElement | URL | string | string[][] | Record<string, string> | URLSearchParams;
 
 const queryPartsRegExp = /(?:[^\s"]+|"[^"]*")+/g;
 function splitQueryString(query: string): string[] {

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -67,7 +67,7 @@ export default class SearchQuery {
 		const cleanQuery = newQuery
 			.trim()
 			// Deduplicate opposite flags by removing all but the last occurrence
-			.replace(/is:(?:pr|issue)(?=.*is:(?:pr|issue))/g, '')
+			.replace(/(^|\s)is:(?:pr|issue)(?=.*is:(?:pr|issue))/g, '')
 			.replace(/\s+/, ' ');
 
 		this.searchParams.set('q', cleanQuery);

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -61,7 +61,12 @@ export default class SearchQuery {
 	}
 
 	set(newQuery: string): void {
-		const cleanQuery = newQuery.trim().replace(/\s+/, ' ');
+		const cleanQuery = newQuery
+			.trim()
+			// Deduplicate opposite flags by removing all but the last occurrence
+			.replace(/is:(?:pr|issue)(?=.*is:(?:pr|issue))/g, '')
+			.replace(/\s+/, ' ');
+
 		this.searchParams.set('q', cleanQuery);
 	}
 

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -67,7 +67,7 @@ export default class SearchQuery {
 		const cleanQuery = newQuery
 			.trim()
 			// Deduplicate opposite flags by removing all but the last occurrence
-			.replace(/(^|\s)is:(?:pr|issue)(?=.*is:(?:pr|issue))/g, '')
+			.replace(/\bis:(?:pr|issue)\s+(?=.*\bis:(?:pr|issue)\b)/g, '')
 			.replace(/\s+/, ' ');
 
 		this.searchParams.set('q', cleanQuery);

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -7,25 +7,23 @@ function splitQueryString(query: string): string[] {
 	return query.match(queryPartsRegExp) ?? [];
 }
 
-// Remove all values from array exept the last occurence of one of the values.
-function deduplicate(array: any[], ...values: any[]): any[] {
-	let indexToKeep = -1;
-	for (const value of values) {
-		const lastIndex = array.lastIndexOf(value);
-		if (lastIndex > indexToKeep) {
-			indexToKeep = lastIndex;
+// Remove all keywords from array exept the last occurence of one of the keywords.
+function deduplicateKeywords(array: string[], ...keywords: string[]): string[] {
+	const deduplicated = [];
+	let wasKeywordFound = false;
+	for (const current of array.reverse()) {
+		const isKeyword = keywords.includes(current);
+		if (!isKeyword || !wasKeywordFound) {
+			deduplicated.unshift(current);
+			wasKeywordFound = wasKeywordFound || isKeyword;
 		}
 	}
 
-	if (indexToKeep === -1) {
-		return array;
-	}
-
-	return array.filter((value, index) => index >= indexToKeep || !values.includes(value));
+	return deduplicated;
 }
 
 function cleanQueryParts(parts: string[]): string[] {
-	return deduplicate(parts, 'is:issue', 'is:pr');
+	return deduplicateKeywords(parts, 'is:issue', 'is:pr');
 }
 
 /**

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -1,17 +1,17 @@
 import {getUsername} from '.';
 
-type Source = HTMLAnchorElement | URL | URLSearchParams | Location;
+type Source = HTMLAnchorElement | URL | URLSearchParams | string;
 
 /**
 Parser/Mutator of GitHub's search query directly on anchors and URL-like objects.
 Notice: if the <a> or `location` changes outside SearchQuery, `get()` will return an outdated value.
 */
 export default class SearchQuery {
-	link?: HTMLAnchorElement | Location;
+	link?: HTMLAnchorElement;
 	searchParams: URLSearchParams;
 
 	constructor(link: Source) {
-		if (link instanceof HTMLAnchorElement || link instanceof Location) {
+		if (link instanceof HTMLAnchorElement) {
 			this.link = link;
 			this.searchParams = new URLSearchParams(link.search);
 			// Keep `.search` property up to date with this `searchParams`
@@ -23,7 +23,7 @@ export default class SearchQuery {
 		} else if (link instanceof URL) {
 			this.searchParams = link.searchParams;
 		} else {
-			this.searchParams = link;
+			this.searchParams = new URLSearchParams(link);
 		}
 	}
 

--- a/source/github-helpers/search-query.ts
+++ b/source/github-helpers/search-query.ts
@@ -2,14 +2,9 @@ import {getUsername} from '.';
 
 type Source = HTMLAnchorElement | URL | URLSearchParams | string;
 
-// TODO: add support for values with spaces, e.g. `label:"help wanted"`
+const queryPartsRegExp = /(?:[^\s"]+|"[^"]*")+/g;
 function splitQueryString(query: string): string[] {
-	const trimmed = query.trim();
-	if (trimmed.length === 0) {
-		return [];
-	}
-
-	return trimmed.split(/\s+/);
+	return query.match(queryPartsRegExp) ?? [];
 }
 
 // Remove all values from array exept the last occurence of one of the values.

--- a/test/search-query.ts
+++ b/test/search-query.ts
@@ -66,3 +66,11 @@ test('defaults', t => {
 	const queryWithLink = new SearchQuery(link);
 	t.is(queryWithLink.get(), 'is:issue is:open');
 });
+
+test('deduplicate is:pr/issue', t => {
+	const query = new SearchQuery(new URLSearchParams('?q=refined+github+is%3Apr'));
+	query.add('is:issue');
+
+	t.false(query.includes('is:pr'));
+	t.true(query.includes('is:issue'));
+});

--- a/test/search-query.ts
+++ b/test/search-query.ts
@@ -4,34 +4,34 @@ import './fixtures/globals';
 import SearchQuery from '../source/github-helpers/search-query';
 
 test('.get', t => {
-	const query = new SearchQuery('?q=wow');
+	const query = new SearchQuery({q: 'wow'});
 	t.is(query.get(), 'wow');
 });
 
 test('.getQueryParts', t => {
-	const query = new SearchQuery('?q=cool+is%3Aissue');
+	const query = new SearchQuery({q: 'cool is:issue'});
 	t.deepEqual(query.getQueryParts(), ['cool', 'is:issue']);
 });
 
 test('getQueryParts with spaces support', t => {
-	const query = new SearchQuery('?q=please+label%3A"under+discussion"');
+	const query = new SearchQuery({q: 'please label:"under discussion"'});
 	t.deepEqual(query.getQueryParts(), ['please', 'label:"under discussion"']);
 });
 
 test('.set', t => {
-	const query = new SearchQuery('?q=wow');
+	const query = new SearchQuery({q: 'wow'});
 	query.set('lol');
 	t.is(query.get(), 'lol');
 });
 
 test('.edit', t => {
-	const query = new SearchQuery('?q=gone+fishing');
+	const query = new SearchQuery({q: 'gone fishing'});
 	query.edit(query => query.split(' ')[0]);
 	t.is(query.get(), 'gone');
 });
 
 test('.replace', t => {
-	const query = new SearchQuery('?q=404+error');
+	const query = new SearchQuery({q: '404 error'});
 	query.replace('error', 'failure');
 	t.is(query.get(), '404 failure');
 
@@ -40,25 +40,25 @@ test('.replace', t => {
 });
 
 test('.remove', t => {
-	const query = new SearchQuery('?q=is%3Aissue+dog+is%3Aopen');
+	const query = new SearchQuery({q: 'is:issue dog is:open'});
 	query.remove('is:issue', 'is:open');
 	t.is(query.get(), 'dog');
 });
 
 test('.add', t => {
-	const query = new SearchQuery('?q=is%3Apr+birds+everywhere');
+	const query = new SearchQuery({q: 'is:pr birds everywhere'});
 	query.add('and', 'aliens');
 	t.is(query.get(), 'is:pr birds everywhere and aliens');
 });
 
 test('.includes', t => {
-	const query = new SearchQuery('?q=label:nonsense');
+	const query = new SearchQuery({q: 'label:nonsense'});
 	t.false(query.includes('nonsense'));
 	t.true(query.includes('label:nonsense'));
 });
 
 test('defaults', t => {
-	const query = new SearchQuery('?q=');
+	const query = new SearchQuery({q: ''});
 	t.is(query.get(), '');
 
 	const link = document.createElement('a');
@@ -68,7 +68,7 @@ test('defaults', t => {
 });
 
 test('deduplicate is:pr/issue', t => {
-	const query = new SearchQuery('?q=refined+github+is%3Apr');
+	const query = new SearchQuery({q: 'refined github is:pr'});
 	query.add('is:issue');
 
 	t.false(query.includes('is:pr'));
@@ -76,6 +76,6 @@ test('deduplicate is:pr/issue', t => {
 });
 
 test('remove additional spaces', t => {
-	const query = new SearchQuery('?q=+refined+++github+');
+	const query = new SearchQuery({q: ' refined   github '});
 	t.is(query.get(), 'refined github');
 });

--- a/test/search-query.ts
+++ b/test/search-query.ts
@@ -4,34 +4,34 @@ import './fixtures/globals';
 import SearchQuery from '../source/github-helpers/search-query';
 
 test('.get', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=wow'));
+	const query = new SearchQuery('?q=wow');
 	t.is(query.get(), 'wow');
 });
 
 test('.getQueryParts', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=cool+is%3Aissue'));
+	const query = new SearchQuery('?q=cool+is%3Aissue');
 	t.deepEqual(query.getQueryParts(), ['cool', 'is:issue']);
 });
 
 test.failing('getQueryParts with spaces support', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=please+label%3A"under+discussion"'));
+	const query = new SearchQuery('?q=please+label%3A"under+discussion"');
 	t.deepEqual(query.getQueryParts(), ['please', 'label:"under discussion"']);
 });
 
 test('.set', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=wow'));
+	const query = new SearchQuery('?q=wow');
 	query.set('lol');
 	t.is(query.get(), 'lol');
 });
 
 test('.edit', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=gone+fishing'));
+	const query = new SearchQuery('?q=gone+fishing');
 	query.edit(query => query.split(' ')[0]);
 	t.is(query.get(), 'gone');
 });
 
 test('.replace', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=404+error'));
+	const query = new SearchQuery('?q=404+error');
 	query.replace('error', 'failure');
 	t.is(query.get(), '404 failure');
 
@@ -40,25 +40,25 @@ test('.replace', t => {
 });
 
 test('.remove', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=is%3Aissue+dog+is%3Aopen'));
+	const query = new SearchQuery('?q=is%3Aissue+dog+is%3Aopen');
 	query.remove('is:issue', 'is:open');
 	t.is(query.get(), 'dog');
 });
 
 test('.add', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=is%3Apr+birds+everywhere'));
+	const query = new SearchQuery('?q=is%3Apr+birds+everywhere');
 	query.add('and', 'aliens');
 	t.is(query.get(), 'is:pr birds everywhere and aliens');
 });
 
 test('.includes', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=label:nonsense'));
+	const query = new SearchQuery('?q=label:nonsense');
 	t.false(query.includes('nonsense'));
 	t.true(query.includes('label:nonsense'));
 });
 
 test('defaults', t => {
-	const query = new SearchQuery(new URLSearchParams('?q='));
+	const query = new SearchQuery('?q=');
 	t.is(query.get(), '');
 
 	const link = document.createElement('a');
@@ -68,7 +68,7 @@ test('defaults', t => {
 });
 
 test('deduplicate is:pr/issue', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=refined+github+is%3Apr'));
+	const query = new SearchQuery('?q=refined+github+is%3Apr');
 	query.add('is:issue');
 
 	t.false(query.includes('is:pr'));
@@ -76,6 +76,6 @@ test('deduplicate is:pr/issue', t => {
 });
 
 test('remove additional spaces', t => {
-	const query = new SearchQuery(new URLSearchParams('?q=+refined+++github+'));
+	const query = new SearchQuery('?q=+refined+++github+');
 	t.is(query.get(), 'refined github');
 });

--- a/test/search-query.ts
+++ b/test/search-query.ts
@@ -13,7 +13,7 @@ test('.getQueryParts', t => {
 	t.deepEqual(query.getQueryParts(), ['cool', 'is:issue']);
 });
 
-test.failing('getQueryParts with spaces support', t => {
+test('getQueryParts with spaces support', t => {
 	const query = new SearchQuery('?q=please+label%3A"under+discussion"');
 	t.deepEqual(query.getQueryParts(), ['please', 'label:"under discussion"']);
 });

--- a/test/search-query.ts
+++ b/test/search-query.ts
@@ -74,3 +74,8 @@ test('deduplicate is:pr/issue', t => {
 	t.false(query.includes('is:pr'));
 	t.true(query.includes('is:issue'));
 });
+
+test('remove additional spaces', t => {
+	const query = new SearchQuery(new URLSearchParams('?q=+refined+++github+'));
+	t.is(query.get(), 'refined github');
+});


### PR DESCRIPTION
Fixes #3824 

Steps to test as mentioned in the issue:
1. Visit https://github.com/search?q=refined+github&type=Issues
2. Click Pull requests (and wait for load)
3. Click Issues

The problem was that `createUrl` always appended the next `is:<type>` query part.
This is also used by Github for the filter and every previous `is:<type>` is ignored.
But the detection did just check for the first occurence of `is:<type>` so the ui wasn't updated correctly.

I changed the code to first clear all `is:<type>` and then add the new filter.
I also improved the detection if multiple `is:<types>` are in the search.
As a bonus I also added that the language and state search parameters are also copied for each url