### PR TITLE
Fix `first-published-tag-for-merged-pr` selector

### DIFF
--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -21,7 +21,7 @@ const getFirstTag = cache.function(async (commit: string): Promise<string | unde
 });
 
 async function init(): Promise<void> {
-	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code.link-gray-dark`)!.textContent!;
+	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`)!.textContent!;
 	const tagName = await getFirstTag(mergeCommit);
 
 	if (!tagName) {

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -6,9 +6,8 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import fetchDom from '../helpers/fetch-dom';
-import * as api from '../github-helpers/api';
 import observeElement from '../helpers/simplified-element-observer';
-import {buildRepoURL, getConversationNumber, getRepo} from '../github-helpers';
+import {buildRepoURL, getRepo} from '../github-helpers';
 
 const getFirstTag = cache.function(async (commit: string): Promise<string | undefined> => {
 	const firstTag = await fetchDom<HTMLAnchorElement>(
@@ -21,24 +20,8 @@ const getFirstTag = cache.function(async (commit: string): Promise<string | unde
 	cacheKey: ([commit]) => `first-tag:${getRepo()!.nameWithOwner}:${commit}`
 });
 
-const getMergeCommit = cache.function(async (prNumber: string): Promise<string> => {
-	const {repository} = await api.v4(`
-		repository() {
-			pullRequest(number: ${prNumber}) {
-				mergeCommit {
-					abbreviatedOid
-				}
-			}
-		}
-	`);
-
-	return repository.pullRequest.mergeCommit.abbreviatedOid;
-}, {
-	cacheKey: ([prNumber]) => __filebasename + ':' + getRepo()!.nameWithOwner + ':' + String(prNumber)
-});
-
 async function init(): Promise<void> {
-	const mergeCommit = await getMergeCommit(getConversationNumber()!);
+	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code.link-gray-dark`)!.textContent!;
 	const tagName = await getFirstTag(mergeCommit);
 
 	if (!tagName) {
@@ -65,9 +48,8 @@ async function init(): Promise<void> {
 
 void features.add(__filebasename, {
 	include: [
-		() => pageDetect.isPR() && pageDetect.isMergedPR()
+		() => pageDetect.isPRConversation() && pageDetect.isMergedPR()
 	],
-	awaitDomReady: false,
 	init() {
 		observeElement(select('#partial-discussion-header')!.parentElement!, init);
 	}


### PR DESCRIPTION
1. LINKED ISSUES:
   None

2. TEST URLS:
   https://github.com/sindresorhus/refined-github/pull/4013

3. SCREENSHOT:
   None

The feature broke because the selector changed its bound to break again.

I figured its only one API request and we then also have it on all pages. It also allows us not to wait for DOM ready.
