### PR TITLE
Hide `useful-forks` on GitHub Enterprise

### DIFF
--- a/source/features/useful-forks.tsx
+++ b/source/features/useful-forks.tsx
@@ -31,6 +31,9 @@ void features.add(__filebasename, {
 		pageDetect.isRepoForksList,
 		pageDetect.isRepoNetworkGraph
 	],
+	exclude: [
+		pageDetect.isEnterprise
+	],
 	awaitDomReady: false,
 	init
 });


### PR DESCRIPTION
1. LINKED ISSUES:
   As per the comment there: https://github.com/sindresorhus/refined-github/pull/3955#issuecomment-787113315

2. TEST URLS:
   I don't use GHE, so that's a bit hard for me to provide.

3. SCREENSHOT:
   Contextually impossible for me.