### PR TITLE
Fix merged button text in `extend-conversation-status-filters`

### DIFF
--- a/source/features/extend-conversation-status-filters.tsx
+++ b/source/features/extend-conversation-status-filters.tsx
@@ -21,13 +21,13 @@ function addMergeLink(): void {
 		if (lastLinkQuery.includes('is:merged')) {
 			// It's a "Total" link for "is:merged"
 			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent!.replace('Total', 'Merged');
-			return;
+			continue;
 		}
 
 		if (lastLinkQuery.includes('is:unmerged')) {
 			// It's a "Total" link for "is:unmerged"
 			lastLink.lastChild!.textContent = lastLink.lastChild!.textContent!.replace('Total', 'Unmerged');
-			return;
+			continue;
 		}
 
 		// In this case, `lastLink` is expected to be a "Closed" link


### PR DESCRIPTION
1. LINKED ISSUES:
   Fixes #3781 

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Amerged

3. SCREENSHOT:
   Before
![image](https://user-images.githubusercontent.com/16872793/106991202-c0cc0d00-6743-11eb-9324-b17e661fbc42.png)

After

![image](https://user-images.githubusercontent.com/16872793/106991238-d04b5600-6743-11eb-9f07-d7e0276b9103.png)


The issue was that there are 2 buttons but returning breaks the loop.
