### PR TITLE
Fix `hide-useless-comments` selectors

### DIFF
--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -13,7 +13,7 @@ function unhide(event: delegate.Event<MouseEvent, HTMLButtonElement>): void {
 	}
 
 	// Expand all "similar comments" boxes
-	for (const similarCommentsExpandButton of select.all('.js-discussion .Details-content--closed > span:only-child')) {
+	for (const similarCommentsExpandButton of select.all('.pagination-loader-container .Details-content--closed > span:only-child')) {
 		similarCommentsExpandButton.click();
 	}
 
@@ -29,7 +29,7 @@ function hideComment(comment: HTMLElement): void {
 function init(): void {
 	let uselessCount = 0;
 
-	for (const similarCommentsBox of select.all('.js-discussion .Details-element')) {
+	for (const similarCommentsBox of select.all('.pagination-loader-container .Details-element')) {
 		hideComment(similarCommentsBox);
 		uselessCount++;
 	}

--- a/source/features/hide-useless-comments.tsx
+++ b/source/features/hide-useless-comments.tsx
@@ -29,7 +29,7 @@ function hideComment(comment: HTMLElement): void {
 function init(): void {
 	let uselessCount = 0;
 
-	for (const similarCommentsBox of select.all('.pagination-loader-container .Details-element')) {
+	for (const similarCommentsBox of select.all('.js-discussion .Details-element:not([data-body-version])')) {
 		hideComment(similarCommentsBox);
 		uselessCount++;
 	}


### PR DESCRIPTION

1. LINKED ISSUES:
   #3992 

2. TEST URLS:
   https://github.com/justinfrankel/licecap/issues/97

3. SCREENSHOT:
   Before
![image](https://user-images.githubusercontent.com/1402241/108786873-37d21580-753a-11eb-80bc-76b15a8cb4c1.png)
after
![image](https://user-images.githubusercontent.com/16872793/108802328-07a06c00-7566-11eb-80b4-59bf5fa3847a.png)

