### PR TITLE
Improve `clean-repo-sidebar`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -311,7 +311,7 @@ Thanks for contributing! 🦋🙌
 ### Fixes for GitHub shortcomings
 
 - [](# "hide-navigation-hover-highlight") Removes the file hover effect in the repo file browser.
-- [](# "clean-repo-sidebar") [Removes unnecessary or redundant information from the repository sidebar.](https://user-images.githubusercontent.com/46634000/102719129-781fd800-42ec-11eb-9552-dd3cfb4eeddd.png)
+- [](# "clean-repo-sidebar") [Removes unnecessary or redundant information from the repository sidebar.](https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png)
 - [](# "fix-first-tab-length") [Corrects the width of the first `tab` in file diffs since it appears 2 columns shorter than it should be.](https://user-images.githubusercontent.com/37769974/87217980-741a8200-c36c-11ea-81e1-fc0782c4624d.png)
 - [](# "hide-disabled-milestone-sorter") [Hides the milestone sorter UI if you don’t have permission to use it.](https://user-images.githubusercontent.com/7753001/56913933-738a2880-6ae5-11e9-9d13-1973cbbf5df0.png)
 - [](# "linkify-branch-references") [Linkifies branch references in "Quick PR" pages.](https://user-images.githubusercontent.com/1402241/30208043-fa1ceaec-94bb-11e7-9c32-feabcf7db296.png)

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -4,11 +4,16 @@
 }
 
 /* Hide "Readme" link made unnecessary by toggle-files-button #3580 */
-.rgh-clean-repo-sidebar .muted-link[href='#readme'] {
+.rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
 	display: none;
 }
 
 /* Hide "+n contributors" link */
 .rgh-clean-repo-sidebar ul.flex-wrap + .mt-3 {
 	display: none;
+}
+
+/* Align the top of the sidebar with the main page content */
+.rgh-clean-repo-sidebar .gutter-condensed > :last-child {
+	margin-top: -16px !important;
 }

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -16,7 +16,7 @@
 /* Merge "About" and "Releases" sections */
 .rgh-clean-releases .BorderGrid-cell {
 	border-color: transparent !important;
-	padding-bottom: 16px;
+	padding-bottom: 16px !important;
 }
 
 .rgh-clean-releases + .BorderGrid-row .BorderGrid-cell {

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -3,11 +3,6 @@
 	display: none;
 }
 
-/* Hide "Readme" link made unnecessary by toggle-files-button #3580 */
-.rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
-	display: none;
-}
-
 /* Hide "+n contributors" link */
 .rgh-clean-repo-sidebar ul.flex-wrap + .mt-3 {
 	display: none;

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -12,13 +12,3 @@
 .rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
 	display: none;
 }
-
-/* Merge "About" and "Releases" sections */
-.rgh-clean-releases .BorderGrid-cell {
-	border-color: transparent !important;
-	padding-bottom: 16px !important;
-}
-
-.rgh-clean-releases + .BorderGrid-row .BorderGrid-cell {
-	padding-top: 0 !important;
-}

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -12,3 +12,8 @@
 .rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
 	display: none;
 }
+
+/* Hide "+n contributors" link */
+.rgh-clean-repo-sidebar ul.flex-wrap + .mt-3 {
+	display: none;
+}

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -3,16 +3,8 @@
 	display: none;
 }
 
-/* Align top of "About" section with main content */
-.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type p,
-.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type .mt-3:first-of-type,
-/* Targets repo-age link when it's the only one in the section */
-.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type .mt-3:last-of-type:nth-of-type(2) {
-	margin-top: 0 !important;
-}
-
 /* Hide "Readme" link made unnecessary by toggle-files-button #3580 */
-.rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
+.rgh-clean-repo-sidebar .muted-link[href='#readme'] {
 	display: none;
 }
 

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -3,8 +3,11 @@
 	display: none;
 }
 
-/* Align description with main content */
-.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type p {
+/* Align top of "About" section with main content */
+.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type p,
+.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type .mt-3:first-of-type,
+/* Targets repo-age link when it's the only one in the section */
+.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type .mt-3:last-of-type:nth-of-type(2) {
 	margin-top: 0 !important;
 }
 

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -12,3 +12,13 @@
 .rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
 	display: none;
 }
+
+/* Merge "About" and "Releases" sections */
+.rgh-clean-releases .BorderGrid-cell {
+	border-color: transparent !important;
+	padding-bottom: 16px;
+}
+
+.rgh-clean-releases + .BorderGrid-row .BorderGrid-cell {
+	padding-top: 0 !important;
+}

--- a/source/features/clean-repo-sidebar.css
+++ b/source/features/clean-repo-sidebar.css
@@ -1,3 +1,13 @@
+/* Hide "About" header */
+.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type h2 {
+	display: none;
+}
+
+/* Align description with main content */
+.rgh-clean-repo-sidebar .BorderGrid-row:first-of-type p {
+	margin-top: 0 !important;
+}
+
 /* Hide "Readme" link made unnecessary by toggle-files-button #3580 */
 .rgh-clean-repo-sidebar h3.sr-only + .mt-3 .muted-link[href='#readme'] {
 	display: none;

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -11,7 +11,7 @@ async function init(): Promise<void> {
 	// Clean up "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
-		const releasesSection = sidebarReleases.closest('.BorderGrid-cell')!
+		const releasesSection = sidebarReleases.closest('.BorderGrid-cell')!;
 
 		// Collapse "Releases" section into previous section
 		releasesSection.classList.add('border-0', 'pt-3');

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -13,14 +13,6 @@ async function init(): Promise<void> {
 	if (sidebarReleases) {
 		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-cell')!;
 		if (select.exists('.octicon-tag', releasesSection)) {
-			// Align latest tag icon with the icons of other meta links
-			const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection)!;
-			if (tagIcon) {
-				tagIcon.classList.add('mr-2');
-				// Remove whitespace node
-				tagIcon.nextSibling!.remove();
-			}
-
 			// Collapse "Releases" section into previous section
 			releasesSection.classList.add('border-0', 'pt-3');
 			sidebarReleases.closest('.BorderGrid-row')!
@@ -32,10 +24,23 @@ async function init(): Promise<void> {
 			for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
 				uselessInformation.hidden = true;
 			}
+
+			// Align latest tag icon with the icons of other meta links
+			const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection)!;
+			if (tagIcon) {
+				tagIcon.classList.add('mr-2');
+				// Remove whitespace node
+				tagIcon.nextSibling!.remove();
+			}
 		} else {
 			// Hide the whole section if there's no releases
 			releasesSection.hidden = true;
 		}
+	}
+
+	// Hide empty meta if it’s not editable by the current user
+	if (!pageDetect.canUserEditRepo()) {
+		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
 	}
 
 	// Hide empty "Packages" section
@@ -44,19 +49,11 @@ async function init(): Promise<void> {
 		packagesCounter.closest<HTMLElement>('.BorderGrid-row')!.hidden = true;
 	}
 
-	// Hide empty meta if it’s not editable by the current user
-	if (!pageDetect.canUserEditRepo()) {
-		select('.repository-content .BorderGrid-cell:first-child > .text-italic')?.remove();
-	}
-
 	// Hide "Language" header
 	const lastSidebarHeader = select('.repository-content .BorderGrid-row:last-of-type h2');
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
-
-	// Align the top of the sidebar with the main page content
-	select('.repository-content .BorderGrid-cell:first-child > .mt-3')?.classList.remove('mt-3');
 }
 
 void features.add(__filebasename, {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -32,10 +32,6 @@ async function init(): Promise<void> {
 	// Hide empty meta if it’s not editable by the current user
 	if (!pageDetect.canUserEditRepo()) {
 		select('.repository-content .BorderGrid-cell:first-child > .text-italic')?.remove();
-		// Hide the "About" section entirely if empty
-		if (!select.exists('.repository-content .BorderGrid-row:first-child .BorderGrid-cell:first-child > :not(h2)')) {
-			select('.repository-content .BorderGrid-row:first-child')!.hidden = true;
-		}
 	}
 
 	// Hide "Language" header

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -24,6 +24,14 @@ async function init(): Promise<void> {
 		for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
 			uselessInformation.hidden = true;
 		}
+
+		// Align latest tag icon with the icons of other meta links
+		const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection);
+		if (tagIcon) {
+			tagIcon.classList.add('mr-2');
+			// Remove whitespace node
+			tagIcon.nextSibling!.remove();
+		}
 	}
 
 	// Hide empty "Packages" section

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -9,12 +9,12 @@ async function init(): Promise<void> {
 	document.body.classList.add('rgh-clean-repo-sidebar');
 
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
-	(await elementReady('.repository-content .BorderGrid-row:first-child .muted-link[href="#readme"]', {waitForChildren: false}))?.parentElement!.remove();
+	(await elementReady('.muted-link[href="#readme"]'))?.parentElement!.remove();
 
 	// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
-	const licenseLinkText = (await elementReady('.repository-content .BorderGrid-row:first-child [href*="/license" i]', {waitForChildren: false}))?.childNodes[2];
-	if (licenseLinkText) {
-		licenseLinkText.textContent = licenseLinkText.textContent!.trim();
+	const licenseLink = await elementReady('.repository-content .octicon-law');
+	if (licenseLink) {
+		licenseLink.nextSibling!.textContent = licenseLink.nextSibling!.textContent!.trim();
 	}
 
 	// Clean up "Releases" section

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -1,57 +1,74 @@
 import './clean-repo-sidebar.css';
 import select from 'select-dom';
+import domLoaded from 'dom-loaded';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-async function init(): Promise<void> {
-	document.body.classList.add('rgh-clean-repo-sidebar');
-
+async function removeReadmeLink(): Promise<void> {
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
 	(await elementReady('.muted-link[href="#readme"]'))?.parentElement!.remove();
+}
 
+async function cleanLicenseText(): Promise<void> {
 	// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
 	const licenseLink = await elementReady('.repository-content .octicon-law');
 	if (licenseLink) {
 		licenseLink.nextSibling!.textContent = licenseLink.nextSibling!.textContent!.trim();
 	}
+}
 
-	// Clean up "Releases" section
+async function cleanReleases(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
-	if (sidebarReleases) {
-		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-cell')!;
-		if (select.exists('.octicon-tag', releasesSection)) {
-			// Collapse "Releases" section into previous section
-			releasesSection.classList.add('border-0', 'pt-3');
-			sidebarReleases.closest('.BorderGrid-row')!
-				.previousElementSibling! // About’s .BorderGrid-row
-				.firstElementChild! // About’s .BorderGrid-cell
-				.classList.add('border-0', 'pb-0');
-
-			// Hide header and footer
-			for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
-				uselessInformation.hidden = true;
-			}
-
-			// Align latest tag icon with the icons of other meta links
-			const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection)!;
-			if (tagIcon) {
-				tagIcon.classList.add('mr-2');
-				// Remove whitespace node
-				tagIcon.nextSibling!.remove();
-			}
-		} else {
-			// Hide the whole section if there's no releases
-			releasesSection.hidden = true;
-		}
+	if (!sidebarReleases) {
+		return;
 	}
 
-	// Hide empty "Packages" section
+	const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-cell')!;
+	if (!select.exists('.octicon-tag', releasesSection)) {
+		// Hide the whole section if there's no releases
+		releasesSection.hidden = true;
+		return;
+	}
+
+	// Collapse "Releases" section into previous section
+	releasesSection.classList.add('border-0', 'pt-3');
+	sidebarReleases.closest('.BorderGrid-row')!
+		.previousElementSibling! // About’s .BorderGrid-row
+		.firstElementChild! // About’s .BorderGrid-cell
+		.classList.add('border-0', 'pb-0');
+
+	// Hide header and footer
+	for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
+		uselessInformation.hidden = true;
+	}
+
+	// Align latest tag icon with the icons of other meta links
+	const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection)!;
+	if (tagIcon) {
+		tagIcon.classList.add('mr-2');
+		// Remove whitespace node
+		tagIcon.nextSibling!.remove();
+	}
+}
+
+async function hideEmptyPackages(): Promise<void> {
 	const packagesCounter = await elementReady('.BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false})!;
 	if (packagesCounter && packagesCounter.textContent === '0') {
 		packagesCounter.closest<HTMLElement>('.BorderGrid-row')!.hidden = true;
 	}
+}
+
+async function init(): Promise<void> {
+	document.body.classList.add('rgh-clean-repo-sidebar');
+
+	void removeReadmeLink();
+	void cleanLicenseText();
+	void cleanReleases();
+	void hideEmptyPackages();
+
+	await domLoaded;
 
 	// Hide empty meta if it’s not editable by the current user
 	if (!pageDetect.canUserEditRepo()) {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -1,11 +1,9 @@
 import './clean-repo-sidebar.css';
-import React from 'dom-chef';
 import select from 'select-dom';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {wrap} from '../helpers/dom-utils';
 
 async function init(): Promise<void> {
 	document.body.classList.add('rgh-clean-repo-sidebar');
@@ -14,13 +12,10 @@ async function init(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
 		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-row')!;
-		const latestRelease = select('a[href*="/releases/"]', releasesSection);
-		if (latestRelease) {
-			releasesSection.previousElementSibling!.firstElementChild!.append(latestRelease);
-			wrap(latestRelease, <div className="mt-3"/>);
+		releasesSection.previousElementSibling!.classList.add('rgh-clean-releases');
+		for (const uselessInformation of select.all('.BorderGrid-cell > :not(a)', releasesSection)) {
+			uselessInformation.hidden = true;
 		}
-
-		releasesSection.hidden = true;
 	}
 
 	// Hide empty "Packages" section

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -11,26 +11,28 @@ async function init(): Promise<void> {
 	// Clean up "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
-		const releasesSection = sidebarReleases.closest('.BorderGrid-cell')!;
-
-		// Collapse "Releases" section into previous section
-		releasesSection.classList.add('border-0', 'pt-3');
-		sidebarReleases.closest('.BorderGrid-row')!
-			.previousElementSibling! // About’s .BorderGrid-row
-			.firstElementChild! // About’s .BorderGrid-cell
-			.classList.add('border-0', 'pb-0');
-
-		// Hide header and footer
-		for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
-			uselessInformation.hidden = true;
-		}
-
-		// Align latest tag icon with the icons of other meta links
+		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-cell')!;
 		const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection);
-		if (tagIcon) {
+		if (!tagIcon) {
+			// Hide the whole section if there's no releases
+			releasesSection.hidden = true;
+		} else {
+			// Align latest tag icon with the icons of other meta links
 			tagIcon.classList.add('mr-2');
 			// Remove whitespace node
 			tagIcon.nextSibling!.remove();
+
+			// Collapse "Releases" section into previous section
+			releasesSection.classList.add('border-0', 'pt-3');
+			sidebarReleases.closest('.BorderGrid-row')!
+				.previousElementSibling! // About’s .BorderGrid-row
+				.firstElementChild! // About’s .BorderGrid-cell
+				.classList.add('border-0', 'pb-0');
+
+			// Hide header and footer
+			for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
+				uselessInformation.hidden = true;
+			}
 		}
 	}
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -11,6 +11,12 @@ async function init(): Promise<void> {
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
 	(await elementReady('.repository-content .BorderGrid-row:first-child .muted-link[href="#readme"]', {waitForChildren: false}))?.parentElement!.remove();
 
+	// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
+	const licenseLinkText = (await elementReady('.repository-content .BorderGrid-row:first-child [href*="/license" i]', {waitForChildren: false}))?.childNodes[2];
+	if (licenseLinkText) {
+		licenseLinkText.textContent = licenseLinkText.textContent!.trim();
+	}
+
 	// Clean up "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
@@ -41,15 +47,15 @@ async function init(): Promise<void> {
 		}
 	}
 
-	// Hide empty meta if it’s not editable by the current user
-	if (!pageDetect.canUserEditRepo()) {
-		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
-	}
-
 	// Hide empty "Packages" section
 	const packagesCounter = await elementReady('.BorderGrid-cell a[href*="/packages?"] .Counter', {waitForChildren: false})!;
 	if (packagesCounter && packagesCounter.textContent === '0') {
 		packagesCounter.closest<HTMLElement>('.BorderGrid-row')!.hidden = true;
+	}
+
+	// Hide empty meta if it’s not editable by the current user
+	if (!pageDetect.canUserEditRepo()) {
+		select('.repository-content .BorderGrid-cell > .text-italic')?.remove();
 	}
 
 	// Hide "Language" header

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -11,9 +11,17 @@ async function init(): Promise<void> {
 	// Clean up "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
-		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-row')!;
-		releasesSection.previousElementSibling!.classList.add('rgh-clean-releases');
-		for (const uselessInformation of select.all('.BorderGrid-cell > :not(a)', releasesSection)) {
+		const releasesSection = sidebarReleases.closest('.BorderGrid-cell')!
+
+		// Collapse "Releases" section into previous section
+		releasesSection.classList.add('border-0');
+		sidebarReleases.closest('.BorderGrid-row')!
+			.previousElementSibling! // About’s .BorderGrid-row
+			.firstElementChild! // About’s .BorderGrid-cell
+			.classList.add('border-0', 'pb-0');
+
+		// Hide header and footer
+		for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
 			uselessInformation.hidden = true;
 		}
 	}

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -12,15 +12,14 @@ async function init(): Promise<void> {
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {
 		const releasesSection = sidebarReleases.closest<HTMLElement>('.BorderGrid-cell')!;
-		const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection);
-		if (!tagIcon) {
-			// Hide the whole section if there's no releases
-			releasesSection.hidden = true;
-		} else {
+		if (select.exists('.octicon-tag', releasesSection)) {
 			// Align latest tag icon with the icons of other meta links
-			tagIcon.classList.add('mr-2');
-			// Remove whitespace node
-			tagIcon.nextSibling!.remove();
+			const tagIcon = select('.octicon-tag:not(.text-green)', releasesSection)!;
+			if (tagIcon) {
+				tagIcon.classList.add('mr-2');
+				// Remove whitespace node
+				tagIcon.nextSibling!.remove();
+			}
 
 			// Collapse "Releases" section into previous section
 			releasesSection.classList.add('border-0', 'pt-3');
@@ -33,6 +32,9 @@ async function init(): Promise<void> {
 			for (const uselessInformation of select.all(':scope > :not(a)', releasesSection)) {
 				uselessInformation.hidden = true;
 			}
+		} else {
+			// Hide the whole section if there's no releases
+			releasesSection.hidden = true;
 		}
 	}
 
@@ -52,6 +54,9 @@ async function init(): Promise<void> {
 	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
+
+	// Align the top of the sidebar with the main page content
+	select('.repository-content .BorderGrid-cell:first-child > .mt-3')?.classList.remove('mt-3');
 }
 
 void features.add(__filebasename, {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -8,6 +8,9 @@ import features from '.';
 async function init(): Promise<void> {
 	document.body.classList.add('rgh-clean-repo-sidebar');
 
+	// Hide "Readme" link made unnecessary by toggle-files-button #3580
+	(await elementReady('.repository-content .BorderGrid-row:first-child .muted-link[href="#readme"]', {waitForChildren: false}))?.parentElement!.remove();
+
 	// Clean up "Releases" section
 	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
 	if (sidebarReleases) {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -14,7 +14,7 @@ async function init(): Promise<void> {
 		const releasesSection = sidebarReleases.closest('.BorderGrid-cell')!
 
 		// Collapse "Releases" section into previous section
-		releasesSection.classList.add('border-0');
+		releasesSection.classList.add('border-0', 'pt-3');
 		sidebarReleases.closest('.BorderGrid-row')!
 			.previousElementSibling! // About’s .BorderGrid-row
 			.firstElementChild! // About’s .BorderGrid-cell

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -40,7 +40,7 @@ async function init(): Promise<void> {
 
 	// Hide "Language" header
 	const lastSidebarHeader = select('.repository-content .BorderGrid-row:last-of-type h2');
-	if (lastSidebarHeader && lastSidebarHeader.textContent === 'Languages') {
+	if (lastSidebarHeader?.textContent === 'Languages') {
 		lastSidebarHeader.hidden = true;
 	}
 }

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -103,8 +103,7 @@ async function init(): Promise<void> {
 	if (sidebarAboutSection) {
 		sidebarAboutSection.append(
 			<h3 className="sr-only">Repository age</h3>,
-			// Only add a top margin if there's other visible elements in the "About" section
-			<div className={select.exists(':scope > .mt-3', sidebarAboutSection) ? 'mt-3' : ''}>
+			<div className="mt-3">
 				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 					<RepoIcon className="mr-2"/>{age}
 				</a>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -110,12 +110,6 @@ async function init(): Promise<void> {
 			</div>
 		);
 
-		// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
-		const licenseLinkText = select('[href$="/license"]', sidebarAboutSection)?.childNodes[2];
-		if (licenseLinkText) {
-			licenseLinkText.textContent = licenseLinkText.textContent!.trim();
-		}
-
 		return;
 	}
 

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -111,8 +111,10 @@ async function init(): Promise<void> {
 		);
 
 		// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
-		const licenseLinkText = select('[href$="/license"]', sidebarAboutSection)!.childNodes[2]!;
-		licenseLinkText.textContent = licenseLinkText.textContent!.trim();
+		const licenseLinkText = select('[href$="/license"]', sidebarAboutSection)?.childNodes[2];
+		if (licenseLinkText) {
+			licenseLinkText.textContent = licenseLinkText.textContent!.trim();
+		}
 
 		return;
 	}

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -110,7 +110,7 @@ async function init(): Promise<void> {
 			</div>
 		);
 
-		// Remove whitespace in license link to fix vertical alignment https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
+		// Remove whitespace in license link to fix alignment of icons https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
 		const licenseLinkText = select('[href$="/license"]', sidebarAboutSection)!.childNodes[2]!;
 		licenseLinkText.textContent = licenseLinkText.textContent!.trim();
 

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -103,7 +103,8 @@ async function init(): Promise<void> {
 	if (sidebarAboutSection) {
 		sidebarAboutSection.append(
 			<h3 className="sr-only">Repository age</h3>,
-			<div className="mt-3">
+			// Only add a top margin if there's other visible elements in the "About" section
+			<div className={select.exists(':scope > .mt-3', sidebarAboutSection) ? 'mt-3' : ''}>
 				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 					<RepoIcon className="mr-2"/>{age}
 				</a>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -105,10 +105,14 @@ async function init(): Promise<void> {
 			<h3 className="sr-only">Repository age</h3>,
 			<div className="mt-3">
 				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
-					<RepoIcon className="mr-2"/> {age}
+					<RepoIcon className="mr-2"/>{age}
 				</a>
 			</div>
 		);
+
+		// Remove whitespace in license link to fix vertical alignment https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892
+		const licenseLinkText = select('[href$="/license"]', sidebarAboutSection)!.childNodes[2]!;
+		licenseLinkText.textContent = licenseLinkText.textContent!.trim();
 
 		return;
 	}


### PR DESCRIPTION
<!-- Please follow the template -->

1. LINKED ISSUES: Closes #3972

2. TEST URLS:
* [Description, releases & no packages](https://github.com/sindresorhus/refined-github)
* [Packages & releases](https://github.com/Jaboo9/github-packages)
* [Empty meta](https://github.com/Witold101/wpw)
* Releases:
  * [No "Releases" section](https://github.com/co1ncidence/mountaineer.vim)
  * [Empty "Releases" section](https://github.com/justinfrankel/licecap)
  * [Tags instead of releases](https://github.com/tpope/vim-unimpaired)
* Alignments:
  * [Top of "About" section with no description](https://github.com/broofa/npmgraph)
  * [Repo age & latest tag icon](https://github.com/tpope/vim-unimpaired)
  * [License, repo age & latest release icons](https://github.com/sindresorhus/refined-github)
3. SCREENSHOTS:

<details>
<summary>Description, releases & no packages</summary>

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

<img src="https://user-images.githubusercontent.com/46634000/107881112-0a0a2280-6ee3-11eb-9f05-67bfbe1f5e55.png" width="220">
	<td valign="top">

<img src="https://user-images.githubusercontent.com/46634000/107881124-24dc9700-6ee3-11eb-8acb-9b52b97af4e8.png" width="220">
</table>

</details>

<details>
<summary>Packages</summary>

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

<img src="https://user-images.githubusercontent.com/46634000/107881220-b8ae6300-6ee3-11eb-8d7e-eb56365742f7.png" width="220">
	<td valign="top">

<img src="https://user-images.githubusercontent.com/46634000/107881233-c19f3480-6ee3-11eb-86ec-def665edaa5c.png" width="220">
</table>

</details>

<details>

<summary>No releases</summary>

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

<img src="https://user-images.githubusercontent.com/46634000/107881258-e0053000-6ee3-11eb-9a80-c224ffa5f905.png" width="220">
	<td valign="top">

<img src="https://user-images.githubusercontent.com/46634000/107881260-e1365d00-6ee3-11eb-9322-386f2c3f4ff0.png" width="220">
</table>

</details>

<details>
<summary>Empty meta</summary>

<table>
<tr>
	<th>Before
	<th>After
<tr>
	<td>

<img src="https://user-images.githubusercontent.com/46634000/107881270-e85d6b00-6ee3-11eb-9e4a-dfe6051f2db0.png" width="220">
	<td valign="top">

<img src="https://user-images.githubusercontent.com/46634000/107881272-e98e9800-6ee3-11eb-88b3-71c97f30be5a.png" width="220">
</table>

</details>

<details>
<summary>Readme demo screenshot</summary>

![clean-repo-sidebar](https://user-images.githubusercontent.com/46634000/107955448-18694480-6f9e-11eb-8bc6-80cc90d910bc.png)

</details>

This PR:
 - Hides the "About" and "Languages" headers
 - Aligns the top of the "About" section with the main page content
 - ~~Moves the latest release link to the "About" section and hides the "Releases" section~~ → Hides everything in the "Releases" section except the latest tag/release and merge "About" with "Releases"
 - Hides the whole "Releases" section if there's no releases
 - ~~Hides the whole "About" section if it's completely empty (no description, no license, no releases)~~ (https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-778843060)
 - Fixes the alignment of the icons for the meta links (license, repo age & latest tag/release) (https://github.com/sindresorhus/refined-github/pull/3974#issuecomment-780213892)

TODO:
 - [x] Test against repos with tags instead of releases
 - [x] Fix "conflict" with `repo-age`
 - [x] Test in Chromium
 - [x] Fix tag spacing
 - [x] Fix top alignment