### PR TITLE
Accept the new token format in the options

### DIFF
--- a/distribution/options.html
+++ b/distribution/options.html
@@ -14,7 +14,7 @@
 		<label>
 			<strong>Personal token</strong> (optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">generate one</a>)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
-			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" pattern="[\da-f]{40}" placeholder=" ">
+			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" pattern="[\da-f]{40}|gp1_\w{36,251}" placeholder=" ">
 			<span id="validation"></span>
 		</label>
 	</p>


### PR DESCRIPTION
## Issue
In the next couple of weeks GitHub will change the format for new authentication tokens.  

https://github.blog/changelog/2021-03-04-authentication-token-format-updates/

The characters used will change from [a-f0-9] to [A-Za-z0-9_] and new tokens will include a prefix ("gp1_" for Personal Access Tokens).  Additionally, after June 1, 2021 the token length will increase to up to 255 characters.  Currently, the form to submit personal tokens in the options page will not accept the new token format.  

## Changes
This PR changes the pattern of the form input to accept both existing tokens and tokens of the new format. 


Related: https://github.com/fregante/github-issue-link-status/pull/46