### PR TITLE
Fix position of `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -96,7 +96,7 @@ async function init(): Promise<false | void> {
 		</a>
 	);
 
-	(await elementReady('#branch-select-menu', {waitForChildren: false}))!.parentElement!.after(link);
+	(await elementReady('#branch-select-menu', {waitForChildren: false}))!.closest('.position-relative')!.after(link);
 	if (currentBranch !== latestTag) {
 		link.append(' ', <span className="css-truncate-target">{latestTag}</span>);
 	}


### PR DESCRIPTION
1. LINKED ISSUES: Fixes #3979 

2. TEST URLS:
 * [Repo root](https://github.com/fregante/GhostText/tree/21.2.3.221)
 * [Single file](https://github.com/fregante/GhostText/blob/21.2.3.221/package.json)
 * [Folder](https://github.com/fregante/GhostText/tree/21.2.3.221/source)
 * [Latest tag](https://github.com/fregante/GhostText/tree/21.2.21)
 * [Old tag](https://github.com/fregante/GhostText/tree/21.1.1)
 * [Branch](https://github.com/fregante/GhostText/tree/future-syntax)

I've noticed that the button disappears when navigating from the repo root to a file/folder. Is that an expected behavior?