### PR TITLE
Fix `suggest-commit-title-limit` input field size

### DIFF
--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -1,7 +1,8 @@
 /* Limit width of commit title to 72 characters */
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input) {
-	width: calc(73ch + 18px);
+	width: calc(72ch + 18px);
 	max-width: 100%;
+	box-sizing: content-box;
 }
 
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input, textarea) {

--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -1,6 +1,6 @@
 /* Limit width of commit title to 72 characters */
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input) {
-	width: calc(72ch + 18px);
+	width: calc(73ch + 18px);
 	max-width: 100%;
 }
 

--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -1,6 +1,6 @@
 /* Limit width of commit title to 72 characters */
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input) {
-	width: calc(72ch + 18px);
+	width: 72ch;
 	max-width: 100%;
 	box-sizing: content-box;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #3998


## Test URLs
Any PR for merge + This 72-char title:

```
123456789 123456789 123456789 123456789 123456789 123456789 123456789 12
```


## Screenshot

Before:
![before](https://user-images.githubusercontent.com/1402241/108570387-600c0b00-72d3-11eb-80c2-d62570092a79.gif)

After:
![suggest-commit-title](https://user-images.githubusercontent.com/19198931/110244999-586b8800-7f9c-11eb-92c8-e04c17e91527.gif)

