### PR TITLE
Enable `parse-backticks` on Discussions

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -41,7 +41,9 @@ function init(): void {
 		'.notifications-list-item p.text-normal', // `isNotifications` issue and PR title
 		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
-		'.js-hovercard-content > .Popover-message .link-gray-dark' // Hovercard
+		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard
+		'.js-issue-title', // for discussion pages'
+		'a[data-hovercard-type="discussion"]' // for discussion listings
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join();
 
 	observe(selectors, {

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -42,8 +42,8 @@ function init(): void {
 		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
 		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard
-		'.js-issue-title', // for discussion pages'
-		'a[data-hovercard-type="discussion"]' // for discussion listings
+		'.js-issue-title', // `isSingleDiscussion`
+		'a[data-hovercard-type="discussion"]' // `isDiscussionList`
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join();
 
 	observe(selectors, {

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -42,7 +42,7 @@ function init(): void {
 		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
 		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard
-		'.js-issue-title', // `isSingleDiscussion`
+		'.js-issue-title', // `isDiscussion`
 		'a[data-hovercard-type="discussion"]' // `isDiscussionList`
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join();
 


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Closes #3975 

2. TEST URLS:
https://github.com/tophf/mpiv/discussions/50
https://github.com/tophf/mpiv/discussions


3. SCREENSHOT:
![2021-02-14_182616](https://user-images.githubusercontent.com/723651/107882473-42fdc380-6ef2-11eb-998e-119dc6a35f02.jpg)
![2021-02-14_182548](https://user-images.githubusercontent.com/723651/107882480-46914a80-6ef2-11eb-8d32-cdb3e991a3c5.jpg)

This PR adds 2 selectors in `source/features/parse-backticks.tsx` (for discussion pages and listings) .