### PR TITLE
Don't mistakenly add `remove-label-faster` when creating a label

### DIFF
--- a/source/features/remove-label-faster.tsx
+++ b/source/features/remove-label-faster.tsx
@@ -37,7 +37,7 @@ async function removeLabelButtonClickHandler(event: delegate.Event<MouseEvent, H
 async function init(): Promise<void> {
 	await api.expectToken();
 
-	observe('.sidebar-labels .IssueLabel:not(.rgh-remove-label-faster-already-added)', {
+	observe('.js-issue-labels .IssueLabel:not(.rgh-remove-label-faster-already-added)', {
 		constructor: HTMLElement,
 		add(label) {
 			label.classList.add('rgh-remove-label-faster-already-added');


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Issue
Currently the close button appears in the new label dialog too, and when clicked the api returns 404 (because of course it doesn't exist, yet)

## Test URLs
Any PR/issue and attempt to type a new label name in the tooltip to open the new label dialog 

## Screenshot

### Before:
![before](https://user-images.githubusercontent.com/26524089/110039522-0a5f4600-7d4a-11eb-8468-0aa3f3887b3b.png)
### After:
![after](https://user-images.githubusercontent.com/26524089/110039534-0f23fa00-7d4a-11eb-81d3-750cc1813830.png)

