### PR TITLE
Fix several features that depended on specific classes

### DIFF
--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -13,7 +13,7 @@
 	padding-right: 4px; /* Space before the build status */
 }
 
-.rgh-align-issue-labels .js-issue-row .mt-1.text-small.text-gray { /* Issue details line */
+.rgh-align-issue-labels .js-issue-row .mt-1.text-small.color-text-secondary { /* Issue details line */
 	flex-basis: 100%;
 }
 

--- a/source/features/align-issue-labels.css
+++ b/source/features/align-issue-labels.css
@@ -13,6 +13,7 @@
 	padding-right: 4px; /* Space before the build status */
 }
 
+.rgh-align-issue-labels .js-issue-row .mt-1.text-small.text-gray, /* GHE */
 .rgh-align-issue-labels .js-issue-row .mt-1.text-small.color-text-secondary { /* Issue details line */
 	flex-basis: 100%;
 }

--- a/source/features/batch-open-conversations.tsx
+++ b/source/features/batch-open-conversations.tsx
@@ -75,7 +75,7 @@ async function init(): Promise<void | false> {
 		);
 		issuesToolbar.append(
 			<div className="table-list-triage flex-auto js-issues-toolbar-triage">
-				<span className="text-gray table-list-header-toggle">
+				<span className="text-gray color-text-secondary table-list-header-toggle">
 					<span data-check-all-count="">1</span>
 					{' selected '}
 					<button type="button" className="btn-link rgh-batch-open-issues pl-3">Open selected</button>
@@ -87,7 +87,7 @@ async function init(): Promise<void | false> {
 		for (const conversation of select.all('.js-issue-row')) {
 			const number = looseParseInt(conversation.id);
 			conversation.firstElementChild!.prepend(
-				<label className="flex-shrink-0 py-2 pl-3  d-none d-md-block">
+				<label className="flex-shrink-0 py-2 pl-3 d-none d-md-block">
 					<input
 						data-check-all-item
 						type="checkbox"

--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -1,4 +1,5 @@
 /* Hide reaction popover text */
+.js-add-reaction-popover .text-gray, /* GHE */
 .js-add-reaction-popover .color-text-secondary,
 .js-add-reaction-popover .dropdown-divider {
 	display: none;

--- a/source/features/center-reactions-popup.css
+++ b/source/features/center-reactions-popup.css
@@ -1,5 +1,5 @@
 /* Hide reaction popover text */
-.js-add-reaction-popover .text-gray,
+.js-add-reaction-popover .color-text-secondary,
 .js-add-reaction-popover .dropdown-divider {
 	display: none;
 }

--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -7,10 +7,14 @@
 * `.js-news-feed-event-group` is only for grouped events
 */
 
-/* Hide duplicate repo name in some non-grouped events */
+/* GHE */
 .rgh-clean-dashboard .dashboard .watch_started .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark,
 .rgh-clean-dashboard .dashboard .repo .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark,
-.rgh-clean-dashboard .dashboard .public .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark {
+.rgh-clean-dashboard .dashboard .public .color-border-secondary.flex-items-baseline .text-bold.text-gray-dark,
+/* Hide duplicate repo name in some non-grouped events */
+.rgh-clean-dashboard .dashboard .watch_started .color-border-secondary.flex-items-baseline .text-bold.color-text-primary,
+.rgh-clean-dashboard .dashboard .repo .color-border-secondary.flex-items-baseline .text-bold.color-text-primary,
+.rgh-clean-dashboard .dashboard .public .color-border-secondary.flex-items-baseline .text-bold.color-text-primary {
 	display: none;
 }
 
@@ -52,12 +56,14 @@
 }
 
 /* Hide footer date on Created Repository events */
-.rgh-clean-dashboard .dashboard .repo .f6.text-gray {
+.rgh-clean-dashboard .dashboard .repo .f6.text-gray, /* GHE */
+.rgh-clean-dashboard .dashboard .repo .f6.color-text-secondary {
 	display: none;
 }
 
 /* Grouped events: Make repo name smaller */
-.rgh-clean-dashboard .dashboard .Details .flex-items-baseline .text-bold.text-gray-dark {
+.rgh-clean-dashboard .dashboard .Details .flex-items-baseline .text-bold.text-gray-dark, /* GHE */
+.rgh-clean-dashboard .dashboard .Details .flex-items-baseline .text-bold.color-text-primary {
 	font-size: 1em !important;
 }
 

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -8,7 +8,7 @@ import features from '.';
 
 async function removeReadmeLink(): Promise<void> {
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
-	(await elementReady('.muted-link[href="#readme"]'))?.parentElement!.remove();
+	(await elementReady('.Link--muted[href="#readme"]'))?.parentElement!.remove();
 }
 
 async function cleanLicenseText(): Promise<void> {

--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -8,7 +8,7 @@ import features from '.';
 
 async function removeReadmeLink(): Promise<void> {
 	// Hide "Readme" link made unnecessary by toggle-files-button #3580
-	(await elementReady('.Link--muted[href="#readme"]'))?.parentElement!.remove();
+	(await elementReady('.muted-link[href="#readme"], .Link--muted[href="#readme"]'))?.parentElement!.remove();
 }
 
 async function cleanLicenseText(): Promise<void> {

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -23,13 +23,13 @@ function init(): void {
 			// Place before the "Updated on" element
 			select('relative-time', repository)!.previousSibling!.before(
 				<a
-					className="muted-link mr-3"
+					className="muted-link Link--muted mr-3"
 					href={repositoryLink.href + '/issues?q=is%3Aissue+is%3Aopen'}
 				>
 					<IssueOpenedIcon/>
 				</a>,
 				<a
-					className="muted-link mr-3"
+					className="muted-link Link--muted mr-3"
 					href={repositoryLink.href + '/pulls?q=is%3Apr+is%3Aopen'}
 				>
 					<GitPullRequestIcon/>

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -23,13 +23,13 @@ function init(): void {
 			// Place before the "Updated on" element
 			select('relative-time', repository)!.previousSibling!.before(
 				<a
-					className="muted-link mr-3"
+					className="Link--muted mr-3"
 					href={repositoryLink.href + '/issues?q=is%3Aissue+is%3Aopen'}
 				>
 					<IssueOpenedIcon/>
 				</a>,
 				<a
-					className="muted-link mr-3"
+					className="Link--muted mr-3"
 					href={repositoryLink.href + '/pulls?q=is%3Apr+is%3Aopen'}
 				>
 					<GitPullRequestIcon/>

--- a/source/features/conversation-links-on-repo-lists.tsx
+++ b/source/features/conversation-links-on-repo-lists.tsx
@@ -23,13 +23,13 @@ function init(): void {
 			// Place before the "Updated on" element
 			select('relative-time', repository)!.previousSibling!.before(
 				<a
-					className="Link--muted mr-3"
+					className="muted-link mr-3"
 					href={repositoryLink.href + '/issues?q=is%3Aissue+is%3Aopen'}
 				>
 					<IssueOpenedIcon/>
 				</a>,
 				<a
-					className="Link--muted mr-3"
+					className="muted-link mr-3"
 					href={repositoryLink.href + '/pulls?q=is%3Apr+is%3Aopen'}
 				>
 					<GitPullRequestIcon/>

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -28,7 +28,7 @@ function init(): void {
 
 			alternativeActions.classList.add('rgh-convert-pr-draft-position');
 			const convertToDraft = existingButton.closest('details')!.cloneNode(true);
-			select('.Link--muted', convertToDraft)!.classList.remove('Link--muted');
+			select('.muted-link, .Link--muted', convertToDraft)!.classList.remove('muted-link', 'Link--muted');
 			alternativeActions.prepend(convertToDraft);
 		}
 	});

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -28,7 +28,7 @@ function init(): void {
 
 			alternativeActions.classList.add('rgh-convert-pr-draft-position');
 			const convertToDraft = existingButton.closest('details')!.cloneNode(true);
-			select('.muted-link', convertToDraft)!.classList.remove('muted-link');
+			select('.Link--muted', convertToDraft)!.classList.remove('Link--muted');
 			alternativeActions.prepend(convertToDraft);
 		}
 	});

--- a/source/features/easier-pr-sha-copy.css
+++ b/source/features/easier-pr-sha-copy.css
@@ -1,5 +1,5 @@
 /* Add margin to commit SHA to reduce likelihood of selection overflow #2508 */
-.repository-content .js-commit .text-right code .text-gray, /* GHE */
+.repository-content .js-commit .text-right code .link-gray, /* GHE */
 .repository-content .js-commit .text-right code .Link--secondary {
 	margin-right: 16px;
 }

--- a/source/features/easier-pr-sha-copy.css
+++ b/source/features/easier-pr-sha-copy.css
@@ -1,4 +1,5 @@
 /* Add margin to commit SHA to reduce likelihood of selection overflow #2508 */
+.repository-content .js-commit .text-right code .text-gray, /* GHE */
 .repository-content .js-commit .text-right code .Link--secondary {
 	margin-right: 16px;
 }

--- a/source/features/easier-pr-sha-copy.css
+++ b/source/features/easier-pr-sha-copy.css
@@ -1,9 +1,4 @@
-/*
-This feature has to work on:
-https://github.com/sindresorhus/refined-github/pulls
-*/
-
-/* Add margin to commit SHA to reduce likelihood of selection overflow */
-.repository-content .js-commit .text-right code .link-gray {
+/* Add margin to commit SHA to reduce likelihood of selection overflow #2508 */
+.repository-content .js-commit .text-right code .Link--secondary {
 	margin-right: 16px;
 }

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -19,7 +19,7 @@ async function addSidebarReviewButton(): Promise<void | false> {
 
 	sidebarReviewsSection!.append(
 		<span style={{fontWeight: 'normal'}}>
-			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review now</a>
+			– <a href={reviewFormUrl.href} className="btn-link muted-link Link--muted" data-hotkey="v">review now</a>
 		</span>
 	);
 }

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -19,7 +19,7 @@ async function addSidebarReviewButton(): Promise<void | false> {
 
 	sidebarReviewsSection!.append(
 		<span style={{fontWeight: 'normal'}}>
-			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review now</a>
+			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v">review now</a>
 		</span>
 	);
 }

--- a/source/features/faster-reviews.tsx
+++ b/source/features/faster-reviews.tsx
@@ -19,7 +19,7 @@ async function addSidebarReviewButton(): Promise<void | false> {
 
 	sidebarReviewsSection!.append(
 		<span style={{fontWeight: 'normal'}}>
-			– <a href={reviewFormUrl.href} className="btn-link Link--muted" data-hotkey="v">review now</a>
+			– <a href={reviewFormUrl.href} className="btn-link muted-link" data-hotkey="v">review now</a>
 		</span>
 	);
 }

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -21,8 +21,7 @@ const getFirstTag = cache.function(async (commit: string): Promise<string | unde
 });
 
 async function init(): Promise<void> {
-	const timelineItemLinkSelector = `.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i]`;
-	const mergeCommit = select(`${timelineItemLinkSelector} > code.Link--primary, ${timelineItemLinkSelector} > code.link-gray-dark`)!.textContent!;
+	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code`)!.textContent!;
 	const tagName = await getFirstTag(mergeCommit);
 
 	if (!tagName) {

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -21,7 +21,8 @@ const getFirstTag = cache.function(async (commit: string): Promise<string | unde
 });
 
 async function init(): Promise<void> {
-	const mergeCommit = select(`.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i] > code.link-gray-dark`)!.textContent!;
+	const timelineItemLinkSelector = `.TimelineItem.js-details-container.Details a[href^="/${getRepo()!.nameWithOwner}/commit/" i]`;
+	const mergeCommit = select(`${timelineItemLinkSelector} > code.Link--primary, ${timelineItemLinkSelector} > code.link-gray-dark`)!.textContent!;
 	const tagName = await getFirstTag(mergeCommit);
 
 	if (!tagName) {

--- a/source/features/linkify-user-edit-history-popup.tsx
+++ b/source/features/linkify-user-edit-history-popup.tsx
@@ -12,7 +12,7 @@ function init(): void {
 		add(avatar) {
 			const userName = avatar.alt.slice(1);
 			// Linkify name first
-			wrap(avatar.nextElementSibling!, <a className="link-gray-dark" href={`/${userName}`}/>);
+			wrap(avatar.nextElementSibling!, <a className="link-gray-dark Link--primary" href={`/${userName}`}/>);
 
 			// Then linkify avatar
 			wrap(avatar, <a href={`/${userName}`}/>);

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -18,7 +18,7 @@ function initDashboard(): void {
 		add(icon) {
 			const url = icon.closest('li')!.querySelector('a')!.pathname + '#partial-timeline';
 			icon.parentElement!.classList.remove('col-1'); // Also fix extra space added by GitHub #3174
-			wrapAll([icon, icon.nextSibling!], <a className="Link--muted" href={url}/>);
+			wrapAll([icon, icon.nextSibling!], <a className="muted-link" href={url}/>);
 		}
 	});
 }

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -18,7 +18,7 @@ function initDashboard(): void {
 		add(icon) {
 			const url = icon.closest('li')!.querySelector('a')!.pathname + '#partial-timeline';
 			icon.parentElement!.classList.remove('col-1'); // Also fix extra space added by GitHub #3174
-			wrapAll([icon, icon.nextSibling!], <a className="muted-link" href={url}/>);
+			wrapAll([icon, icon.nextSibling!], <a className="Link--muted" href={url}/>);
 		}
 	});
 }

--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -18,7 +18,7 @@ function initDashboard(): void {
 		add(icon) {
 			const url = icon.closest('li')!.querySelector('a')!.pathname + '#partial-timeline';
 			icon.parentElement!.classList.remove('col-1'); // Also fix extra space added by GitHub #3174
-			wrapAll([icon, icon.nextSibling!], <a className="muted-link" href={url}/>);
+			wrapAll([icon, icon.nextSibling!], <a className="muted-link Link--muted" href={url}/>);
 		}
 	});
 }

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -12,7 +12,8 @@ function init(): void {
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
 		'.js-commits-list-item .mb-1', // `isCommitList` commit message
 		'.js-commits-list-item pre', // `isCommitList` commit description
-		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message
+		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.Link--primary', // `isRepoRoot` commit message
+		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message (GHE)
 		'.commit-title', // `isCommit` commit message
 		'.commit-desc', // `isCommit` commit description
 		'.js-commit .pr-1 > code', // `isPRConversation` pushed commits
@@ -30,8 +31,10 @@ function init(): void {
 		'.js-pinned-issue-list-item > .d-block', // Pinned Issues
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR
-		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title
-		'[id^="check_suite"] a.link-gray-dark', // `isRepositoryActions`
+		'#pull-requests a.Link--primary', // `isPulse` issue and PR title
+		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE)
+		'[id^="check_suite"] a.Link--primary', // `isRepositoryActions`
+		'[id^="check_suite"] a.link-gray-dark', // `isRepositoryActions` (GHE)
 		'.checks-summary-conclusion + .flex-auto .f3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
 		'.wiki-wrapper .gh-header-title', // `isWiki` page title
@@ -41,7 +44,8 @@ function init(): void {
 		'.notifications-list-item p.text-normal', // `isNotifications` issue and PR title
 		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
-		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard
+		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
+		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard (GHE)
 		'.js-issue-title', // `isDiscussion`
 		'a[data-hovercard-type="discussion"]' // `isDiscussionList`
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join();

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -12,8 +12,8 @@ function init(): void {
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
 		'.js-commits-list-item .mb-1', // `isCommitList` commit message
 		'.js-commits-list-item pre', // `isCommitList` commit description
-		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.Link--primary', // `isRepoRoot` commit message
 		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message (GHE)
+		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.Link--primary', // `isRepoRoot` commit message
 		'.commit-title', // `isCommit` commit message
 		'.commit-desc', // `isCommit` commit description
 		'.js-commit .pr-1 > code', // `isPRConversation` pushed commits
@@ -26,26 +26,29 @@ function init(): void {
 		'[id^=ref-issue-]', // `isIssue` issue and PR references
 		'[id^=ref-pullrequest-]', // `isPRConversation` issue and PR references
 		'[aria-label="Link issues"] a', // `isIssue`, `isPRConversation` linked issue and PR
-		'.Box-header.Details .link-gray', // `isSingleFile` commit message
+		'.Box-header.Details .link-gray', // `isSingleFile` commit message (GHE)
+		'.Box-header.Details .Link--secondary', // `isSingleFile` commit message
 		'.Box-header.Details pre', // `isSingleFile` commit description
 		'.js-pinned-issue-list-item > .d-block', // Pinned Issues
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR
-		'#pull-requests a.Link--primary', // `isPulse` issue and PR title
 		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE)
-		'[id^="check_suite"] a.Link--primary', // `isRepositoryActions`
+		'#pull-requests a.Link--primary', // `isPulse` issue and PR title
 		'[id^="check_suite"] a.link-gray-dark', // `isRepositoryActions` (GHE)
+		'[id^="check_suite"] a.Link--primary', // `isRepositoryActions`
 		'.checks-summary-conclusion + .flex-auto .f3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
 		'.wiki-wrapper .gh-header-title', // `isWiki` page title
 		'.js-recent-activity-container .text-bold', // `isDashboard` "Recent activity" titles
-		'.issues_labeled .text-gray-dark > a', // `isDashboard` "help wanted" event titles
+		'.issues_labeled .text-gray-dark > a', // `isDashboard` "help wanted" event titles (GHE)
+		'.issues_labeled .color-text-primary > a', // `isDashboard` "help wanted" event titles
 		'.commits blockquote', // `isDashboard` newsfeed commits
 		'.notifications-list-item p.text-normal', // `isNotifications` issue and PR title
-		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title
+		'.profile-timeline-card .text-gray-dark', // `isUserProfileMainTab` issue and PR title (GHE)
+		'.TimelineItem-body .color-text-primary', // `isUserProfileMainTab` issue and PR title
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
-		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard (GHE)
+		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
 		'.js-issue-title', // `isDiscussion`
 		'a[data-hovercard-type="discussion"]' // `isDiscussionList`
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join();

--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -1,8 +1,10 @@
 /* Show approvals count in PR list */
+.js-issue-row .text-gray [aria-label*='approval'], /* GHE */
 .js-issue-row .color-text-secondary [aria-label*='approval'] {
 	font-size: 0;
 }
 
+.js-issue-row .text-gray [aria-label*='approval']::before, /* GHE */
 .js-issue-row .color-text-secondary [aria-label*='approval']::before {
 	all: unset;
 	content: attr(aria-label);
@@ -11,6 +13,7 @@
 	font-size: 12px;
 }
 
+.js-issue-row .text-gray [aria-label*='changes'], /* GHE */
 .js-issue-row .color-text-secondary [aria-label*='changes'] {
 	color: var(--github-red) !important;
 }

--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -1,9 +1,9 @@
 /* Show approvals count in PR list */
-.js-issue-row .text-gray [aria-label*='approval'] {
+.js-issue-row .color-text-secondary [aria-label*='approval'] {
 	font-size: 0;
 }
 
-.js-issue-row .text-gray [aria-label*='approval']::before {
+.js-issue-row .color-text-secondary [aria-label*='approval']::before {
 	all: unset;
 	content: attr(aria-label);
 	display: inline !important;
@@ -11,6 +11,6 @@
 	font-size: 12px;
 }
 
-.js-issue-row .text-gray [aria-label*='changes'] {
+.js-issue-row .color-text-secondary [aria-label*='changes'] {
 	color: var(--github-red) !important;
 }

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -104,7 +104,7 @@ async function init(): Promise<void> {
 		sidebarAboutSection.append(
 			<h3 className="sr-only">Repository age</h3>,
 			<div className="mt-3">
-				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
+				<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 					<RepoIcon className="mr-2"/>{age}
 				</a>
 			</div>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -104,7 +104,7 @@ async function init(): Promise<void> {
 		sidebarAboutSection.append(
 			<h3 className="sr-only">Repository age</h3>,
 			<div className="mt-3">
-				<a href={firstCommitHref} className="Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>
+				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 					<RepoIcon className="mr-2"/>{age}
 				</a>
 			</div>

--- a/source/features/repo-age.tsx
+++ b/source/features/repo-age.tsx
@@ -104,7 +104,7 @@ async function init(): Promise<void> {
 		sidebarAboutSection.append(
 			<h3 className="sr-only">Repository age</h3>,
 			<div className="mt-3">
-				<a href={firstCommitHref} className="muted-link" title={`First commit dated ${dateFormatter.format(birthday)}`}>
+				<a href={firstCommitHref} className="muted-link Link--muted" title={`First commit dated ${dateFormatter.format(birthday)}`}>
 					<RepoIcon className="mr-2"/>{age}
 				</a>
 			</div>

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -80,7 +80,7 @@ async function init(): Promise<void> {
 						<a
 							data-issue-and-pr-hovercards-enabled
 							href={prInfo.url}
-							className="muted-link"
+							className="Link--muted"
 							data-hovercard-type="pull_request"
 							data-hovercard-url={prInfo.url + '/hovercard'}
 						>

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -80,7 +80,7 @@ async function init(): Promise<void> {
 						<a
 							data-issue-and-pr-hovercards-enabled
 							href={prInfo.url}
-							className="muted-link"
+							className="muted-link Link--muted"
 							data-hovercard-type="pull_request"
 							data-hovercard-url={prInfo.url + '/hovercard'}
 						>

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -80,7 +80,7 @@ async function init(): Promise<void> {
 						<a
 							data-issue-and-pr-hovercards-enabled
 							href={prInfo.url}
-							className="Link--muted"
+							className="muted-link"
 							data-hovercard-type="pull_request"
 							data-hovercard-url={prInfo.url + '/hovercard'}
 						>

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -43,7 +43,7 @@ function needsSubmission(): boolean {
 function getUI(): HTMLElement {
 	return select(`${mergeFormSelector} .rgh-sync-pr-commit-title-note`) ?? (
 		<p className="note rgh-sync-pr-commit-title-note">
-			The title of this PR will be updated to match this title. <button type="button" className="btn-link Link--muted text-underline rgh-sync-pr-commit-title">Cancel</button>
+			The title of this PR will be updated to match this title. <button type="button" className="btn-link muted-link text-underline rgh-sync-pr-commit-title">Cancel</button>
 		</p>
 	);
 }

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -43,7 +43,7 @@ function needsSubmission(): boolean {
 function getUI(): HTMLElement {
 	return select(`${mergeFormSelector} .rgh-sync-pr-commit-title-note`) ?? (
 		<p className="note rgh-sync-pr-commit-title-note">
-			The title of this PR will be updated to match this title. <button type="button" className="btn-link muted-link text-underline rgh-sync-pr-commit-title">Cancel</button>
+			The title of this PR will be updated to match this title. <button type="button" className="btn-link muted-link Link--muted text-underline rgh-sync-pr-commit-title">Cancel</button>
 		</p>
 	);
 }

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -43,7 +43,7 @@ function needsSubmission(): boolean {
 function getUI(): HTMLElement {
 	return select(`${mergeFormSelector} .rgh-sync-pr-commit-title-note`) ?? (
 		<p className="note rgh-sync-pr-commit-title-note">
-			The title of this PR will be updated to match this title. <button type="button" className="btn-link muted-link text-underline rgh-sync-pr-commit-title">Cancel</button>
+			The title of this PR will be updated to match this title. <button type="button" className="btn-link Link--muted text-underline rgh-sync-pr-commit-title">Cancel</button>
 		</p>
 	);
 }

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -105,7 +105,7 @@ async function init(): Promise<void> {
 			lastLink.after(
 				<li className={lastLink.className + ' rgh-changelog-link'}>
 					<a
-						className="muted-link tooltipped tooltipped-n"
+						className="muted-link Link--muted tooltipped tooltipped-n"
 						aria-label={'See changes since ' + decodeURIComponent(previousTag)}
 						href={buildRepoURL(`compare/${previousTag}...${allTags[index].tag}`)}
 					>

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -105,7 +105,7 @@ async function init(): Promise<void> {
 			lastLink.after(
 				<li className={lastLink.className + ' rgh-changelog-link'}>
 					<a
-						className="Link--muted tooltipped tooltipped-n"
+						className="muted-link tooltipped tooltipped-n"
 						aria-label={'See changes since ' + decodeURIComponent(previousTag)}
 						href={buildRepoURL(`compare/${previousTag}...${allTags[index].tag}`)}
 					>

--- a/source/features/tag-changelog-link.tsx
+++ b/source/features/tag-changelog-link.tsx
@@ -105,7 +105,7 @@ async function init(): Promise<void> {
 			lastLink.after(
 				<li className={lastLink.className + ' rgh-changelog-link'}>
 					<a
-						className="muted-link tooltipped tooltipped-n"
+						className="Link--muted tooltipped tooltipped-n"
 						aria-label={'See changes since ' + decodeURIComponent(previousTag)}
 						href={buildRepoURL(`compare/${previousTag}...${allTags[index].tag}`)}
 					>

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -20,6 +20,7 @@ const defaults = Object.assign({
 const migrations = [
 	featureWasRenamed('pr-easy-toggle-files', 'easy-toggle-files'), // Merged in December
 	featureWasRenamed('cleanup-repo-filelist-actions', 'clean-repo-filelist-actions'), // Merged in February
+	// TODO[2021-10-01]: Drop classes `muted-link` and `link-gray-dark` #4021
 
 	// Removed features will be automatically removed from the options as well
 	OptionsSyncPerDomain.migrations.removeUnused

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -17,7 +17,7 @@ const defaults = Object.assign({
 	logging: false
 }, Object.fromEntries(__features__.map(id => [`feature:${id}`, true])));
 
-// TODO[2021-10-01]: Drop classes `muted-link` and `link-gray-dark` #4021
+// TODO[2021-10-01]: Drop classes `muted-link`, `link-gray-dark` and `text-gray` (only where replaced by `color-text-secondary`) #4021
 const migrations = [
 	featureWasRenamed('pr-easy-toggle-files', 'easy-toggle-files'), // Merged in December
 	featureWasRenamed('cleanup-repo-filelist-actions', 'clean-repo-filelist-actions'), // Merged in February

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -17,7 +17,7 @@ const defaults = Object.assign({
 	logging: false
 }, Object.fromEntries(__features__.map(id => [`feature:${id}`, true])));
 
-// TODO[2021-10-01]: Drop classes `muted-link`, `link-gray-dark`, `text-gray` and `text-gray-dark` #4021
+// TODO[2021-10-01]: Drop classes `muted-link`, `link-gray`, `link-gray-dark`, `text-gray` and `text-gray-dark` #4021
 const migrations = [
 	featureWasRenamed('pr-easy-toggle-files', 'easy-toggle-files'), // Merged in December
 	featureWasRenamed('cleanup-repo-filelist-actions', 'clean-repo-filelist-actions'), // Merged in February

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -17,7 +17,7 @@ const defaults = Object.assign({
 	logging: false
 }, Object.fromEntries(__features__.map(id => [`feature:${id}`, true])));
 
-// TODO[2021-10-01]: Drop classes `muted-link`, `link-gray-dark` and `text-gray` (only where replaced by `color-text-secondary`) #4021
+// TODO[2021-10-01]: Drop classes `muted-link`, `link-gray-dark`, `text-gray` and `text-gray-dark` #4021
 const migrations = [
 	featureWasRenamed('pr-easy-toggle-files', 'easy-toggle-files'), // Merged in December
 	featureWasRenamed('cleanup-repo-filelist-actions', 'clean-repo-filelist-actions'), // Merged in February

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -113,12 +113,12 @@ highlight-collaborators-and-own-conversations
 parse-backticks
 pr-branches
 */
-.js-issue-row .text-small.text-gray {
+.js-issue-row .text-small.color-text-secondary {
 	line-height: 1.8;
 }
 
 /* Reset `vertical-align` for .octicons to work with above increased line-height */
-.js-issue-row .text-small.text-gray .octicon {
+.js-issue-row .text-small.color-text-secondary .octicon {
 	vertical-align: middle;
 }
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -113,11 +113,13 @@ highlight-collaborators-and-own-conversations
 parse-backticks
 pr-branches
 */
+.js-issue-row .text-small.text-gray, /* GHE */
 .js-issue-row .text-small.color-text-secondary {
 	line-height: 1.8;
 }
 
 /* Reset `vertical-align` for .octicons to work with above increased line-height */
+.js-issue-row .text-small.text-gray .octicon, /* GHE */
 .js-issue-row .text-small.color-text-secondary .octicon {
 	vertical-align: middle;
 }


### PR DESCRIPTION
1. LINKED ISSUES: 
	Replaces and closes #4017 
	Fixes #4026 
2. TEST URLS:
 * [`clean-repo-sidebar`](https://github.com/sindresorhus/refined-github)
 * `convert-pr-to-draft-improvements`
 * `parse-backticks`
   * [Commit title above files list](https://github.com/sindresorhus/refined-github/tree/0887b196c66ec3e170da89f6a42ab295fb324fdd)
   * [Commit title above single file](https://github.com/sindresorhus/refined-github/blob/0887b196c66ec3e170da89f6a42ab295fb324fdd/readme.md)
   * ["Pulse" page](https://github.com/sindresorhus/refined-github/pulse)
 * [`first-published-tag-for-merged-pr`](https://github.com/sindresorhus/refined-github/pull/4013)
 * [`align-issue-labels`](https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)

GitHub changed some class names related to links, which broke a few features:
  * `.muted-link` → `.Link--muted` (`clean-repo-sidebar`, `convert-pr-to-draft-improvements`)
  * `.link-gray` → `.Link--secondary` (`parse-backticks`, `easier-pr-sha-copy`)
  * `.link-gray-dark` → `.Link--primary` (`parse-backticks`, `first-published-tag-for-merged-pr`)
  * `.text-gray` → `.color-text-secondary` (`align-issue-labels`, `pr-approvals-count`, `center-reactions-popup`, and probably others)
  * `.text-gray-dark` → `.color-text-primary` (`clean-dashboard`, `parse-backticks`)