### PR TITLE
Drop duplicate icon from `highest-rated-comment`

### DIFF
--- a/source/features/highest-rated-comment.tsx
+++ b/source/features/highest-rated-comment.tsx
@@ -48,10 +48,6 @@ function getBestComment(): HTMLElement | undefined {
 }
 
 function highlightBestComment(bestComment: Element): void {
-	const avatar = select('.TimelineItem-avatar', bestComment)!;
-	avatar.classList.add('flex-column', 'flex-items-center', 'd-md-flex');
-	avatar.append(<CheckIcon width={24} height={32} className="mt-4 text-green"/>);
-
 	select('.unminimized-comment', bestComment)!.classList.add('rgh-highest-rated-comment');
 	select('.unminimized-comment .timeline-comment-header-text', bestComment)!.before(
 		<span


### PR DESCRIPTION
Too many checks, one is enough. 

<img width="823" alt="Screen Shot 2020-12-28 at 19 55 21" src="https://user-images.githubusercontent.com/1402241/103253402-a33aa500-4946-11eb-975f-c961b8fbcaba.png">


The one on the title bar:

- has a tooltip
- poses no overlapping risks
- is also visible on "mobile view"



<img width="732" alt="Screen Shot 2020-12-28 at 19 56 25" src="https://user-images.githubusercontent.com/1402241/103253438-cd8c6280-4946-11eb-921b-808f49672716.png">