### PR TITLE
Restore `clone-branch` feature

### DIFF
--- a/source/features/clone-branch.tsx
+++ b/source/features/clone-branch.tsx
@@ -73,7 +73,7 @@ async function init(): Promise<void | false> {
 	await api.expectToken();
 	const deleteIconClass = [
 		'branch-filter-item-controller .octicon-trashcan', // Pre "Repository refresh" layout
-		'branch-filter-item .octicon-trashcan'
+		'branch-filter-item .octicon-trash'
 	].join();
 
 	observe(deleteIconClass, {


### PR DESCRIPTION
Fixes #4083

Was renamed see https://github.com/primer/octicons/releases/tag/v12.0.0
## Test URLs
https://github.com/fregante/webextension-polyfill/branches
https://github.com/yakov116/refined-github/branches
https://github.com/sindresorhus/refined-github/branches

## Screenshot

![image](https://user-images.githubusercontent.com/16872793/110709909-fe043e80-81ca-11eb-9980-85b331ff9355.png)


This is one of the downsides of using select-observer, we do not get to see the errors.
