### PR TITLE
Don't trigger `unfinished-comments` for open comment dropdowns

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -7,7 +7,7 @@ let documentTitle: string | undefined;
 
 function hasDraftComments(): boolean {
 	// `[disabled]` excludes the PR description field that `wait-for-build` disables while it waits
-	// `[id^="convert-to-issue-body"]` excludes hidden textareas created when opening the dropdown menu of review comments
+	// `[id^="convert-to-issue-body"]` excludes the hidden pre-filled textareas created when opening the dropdown menu of review comments
 	return select.all('textarea:not([disabled]):not([id^="convert-to-issue-body"])').some(textarea =>
 		textarea.value !== textarea.textContent && // Exclude comments being edited but not yet changed (and empty comment fields)
 		!select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -7,7 +7,8 @@ let documentTitle: string | undefined;
 
 function hasDraftComments(): boolean {
 	// `[disabled]` excludes the PR description field that `wait-for-build` disables while it waits
-	return select.all('textarea:not([disabled])').some(textarea =>
+	// `[id^="convert-to-issue-body"]` excludes hidden textareas created when opening the dropdown menu of review comments
+	return select.all('textarea:not([disabled]):not([id^="convert-to-issue-body"])').some(textarea =>
 		textarea.value !== textarea.textContent && // Exclude comments being edited but not yet changed (and empty comment fields)
 		!select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
 	);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Test URLs
1. Go to a PR with reviews, e.g. https://github.com/sindresorhus/refined-github/pull/4023
2. Open the dropdown menu of any review comment
3. Go to a different tab
4. The title of the previous tab should NOT say `(Draft comment)`