### PR TITLE
Restore features in file lists

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -264,7 +264,12 @@ void add(__filebasename, {
 	init: async () => {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();
-		select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
+
+		select.last(`
+			#repo-content-pjax-container,
+			#js-repo-pjax-container,
+			#js-pjax-container
+		`)?.append(<has-rgh/>); // They may be nested; .last should select the nested-est one.
 	}
 });
 


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/3945 and maybe more

It seems that there's a new nested ajax container. The `pjax:end` listener was being called, but `has-rgh` was not being removed by GitHub because GitHub changed a niece of `has-rgh` instead of its parent.

