### PR TITLE
Restore branch name in `clean-conversation-headers`

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -47,7 +47,6 @@ function initPR(): void {
 			}
 		}
 	});
-	deinit.push(observer.abort);
 }
 
 void features.add(__filebasename, {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -41,16 +41,13 @@ function initPR(): void {
 				byline.prepend('by ');
 			}
 
-			if (isDefaultBranch || (pageDetect.isClosedPR() && baseBranch.title.endsWith(':master'))) {
-				// Removes: octocat wants to merge 1 commit into [github:dev] from octocat:feature
-				baseBranch.hidden = true;
-			} else {
-				// Add back "into" if the PR base branch is not the default branch
-				baseBranch.before(' into ');
+			baseBranch.before(' into ');
+			if (!(isDefaultBranch || (pageDetect.isClosedPR() && baseBranch.title.endsWith(':master')))) {
 				baseBranch.classList.add('rgh-clean-conversation-headers-non-default-branch');
 			}
 		}
 	});
+	deinit.push(observer.abort);
 }
 
 void features.add(__filebasename, {


### PR DESCRIPTION
Closes #3808 


## Test URLs
https://github.com/excalidraw/excalidraw/pull/3230
https://github.com/twbs/bootstrap/pull/33334 (non default branch)

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/110969036-39675000-8326-11eb-9708-a5c28b310035.png)

