### PR TITLE
Meta: Move new features to the top on the Options page

### DIFF
--- a/source/options.tsx
+++ b/source/options.tsx
@@ -81,8 +81,14 @@ async function validateToken(): Promise<void> {
 	}
 }
 
-function moveDisabledFeaturesToTop(): void {
+function moveNewAndDisabledFeaturesToTop(): void {
 	const container = select('.js-features')!;
+
+	for (const newFeature of select.all('.feature-new', container).reverse()) {
+		// .reverse() needed to preserve alphabetical order while prepending
+		container.prepend(newFeature);
+	}
+
 	for (const unchecked of select.all('.feature [type=checkbox]:not(:checked)', container).reverse()) {
 		// .reverse() needed to preserve alphabetical order while prepending
 		container.prepend(unchecked.closest('.feature')!);
@@ -159,8 +165,8 @@ async function generateDom(): Promise<void> {
 	await perDomainOptions.syncForm('form');
 
 	// Decorate list
-	moveDisabledFeaturesToTop();
-	void highlightNewFeatures();
+	await highlightNewFeatures();
+	moveNewAndDisabledFeaturesToTop();
 	void validateToken();
 
 	// Move debugging tools higher when side-loaded

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -84,14 +84,14 @@ async function validateToken(): Promise<void> {
 function moveNewAndDisabledFeaturesToTop(): void {
 	const container = select('.js-features')!;
 
-	for (const newFeature of select.all('.feature-new', container).reverse()) {
-		// .reverse() needed to preserve alphabetical order while prepending
-		container.prepend(newFeature);
-	}
-
 	for (const unchecked of select.all('.feature [type=checkbox]:not(:checked)', container).reverse()) {
 		// .reverse() needed to preserve alphabetical order while prepending
 		container.prepend(unchecked.closest('.feature')!);
+	}
+
+	for (const newFeature of select.all('.feature-new', container).reverse()) {
+		// .reverse() needed to preserve alphabetical order while prepending
+		container.prepend(newFeature);
 	}
 }
 


### PR DESCRIPTION
1. LINKED ISSUES: Closes #4012 

2. TEST URLS: the options page

3. SCREENSHOT:
![screenshot-1614159444](https://user-images.githubusercontent.com/46634000/108981225-d2426e00-768c-11eb-9b9a-aadd586f418b.png)

I chose a method with very little code, but I'm not sure about `await`ing `highlightNewFeatures()`. It causes a small but noticeable content jump when opening the options page.