### PR TITLE
Make `latest-tag-button` more reliable

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -1,7 +1,7 @@
 import './latest-tag-button.css';
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
-import select from 'select-dom';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 import {DiffIcon, TagIcon} from '@primer/octicons-react';
 
@@ -96,7 +96,7 @@ async function init(): Promise<false | void> {
 		</a>
 	);
 
-	select('#branch-select-menu')!.parentElement!.after(link);
+	(await elementReady('#branch-select-menu', {waitForChildren: false}))!.parentElement!.after(link);
 	if (currentBranch !== latestTag) {
 		link.append(' ', <span className="css-truncate-target">{latestTag}</span>);
 	}


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: -

2. TEST URLS: Go to a repo homepage (e.g. https://github.com/sindresorhus/refined-github) and hard-refresh a few times.

I noticed this feature failing with an error once in a while (especially when my connection is sluggish). Waiting for the `#branch-select-menu` element seems to fix it.