### PR TITLE
Fix `clean-conversation-filters`

### DIFF
--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -33,8 +33,7 @@ function getCount(element: HTMLElement): number {
 async function hideMilestones(): Promise<void> {
 	const milestones = select('[data-selected-links^="repo_milestones"] .Counter')!;
 	if (getCount(milestones) === 0) {
-		const milestonesDropdown = await elementReady('[data-hotkey="m"]');
-		milestonesDropdown!.parentElement!.remove();
+		(await elementReady('[data-hotkey="m"]'))!.parentElement!.remove();
 	}
 }
 
@@ -56,8 +55,7 @@ async function hasProjects(): Promise<boolean> {
 
 async function hideProjects(): Promise<void> {
 	if (!await hasProjects()) {
-		const projectsDropdown = await elementReady('[data-hotkey="p"]');
-		projectsDropdown!.parentElement!.remove();
+		(await elementReady('[data-hotkey="p"]'))!.parentElement!.remove();
 	}
 }
 

--- a/source/features/clean-conversation-filters.tsx
+++ b/source/features/clean-conversation-filters.tsx
@@ -33,7 +33,8 @@ function getCount(element: HTMLElement): number {
 async function hideMilestones(): Promise<void> {
 	const milestones = select('[data-selected-links^="repo_milestones"] .Counter')!;
 	if (getCount(milestones) === 0) {
-		select('[data-hotkey="m"]')!.parentElement!.remove();
+		const milestonesDropdown = await elementReady('[data-hotkey="m"]');
+		milestonesDropdown!.parentElement!.remove();
 	}
 }
 
@@ -55,7 +56,8 @@ async function hasProjects(): Promise<boolean> {
 
 async function hideProjects(): Promise<void> {
 	if (!await hasProjects()) {
-		select('[data-hotkey="p"]')!.parentElement!.remove();
+		const projectsDropdown = await elementReady('[data-hotkey="p"]');
+		projectsDropdown!.parentElement!.remove();
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: -

2. TEST URLS: Go to [the issues page](https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc) or [the PRs page](https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc) and refresh with Ctrl-F5 a few times. (The errors may only pop up on a slow connection).


This fixes a similar bug as #3898, where the elements targeted by the two selectors sometimes don't exist.