### PR TITLE
Don't apply `wait-for-build` when auto-merge is enabled

### DIFF
--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -32,9 +32,14 @@ function showCheckboxIfNecessary(): void {
 	const checkbox = getCheckbox();
 	const isNecessary = prCiStatus.get() === prCiStatus.PENDING;
 	if (!checkbox && isNecessary) {
-		const container = select('.commit-form-actions .select-menu');
-		if (container) {
-			container.append(generateCheckbox());
+		const containers = select.all('.commit-form-actions .select-menu');
+		for (const container of containers) {
+			const container_form = container.closest('form');
+			// Only show checkbox for merge form, not for auto merge form
+			if (container_form?.classList.contains('js-merge-form')) {
+				container.append(generateCheckbox());
+				break;
+			}
 		}
 	} else if (checkbox && !isNecessary) {
 		checkbox.parentElement!.remove();

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -32,14 +32,7 @@ function showCheckboxIfNecessary(): void {
 	const checkbox = getCheckbox();
 	const isNecessary = prCiStatus.get() === prCiStatus.PENDING;
 	if (!checkbox && isNecessary) {
-		const containers = select.all('.commit-form-actions .select-menu');
-		for (const container of containers) {
-			const container_form = container.closest('form');
-			// Only show checkbox for merge form, not for auto merge form
-			if (container_form?.classList.contains('js-merge-form')) {
-				container.append(generateCheckbox());
-				break;
-			}
+		select('.js-merge-form .select-menu')?.append(generateCheckbox());
 		}
 	} else if (checkbox && !isNecessary) {
 		checkbox.parentElement!.remove();

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -33,7 +33,6 @@ function showCheckboxIfNecessary(): void {
 	const isNecessary = prCiStatus.get() === prCiStatus.PENDING;
 	if (!checkbox && isNecessary) {
 		select('.js-merge-form .select-menu')?.append(generateCheckbox());
-		}
 	} else if (checkbox && !isNecessary) {
 		checkbox.parentElement!.remove();
 	}


### PR DESCRIPTION
1. LINKED ISSUES:
   Fixes #3887

2. TEST URLS:
   Not possible to provide, the tester will need to make a repo with proper conditions met themselves.
   See SCREENSHOT section below for possible conditions.

3. SCREENSHOT:
   - [x] Auto-merge (GH only shows it when there are pending required checks):
   ![image](https://user-images.githubusercontent.com/6032823/104434890-128dd700-558c-11eb-90c0-bd3b9bd83fdf.png)
   - [x] Regular merge, auto-merge enabled, pending optional checks:
   ![image](https://user-images.githubusercontent.com/6032823/104435172-5c76bd00-558c-11eb-8beb-3938d10dedf2.png)
   - [x] Regular merge, auto-merge enabled, all optional and required checks have passed already:
   ![image](https://user-images.githubusercontent.com/6032823/104434981-2cc7b500-558c-11eb-9971-b57d114d6e2f.png)
   - [x] Admin merge (GH only shows it when there are pending required checks), auto-merge enabled:
   ![image](https://user-images.githubusercontent.com/6032823/104434579-ac08b900-558b-11eb-9065-87c013428bc1.png)
   ![image](https://user-images.githubusercontent.com/6032823/104434632-bcb92f00-558b-11eb-9efb-b9917c7f15cc.png)
   - [x] Regular merge, auto-merge disabled, pending optional checks:
   ![image](https://user-images.githubusercontent.com/6032823/104433968-f89fc480-558a-11eb-8d24-1fff30e86010.png)
   ![image](https://user-images.githubusercontent.com/6032823/104434028-0b19fe00-558b-11eb-94b8-b0e5364b357f.png)
   - [x] Admin merge (GH only shows it when there are pending required checks), auto-merge disabled:
   ![image](https://user-images.githubusercontent.com/6032823/104434204-41f01400-558b-11eb-8f05-6c78dc1d751d.png)
   ![image](https://user-images.githubusercontent.com/6032823/104434376-72d04900-558b-11eb-9498-89ac448cd8d5.png)
