### PR TITLE
Ensure `update-pr-from-base-branch` is always clickable

### DIFF
--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
+import delegate from 'delegate-it';
 import {AlertIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 import {observe, Observer} from 'selector-observer';
@@ -29,13 +30,13 @@ async function mergeBranches(): Promise<AnyObject> {
 	});
 }
 
-async function handler({currentTarget}: React.MouseEvent): Promise<void> {
+async function handler({delegateTarget}: delegate.Event): Promise<void> {
 	const {base, head} = getBranches();
 	if (!confirm(`Merge the ${base} branch into ${head}?`)) {
 		return;
 	}
 
-	const statusMeta = currentTarget.parentElement!;
+	const statusMeta = delegateTarget.parentElement!;
 	statusMeta.textContent = 'Updating branch…';
 	observer.abort();
 
@@ -56,13 +57,14 @@ async function addButton(position: Element): Promise<void> {
 	if (status === 'diverged') {
 		position.append(' ', (
 			<span className="status-meta d-inline-block rgh-update-pr-from-base-branch">
-				You can <button type="button" className="btn-link" onClick={handler}>update the base branch</button>.
+				You can <button type="button" className="btn-link">update the base branch</button>.
 			</span>
 		));
 	}
 }
 
 const waitForText = onetime(() => {
+	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler)
 	observer = observe(selectorForPushablePRNotice, {
 		add(position) {
 			position.classList.add('rgh-update-pr');

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -64,7 +64,7 @@ async function addButton(position: Element): Promise<void> {
 }
 
 const waitForText = onetime(() => {
-	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler)
+	delegate(document, '.rgh-update-pr-from-base-branch', 'click', handler);
 	observer = observe(selectorForPushablePRNotice, {
 		add(position) {
 			position.classList.add('rgh-update-pr');


### PR DESCRIPTION
Caused by #3931 

I was hoping that the link was short-lived enough that its listener wouldn't be lost. I was wrong. Event delegation it is, as it was.

1. Open a PR that needs to be updated, like https://github.com/sindresorhus/refined-github/pull/3955
2. Visit the PR Commits tab
3. Hit the browser’s back button
4. Try clicking the "Update base branch" button, it won't work