### PR TITLE
Fix "Edit last comment" in `comment-fields-keyboard-shortcuts`

### DIFF
--- a/source/features/comment-fields-keyboard-shortcuts.tsx
+++ b/source/features/comment-fields-keyboard-shortcuts.tsx
@@ -29,7 +29,7 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement>)
 	} else if (event.key === 'ArrowUp' && field.value === '') {
 		const currentConversationContainer = field.closest([
 			'.js-inline-comments-container', // Current review thread container
-			'.discussion-timeline', // Or just ALL the comments in issues
+			'#discussion_bucket', // Or just ALL the comments in issues
 			'#all_commit_comments' // Single commit comments at the bottom
 		].join())!;
 		const lastOwnComment = select


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #3662 

## Test URLs
- [an issue commented by you](https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+commenter%3A%40me)
- [a PR commented/reviewed by you](https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+commenter%3A%40me)

Note: when the comment field at the bottom of a PR thread is selected, pressing Up will edit the last comment _regardless if it's a review comment or a "regular" comment_ (i.e. in the main thread).

Is that intended behavior? Or a small issue with a fix too complex to bother with? (checked the feature history but didn't find mention of this)