### PR TITLE
Meta: Simplify Octicons usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 		"": {
 			"dependencies": {
 				"@cheap-glitch/mi-cron": "^1.0.1",
-				"@primer/octicons-react": "^12.0.0",
+				"@primer/octicons-react": "^12.1.0",
 				"copy-text-to-clipboard": "^3.0.0",
 				"debounce-fn": "^4.0.0",
 				"delay": "^5.0.0",
@@ -554,9 +554,9 @@
 			}
 		},
 		"node_modules/@primer/octicons-react": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-12.0.0.tgz",
-			"integrity": "sha512-L1u2kjhAEMoOeNOZqQSc4xGE7/Cl6kjhuiIKrJOmNa6M86Zy+/pv1zFlvFnWzxu2FhPTlZWC4LLazTYf5spceA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-12.1.0.tgz",
+			"integrity": "sha512-eb/5Obsp6/pVkyzzGhobK6aPAkKqx6VleF/7HYeihGTYm3rGZc+prL/jhxD5Mo1P6U343YEkHjc2gKuvtENn1g==",
 			"engines": {
 				"node": ">=8"
 			},
@@ -2564,7 +2564,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
@@ -4154,8 +4153,7 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"optionator": "^0.8.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -7324,7 +7322,6 @@
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
 			"dependencies": {
-				"graceful-fs": "^4.1.6",
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {
@@ -14941,9 +14938,9 @@
 			}
 		},
 		"@primer/octicons-react": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-12.0.0.tgz",
-			"integrity": "sha512-L1u2kjhAEMoOeNOZqQSc4xGE7/Cl6kjhuiIKrJOmNa6M86Zy+/pv1zFlvFnWzxu2FhPTlZWC4LLazTYf5spceA==",
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-12.1.0.tgz",
+			"integrity": "sha512-eb/5Obsp6/pVkyzzGhobK6aPAkKqx6VleF/7HYeihGTYm3rGZc+prL/jhxD5Mo1P6U343YEkHjc2gKuvtENn1g==",
 			"requires": {}
 		},
 		"@sindresorhus/is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
 				"copy-webpack-plugin": "^7.0.0",
 				"css-loader": "^5.0.2",
 				"daily-version": "^2.0.0",
-				"decamelize": "^5.0.0",
 				"dot-json": "^1.2.1",
 				"esbuild-loader": "^2.9.1",
 				"eslint-config-xo-react": "^0.23.0",
@@ -3455,18 +3454,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"node_modules/decamelize": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
-			"integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
 		},
 		"node_modules/decamelize-keys": {
 			"version": "1.1.0",
@@ -17253,12 +17240,6 @@
 					"dev": true
 				}
 			}
-		},
-		"decamelize": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.0.tgz",
-			"integrity": "sha512-U75DcT5hrio3KNtvdULAWnLiAPbFUC4191ldxMmj4FA/mRuBnmDwU0boNfPyFRhnan+Jm+haLeSn3P0afcBn4w==",
-			"dev": true
 		},
 		"decamelize-keys": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
 		"copy-webpack-plugin": "^7.0.0",
 		"css-loader": "^5.0.2",
 		"daily-version": "^2.0.0",
-		"decamelize": "^5.0.0",
 		"dot-json": "^1.2.1",
 		"esbuild-loader": "^2.9.1",
 		"eslint-config-xo-react": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 	},
 	"dependencies": {
 		"@cheap-glitch/mi-cron": "^1.0.1",
-		"@primer/octicons-react": "^12.0.0",
+		"@primer/octicons-react": "^12.1.0",
 		"copy-text-to-clipboard": "^3.0.0",
 		"debounce-fn": "^4.0.0",
 		"delay": "^5.0.0",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -5,7 +5,6 @@ import {readFileSync} from 'fs';
 
 import regexJoin from 'regex-join';
 import SizePlugin from 'size-plugin';
-import decamelize from 'decamelize';
 import TerserPlugin from 'terser-webpack-plugin';
 import {ESBuildPlugin} from 'esbuild-loader';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
@@ -79,16 +78,6 @@ const config: Configuration = {
 	},
 	module: {
 		rules: [
-			{
-				test: /octicons-react\//,
-				loader: 'string-replace-loader',
-				options: {
-					search: /(\w+)Icon\.defaultProps = {\n\s+className: 'octicon'/g,
-					replace: (match: string, name: string) => {
-						return match.replace('octicon', 'octicon octicon-' + decamelize(name, {separator: '-'}));
-					}
-				}
-			},
 			{
 				test: /\.tsx?$/,
 				loader: 'esbuild-loader',


### PR DESCRIPTION
They finally merged https://github.com/primer/octicons/pull/453 and released a new version :tada:

So we can drop the workaround from #3227 :blush: