### PR TITLE
Preserve `sticky-sidebar` after a new comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
 				"@types/jsdom": "^16.2.6",
 				"@types/mini-css-extract-plugin": "^1.2.2",
 				"@types/react": "^17.0.2",
+				"@types/resize-observer-browser": "^0.1.5",
 				"@types/terser-webpack-plugin": "^5.0.2",
 				"ava": "^3.15.0",
 				"copy-webpack-plugin": "^7.0.0",
@@ -850,6 +851,12 @@
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
+		},
+		"node_modules/@types/resize-observer-browser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+			"integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+			"dev": true
 		},
 		"node_modules/@types/source-list-map": {
 			"version": "0.1.2",
@@ -15245,6 +15252,12 @@
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
+		},
+		"@types/resize-observer-browser": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+			"integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+			"dev": true
 		},
 		"@types/source-list-map": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"@types/jsdom": "^16.2.6",
 		"@types/mini-css-extract-plugin": "^1.2.2",
 		"@types/react": "^17.0.2",
+		"@types/resize-observer-browser": "^0.1.5",
 		"@types/terser-webpack-plugin": "^5.0.2",
 		"ava": "^3.15.0",
 		"copy-webpack-plugin": "^7.0.0",

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -23,6 +23,7 @@ function init(): void {
 			new ResizeObserver(onResize).observe(sidebar, {box: 'border-box'});
 		}
 	});
+	window.addEventListener('resize', onResize);
 }
 
 void features.add(__filebasename, {
@@ -32,11 +33,6 @@ void features.add(__filebasename, {
 	],
 	exclude: [
 		pageDetect.isEmptyRepoRoot
-	],
-	additionalListeners: [
-		() => {
-			window.addEventListener('resize', onResize);
-		}
 	],
 	init
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-// The two selectors are present on conversation pages so we need to discriminate
+// Both selectors are present on conversation pages so we need to discriminate
 const sidebarSelector = pageDetect.isRepoRoot() ? '.repository-content .flex-column > :last-child [data-pjax]' : '#partial-discussion-sidebar';
 
 function updateStickiness(): void {

--- a/source/helpers/on-element-removal.ts
+++ b/source/helpers/on-element-removal.ts
@@ -3,7 +3,6 @@ import mem from 'mem';
 const onElementRemoval = mem(
 	async (element: Element): Promise<void> => (
 		new Promise(resolve => {
-			// @ts-expect-error until https://github.com/microsoft/TypeScript/issues/37861
 			new ResizeObserver(([{target}], observer) => {
 				if (!target.isConnected) {
 					observer.disconnect();


### PR DESCRIPTION
<!-- Please follow the template -->
1. LINKED ISSUES: Closes #3582 

2. TEST URLS:
 * Conversation sidebar
   * [PR]()
   * [Issue](https://github.com/sindresorhus/refined-github/issues/3582)
 * Repo root
   * [Small sidebar](https://github.com/co1ncidence/mountaineer.vim)
   * [Sidebar too tall for viewport](https://github.com/sindresorhus/refined-github) (disable `clean-repo-sidebar` before)

3. SCREENSHOT: -

I've added types for `ResizeObserver` but I don't know if those are "official" (seems like the TS issue referenced in `on-element-removal` was closed but idk if the changes have been released yet).