### PR TITLE
Fix text overflow in `latest-tag-button`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -91,7 +91,7 @@ async function init(): Promise<false | void> {
 	});
 
 	const link = (
-		<a className="btn btn-sm btn-outline ml-2 flex-self-center rgh-latest-tag-button" href={String(url)}>
+		<a className="btn btn-sm btn-outline ml-2 flex-self-center css-truncate rgh-latest-tag-button" href={String(url)}>
 			<TagIcon/>
 		</a>
 	);


### PR DESCRIPTION
<!-- Please follow the template -->
Thanks for contributing! 🍄

1. LINKED ISSUES:

   __New issue:__
	
   The text inside the latest tag button isn’t being truncated, despite having `css-truncate-target`. This causes the file navigation row to overflow (see screenshots).

   __Changes:__

   This PR adds `css-truncate` to the button to enable the `css-truncate-target` styling.

2. TEST URLS:

   https://github.com/gfx-rs/wgpu/

3. SCREENSHOT:
   
   Before:
	
   ![before](https://user-images.githubusercontent.com/7572407/109427192-44ef7880-7a02-11eb-9fc6-be6b2f25b139.jpg)

   After:

   ![after](https://user-images.githubusercontent.com/7572407/109427200-50db3a80-7a02-11eb-97d5-8b76b9d91a2c.jpg)


