### PR TITLE
Improve automatic dark mode support

### DIFF
--- a/source/features/conflict-marker.css
+++ b/source/features/conflict-marker.css
@@ -6,3 +6,9 @@
 [data-color-mode='dark'] .rgh-conflict-marker svg {
 	color: #505050;
 }
+
+@media (prefers-color-scheme: 'dark') {
+	[data-color-mode='auto'] .rgh-conflict-marker svg {
+		color: #505050;
+	}
+}

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -21,7 +21,7 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-left: -0.5em;
 	vertical-align: middle;
 	background: var(--color-bg-canvas-inset, #efefef); /* Placeholder before the images load */
-	box-shadow: 0 0 0 2px var(--color-bg-info, var(--color-bg-primary, #fff));
+	box-shadow: 0 0 0 2px var(--color-bg-info, #fff);
 	font-size: 10px; /* Base sizer */
 }
 
@@ -40,5 +40,5 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item a img { /* `a` required for #3237 */
 	max-width: 100%;
-	background-color: var(--color-bg-info, var(--color-bg-primary, #fff));
+	background-color: var(--color-bg-info, #fff);
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -21,6 +21,12 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	--background: #111d2f;
 }
 
+@media (prefers-color-scheme: 'dark') {
+	[data-color-mode='auto'] .reaction-summary-item.user-has-reacted {
+		--background: #111d2f;
+	}
+}
+
 .reaction-summary-item a {
 	display: inline-block;
 	width: 2em;

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -13,20 +13,6 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-top: -1px; /* Makes up for `.reaction-summary-item {border-top}` */
 }
 
-.reaction-summary-item.user-has-reacted {
-	--background: #f2f8fa;
-}
-
-[data-color-mode='dark'] .reaction-summary-item.user-has-reacted {
-	--background: #111d2f;
-}
-
-@media (prefers-color-scheme: 'dark') {
-	[data-color-mode='auto'] .reaction-summary-item.user-has-reacted {
-		--background: #111d2f;
-	}
-}
-
 .reaction-summary-item a {
 	display: inline-block;
 	width: 2em;
@@ -35,7 +21,7 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-left: -0.5em;
 	vertical-align: middle;
 	background: var(--color-bg-canvas-inset, #efefef); /* Placeholder before the images load */
-	box-shadow: 0 0 0 2px var(--background, var(--color-bg-primary, #fff));
+	box-shadow: 0 0 0 2px var(--color-bg-info, var(--color-bg-primary, #fff));
 	font-size: 10px; /* Base sizer */
 }
 
@@ -54,5 +40,5 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item a img { /* `a` required for #3237 */
 	max-width: 100%;
-	background-color: var(--background);
+	background-color: var(--color-bg-info, var(--color-bg-primary, #fff));
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -6,29 +6,11 @@
 }
 
 [data-rgh-whitespace='tab'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(36,41,46,25%)"/%3E%3C/svg%3E');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(128, 128, 128, 50%)"/%3E%3C/svg%3E');
 	background-size: calc(var(--tab-size, 4) * 1ch) 1.25em;
 }
 
 [data-rgh-whitespace='space'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(36,41,46,25%)"/%3E%3C/svg%3E');
+	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(128, 128, 128, 50%)"/%3E%3C/svg%3E');
 	background-size: 1ch 1.25em;
-}
-
-[data-color-mode='dark'] [data-rgh-whitespace='tab'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
-}
-
-[data-color-mode='dark'] [data-rgh-whitespace='space'] {
-	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
-}
-
-@media (prefers-color-scheme: 'dark') {
-	[data-color-mode='auto'] [data-rgh-whitespace='tab'] {
-		background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
-	}
-
-	[data-color-mode='auto'] [data-rgh-whitespace='space'] {
-		background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
-	}
 }

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -22,3 +22,13 @@
 [data-color-mode='dark'] [data-rgh-whitespace='space'] {
 	background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
 }
+
+@media (prefers-color-scheme: 'dark') {
+	[data-color-mode='auto'] [data-rgh-whitespace='tab'] {
+		background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M9.5 10.44L6.62 8.12L7.32 7.26L12.04 11V11.44L7.28 14.9L6.62 13.9L9.48 11.78H0V10.44H9.5Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
+	}
+
+	[data-color-mode='auto'] [data-rgh-whitespace='space'] {
+		background-image: url('data:image/svg+xml,%3Csvg preserveAspectRatio="xMinYMid meet" viewBox="0 0 12 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M4.5 11C4.5 10.1716 5.17157 9.5 6 9.5C6.82843 9.5 7.5 10.1716 7.5 11C7.5 11.8284 6.82843 12.5 6 12.5C5.17157 12.5 4.5 11.8284 4.5 11Z" fill="rgba(240,246,252,25%)"/%3E%3C/svg%3E');
+	}
+}


### PR DESCRIPTION
for `prefers-color-scheme: dark` @media query
and `[data-color-mode: auto]`


1. LINKED ISSUES:
   https://github.com/sindresorhus/refined-github/pull/3806#issuecomment-761849635

2. TEST ENVIRONMENT:
   - Dark Mode is enabled for GitHub
   - System-wide dark mode is enabled
      - some way where the `<html>` tag has `data-color-mode: auto`

3. STEPS TO TEST
   1. Show Whitespace
      - open any source file
      - confirm whether whitespace indicators are displayed
   2. Conflict Markers
      - open a pull request with merge conflicts
      - confirm whether the :warning: sign is darker
   3. Reaction Avatars
      - open any issue page
      - react on any comment
      - confirm whether there are incorrect white borders on the reaction
        emoji or the reaction avatars
