### PR TITLE
Move `update-pr-from-base-branch` to a more reliable position

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -221,7 +221,7 @@ Thanks for contributing! 🦋🙌
 ### Editing pull requests
 
 - [](# "sync-pr-commit-title") 🔥 [Uses the PR’s title as the default squash commit title](https://github.com/sindresorhus/refined-github/issues/276) and [updates the PR’s title to the match the commit title, if changed.](https://user-images.githubusercontent.com/1402241/51669708-9a712400-1ff7-11e9-913a-ac1ea1050975.png)
-- [](# "update-pr-from-base-branch") [Adds a button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/57941992-f2170080-7902-11e9-8f8a-594aad983559.png) GitHub only adds it when the base branch is "protected".
+- [](# "update-pr-from-base-branch") [Adds a button to update a PR from the base branch to ensure it builds correctly before merging the PR itself.](https://user-images.githubusercontent.com/1402241/106494023-816d9a00-647f-11eb-8cb1-7c97aa8a5546.png) GitHub only adds it when the base branch is "protected".
 - [](# "quick-review-buttons") [Simplifies the PR review form: Approve or reject reviews faster with one-click review-type buttons.](https://user-images.githubusercontent.com/1402241/34326942-529cb7c0-e8f3-11e7-9bee-98b667e18a90.png)
 - [](# "warn-pr-from-master") [Warns you when creating a pull request from the default branch, as it’s an anti-pattern.](https://user-images.githubusercontent.com/1402241/52543516-3ca94e00-2de5-11e9-9f80-ff8f9fe8bdc4.png)
 - [](# "warning-for-disallow-edits") [Warns you when unchecking `Allow edits from maintainers`, as it’s maintainer-hostile.](https://user-images.githubusercontent.com/1402241/53151888-24101380-35ef-11e9-8d30-d6315ad97325.gif)

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -56,7 +56,7 @@ async function addButton(position: Element): Promise<void> {
 	if (status === 'diverged') {
 		position.append(' ', (
 			<span className="status-meta d-inline-block rgh-update-pr-from-base-branch">
-				You can <button type="button" className="btn-link" onClick={handler}>update the PR</button>.
+				You can <button type="button" className="btn-link" onClick={handler}>update the base branch</button>.
 			</span>
 		));
 	}

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -1,15 +1,15 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import delegate from 'delegate-it';
+import onetime from 'onetime';
+import {observe} from 'selector-observer';
 import {AlertIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import * as api from '../github-helpers/api';
-import observeElement from '../helpers/simplified-element-observer';
 import {getConversationNumber} from '../github-helpers';
 
-let observer: MutationObserver;
+const selectorForPushablePRNotice = '.merge-pr > .text-gray:first-child:not(.rgh-update-pr)';
 
 function getBranches(): {base: string; head: string} {
 	return {
@@ -28,15 +28,14 @@ async function mergeBranches(): Promise<AnyObject> {
 	});
 }
 
-async function handler({delegateTarget}: delegate.Event): Promise<void> {
+async function handler({currentTarget}: React.MouseEvent): Promise<void> {
 	const {base, head} = getBranches();
 	if (!confirm(`Merge the ${base} branch into ${head}?`)) {
 		return;
 	}
 
-	const statusMeta = delegateTarget.parentElement!;
+	const statusMeta = currentTarget.parentElement!;
 	statusMeta.textContent = 'Updating branch…';
-	observer.disconnect();
 
 	const response = await mergeBranches();
 	if (response.ok) {
@@ -48,59 +47,42 @@ async function handler({delegateTarget}: delegate.Event): Promise<void> {
 	}
 }
 
-function createButton(): HTMLElement {
-	const button = <button type="button" className="btn-link">update the base branch</button>;
-	return <span className="status-meta rgh-update-pr-from-base-branch">You can {button}.</span>;
-}
-
-async function addButton(): Promise<void> {
-	if (select.exists('.rgh-update-pr-from-base-branch, .branch-action-btn:not([action$="ready_for_review"]) > .btn')) {
-		return;
-	}
-
-	const stillLoading = select('#partial-pull-merging poll-include-fragment');
-	if (stillLoading) {
-		stillLoading.addEventListener('load', addButton);
-		return;
-	}
-
+async function addButton(position: Element): Promise<void> {
 	const {base, head} = getBranches();
-
-	if (head === 'unknown repository') {
-		return;
-	}
-
-	// Draft PRs already have this info on the page
-	const outOfDateContainer = select.all('.completeness-indicator-problem + .status-heading')
-		.find(title => title.textContent!.includes('out-of-date'));
-	if (outOfDateContainer) {
-		const meta = outOfDateContainer.nextElementSibling!;
-		meta.after(' ', createButton());
-		return;
-	}
-
 	const {status} = await api.v3(`compare/${base}...${head}`);
-	if (status !== 'diverged') {
-		return;
-	}
 
-	for (const meta of select.all('.mergeability-details > :not(.js-details-container) .status-meta')) {
-		meta.after(' ', createButton());
+	if (status === 'diverged') {
+		position.append(' ', (
+			<span className="status-meta d-inline-block rgh-update-pr-from-base-branch">
+				You can <button type="button" className="btn-link" onClick={handler}>update the PR</button>.
+			</span>
+		));
 	}
 }
+
+const waitForText = onetime(() => {
+	observe(selectorForPushablePRNotice, {
+		add(position) {
+			position.classList.add('rgh-update-pr');
+			void addButton(position);
+		}
+	});
+});
 
 async function init(): Promise<void | false> {
 	await api.expectToken();
 
-	// This link does the same thing as this feature: Updates the head branch from the base
-	const hasResolveConflictsLink = select.exists('.js-merge-pr a[href$="/conflicts"]');
-	const currentUserCanPush = select.exists('.merge-pr > .text-gray:first-child');
-	if (!currentUserCanPush || hasResolveConflictsLink) {
+	// "Resolve conflicts" is the native button to update the PR
+	if (select.exists('.js-merge-pr a[href$="/conflicts"]')) {
 		return false;
 	}
 
-	observer = observeElement('.discussion-timeline-actions', addButton)!;
-	delegate(document, '.rgh-update-pr-from-base-branch button', 'click', handler);
+	// Quick check before using selector-observer on it
+	if (!select.exists(selectorForPushablePRNotice)) {
+		return false;
+	}
+
+	waitForText();
 }
 
 void features.add(__filebasename, {

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -1,15 +1,16 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
-import {observe} from 'selector-observer';
 import {AlertIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
+import {observe, Observer} from 'selector-observer';
 
 import features from '.';
 import * as api from '../github-helpers/api';
 import {getConversationNumber} from '../github-helpers';
 
 const selectorForPushablePRNotice = '.merge-pr > .text-gray:first-child:not(.rgh-update-pr)';
+let observer: Observer;
 
 function getBranches(): {base: string; head: string} {
 	return {
@@ -36,6 +37,7 @@ async function handler({currentTarget}: React.MouseEvent): Promise<void> {
 
 	const statusMeta = currentTarget.parentElement!;
 	statusMeta.textContent = 'Updating branch…';
+	observer.abort();
 
 	const response = await mergeBranches();
 	if (response.ok) {
@@ -61,7 +63,7 @@ async function addButton(position: Element): Promise<void> {
 }
 
 const waitForText = onetime(() => {
-	observe(selectorForPushablePRNotice, {
+	observer = observe(selectorForPushablePRNotice, {
 		add(position) {
 			position.classList.add('rgh-update-pr');
 			void addButton(position);


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3927
Fixes https://github.com/sindresorhus/refined-github/issues/3699

I noticed that the mergeability [box](https://user-images.githubusercontent.com/1402241/106494253-cd204380-647f-11eb-90aa-df05213f8a38.png) [varies](https://user-images.githubusercontent.com/1402241/106494275-d27d8e00-647f-11eb-848d-d73280c5fad9.png) [a](https://user-images.githubusercontent.com/1402241/106494261-cf829d80-647f-11eb-831b-2a0d3d4d1878.png) [lot](https://user-images.githubusercontent.com/1402241/106494266-d0b3ca80-647f-11eb-977e-8e3576c3941e.png) and it's a pain to cover all the cases reliably. So I just moved the action next to the text that tells _we can update it by pushing,_ which makes sense. Also it helps that this text doesn't change that often.

The only drawback is that it wraps more often than it did before, pushing the box lower by 20px.

<img width="927" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/106494023-816d9a00-647f-11eb-8cb1-7c97aa8a5546.png">

cc @yakov116 