### PR TITLE
Ignore triple-backtick blocks in `parse-backticks`

### DIFF
--- a/source/github-helpers/parse-backticks.tsx
+++ b/source/github-helpers/parse-backticks.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 
-const splittingRegex = /`` (.*?) ``|`(.*?)`/g;
+const splittingRegex = /`` (.*?) ``|`([^\n].+?)`/g;
 
 export function getParsedBackticksParts(string: string): string[] {
 	return string.split(splittingRegex)

--- a/source/github-helpers/parse-backticks.tsx
+++ b/source/github-helpers/parse-backticks.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 
-const splittingRegex = /`` (.*?) ``|`([^`]+)`/g;
+const splittingRegex = /`` (.*?) ``|`([^`\n]+)`/g;
 
 export function getParsedBackticksParts(string: string): string[] {
 	return string.split(splittingRegex)

--- a/source/github-helpers/parse-backticks.tsx
+++ b/source/github-helpers/parse-backticks.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 
-const splittingRegex = /`` (.*?) ``|`([^\n].+?)`/g;
+const splittingRegex = /`` (.*?) ``|`([^`\n].*?)`/g;
 
 export function getParsedBackticksParts(string: string): string[] {
 	return string.split(splittingRegex)

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -281,6 +281,16 @@ test('parseBackticks', t => {
 			in some text #3990
 		`
 	);
