### PR TITLE
Fix console error in `clean-conversation-headers`

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -7,8 +7,10 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function initIssue(): void {
-	observe('.gh-header-meta .flex-auto', {
-		add({childNodes: bylineNodes}) {
+	observe('.gh-header-meta .flex-auto:not(.rgh-clean-conversation-header)', {
+		add(byline) {
+			byline.classList.add('rgh-clean-conversation-header');
+			const {childNodes: bylineNodes} = byline;
 			// Removes: octocat opened this issue on 1 Jan [·] 1 comments
 			bylineNodes[4].textContent = bylineNodes[4].textContent!.replace('·', '');
 


### PR DESCRIPTION
1. LINKED ISSUES:
   None

2. TEST URLS:
   Go to https://github.com/sindresorhus/refined-github/issues/3545#issuecomment-783811667 click on the commit link then go back `history.back()`

3. SCREENSHOT:
   None

This also prevents it from running 3 times
