### PR TITLE
Move `download-folder-button` to the dropdown

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -41,6 +41,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
-	repeatOnBackButton: true,
+	repeatOnBackButton: true, // Due to anti-duplication mechanism #3945
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -22,12 +22,9 @@ function init(): void {
 	} else {
 		// "Repository refresh" layout
 		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]:not(.rgh-download-folder)`)) {
-			deleteButton.classList.add('rgh-download-folder');
+			deleteButton.classList.add('rgh-download-folder'); // TODO: Drop when #3945 is completely fixed
 			deleteButton.before(
-				<a
-					className="dropdown-item btn-link"
-					href={downloadUrl.href}
-				>
+				<a className="dropdown-item" href={downloadUrl.href}>
 					Download directory
 				</a>
 			);

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -1,9 +1,9 @@
 import React from 'dom-chef';
 import select from 'select-dom';
-import {DownloadIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {getRepo} from '../github-helpers';
 
 function init(): void {
 	const downloadUrl = new URL('https://download-directory.github.io/');
@@ -21,15 +21,16 @@ function init(): void {
 		);
 	} else {
 		// "Repository refresh" layout
-		select('.file-navigation > .d-flex:last-child')!.append(
-			<a
-				className="btn ml-2"
-				href={downloadUrl.href}
-			>
-				<DownloadIcon className="mr-1"/>
-				Download
-			</a>
-		);
+		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`)) {
+			deleteButton.before(
+				<a
+					className="dropdown-item btn-link"
+					href={downloadUrl.href}
+				>
+					Download directory
+				</a>
+			);
+		}
 	}
 }
 
@@ -40,5 +41,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
+	repeatOnBackButton: true,
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -42,6 +42,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
-	repeatOnBackButton: true, // Due to anti-duplication mechanism #3945
+	repeatOnBackButton: true, // TODO: Drop when #3945 is completely fixed
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -21,7 +21,8 @@ function init(): void {
 		);
 	} else {
 		// "Repository refresh" layout
-		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`)) {
+		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]:not(.rgh-download-folder)`)) {
+			deleteButton.classList.add('rgh-download-folder');
 			deleteButton.before(
 				<a
 					className="dropdown-item btn-link"


### PR DESCRIPTION
1. LINKED ISSUES:
   Resolves #3949 

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/tree/main/media

3. SCREENSHOT:

	![image](https://user-images.githubusercontent.com/16872793/107176127-84471e00-699c-11eb-940c-b402493acdfc.png)

I added `repeatOnBackButton: true,` since I found that when going from dir to dir it was not applying unless I refreshed (nothing to do with the current PR)