+	t.is(
+		parseBackticks(`
+			hello\`
+			\`world
+		`),
+		`
+			hello\`
+			\`world
+		`
+	);
 });
 
 test('isUselessComment', t => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -266,7 +266,7 @@ test('parseBackticks', t => {
 	t.is(
 		parseBackticks(`
 			triple-backtick multiline block
-			${'```'}javascript
+			${'```'}
 			foo
 			bar
 			${'```'}
@@ -274,6 +274,36 @@ test('parseBackticks', t => {
 		`),
 		`
 			triple-backtick multiline block
+			${'```'}
+			foo
+			bar
+			${'```'}
+			in some text #3990
+		`
+	);
+	t.is(
+		parseBackticks(`
+			empty triple-backtick block
+			${'```'}
+			${'```'}
+		`),
+		`
+			empty triple-backtick block
+			${'```'}
+			${'```'}
+		`
+	);
+	t.is(
+		parseBackticks(`
+			triple-backtick code block
+			${'```'}javascript
+			foo
+			bar
+			${'```'}
+			in some text #3990
+		`),
+		`
+			triple-backtick code block
 			${'```'}javascript
 			foo
 			bar

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -14,7 +14,6 @@ import {
 	prCommitUrlRegex,
 	prCompareUrlRegex
 } from '../source/github-helpers';
-import {getParsedBackticksParts} from '../source/github-helpers/parse-backticks';
 import isUselessComment from '../source/helpers/useless-comments';
 
 test('getConversationNumber', t => {
@@ -229,97 +228,6 @@ test('preventPrCommitLinkLoss', t => {
 		replaceCompareLink('I like [turtles](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)'),
 		'I like [turtles](https://github.com/sindresorhus/got/compare/v11.5.2...v11.6.0#diff-6be2971b2bb8dbf48d15ff680dd898b0R191)',
 		'It should ignore Markdown links'
-	);
-});
-
-function parseBackticks(string: string): string {
-	return getParsedBackticksParts(string).map(
-		(part, index) => index % 2 && part.length > 0 ? `<code>${part.trim()}</code>` : part
-	).join('');
-}
-
-test('parseBackticks', t => {
-	t.is(
-		parseBackticks('multiple `code spans` between ` other ` text'),
-		'multiple <code>code spans</code> between <code>other</code> text'
-	);
-	t.is(
-		parseBackticks('`code` at the start'),
-		'<code>code</code> at the start'
-	);
-	t.is(
-		parseBackticks('code at the `end`'),
-		'code at the <code>end</code>'
-	);
-	t.is(
-		parseBackticks('single backtick in a code span: `` ` ``'),
-		'single backtick in a code span: <code>`</code>'
-	);
-	t.is(
-		parseBackticks('backtick-delimited string in a code span: `` `foo` ``'),
-		'backtick-delimited string in a code span: <code>`foo`</code>'
-	);
-	t.is(
-		parseBackticks('single-character code span: `a`'),
-		'single-character code span: <code>a</code>'
-	);
-	t.is(
-		parseBackticks(`
-			triple-backtick multiline block
-			${'```'}
-			foo
-			bar
-			${'```'}
-			in some text #3990
-		`),
-		`
-			triple-backtick multiline block
-			${'```'}
-			foo
-			bar
-			${'```'}
-			in some text #3990
-		`
-	);
-	t.is(
-		parseBackticks(`
-			empty triple-backtick block
-			${'```'}
-			${'```'}
-		`),
-		`
-			empty triple-backtick block
-			${'```'}
-			${'```'}
-		`
-	);
-	t.is(
-		parseBackticks(`
-			triple-backtick code block
-			${'```'}javascript
-			foo
-			bar
-			${'```'}
-			in some text #3990
-		`),
-		`
-			triple-backtick code block
-			${'```'}javascript
-			foo
-			bar
-			${'```'}
-			in some text #3990
-		`
-	);
-	t.is(
-		parseBackticks(`
-			hello\`
-			\`world
-		`),
-		`
-			hello\`
-			\`world
-		`
 	);
 });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -259,6 +259,24 @@ test('parseBackticks', t => {
 		parseBackticks('backtick-delimited string in a code span: `` `foo` ``'),
 		'backtick-delimited string in a code span: <code>`foo`</code>'
 	);
+	t.is(
+		parseBackticks(`
+			triple-backtick multiline block
+			${'```'}javascript
+			foo
+			bar
+			${'```'}
+			in some text #3990
+		`),
+		`
+			triple-backtick multiline block
+			${'```'}javascript
+			foo
+			bar
+			${'```'}
+			in some text #3990
+		`
+	);
 });
 
 test('isUselessComment', t => {

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -260,6 +260,10 @@ test('parseBackticks', t => {
 		'backtick-delimited string in a code span: <code>`foo`</code>'
 	);
 	t.is(
+		parseBackticks('single-character code span: `a`'),
+		'single-character code span: <code>a</code>'
+	);
+	t.is(
 		parseBackticks(`
 			triple-backtick multiline block
 			${'```'}javascript

--- a/test/parse-backticks.ts
+++ b/test/parse-backticks.ts
@@ -1,0 +1,94 @@
+import test from 'ava';
+
+import {getParsedBackticksParts} from '../source/github-helpers/parse-backticks';
+
+function parseBackticks(string: string): string {
+	return getParsedBackticksParts(string).map(
+		(part, index) => index % 2 && part.length > 0 ? `<code>${part.trim()}</code>` : part
+	).join('');
+}
+
+test('parseBackticks', t => {
+	t.is(
+		parseBackticks('multiple `code spans` between ` other ` text'),
+		'multiple <code>code spans</code> between <code>other</code> text'
+	);
+	t.is(
+		parseBackticks('`code` at the start'),
+		'<code>code</code> at the start'
+	);
+	t.is(
+		parseBackticks('code at the `end`'),
+		'code at the <code>end</code>'
+	);
+	t.is(
+		parseBackticks('single backtick in a code span: `` ` ``'),
+		'single backtick in a code span: <code>`</code>'
+	);
+	t.is(
+		parseBackticks('backtick-delimited string in a code span: `` `foo` ``'),
+		'backtick-delimited string in a code span: <code>`foo`</code>'
+	);
+	t.is(
+		parseBackticks('single-character code span: `a`'),
+		'single-character code span: <code>a</code>'
+	);
+	t.is(
+		parseBackticks(`
+			triple-backtick multiline block
+			\`\`\`
+			foo
+			bar
+			\`\`\`
+			in some text #3990
+		`),
+		`
+			triple-backtick multiline block
+			\`\`\`
+			foo
+			bar
+			\`\`\`
+			in some text #3990
+		`
+	);
+	t.is(
+		parseBackticks(`
+			empty triple-backtick block
+			\`\`\`
+			\`\`\`
+		`),
+		`
+			empty triple-backtick block
+			\`\`\`
+			\`\`\`
+		`
+	);
+	t.is(
+		parseBackticks(`
+			triple-backtick code block
+			\`\`\`
+			foo
+			bar
+			\`\`\`
+			in some text #3990
+		`),
+		`
+			triple-backtick code block
+			\`\`\`
+			foo
+			bar
+			\`\`\`
+			in some text #3990
+		`
+	);
+	t.is(
+		parseBackticks(`
+			hello\`
+			\`world
+		`),
+		`
+			hello\`
+			\`world
+		`
+	);
+});


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES: Fixes #3990 

2. TEST URLS: [`09c0354` (#3991)](https://github.com/sindresorhus/refined-github/pull/3991/commits/09c03549819592b9245ff9c1a4cb8817b17c50a4)

3. SCREENSHOT:

<table>
<tr>
	<th>Before</th>
	<th>After</th>
</tr>
<tr>
	<td valign="top"><img src="https://user-images.githubusercontent.com/46634000/108341218-bbf26900-71d9-11eb-81c2-f5e648105618.png"></td>
	<td valign="top"><img src="https://user-images.githubusercontent.com/46634000/108341085-97968c80-71d9-11eb-8f81-9efc77962ceb.png"></td>
</tr>
</table>