### PR TITLE
Fix `separate-draft-pr-button` position 

### DIFF
--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -13,7 +13,7 @@ function init(): void | false {
 		return false;
 	}
 
-	const buttonBar = select('.timeline-comment > :last-child', previewForm)!;
+	const buttonBar = select('.js-slash-command-surface > :last-child', previewForm)!;
 	const createPrButtonGroup = select('.BtnGroup', buttonBar);
 	if (!createPrButtonGroup) {
 		// Free accounts can't open Draft PRs in private repos, so this element is missing

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -13,8 +13,7 @@ function init(): void | false {
 		return false;
 	}
 
-	const buttonBar = select('.js-slash-command-surface > :last-child', previewForm)!;
-	const createPrButtonGroup = select('.BtnGroup', buttonBar);
+	const createPrButtonGroup = select('.hx_create-pr-button');
 	if (!createPrButtonGroup) {
 		// Free accounts can't open Draft PRs in private repos, so this element is missing
 		return false;

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -19,7 +19,7 @@ function init(): void | false {
 		return false;
 	}
 
-	const createPrDropdownItems = select.all('.select-menu-item', createPrButtonGroup);
+	const createPrDropdownItems = select.all('.select-menu-item', previewForm);
 
 	for (const dropdownItem of createPrDropdownItems) {
 		let title = select('.select-menu-item-heading', dropdownItem)!.textContent!.trim();
@@ -33,7 +33,7 @@ function init(): void | false {
 			classList.push('btn-primary');
 		}
 
-		buttonBar.prepend(
+		createPrButtonGroup.after(
 			<button
 				className={classList.join(' ')}
 				aria-label={description}
@@ -46,6 +46,7 @@ function init(): void | false {
 		);
 	}
 
+	select('details', createPrButtonGroup.parentElement!)!.remove();
 	createPrButtonGroup.remove();
 }
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fix #3871 

2. TEST URLS:
 * https://github.com/sindresorhus/refined-github/compare/unknow-feature-name?expand=1

3. SCREENSHOT:
<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![Screenshot_2021-01-09 sindresorhus refined-github](https://user-images.githubusercontent.com/46634000/104092215-c50b2480-5282-11eb-80e3-522e0ec4b320.png)
	</td>
	<td>

![Screenshot_2021-01-09 sindresorhus refined-github(1)](https://user-images.githubusercontent.com/46634000/104092216-c76d7e80-5282-11eb-91cf-c3ec0c7ab860.png)
	</td>
</table>

Bug was caused by a new wrapper around the PR form.