### PR TITLE
Simplify `hide-readme-header`: Fixes "Jump to definition" bug

### DIFF
--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -1,36 +1,15 @@
-/* Hide the header in README section */
-.repository-content #readme:not(.blob) {
-	position: relative;
+.repository-content #readme:not(.blob) .Box-title {
+	visibility: hidden;
 }
 
 .repository-content #readme:not(.blob) .Box-header {
-	position: absolute;
-	top: 0;
-	right: 0;
-	background-color: transparent !important;
-	padding: 0 !important;
-	border: none;
-}
-
-.repository-content #readme:not(.blob) .Box-header .Box-title {
-	display: none;
+	margin-bottom: -40px;
 }
 
 .repository-content #readme:not(.blob) .Box-header .btn-octicon {
-	margin: 0;
-	padding: 12px;
-	right: 0;
-	top: 0;
-	opacity: 20%;
 	transition: opacity 0.25s;
 }
 
-.repository-content #readme:not(.blob) .Box-header .btn-octicon:hover,
-.repository-content #readme:not(.blob) .Box-header .btn-octicon:focus {
-	opacity: 100%;
-}
-
-/* Restore spacing #3495 */
-.repository-content #readme:not(.blob) .Box-body {
-	padding-top: 32px;
+.repository-content #readme:not(.blob) .Box-header .btn-octicon:not(:hover, :focus) {
+	opacity: 20%;
 }


### PR DESCRIPTION
Fixes #4033 

## Test

https://github.com/sindresorhus/refined-github
https://github.com/probablykasper/vidl <-- the spacing should be reasonable, ref: https://github.com/sindresorhus/refined-github/issues/3495
https://github.com/no2chem/bigint-buffer <-- the popover position should be right, ref #4033 

## Screenshots

<img width="923" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/109638140-3fce1e80-7b13-11eb-94ec-7a1848dfe4ac.png">

<img width="931" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/109638149-4361a580-7b13-11eb-8380-a689d64e43a6.png">

<img width="592" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/109638439-a2271f00-7b13-11eb-9789-d45e925ad887.png">
