### PR TITLE
Fix `tag-changelog-link` on Safari

### DIFF
--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -33,7 +33,7 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
-	const {pathname: tagUrl} = select('a[href*="/releases/tag/"]', element)!;
+	const {pathname: tagUrl} = new URL(select('a[href*="/releases/tag/"]', element)!);
 	const tag = /\/releases\/tag\/(.*)/.exec(tagUrl)![1];
 
 	return {

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -33,7 +33,8 @@ async function getNextPage(): Promise<DocumentFragment> {
 }
 
 function parseTags(element: HTMLElement): TagDetails {
-	const {pathname: tagUrl} = new URL(select('a[href*="/releases/tag/"]', element)!);
+	// Safari doesn't correctly parse links if they're loaded via AJAX #3899
+	const {pathname: tagUrl} = new URL(select('a[href*="/releases/tag/"]', element)!.href);
 	const tag = /\/releases\/tag\/(.*)/.exec(tagUrl)![1];
 
 	return {


### PR DESCRIPTION
Fixes #3899 

<img width="332" alt="Screen Shot 12" src="https://user-images.githubusercontent.com/1402241/104874563-d7d3c800-5918-11eb-8bcb-fef846251399.png">
