### PR TITLE
Fix separate draft pr button on GHE

### DIFF
--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -13,13 +13,13 @@ function init(): void | false {
 		return false;
 	}
 
-	const createPrButtonGroup = select('.hx_create-pr-button');
+	const createPrButtonGroup = select(['.hx_create-pr-button', '.timeline-comment > :last-child > .BtnGroup']);
 	if (!createPrButtonGroup) {
 		// Free accounts can't open Draft PRs in private repos, so this element is missing
 		return false;
 	}
 
-	const createPrButtonGroup = select(['.hx_create-pr-button', '.timeline-comment > :last-child > .BtnGroup']);
+	const createPrDropdownItems = select.all('.select-menu-item', previewForm);
 
 	for (const dropdownItem of createPrDropdownItems) {
 		let title = select('.select-menu-item-heading', dropdownItem)!.textContent!.trim();

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -13,7 +13,10 @@ function init(): void | false {
 		return false;
 	}
 
-	const createPrButtonGroup = select(['.hx_create-pr-button', '.timeline-comment > :last-child > .BtnGroup']);
+	const createPrButtonGroup = select([
+		'.hx_create-pr-button',
+		'.timeline-comment > :last-child > .BtnGroup' // GHE
+	]);
 	if (!createPrButtonGroup) {
 		// Free accounts can't open Draft PRs in private repos, so this element is missing
 		return false;

--- a/source/features/separate-draft-pr-button.tsx
+++ b/source/features/separate-draft-pr-button.tsx
@@ -19,7 +19,7 @@ function init(): void | false {
 		return false;
 	}
 
-	const createPrDropdownItems = select.all('.select-menu-item', previewForm);
+	const createPrButtonGroup = select(['.hx_create-pr-button', '.timeline-comment > :last-child > .BtnGroup']);
 
 	for (const dropdownItem of createPrDropdownItems) {
 		let title = select('.select-menu-item-heading', dropdownItem)!.textContent!.trim();


### PR DESCRIPTION
Old selector is still needed on GHE, at least on 2.21 still. I normally don't make a lot of draft PRs, but needed to do a handful the last few days and noticed it was more cumbersome than usual.  :D

1. LINKED ISSUES:
N/A

2. TEST URLS:
N/A

3. SCREENSHOT:
GHE:
![image](https://user-images.githubusercontent.com/857700/106086091-115dbd80-60e7-11eb-89be-8c23618c1786.png)
GH:
![image](https://user-images.githubusercontent.com/857700/106086114-1de21600-60e7-11eb-9315-c775229d37cd.png)

