### PR TITLE
Exclude human-co-authored commits in `dim-bots`

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -17,7 +17,10 @@ const botSelectors = [
 
 function init(): void {
 	for (const bot of select.all(botSelectors)) {
-		bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
+		// Exclude co-authored commits
+		if (select.all('a', bot.parentElement!).length === 1) {
+			bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
+		}
 	}
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -4,8 +4,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-// eslint-disable-next-line import/prefer-default-export
-export const botSelectors = [
+const botSelectors = [
 	/* Commits */
 	'.commit-author[href$="%5Bbot%5D"]:first-child',
 	'.commit-author[href$="renovate-bot"]:first-child',

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -4,21 +4,21 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-const botSelectors = [
+const botSelector = [
 	/* Commits */
-	'.commit-author[href$="%5Bbot%5D"]:first-child',
-	'.commit-author[href$="renovate-bot"]:first-child',
-	'.commit-author[href$="scala-steward"]:first-child',
+	'.commit-author[href$="%5Bbot%5D"]',
+	'.commit-author[href$="renovate-bot"]',
+	'.commit-author[href$="scala-steward"]',
 
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
 	'.labels [href$="label%3Abot"]'
-];
+].join();
 
 function init(): void {
-	for (const bot of select.all(botSelectors)) {
+	for (const bot of select.all(botSelector)) {
 		// Exclude co-authored commits
-		if (select.all('a', bot.parentElement!).length === 1) {
+		if (select.all('a', bot.parentElement!).every(link => link.matches(botSelector))) {
 			bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 		}
 	}


### PR DESCRIPTION
Test URL: https://github.com/OpenLightingProject/open-fixture-library/commits/c18c0b9caf5127637c56ff518623a0fd3effb738/.github/workflows/test.yaml

The commit from Jun 26, 2020 is dimmed correctly, as the squash-merged PR was opened by a bot.

The commit from Dec 27, 2019 is dimmed incorrectly IMHO, as the squash-merged PR was opened by a bot, but enhanced by me. So also squash merge commit was co-authored by me. This PR fixes that.