### PR TITLE
Fix `deprioritize-marketplace-link` error in some instances

### DIFF
--- a/source/github-events/on-profile-dropdown-load.ts
+++ b/source/github-events/on-profile-dropdown-load.ts
@@ -1,10 +1,15 @@
+import select from 'select-dom';
 import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 
 export default async function onProfileDropdownLoad(): Promise<Element> {
 	const dropdown = await elementReady('.Header-item:last-child .dropdown-menu');
-	if (!exists()) {
-		await oneMutation(dropdown!, {childList: true, filter: exists});		
+	if (!dropdownContentExists()) {
+		await oneMutation(dropdown!, {childList: true, filter: dropdownContentExists});
 	}
 	return dropdown!;
+}
+
+function dropdownContentExists() {
+	return select.exists('.Header-item:last-child .dropdown-menu .dropdown-item')
 }

--- a/source/github-events/on-profile-dropdown-load.ts
+++ b/source/github-events/on-profile-dropdown-load.ts
@@ -2,7 +2,9 @@ import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 
 export default async function onProfileDropdownLoad(): Promise<Element> {
-	const dropdown = await elementReady('.Header-item:last-child .dropdown-menu', {waitForChildren: false});
-	await oneMutation(dropdown!, {childList: true});
+	const dropdown = await elementReady('.Header-item:last-child .dropdown-menu');
+	if (!exists()) {
+		await oneMutation(dropdown!, {childList: true, filter: exists});		
+	}
 	return dropdown!;
 }

--- a/source/github-events/on-profile-dropdown-load.ts
+++ b/source/github-events/on-profile-dropdown-load.ts
@@ -7,9 +7,10 @@ export default async function onProfileDropdownLoad(): Promise<Element> {
 	if (!dropdownContentExists()) {
 		await oneMutation(dropdown!, {childList: true, filter: dropdownContentExists});
 	}
+
 	return dropdown!;
 }
 
-function dropdownContentExists() {
-	return select.exists('.Header-item:last-child .dropdown-menu .dropdown-item')
+function dropdownContentExists(): boolean {
+	return select.exists('.Header-item:last-child .dropdown-menu .dropdown-item');
 }

--- a/source/github-events/on-profile-dropdown-load.ts
+++ b/source/github-events/on-profile-dropdown-load.ts
@@ -1,7 +1,8 @@
 import oneMutation from 'one-mutation';
+import elementReady from 'element-ready';
 
 export default async function onProfileDropdownLoad(): Promise<Element> {
-	const dropdown = document.querySelector('.Header-item:last-child .dropdown-menu')!;
-	await oneMutation(dropdown, {childList: true});
-	return dropdown;
+	const dropdown = await elementReady('.Header-item:last-child .dropdown-menu', {waitForChildren: false});
+	await oneMutation(dropdown!, {childList: true});
+	return dropdown!;
 }


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3898 

2. TEST URLS: Go to [the PR list](https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) and do a few "hard refresh" (Ctrl-F5). This triggers the error almost every time for me.

I think #3898 was caused by `awaitDomReady: false` combined with the plain `document.querySelector()` in `onProfileDropdownLoad()`. Using `elementReady` seems to fix it.

Also `set-default-repositories-type-to-sources` is unaffected.