### PR TITLE
Hide and auto-expand Similar comments in `hide-useless-comments`

### DIFF
--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -12,12 +12,28 @@ function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 		comment.hidden = false;
 	}
 
+	// Expand all "similar comments" boxes
+	for (const similarCommentsExpandButton of select.all('.Details-content--closed > :first-child')) {
+		similarCommentsExpandButton.click();
+	}
+
 	select('.rgh-hidden-comment')!.scrollIntoView();
 	event.delegateTarget.parentElement!.remove();
 }
 
+function hideComment(comment: HTMLElement): void {
+	comment.hidden = true;
+	comment.classList.add('rgh-hidden-comment');
+}
+
 function init(): void {
 	let uselessCount = 0;
+
+	for (const similarCommentsBox of select.all('.Details-element')) {
+		hideComment(similarCommentsBox);
+		uselessCount++;
+	}
+
 	for (const commentText of select.all('.comment-body > p:only-child')) {
 		if (!isUselessComment(commentText.textContent!)) {
 			continue;
@@ -43,8 +59,7 @@ function init(): void {
 			continue;
 		}
 
-		comment.hidden = true;
-		comment.classList.add('rgh-hidden-comment');
+		hideComment(comment);
 		uselessCount++;
 	}
 

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -13,7 +13,7 @@ function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	}
 
 	// Expand all "similar comments" boxes
-	for (const similarCommentsExpandButton of select.all('.Details-content--closed > :first-child')) {
+	for (const similarCommentsExpandButton of select.all('.js-discussion .Details-content--closed > span:only-child')) {
 		similarCommentsExpandButton.click();
 	}
 
@@ -29,7 +29,7 @@ function hideComment(comment: HTMLElement): void {
 function init(): void {
 	let uselessCount = 0;
 
-	for (const similarCommentsBox of select.all('.Details-element')) {
+	for (const similarCommentsBox of select.all('.js-discussion .Details-element')) {
 		hideComment(similarCommentsBox);
 		uselessCount++;
 	}


### PR DESCRIPTION
<!-- Please follow the template -->
1. LINKED ISSUES: Closes #3830 

2. TEST URLS: https://github.com/justinfrankel/licecap/issues/97

Picked up where #3839 left off. This PR:
 - always hides "similar comment(s)" boxes
 - expand every one of them when the link to show useless comments is clicked

This is not exactly what was described in #3830, rather it's following this review comment: https://github.com/sindresorhus/refined-github/pull/3839#discussion_r548323403

The idea is to consider every similar comment as useless by default, and not expand them to actually check their contents, since there can be a lot of them (I remember seeing issues with 200+ similar comments). Thoughts?