### PR TITLE
Reposition `tag-changelog-link`

### DIFF
--- a/source/features/tag-changelog-link.css
+++ b/source/features/tag-changelog-link.css
@@ -1,5 +1,6 @@
 /* Reserve some space above the "Compare" dropdown (the selector will be disabled as soon as the "Changelog" link is inserted) */
 .rgh-tag-changelog-link .release:not(.label-draft) .list-style-none > .d-block:nth-child(3):not(.rgh-changelog-link) {
-	/* Use padding to avoid overwriting the margin already present on the element */
+	/* Use the padding to avoid overwriting the margin already present on the element
+	 * The height in pixels is taken from the commit link element (https://user-images.githubusercontent.com/1402241/103394704-bf2d7a80-4aef-11eb-8377-5c59b46cc2b3.png) */
 	padding-top: 21px !important;
 }

--- a/source/features/tag-changelog-link.css
+++ b/source/features/tag-changelog-link.css
@@ -1,0 +1,3 @@
+.rgh-tag-changelog-link .release:not(.label-draft) .list-style-none > .d-block:nth-child(3):not(.rgh-changelog-link) {
+	padding-top: 21px !important;
+}

--- a/source/features/tag-changelog-link.css
+++ b/source/features/tag-changelog-link.css
@@ -1,6 +1,5 @@
 /* Reserve some space above the "Compare" dropdown (the selector will be disabled as soon as the "Changelog" link is inserted) */
 .rgh-tag-changelog-link .release:not(.label-draft) .list-style-none > .d-block:nth-child(3):not(.rgh-changelog-link) {
-	/* Use the padding to avoid overwriting the margin already present on the element
-	 * The height in pixels is taken from the commit link element (https://user-images.githubusercontent.com/1402241/103394704-bf2d7a80-4aef-11eb-8377-5c59b46cc2b3.png) */
+	/* 21px is the height of the link that is being inserted https://user-images.githubusercontent.com/1402241/103394704-bf2d7a80-4aef-11eb-8377-5c59b46cc2b3.png */
 	padding-top: 21px !important;
 }

--- a/source/features/tag-changelog-link.css
+++ b/source/features/tag-changelog-link.css
@@ -1,3 +1,4 @@
+/* Reserve some space above the "Compare" dropdown (the selector will be disabled as soon as the "Changelog" link is inserted) */
 .rgh-tag-changelog-link .release:not(.label-draft) .list-style-none > .d-block:nth-child(3):not(.rgh-changelog-link) {
 	padding-top: 21px !important;
 }

--- a/source/features/tag-changelog-link.css
+++ b/source/features/tag-changelog-link.css
@@ -1,4 +1,5 @@
 /* Reserve some space above the "Compare" dropdown (the selector will be disabled as soon as the "Changelog" link is inserted) */
 .rgh-tag-changelog-link .release:not(.label-draft) .list-style-none > .d-block:nth-child(3):not(.rgh-changelog-link) {
+	/* Use padding to avoid overwriting the margin already present on the element */
 	padding-top: 21px !important;
 }

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -110,6 +110,8 @@ async function init(): Promise<void> {
 					</a>
 				</li>
 			);
+			/* Fix spacing issue when the window is < 700px wide https://github.com/sindresorhus/refined-github/pull/3841#issuecomment-754325056 */
+			lastLink.classList.remove('flex-auto');
 		}
 	}
 }

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -1,6 +1,7 @@
 import './tag-changelog-link.css';
 import React from 'dom-chef';
 import select from 'select-dom';
