### PR TITLE
Improve GitHub Sponsors UX

### DIFF
--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -1,4 +1,5 @@
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -18,9 +19,47 @@ function wiggleWiggleWiggle(): void {
 	}, 600);
 }
 
-function init(): void {
+async function suchLove({delegateTarget}: delegate.Event): Promise<void> {
+	const heart = select('.octicon-heart', delegateTarget);
+	if (!heart || delegateTarget.closest('details[open]')) {
+		return;
+	}
+
+	const rect = heart.getBoundingClientRect();
+	const love = heart.cloneNode(true);
+	Object.assign(love.style, {
+		position: 'fixed',
+		zIndex: '9999999999',
+		left: `${rect.x}px`,
+		top: `${rect.y}px`
+	});
+
+	document.body.append(love);
+
+	await love.animate({
+		transform: [
+			'translateZ(0)',
+			'translateZ(0) scale(80)'
+		],
+		opacity: [
+			1,
+			0
+		]
+	}, {
+		duration: 600,
+		easing: 'ease-out'
+	}).finished;
+
+	love.remove(); // 💔
+}
+
+function handleNewIssue(): void {
 	select('.btn-primary[href$="/issues/new/choose"], .btn-primary[href$="/issues/new"]')
 		?.addEventListener('mouseenter', wiggleWiggleWiggle);
+}
+
+function handleSponsorButton(): void {
+	delegate(document, '#sponsor-button-repo, #sponsor-profile-button, [aria-label^="Sponsor @"]', 'click', suchLove);
 }
 
 void features.add(__filebasename, {
@@ -28,5 +67,14 @@ void features.add(__filebasename, {
 		pageDetect.isIssue,
 		pageDetect.isRepoIssueList
 	],
-	init
+	init: handleNewIssue
+});
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isRepo,
+		pageDetect.isUserProfile,
+		pageDetect.isOrganizationProfile
+	],
+	init: handleSponsorButton
 });

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -68,9 +68,7 @@ void features.add(__filebasename, {
 		pageDetect.isRepoIssueList
 	],
 	init: handleNewIssue
-});
-
-void features.add(__filebasename, {
+}, {
 	include: [
 		pageDetect.isRepo,
 		pageDetect.isUserProfile,

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -1,0 +1,32 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function wiggleWiggleWiggle(): void {
+	select('#sponsor-button-repo')?.animate({
+		transform: [
+			'none',
+			'rotate(-2deg) scale(1.05)',
+			'rotate(2deg) scale(1.1)',
+			'rotate(-2deg) scale(1.1)',
+			'rotate(2deg) scale(1.1)',
+			'rotate(-2deg) scale(1.1)',
+			'rotate(2deg) scale(1.05)',
+			'none'
+		]
+	}, 600);
+}
+
+function init(): void {
+	select('.btn-primary[href$="/issues/new/choose"], .btn-primary[href$="/issues/new"]')
+		?.addEventListener('mouseenter', wiggleWiggleWiggle);
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isIssue,
+		pageDetect.isRepoIssueList
+	],
+	init
+});

--- a/source/features/rgh-sponsor-button.tsx
+++ b/source/features/rgh-sponsor-button.tsx
@@ -1,3 +1,27 @@
+/*
+
+                                                       ..       :
+                    .                  .               .   .  .
+      .           .                .               .. .  .  *
+             *          .                    ..        .
+                           .             .     . :  .   .    .  .
+            .                         .   .  .  .   .
+                                         . .  *:. . .
+.                                 .  .   . .. .         .
+                         .     . .  . ...    .    .
+       .              .  .  . .    . .  . .
+                        .    .     . ...   ..   .       .               .
+                 .  .    . *.   . .
+    .                   :.  .           .
+                 .   .    .    .
+             .  .  .    ./|\
+            .  .. :.    . |             .               .
+     .   ... .            |
+ .    :.  . .   *.        |     .               .
+   .  *.             You are here.
+ . .    .               .             *.                         .
+
+*/
 import select from 'select-dom';
 import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
@@ -21,6 +45,8 @@ function wiggleWiggleWiggle(): void {
 
 async function suchLove({delegateTarget}: delegate.Event): Promise<void> {
 	const heart = select('.octicon-heart', delegateTarget);
+
+	// .closest ensures that clicking the lightbox’ background doesn't also trigger the animation
 	if (!heart || delegateTarget.closest('details[open]')) {
 		return;
 	}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -211,6 +211,7 @@ import './features/wait-for-attachments';
 import './features/useful-forks';
 import './features/link-to-changelog-file';
 import './features/hide-markdown-diff';
+import './features/rgh-sponsor-button';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Just a silly feel-good feature.

![gif](https://user-images.githubusercontent.com/1402241/108609277-7f1da200-7392-11eb-848e-7b5fcd485d2f.gif)


Named `rgh-` because it's safe so it doesn't need to be documented, but it's not limited to RG.

I'll probably also add an animation on [Sponsor] click

## Test


https://github.com/sindresorhus/refined-github/issues
https://github.com/babel