### PR TITLE
Enable `faster-pr-diff-options` on compare pages

### DIFF
--- a/source/features/faster-pr-diff-options.tsx
+++ b/source/features/faster-pr-diff-options.tsx
@@ -56,7 +56,7 @@ function createWhitespaceButton(): HTMLElement {
 }
 
 function wrap(...elements: Node[]): DocumentFragment {
-	if (pageDetect.isSingleCommit()) {
+	if (pageDetect.isSingleCommit() || pageDetect.isCompare()) {
 		return (
 			<div className="float-right">
 				{elements.map(element => <div className="ml-3 BtnGroup">{element}</div>)}
@@ -110,7 +110,8 @@ function init(): false | void {
 void features.add(__filebasename, {
 	include: [
 		// Disabled because of #2291 // pageDetect.isPRFiles
-		pageDetect.isCommit
+		pageDetect.isCommit,
+		pageDetect.isCompare
 	],
 	shortcuts: {
 		'd w': 'Show/hide whitespaces in diffs'


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3870

2. TEST URLS:
 * https://github.com/drichard/mindmaps/compare/master...eitwizlearn:master

3. SCREENSHOT:
<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

![Screenshot_2021-01-09 drichard mindmaps(1)](https://user-images.githubusercontent.com/46634000/104092821-b6bf0780-5286-11eb-8b90-682f3a0bd31c.png)

</td>
	<td>

![Screenshot_2021-01-09 drichard mindmaps](https://user-images.githubusercontent.com/46634000/104092813-a9a21880-5286-11eb-8ac7-5af6c8340629.png)

</td>
</table>