### PR TITLE
Enable `edit-comments-faster` on locked conversations

### DIFF
--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -16,15 +16,15 @@ function init(): void {
 				.closest('.js-comment')!
 				.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
 				.before(
-				<button
-					type="button"
-					role="menuitem"
-					className="timeline-comment-action btn-link js-comment-edit-button"
-					aria-label="Edit comment"
-				>
-					<PencilIcon/>
-				</button>
-			);
+					<button
+						type="button"
+						role="menuitem"
+						className="timeline-comment-action btn-link js-comment-edit-button"
+						aria-label="Edit comment"
+					>
+						<PencilIcon/>
+					</button>
+				);
 		}
 	});
 }

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,7 +12,10 @@ function init(): void {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 
-			comment.closest('.js-comment')!.querySelector('.js-comment-header-reaction-button')!.after(
+			comment
+				.closest('.js-comment')!
+				.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+				.before(
 				<button
 					type="button"
 					role="menuitem"


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/4031

Testable on https://github.com/sindresorhus/refined-github/issues/4030

## Screenshot

Notice the edit button on a locked issue:

<img width="905" alt="Screen Shot 13" src="https://user-images.githubusercontent.com/1402241/109457572-bc340500-7a20-11eb-9f72-2d421b8c74b1.png">
