### PR TITLE
Fix error in `clean-repo-sidebar`

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -10,7 +10,9 @@ async function init(): Promise<void> {
 
 	// Hide redundant "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
-	sidebarReleases!.closest<HTMLElement>('.BorderGrid-row')!.hidden = true;
+	if (sidebarReleases) {
+		sidebarReleases.closest<HTMLElement>('.BorderGrid-row')!.hidden = true;
+	}
 
 	// Hide empty "Packages" section
 	const packagesCounter = await elementReady('.BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false})!;


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: -

2. TEST URLS: [Repo with releases disabled in the sidebar](https://github.com/co1ncidence/mountaineer.vim)

This PR prevents an error in the console, when the "Releases" section in the repo sidebar has been deactivated by the owner.