### PR TITLE
Prevent soft line-wrap caused by `show-whitespace`

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,6 +1,5 @@
 [data-rgh-whitespace] {
 	line-height: 1em;
-	white-space: break-spaces;
 	background-clip: border-box;
 	background-repeat: repeat-x;
 	background-position: left center;


### PR DESCRIPTION
Closes #3542

pls, can the reporter test this out with *tabs* (only had space indented repos handy) and post a screenshot?

I also tested the implied-github-softwrap discussed in the issue by going to https://github.com/sindresorhus/refined-github/issues/2991 and it seems that is not triggering the same things as discussed in the issue #3542 . As the class name changed here doesn't even apply on that diff.

also, some times forced soft-line-wrap is a desirable feature. Will try to move to it's own setting later on.