+import domLoaded from 'dom-loaded';
 import {DiffIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import tinyVersionCompare from 'tiny-version-compare';
@@ -86,6 +87,7 @@ async function init(): Promise<void> {
 
 	// Look for tags in the current page and the next page
 	const pages = [document, await getNextPage()];
+	await domLoaded;
 	const allTags = select.all(tagsSelector, pages).map(parseTags);
 
 	for (const [index, container] of allTags.entries()) {

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -90,25 +90,22 @@ async function init(): Promise<void> {
 
 	for (const [index, container] of allTags.entries()) {
 		const previousTag = getPreviousTag(index, allTags);
+		if (!previousTag) {
+			return;
+		}
 
-		if (previousTag) {
-			for (const lastLink of select.all('.list-style-none > .d-block:nth-child(2), .list-style-none > .d-inline-block:last-child', container.element)) {
-				lastLink.after(
-					<li className={lastLink.className + ' rgh-changelog-link'}>
-						<a
-							className="muted-link tooltipped tooltipped-n"
-							aria-label={'See changes since ' + decodeURIComponent(previousTag)}
-							href={buildRepoURL(`compare/${previousTag}...${allTags[index].tag}`)}
-						>
-							<DiffIcon/> Changelog
-						</a>
-					</li>
-				);
-
-				// `lastLink` is no longer the last link, so it shouldn't push our new link away.
-				// Same page as before: https://github.com/tensorflow/tensorflow/releases?after=v1.12.0-rc1
-				lastLink.classList.remove('flex-auto');
-			}
+		for (const lastLink of select.all('.list-style-none > .d-block:nth-child(2), .list-style-none > .d-inline-block:last-child', container.element)) {
+			lastLink.after(
+				<li className={lastLink.className + ' rgh-changelog-link'}>
+					<a
+						className="muted-link tooltipped tooltipped-n"
+						aria-label={'See changes since ' + decodeURIComponent(previousTag)}
+						href={buildRepoURL(`compare/${previousTag}...${allTags[index].tag}`)}
+					>
+						<DiffIcon/> Changelog
+					</a>
+				</li>
+			);
 		}
 	}
 }

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -1,3 +1,4 @@
+import './tag-changelog-link.css';
 import React from 'dom-chef';
 import select from 'select-dom';
 import {DiffIcon} from '@primer/octicons-react';
@@ -70,6 +71,8 @@ const getPreviousTag = (current: number, allTags: TagDetails[]): string | undefi
 };
 
 async function init(): Promise<void> {
+	document.body.classList.add('rgh-tag-changelog-link');
+
 	const tagsSelector = [
 		// https://github.com/facebook/react/releases (release in releases list)
 		'.release:not(.label-draft)',
@@ -89,11 +92,9 @@ async function init(): Promise<void> {
 		const previousTag = getPreviousTag(index, allTags);
 
 		if (previousTag) {
-			// Signed releases include on mobile include a "Verified" <details> inside the `ul`. `li:last-of-type` excludes it.
-			// Example: https://github.com/tensorflow/tensorflow/releases?after=v1.12.0-rc1
-			for (const lastLink of select.all('.list-style-none > li:last-of-type', container.element)) {
+			for (const lastLink of select.all('.list-style-none > .d-block:nth-child(2), .list-style-none > .d-inline-block:last-child', container.element)) {
 				lastLink.after(
-					<li className={lastLink.className}>
+					<li className={lastLink.className + ' rgh-changelog-link'}>
 						<a
 							className="muted-link tooltipped tooltipped-n"
 							aria-label={'See changes since ' + decodeURIComponent(previousTag)}

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -91,10 +91,14 @@ async function init(): Promise<void> {
 	for (const [index, container] of allTags.entries()) {
 		const previousTag = getPreviousTag(index, allTags);
 		if (!previousTag) {
-			return;
+			continue;
 		}
 
-		for (const lastLink of select.all('.list-style-none > .d-block:nth-child(2), .list-style-none > .d-inline-block:last-child', container.element)) {
+		const lastLinks = select.all([
+			'.list-style-none > .d-block:nth-child(2)', // XXX
+			'.list-style-none > .d-inline-block:last-child' // YYY
+		], container.element);
+		for (const lastLink of lastLinks) {
 			lastLink.after(
 				<li className={lastLink.className + ' rgh-changelog-link'}>
 					<a

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -95,8 +95,8 @@ async function init(): Promise<void> {
 		}
 
 		const lastLinks = select.all([
-			'.list-style-none > .d-block:nth-child(2)', // XXX
-			'.list-style-none > .d-inline-block:last-child' // YYY
+			'.list-style-none > .d-block:nth-child(2)', // Link to commit in release sidebar
+			'.list-style-none > .d-inline-block:last-child' // Link to source tarball under release tag
 		], container.element);
 		for (const lastLink of lastLinks) {
 			lastLink.after(

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -121,5 +121,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isEmptyRepoRoot
 	],
+	awaitDomReady: false,
 	init
 });


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #2699 

2. TEST URLS:
  * [Single release](https://github.com/sindresorhus/refined-github/releases/tag/20.1.6)
  * [Multiple releases](https://github.com/facebook/react/releases)
  * [Tags in release list](https://github.com/facebook/react/releases?after=v16.7.0)
  * [Tags list](https://github.com/facebook/react/tags)
  * [Release with "Verified" badge](https://github.com/tensorflow/tensorflow/releases?after=v1.12.0-rc1)

3. SCREENSHOT:
<table>
<tr>
	<td><strong>Before</strong>
	<td><strong>After</strong>
<tr>
	<td><img src="https://user-images.githubusercontent.com/46634000/103087064-9fc1b980-45e6-11eb-8980-3bfa6c362fce.png">
	<td><img src="https://user-images.githubusercontent.com/46634000/103087106-b831d400-45e6-11eb-80bb-cd4eb040fd98.png">
</table>

This PR:
  * Moves the "Changelog" link above the GH dropdown. It relies on some GH class names so it might not be the best approach, but it keeps things simple.
  * Mitigates the content jump by reserving some space with CSS (there is still a jump but it happens much sooner in the page load). The magic number is not great though.
  * cleans up some outdated code regarding the "Verified" label (it's now properly wrapped inside a `<li>` element)