### PR TITLE
Fix `more-dropdown`

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -38,8 +38,8 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 }
 
 function onlyShowInDropdown(id: string): void {
-	select(`[data-tab-item="${id}"]`)!.parentElement!.remove();
-	const menuItem = select(`[data-menu-item="${id}"]`)!;
+	select(`[data-tab-item$="${id}"]`)!.parentElement!.remove();
+	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;
 
@@ -72,8 +72,8 @@ async function init(): Promise<void> {
 			createDropdownItem('Branches', branchesUrl)
 		);
 
-		onlyShowInDropdown('i4security-tab');
-		onlyShowInDropdown('i5insights-tab');
+		onlyShowInDropdown('security-tab');
+		onlyShowInDropdown('insights-tab');
 		return;
 	}
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: none

2. TEST URLS:
 * [Repo with actions](https://github.com/sindresorhus/refined-github)
 * [Repo with wiki](https://github.com/justinfrankel/licecap)
 * [Repo with projects & wiki](https://github.com/polybar/polybar)
 * [Repo with discussions](https://github.com/CoderLine/alphaTab)

I noticed that `more-dropdown` was still broken on repos with "Wiki" or "Discussions" tab(s). This is because the `data-tab-item` and `data-menu-item` attributes were changed to the following format:
```
i<tab index><tab name>-tab
```
This should be fixed for good now.