### PR TITLE
Exclude folders from `link-to-changelog-file`

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -41,7 +41,12 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 			}
 		}
 	`);
-	const files: string[] = repository.object.entries.filter((entry: AnyObject) => entry.type === 'blob').map((file: AnyObject) => file.name);
+	const files: string[] = [];
+	for (const entry of repository.object.entries) {
+		if (entry.type === 'blob') {
+			files.push(file.name)
+		}
+	}
 	return findChangelogName(files);
 }, {
 	cacheKey: getCacheKey

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -41,12 +41,14 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 			}
 		}
 	`);
+
 	const files: string[] = [];
 	for (const entry of repository.object.entries) {
 		if (entry.type === 'blob') {
-			files.push(entry.name)
+			files.push(entry.name);
 		}
 	}
+
 	return findChangelogName(files);
 }, {
 	cacheKey: getCacheKey

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -23,7 +23,7 @@ function findChangelogName(files: string[]): string | false {
 }
 
 function parseFromDom(): false {
-	const files = select.all('[aria-labelledby="files"] .js-navigation-open').map(file => file.title);
+	const files = select.all('[aria-labelledby="files"] .js-navigation-open[href*="/blob/"').map(file => file.title);
 	void cache.set(getCacheKey(), findChangelogName(files));
 	return false;
 }
@@ -35,12 +35,13 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 				...on Tree {
 					entries {
 						name
+						type
 					}
 				}
 			}
 		}
 	`);
-	const files: string[] = repository.object.entries.map((file: AnyObject) => file.name);
+	const files: string[] = repository.object.entries.filter((entry: AnyObject) => entry.type === 'blob').map((file: AnyObject) => file.name);
 	return findChangelogName(files);
 }, {
 	cacheKey: getCacheKey

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -44,7 +44,7 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 	const files: string[] = [];
 	for (const entry of repository.object.entries) {
 		if (entry.type === 'blob') {
-			files.push(file.name)
+			files.push(entry.name)
 		}
 	}
 	return findChangelogName(files);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4066 

## Test URLs
https://github.com/pypa/pip/releases

Two things to test:
- going directly to the release page
- going to the repo root (with a cleared cache), then to the release page

It was unclear to me what was decided about this, so this PR takes the simplest approach of ignoring folders altogether.

If we want to include them but prioritize files, it would be as simple as separating the list in two instead of filtering it (and maybe also make the selection logic a bit stricter as mentioned in https://github.com/sindresorhus/refined-github/issues/3999#issuecomment-784258402).