### PR TITLE
Fix `more-dropdown` on GHE

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -38,7 +38,12 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 }
 
 function onlyShowInDropdown(id: string): void {
-	select(`[data-tab-item$="${id}"]`)!.parentElement!.remove();
+	const tabItem = select(`[data-tab-item$="${id}"]`);
+	if (!tabItem) {
+		return;
+	}
+
+	tabItem.parentElement!.remove();
 	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -39,7 +39,7 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 
 function onlyShowInDropdown(id: string): void {
 	const tabItem = select(`[data-tab-item$="${id}"]`);
-	if (!tabItem && pageDetect.isEnterprise()) {
+	if (!tabItem && pageDetect.isEnterprise()) { // GHE might not have the Security tab #3962
 		return;
 	}
 

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -39,11 +39,11 @@ export function createDropdownItem(label: string, url: string, attributes?: Reco
 
 function onlyShowInDropdown(id: string): void {
 	const tabItem = select(`[data-tab-item$="${id}"]`);
-	if (!tabItem) {
+	if (!tabItem && pageDetect.isEnterprise()) {
 		return;
 	}
 
-	tabItem.parentElement!.remove();
+	tabItem!.parentElement!.remove();
 	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3953 

2. TEST URLS: Any repo page. The "Security" and "Insights" tabs should be moved to the dropdown.


My guess is that the bug is caused by the absence of the "Security" tab when doing:
```typescript
onlyShowInDropdown('security-tab');
onlyShowInDropdown('insights-tab');
```
I can't test this on GHE, but checking for the existence of the tab element should fix this.