### PR TITLE
Support more filenames in `link-to-changelog-file`

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -13,7 +13,7 @@ const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
 
 function parseFromDom(): false {
-	void cache.set(getCacheKey(), select(changelogNames.map(name => `.js-navigation-item [title^="${name}" i]`).join())?.textContent ?? false);
+	void cache.set(getCacheKey(), select(changelogNames.map(filename => `.js-navigation-item [title^="${filename}" i]`).join())?.textContent ?? false);
 	return false;
 }
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -17,8 +17,7 @@ function isChangelogFilename(filename: string): boolean {
 }
 
 function parseFromDom(): false {
-	const selector = changelogNames.map(filename => `.js-navigation-open[title^="${filename}" i]`);
-	const filename = select.all(selector).map(filenameElement => filenameElement?.textContent ?? '').find(isChangelogFilename);
+	const filename = select.all('.js-navigation-open').map(filenameElement => filenameElement.textContent ?? '').find(isChangelogFilename);
 	void cache.set(getCacheKey(), filename ?? false);
 
 	return false;

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -78,8 +78,5 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoHome
 	],
-	exclude: [
-		pageDetect.isEmptyRepoRoot
-	],
 	init: parseFromDom
 });

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -12,10 +12,10 @@ import {buildRepoURL, getRepo} from '../github-helpers';
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
 
-function getChangelogName(files: string[]): string | false {
+function findChangelogName(files: string[]): string | false {
 	for (const file of files) {
-		if (changelogNames.includes(files.toLowerCase().split('.', 1)[0])) {
-			return file.name;
+		if (changelogNames.includes(file.toLowerCase().split('.', 1)[0])) {
+			return file;
 		}
 	}
 
@@ -24,7 +24,7 @@ function getChangelogName(files: string[]): string | false {
 
 function parseFromDom(): false {
 	const files = select.all('[aria-labelledby="files"] .js-navigation-open').map(file => file.title!);
-	void cache.set(getCacheKey(), getChangelogName(files));
+	void cache.set(getCacheKey(), findChangelogName(files));
 	return false;
 }
 
@@ -40,8 +40,8 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 			}
 		}
 	`);
-	const files: string[] = repository.object.entries.map(file => file.name);
-	return getChangelogName(files);
+	const files: string[] = repository.object.entries.map((file: AnyObject) => file.name);
+	return findChangelogName(files);
 }, {
 	cacheKey: getCacheKey
 });

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -17,9 +17,11 @@ function isChangelogFilename(filename: string): boolean {
 }
 
 function parseFromDom(): false {
-	const filename = select.all('.js-navigation-open').map(filenameElement => filenameElement.textContent ?? '').find(isChangelogFilename);
-	void cache.set(getCacheKey(), filename ?? false);
+	const filename = select.all('[aria-labelledby="files"] .js-navigation-open')
+		.map(file => file.title!)
+		.find(isChangelogFilename);
 
+	void cache.set(getCacheKey(), filename ?? false);
 	return false;
 }
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -10,9 +10,10 @@ import * as api from '../github-helpers/api';
 import {buildRepoURL, getRepo} from '../github-helpers';
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
+const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
 
 function parseFromDom(): false {
-	void cache.set(getCacheKey(), select('.js-navigation-item [title^="changelog" i]')?.textContent ?? false);
+	void cache.set(getCacheKey(), select(changelogNames.map(name => `.js-navigation-item [title^="${name}" i]`).join())?.textContent ?? false);
 	return false;
 }
 
@@ -30,7 +31,7 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 	`);
 
 	for (const file of repository.object.entries) {
-		if (file.name.toLowerCase().startsWith('changelog')) {
+		if (changelogNames.includes(file.name.toLowerCase().split('.', 1)[0])) {
 			return file.name;
 		}
 	}

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -12,8 +12,15 @@ import {buildRepoURL, getRepo} from '../github-helpers';
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
 
+function isChangelogFilename(filename: string): boolean {
+	return changelogNames.includes(filename.toLowerCase().split('.', 1)[0]);
+}
+
 function parseFromDom(): false {
-	void cache.set(getCacheKey(), select(changelogNames.map(filename => `.js-navigation-item .js-navigation.open[title^="${filename}" i]`).join())?.textContent ?? false);
+	const selector = changelogNames.map(filename => `.js-navigation-open[title^="${filename}" i]`);
+	const filename = select.all(selector).map(filenameElement => filenameElement?.textContent ?? '').find(isChangelogFilename);
+	void cache.set(getCacheKey(), filename ?? false);
+
 	return false;
 }
 
@@ -31,7 +38,7 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 	`);
 
 	for (const file of repository.object.entries) {
-		if (changelogNames.includes(file.name.toLowerCase().split('.', 1)[0])) {
+		if (isChangelogFilename(file.name)) {
 			return file.name;
 		}
 	}

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -13,7 +13,7 @@ const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
 
 function parseFromDom(): false {
-	void cache.set(getCacheKey(), select(changelogNames.map(filename => `.js-navigation-item [title^="${filename}" i]`).join())?.textContent ?? false);
+	void cache.set(getCacheKey(), select(changelogNames.map(filename => `.js-navigation-item .js-navigation.open[title^="${filename}" i]`).join())?.textContent ?? false);
 	return false;
 }
 

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -10,11 +10,11 @@ import * as api from '../github-helpers/api';
 import {buildRepoURL, getRepo} from '../github-helpers';
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
-const changelogNames = ['changelog', 'news', 'changes', 'history', 'release', 'whatsnew'];
+const changelogNames = new Set(['changelog', 'news', 'changes', 'history', 'release', 'whatsnew']);
 
 function findChangelogName(files: string[]): string | false {
 	for (const file of files) {
-		if (changelogNames.includes(file.toLowerCase().split('.', 1)[0])) {
+		if (changelogNames.has(file.toLowerCase().split('.', 1)[0])) {
 			return file;
 		}
 	}
@@ -23,7 +23,7 @@ function findChangelogName(files: string[]): string | false {
 }
 
 function parseFromDom(): false {
-	const files = select.all('[aria-labelledby="files"] .js-navigation-open').map(file => file.title!);
+	const files = select.all('[aria-labelledby="files"] .js-navigation-open').map(file => file.title);
 	void cache.set(getCacheKey(), findChangelogName(files));
 	return false;
 }


### PR DESCRIPTION
1. LINKED ISSUES: Closes #3999 

2. TEST URLS:
 * [`CHANGELOG.md`](https://github.com/nodeca/js-yaml/releases/tag/4.0.0)
 * [`CHANGELOG.rst`](https://github.com/pyca/cryptography/releases)
 * [`CHANGES`](https://github.com/sphinx-doc/sphinx/releases)
 * [`news`](https://github.com/pypa/pip/releases)
 * [`HISTORY.md`](https://github.com/psf/requests/releases)
 * note: for every URL, there are two things to test:
   1. going directly to the release page
   2. going to the repo root (with a cleared cache), _then_ to the release page

