### PR TITLE
Fix `hide-comments-faster`

### DIFF
--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -18,7 +18,7 @@ function generateSubmenu(hideButton: Element): void {
 	const hideCommentForm = select('.js-comment-minimize', comment)!;
 
 	// Generate dropdown items
-	for (const reason of select.all('[name="classifier"] input:not([value=""])', comment)) {
+	for (const reason of select.all('[name="classifier"] option:not([value=""])', comment)) {
 		hideCommentForm.append(
 			<button
 				type="submit"

--- a/source/features/hide-comments-faster.tsx
+++ b/source/features/hide-comments-faster.tsx
@@ -44,7 +44,7 @@ function generateSubmenu(hideButton: Element): void {
 
 // Shows menu on top of mainDropdownContent when "Hide" is clicked;
 // Hide it when dropdown closes.
-// Uses `v-hidden` and `d-none` to avoid conflicts with `close-out-of-view-modals`
+// Uses `v-hidden` to avoid conflicts with `close-out-of-view-modals`
 function toggleSubMenu(hideButton: Element, show: boolean): void {
 	const dropdown = hideButton.closest('details')!;
 
@@ -52,7 +52,7 @@ function toggleSubMenu(hideButton: Element, show: boolean): void {
 	select('details-menu', dropdown)!.classList.toggle('v-hidden', show);
 
 	// "Hide comment" dropdown
-	select('form.js-comment-minimize', dropdown)!.classList.toggle('d-none', !show);
+	select('form.js-comment-minimize', dropdown)!.classList.toggle('v-hidden', !show);
 }
 
 function resetDropdowns(event: delegate.Event): void {


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3867

2. TEST URLS: see test comment below

3. SCREENSHOT: -

Edit: this also fixes a bug where if the "Hide" drop-down is opened then closed by clicking outside, it will subsequently always appear on top of the main drop-down when clicking the "..." button. Seems like the `d-none` class had no effect anymore, so I replaced it by `v-hidden`.