### PR TITLE
Fix `embed-gist-inline` style and preserve the original link

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -32,7 +32,7 @@ const messageHandlers = {
 browser.runtime.onMessage.addListener((message, sender) => {
 	for (const id of Object.keys(message ?? {}) as Array<keyof typeof messageHandlers>) {
 		if (id in messageHandlers) {
-			return messageHandlers[id](message, sender);
+			return messageHandlers[id](message[id], sender);
 		}
 	}
 });

--- a/source/background.ts
+++ b/source/background.ts
@@ -3,6 +3,9 @@ import cache from 'webext-storage-cache'; // Also needed to regularly clear the 
 import addDomainPermissionToggle from 'webext-domain-permission-toggle';
 import './options-storage';
 
+// GitHub Enterprise support
+addDomainPermissionToggle();
+
 const messageHandlers = {
 	openUrls(urls: string[], {tab}: browser.runtime.MessageSender) {
 		for (const [i, url] of urls.entries()) {
@@ -58,6 +61,3 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 	// Hope that the feature was fixed in this version
 	await cache.delete('hotfix');
 });
-
-// GitHub Enterprise support
-addDomainPermissionToggle();

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -19,11 +19,10 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 	link.after(info);
 
 	try {
-		// Get the gist via background.js due to CORB policies introduced in Chrome 73
-		const gistData = JSON.parse(await browser.runtime.sendMessage({request: `${link.href}.json`}));
+		// Fetch via background.js due to CORB policies
+		const gistData = await browser.runtime.sendMessage({fetchJSON: `${link.href}.json`});
 
 		const fileCount: number = gistData.files.length;
-
 		if (fileCount > 1) {
 			info.textContent = ` (${fileCount} files)`;
 		} else {

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -22,7 +22,7 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 		// Get the gist via background.js due to CORB policies introduced in Chrome 73
 		const gistData = JSON.parse(await browser.runtime.sendMessage({request: `${link.href}.json`}));
 
-		const fileCount = gistData.files.length;
+		const fileCount: number = gistData.files.length;
 
 		if (fileCount > 1) {
 			info.textContent = ` (${fileCount} files)`;

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -20,15 +20,15 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 
 	try {
 		// Get the gist via background.js due to CORB policies introduced in Chrome 73
-		const gistData = await browser.runtime.sendMessage({request: `${link.href}.json`});
+		const gistData = JSON.parse(await browser.runtime.sendMessage({request: `${link.href}.json`}));
 
-		const files = domify.one(JSON.parse(gistData).div)!;
-		const fileCount = files.children.length;
+		const fileCount = gistData.files.length;
 
 		if (fileCount > 1) {
 			info.textContent = ` (${fileCount} files)`;
 		} else {
-			link.parentElement!.attachShadow({mode: 'open'}).append(
+			const container = <div/>;
+			container.attachShadow({mode: 'open'}).append(
 				<style>{`
 					.gist .gist-data {
 						max-height: 16em;
@@ -37,8 +37,10 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 				`}
 				</style>,
 				<link rel="stylesheet" href={gistData.stylesheet}/>,
-				files
+				domify.one(gistData.div as string)!
 			);
+			link.parentElement!.after(container);
+			info.remove();
 		}
 	} catch {
 		info.remove();

--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -37,7 +37,7 @@ async function embedGist(link: HTMLAnchorElement): Promise<void> {
 				`}
 				</style>,
 				<link rel="stylesheet" href={gistData.stylesheet}/>,
-				domify.one(gistData.div as string)!
+				domify.one(gistData.div)!
 			);
 			link.parentElement!.after(container);
 			info.remove();

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -15,7 +15,9 @@ import {buildRepoURL} from '../github-helpers';
 const lineActions = onetime(async () => {
 	// Avoid having to create the entire 60 lines of JSX. The URL is hardcoded to a file we know the DOM exists.
 	const randomKnownFile = 'https://github.com/sindresorhus/refined-github/blob/b1229bbaeb8cf071f0711bc2ed1b40dd96cd7a05/.editorconfig';
-	const html = await browser.runtime.sendMessage({request: randomKnownFile});
+
+	// Fetch background.js due to CORB policies
+	const html = await browser.runtime.sendMessage({fetch: randomKnownFile});
 	const blobToolbar = domify(html).querySelector('.BlobToolbar')!;
 	select('a#js-view-git-blame', blobToolbar)!.href = new GitHubURL(location.href).assign({route: 'blame'}).href;
 	select('a#js-new-issue', blobToolbar)!.href = buildRepoURL('issues/new');


### PR DESCRIPTION
Fixes #3865 

The feature’s style has probably been broken since https://github.com/sindresorhus/refined-github/pull/3640

## Test

Test on: https://github.com/expressjs/express/issues/2761#issuecomment-628549001

## Live demo

Pure link here:

https://gist.github.com/sompylasar/99b5d307da3168b833c1119fb95caf11

[Text link here](https://gist.github.com/sompylasar/99b5d307da3168b833c1119fb95caf11)

## Screenshot 
<img width="643" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/103814121-cb9d6000-5026-11eb-830a-1d03966d1d19.png">


