### PR TITLE
Force `init` for some features

### DIFF
--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -65,5 +65,6 @@ void features.add(__filebasename, {
 		pageDetect.isSingleFile,
 		pageDetect.isGist
 	],
+	forceReinit: true,
 	init
 });

--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -39,6 +39,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
-	repeatOnBackButton: true, // TODO: Drop when #3945 is completely fixed
+	forceReinit: true,
 	init
 });

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -25,6 +25,9 @@ interface FeatureLoader extends Partial<InternalRunConfig> {
 	/** When pressing the back button, the DOM and listeners are still there, so normally `init` isn’t called again. If this is true, it’s called anyway.  @default false */
 	repeatOnBackButton?: true;
 
+	/** Force re-initialization on pjax:end event @default false */
+	forceReinit?: boolean;
+
 	/** When true, don’t run the `init` on page load but only add the `additionalListeners`. @default false */
 	onlyAdditionalListeners?: true;
 
@@ -211,6 +214,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 			awaitDomReady = true,
 			repeatOnBackButton = false,
 			onlyAdditionalListeners = false,
+			forceReinit = false,
 			additionalListeners = []
 		} = loader;
 
@@ -237,7 +241,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		}
 
 		document.addEventListener('pjax:end', () => {
-			if (repeatOnBackButton || !select.exists('has-rgh')) {
+			if (repeatOnBackButton || !select.exists('has-rgh') || forceReinit) {
 				void setupPageLoad(id, details);
 			}
 		});


### PR DESCRIPTION
Navigating to files doesn't reload the whole page. This causes some of the features to not initialize - a similar situation to `Go back` in the browser history.

Solution:

Added additional flag to force re-init on `pjax:end`, but it does the same thing as `repeatOnBackButton`. According to [pjax docs](https://github.com/defunkt/jquery-pjax#reinitializing-pluginswidget-on-new-page-content) this is something that we should do.

I added an additional flag for this one because the `repeatOnBackButton` name doesn't really fit in this case. I can merge those two with a better name if we agree that this solution is okay.

cc @fregante 

Closes #3945 
