### PR TITLE
Fix `table-input` at 90% zoom

### DIFF
--- a/source/features/table-input.css
+++ b/source/features/table-input.css
@@ -1,9 +1,9 @@
 :root .rgh-table-input {
-	width: 108px;
+	width: auto;
 	padding: 3px;
 	z-index: 99;
-	display: flex;
-	flex-wrap: wrap;
+	display: grid;
+	grid-template: repeat(5, 20px) / repeat(5, 20px);
 }
 
 :root .rgh-table-input-cell {


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3936 

2. TEST URLS: any rich text editor

The bug was caused by the fixed width of `108px`. Setting it to `auto` and using CSS Grid for the layout solves the problem.

Tested in Firefox & Chromium only.