### PR TITLE
Add `link-to-changelog-file` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ Thanks for contributing! 🦋🙌
 - [](# "tag-changelog-link") 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/74594998-71df2080-5077-11ea-927c-b484ca656e88.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/16872793/90017455-8e03f900-dc79-11ea-95c5-377e0a82d4ea.png)
-- [](# "link-to-changelog.md") [Adds a button to view the changelog.md file if there is no release body.](https://user-images.githubusercontent.com/16872793/107317566-e40afb00-6a68-11eb-9d8b-b01da307dfb6.png)
+- [](# "link-to-changelog-file") [Adds a button to view the changelog.md file if there is no release body.](https://user-images.githubusercontent.com/16872793/107317566-e40afb00-6a68-11eb-9d8b-b01da307dfb6.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ Thanks for contributing! 🦋🙌
 - [](# "tag-changelog-link") 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/74594998-71df2080-5077-11ea-927c-b484ca656e88.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/16872793/90017455-8e03f900-dc79-11ea-95c5-377e0a82d4ea.png)
-- [](# "link-to-changelog-file") [Adds a button to view the changelog.md file if there is no release body.](https://user-images.githubusercontent.com/16872793/107317566-e40afb00-6a68-11eb-9d8b-b01da307dfb6.png)
+- [](# "link-to-changelog-file") [Adds a button to view the changelog file from the releases page.](https://user-images.githubusercontent.com/16872793/107465446-5bf02880-6b30-11eb-9e8b-f6b311e38489.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ Thanks for contributing! 🦋🙌
 - [](# "tag-changelog-link") 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/74594998-71df2080-5077-11ea-927c-b484ca656e88.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/16872793/90017455-8e03f900-dc79-11ea-95c5-377e0a82d4ea.png)
-- [](# "link-to-changelog-file") [Adds a button to view the changelog file from the releases page.](https://user-images.githubusercontent.com/16872793/107465446-5bf02880-6b30-11eb-9e8b-f6b311e38489.png)
+- [](# "link-to-changelog-file") [Adds a button to view the changelog file from the releases page.](https://user-images.githubusercontent.com/16872793/107520428-684fa200-6b7f-11eb-8f7c-59172db71160.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,7 @@ Thanks for contributing! 🦋🙌
 - [](# "tag-changelog-link") 🔥 [Adds a link to an automatic changelog for each tag/release.](https://user-images.githubusercontent.com/1402241/57081611-ad4a7180-6d27-11e9-9cb6-c54ec1ac18bb.png)
 - [](# "latest-tag-button") [Adds a link to the latest version tag on directory listings and files.](https://user-images.githubusercontent.com/1402241/74594998-71df2080-5077-11ea-927c-b484ca656e88.png)
 - [](# "convert-release-to-draft") [Adds a button to convert a release to draft.](https://user-images.githubusercontent.com/16872793/90017455-8e03f900-dc79-11ea-95c5-377e0a82d4ea.png)
+- [](# "link-to-changelog.md") [Adds a button to view the changelog.md file if there is no release body.](https://user-images.githubusercontent.com/16872793/107317566-e40afb00-6a68-11eb-9d8b-b01da307dfb6.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -28,10 +28,16 @@ async function fetchFromApi(): Promise<string | false > {
 		}
 	`);
 
-	return repository.object.entries.find((file: {name: string}) => file.name.toLowerCase().startsWith('changelog.'))?.name ?? false;
+	for (const file of repository.object.entries) {
+		if (file.name.toLowerCase().startsWith('changelog')) {
+			return file.name;
+		}
+	}
+
+	return false;
 }
 
-const doesChangelogExist = cache.function(async () => pageDetect.isRepoHome() ? parseFromDom() : fetchFromApi(), {
+const getChangelogName = cache.function(async () => pageDetect.isRepoHome() ? parseFromDom() : fetchFromApi(), {
 	cacheKey: getCacheKey
 });
 
@@ -48,10 +54,14 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	const url = buildRepoURL('blob', 'HEAD', changelog);
-	const tooltip = 'View the ' + changelog + ' file';
 	(await elementReady('.subnav div', {waitForChildren: false}))!.after(
-		<a className="btn ml-3 tooltipped tooltipped-n" aria-label={tooltip} href={url} style={{padding: '6px 16px'}} role="button">
+		<a
+			className="btn ml-3 tooltipped tooltipped-n"
+			aria-label={`View the ${changelog} file`}
+			href={buildRepoURL('blob', 'HEAD', changelog)}
+			style={{padding: '6px 16px'}}
+			role="button"
+		>
 			<BookIcon className="text-blue mr-2"/>
 			<span>Changelog</span>
 		</a>

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -13,7 +13,7 @@ const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
 async function parseFromDom(): Promise<false> {
 	await cache.delete(getCacheKey());
-	void cache.set(getCacheKey(), select('.js-navigation-item [title^="changelog." i]')?.textContent ?? false);
+	void cache.set(getCacheKey(), select('.js-navigation-item [title^="changelog" i]')?.textContent ?? false);
 	return false;
 }
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -12,7 +12,7 @@ import {buildRepoURL, getRepo} from '../github-helpers';
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
 function parseFromDom(): string | false {
-	return select('.js-navigation-item [title^="changelog" i]')?.textContent ?? false;
+	return select('.js-navigation-item [title^="changelog." i]')?.textContent ?? false;
 }
 
 async function fetchFromApi(): Promise<string | false > {
@@ -28,7 +28,7 @@ async function fetchFromApi(): Promise<string | false > {
 		}
 	`);
 
-	return repository.object.entries.find((file: {name: string}) => file.name.toLowerCase().startsWith('changelog'))?.name ?? false;
+	return repository.object.entries.find((file: {name: string}) => file.name.toLowerCase().startsWith('changelog.'))?.name ?? false;
 }
 
 const doesChangelogExist = cache.function(async () => pageDetect.isRepoHome() ? parseFromDom() : fetchFromApi(), {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -1,8 +1,8 @@
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import elementReady from 'element-ready';
 import {BookIcon} from '@primer/octicons-react';
+import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -51,7 +51,7 @@ async function init(): Promise<void | false> {
 	const url = buildRepoURL('blob', 'HEAD', changelog);
 	const tooltip = 'View the ' + changelog + ' file';
 	(await elementReady('.subnav div', {waitForChildren: false}))!.after(
-		<a className="btn ml-2 tooltipped tooltipped-s" aria-label={tooltip} href={url} style={{padding: '6px 16px'}} role="button">
+		<a className="btn ml-3 tooltipped tooltipped-n" aria-label={tooltip} href={url} style={{padding: '6px 16px'}} role="button">
 			<BookIcon className="text-blue mr-2"/>
 			<span>Changelog</span>
 		</a>

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -16,7 +16,7 @@ function parseFromDom(): false {
 	return false;
 }
 
-const getChangelogName = cache.function(async (): Promise<string | false > => {
+const getChangelogName = cache.function(async (): Promise<string | false> => {
 	const {repository} = await api.v4(`
 		repository() {
 			object(expression: "HEAD:") {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -11,8 +11,7 @@ import {buildRepoURL, getRepo} from '../github-helpers';
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
-async function parseFromDom(): Promise<false> {
-	await cache.delete(getCacheKey());
+function parseFromDom(): false {
 	void cache.set(getCacheKey(), select('.js-navigation-item [title^="changelog" i]')?.textContent ?? false);
 	return false;
 }

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -49,8 +49,9 @@ async function init(): Promise<void | false> {
 	}
 
 	const url = buildRepoURL('blob', 'HEAD', changelog);
+	const tooltip = 'View the ' + changelog + ' file';
 	(await elementReady('.subnav div', {waitForChildren: false}))!.after(
-		<a className="btn ml-2" href={url} style={{padding: '6px 16px'}} role="button">
+		<a className="btn ml-2 tooltipped tooltipped-s" aria-label={tooltip} href={url} style={{padding: '6px 16px'}} role="button">
 			<BookIcon className="text-blue mr-2"/>
 			<span>Changelog</span>
 		</a>

--- a/source/features/link-to-changelog.md.tsx
+++ b/source/features/link-to-changelog.md.tsx
@@ -11,7 +11,7 @@ import {buildRepoURL, getRepo} from '../github-helpers';
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
 function parseFromDom(): string | false {
-	return select('.js-navigation-item [title="changelog.md" i]')?.textContent ?? false;
+	return select('.js-navigation-item [title^="changelog" i]')?.textContent ?? false;
 }
 
 async function fetchFromApi(): Promise<string | false > {
@@ -27,7 +27,7 @@ async function fetchFromApi(): Promise<string | false > {
 		}
 	`);
 
-	return repository.object.entries.find((file: {name: string}) => /changelog\.md/i.exec(file.name))?.name ?? false;
+	return repository.object.entries.find((file: {name: string}) => file.name.toLowerCase().startsWith('changelog'))?.name ?? false;
 }
 
 const doesChangelogExist = cache.function(async () => pageDetect.isRepoHome() ? parseFromDom() : fetchFromApi(), {

--- a/source/features/link-to-changelog.md.tsx
+++ b/source/features/link-to-changelog.md.tsx
@@ -1,7 +1,8 @@
 import React from 'dom-chef';
 import cache from 'webext-storage-cache';
 import select from 'select-dom';
-import {FileIcon} from '@primer/octicons-react';
+import elementReady from 'element-ready';
+import {BookIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -48,21 +49,19 @@ async function init(): Promise<void | false> {
 	}
 
 	const url = buildRepoURL('blob', 'HEAD', changelog);
-	select('.details-reset.Details-element')!.before(
-		<a className="btn btn-sm btn-invisible mt-2 p-0" href={url} type="button">
-			<FileIcon/>
-			<span>View {changelog}</span>
+	(await elementReady('.subnav div', {waitForChildren: false}))!.after(
+		<a className="btn ml-2" href={url} style={{padding: '6px 16px'}} role="button">
+			<BookIcon className="text-blue mr-2"/>
+			<span>Changelog</span>
 		</a>
 	);
 }
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.isSingleTag
+		pageDetect.isReleasesOrTags
 	],
-	exclude: [
-		() => select.exists('.markdown-body, .label-draft')
-	],
+	awaitDomReady: false,
 	init
 }, {
 	include: [

--- a/source/features/link-to-changelog.md.tsx
+++ b/source/features/link-to-changelog.md.tsx
@@ -1,0 +1,75 @@
+import React from 'dom-chef';
+import cache from 'webext-storage-cache';
+import select from 'select-dom';
+import {FileIcon} from '@primer/octicons-react';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import * as api from '../github-helpers/api';
+import {buildRepoURL, getRepo} from '../github-helpers';
+
+const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
+
+function parseFromDom(): string | false {
+	return select('.js-navigation-item [title="changelog.md" i]')?.textContent ?? false;
+}
+
+async function fetchFromApi(): Promise<string | false > {
+	const {repository} = await api.v4(`
+		repository() {
+			object(expression: "HEAD:") {
+				...on Tree {
+					entries {
+						name
+					}
+				}
+			}
+		}
+	`);
+
+	return repository.object.entries.find((file: {name: string}) => /changelog\.md/i.exec(file.name))?.name ?? false;
+}
+
+const doesChangelogExist = cache.function(async () => pageDetect.isRepoHome() ? parseFromDom() : fetchFromApi(), {
+	cacheKey: getCacheKey
+});
+
+async function init(): Promise<void | false> {
+	// Always prefer the information in the DOM
+	if (pageDetect.isRepoHome()) {
+		await cache.delete(getCacheKey());
+		void doesChangelogExist();
+		return;
+	}
+
+	const changelog = await doesChangelogExist();
+	if (!changelog) {
+		return false;
+	}
+
+	const url = buildRepoURL('blob', 'HEAD', changelog);
+	select('.details-reset.Details-element')!.before(
+		<a className="btn btn-sm btn-invisible mt-2 p-0" href={url} type="button">
+			<FileIcon/>
+			<span>View {changelog}</span>
+		</a>
+	);
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isSingleTag
+	],
+	exclude: [
+		() => select.exists('.markdown-body, .label-draft')
+	],
+	init
+}, {
+	include: [
+		pageDetect.isRepoHome
+	],
+	exclude: [
+		pageDetect.isEmptyRepoRoot
+	],
+	init
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -207,7 +207,7 @@ import './features/easy-toggle-files';
 import './features/quick-repo-deletion';
 import './features/clean-repo-sidebar';
 import './features/rgh-feature-descriptions';
-import './features/link-to-changelog.md';
+import './features/link-to-changelog-file';
 
 // Add global for easier debugging
 (window as any).select = select;

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -207,6 +207,7 @@ import './features/easy-toggle-files';
 import './features/quick-repo-deletion';
 import './features/clean-repo-sidebar';
 import './features/rgh-feature-descriptions';
+import './features/link-to-changelog.md';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
1. LINKED ISSUES:
   Closes #3930 

2. TEST URLS: (will add more later)
   https://github.com/nodeca/js-yaml/releases/tag/4.0.0
https://github.com/pyca/cryptography/releases


3. SCREENSHOT: (Will update when layout confirmed)
   
![image](https://user-images.githubusercontent.com/16872793/107520428-684fa200-6b7f-11eb-8f7c-59172db71160.png)


