### PR TITLE
Keep diff stats in "Jump to" dropdown when header is fixed

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -131,3 +131,8 @@ pr-branches
 .WorkflowRunLogsScroll {
 	height: auto !important;
 }
+
+/* Fix #3925 */
+.select-menu-item-text .diffstat {
+	display: inline !important;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -132,7 +132,7 @@ pr-branches
 	height: auto !important;
 }
 
-/* Fix #3925 */
+/* Keep diff stats in "Jump to" dropdown when header is fixed (fix https://github.com/sindresorhus/refined-github/issues/3925) */
 .select-menu-item-text .diffstat {
 	display: inline !important;
 }

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -132,7 +132,7 @@ pr-branches
 	height: auto !important;
 }
 
-/* Keep diff stats in "Jump to" dropdown when header is fixed (fix https://github.com/sindresorhus/refined-github/issues/3925) */
+/* Keep diff stats in "Jump to" dropdown when the header is fixed #3925 */
 .select-menu-item-text .diffstat {
 	display: inline !important;
 }


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3925 

2. TEST URLS: https://github.com/sindresorhus/refined-github/pull/3922/files

3. SCREENSHOT:
<table>
<tr>
	<th>Before
	<td>

![image](https://user-images.githubusercontent.com/46634000/107958476-55cfd100-6fa2-11eb-92ae-056a87bd403d.png)
<tr>
	<th>After
	<td>

![image](https://user-images.githubusercontent.com/46634000/107958344-26b95f80-6fa2-11eb-8e21-40e442560877.png)
</table>

The original selector that hides the diff stats is `.is-stuck .diffbar .diffstat`, but since I don't know what else it might affect, I chose something more specific to this particular layout.

Also should this be added to the readme?