### PR TITLE
Fix `clean-dashboard`

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -3,14 +3,14 @@
 *
 * Notes:
 * `.flex-items-baseline` excludes label events
-* `.border-gray` excludes grouped events
+* `.color-border-secondary` excludes grouped events
 * `.js-news-feed-event-group` is only for grouped events
 */
 
 /* Hide duplicate repo name in some non-grouped events */
-.rgh-clean-dashboard .dashboard .watch_started .border-gray.flex-items-baseline .text-bold.text-gray-dark,
-.rgh-clean-dashboard .dashboard .repo .border-gray.flex-items-baseline .text-bold.text-gray-dark,
-.rgh-clean-dashboard .dashboard .public .border-gray.flex-items-baseline .text-bold.text-gray-dark {
+.rgh-clean-dashboard .dashboard .watch_started .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark,
+.rgh-clean-dashboard .dashboard .repo .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark,
+.rgh-clean-dashboard .dashboard .public .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark {
 	display: none;
 }
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3880 

2. TEST URLS: homepage feed

3. SCREENSHOT:
<table>
<tr>
	<th> Before </th>
	<th> After </th>
</tr>
<tr>
	<td>

![Screenshot_2021-01-10 Build software better, together(1)](https://user-images.githubusercontent.com/46634000/104122692-cd2c9800-5346-11eb-932b-150bcbba7bf4.png)
	</td>
	<td>

![Screenshot_2021-01-10 Build software better, together(2)](https://user-images.githubusercontent.com/46634000/104122694-d0c01f00-5346-11eb-89a4-c6d56ec70048.png)
	</td>
</tr>
</table>

I only have `.watch-started` events in my feed so I can only test those. Also, is there a reason why non-grouped fork events are left untouched?