### PR TITLE
Reimplement deduplication of features

### DIFF
--- a/source/features/download-folder-button.tsx
+++ b/source/features/download-folder-button.tsx
@@ -21,8 +21,7 @@ function init(): void {
 		);
 	} else {
 		// "Repository refresh" layout
-		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]:not(.rgh-download-folder)`)) {
-			deleteButton.classList.add('rgh-download-folder'); // TODO: Drop when #3945 is completely fixed
+		for (const deleteButton of select.all(`form[action^="/${getRepo()!.nameWithOwner}/tree/delete"]`)) {
 			deleteButton.before(
 				<a className="dropdown-item" href={downloadUrl.href}>
 					Download directory
@@ -39,6 +38,5 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isRepoRoot // Already has an native download ZIP button
 	],
-	repeatOnBackButton: true, // TODO: Drop when #3945 is completely fixed
 	init
 });

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -271,9 +271,11 @@ This marks each as "processed"
 */
 void add(__filebasename, {
 	init: () => {
-		if (!select.exists('rgh-features')) {
-			select('#js-repo-pjax-container, #js-pjax-container')?.append(<rgh-features/>);
+		if (select.exists('rgh-features')) {
+			select('rgh-features')?.remove()
 		}
+
+		select('#js-repo-pjax-container, #js-pjax-container')?.append(<rgh-features/>);
 	}
 });
 

--- a/source/globals.d.ts
+++ b/source/globals.d.ts
@@ -43,7 +43,7 @@ declare namespace JSX {
 		'clipboard-copy': IntrinsicElements.button & {for?: string};
 		'details-dialog': IntrinsicElements.div & {tabindex: string};
 		'details-menu': IntrinsicElements.div & {src?: string; preload?: boolean};
-		'has-rgh': IntrinsicElements.div;
+		'rgh-features': IntrinsicElements.div;
 		'include-fragment': IntrinsicElements.div & {src?: string};
 		'label': IntrinsicElements.label & {for?: string};
 		'relative-time': IntrinsicElements.div & {datetime: string};


### PR DESCRIPTION
Proposing a solution for a new feature deduplication mechanism. Instead of creating one empty `has-rgh` element, now we create `rgh-feature` element with different attributes. Whenever a feature loads, it adds an attribute to `rgh-feature` tag, preventing it from being loaded again in `pjax:end`.

I was roughly testing it on different pages but didn't notice anything wrong or unusual. Also, I am not sure if we should remove an attribute for features that have `deinit` function.

cc. @fregante 

Closes #3945
