### PR TITLE
Correctly remove listeners when leaving certain pages

### DIFF
--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -53,6 +53,7 @@ function initPR(): void {
 			}
 		}
 	});
+	deinit.push(observer.abort);
 }
 
 void features.add(__filebasename, {

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -1,13 +1,14 @@
 import './clean-conversation-headers.css';
 import select from 'select-dom';
-import onetime from 'onetime';
 import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
+const deinit: VoidFunction[] = [];
+
 function initIssue(): void {
-	observe('.gh-header-meta .flex-auto:not(.rgh-clean-conversation-header)', {
+	const observer = observe('.gh-header-meta .flex-auto:not(.rgh-clean-conversation-header)', {
 		add(byline) {
 			byline.classList.add('rgh-clean-conversation-header');
 			const {childNodes: bylineNodes} = byline;
@@ -20,10 +21,11 @@ function initIssue(): void {
 			}
 		}
 	});
+	deinit.push(observer.abort);
 }
 
 function initPR(): void {
-	observe('.gh-header-meta .flex-auto:not(.rgh-clean-conversation-header)', {
+	const observer = observe('.gh-header-meta .flex-auto:not(.rgh-clean-conversation-header)', {
 		add(byline) {
 			byline.classList.add('rgh-clean-conversation-header');
 			const isSameAuthor = select('.js-discussion > .TimelineItem:first-child .author')?.textContent === select('.author', byline)!.textContent;
@@ -58,11 +60,13 @@ void features.add(__filebasename, {
 		pageDetect.isIssue
 	],
 	awaitDomReady: false,
-	init: onetime(initIssue)
+	init: initIssue,
+	deinit
 }, {
 	include: [
 		pageDetect.isPR
 	],
 	awaitDomReady: false,
-	init: onetime(initPR)
+	init: initPR,
+	deinit
 });

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -1,9 +1,9 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import {observe} from 'selector-observer';
 import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
-import {observe} from 'selector-observer';
 
 import features from '.';
 

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -3,11 +3,11 @@ import select from 'select-dom';
 import oneMutation from 'one-mutation';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
-import {observe, Observer} from 'selector-observer';
+import {observe} from 'selector-observer';
 
 import features from '.';
 
-let observer: Observer;
+const deinit: VoidFunction[] = [];
 
 async function loadDeferred(jumpList: Element): Promise<void> {
 	// This event will trigger the loading, but if run too early, GitHub might not have attached the listener yet, so we try multiple times.
@@ -33,7 +33,7 @@ async function init(): Promise<void | false> {
 		await loadDeferred(fileList!);
 	}
 
-	observer = observe('.file-info [href]:not(.rgh-pr-file-state)', {
+	const observer = observe('.file-info [href]:not(.rgh-pr-file-state)', {
 		constructor: HTMLAnchorElement,
 		add(filename) {
 			filename.classList.add('rgh-pr-file-state');
@@ -58,6 +58,7 @@ async function init(): Promise<void | false> {
 			);
 		}
 	});
+	deinit.push(observer.abort);
 }
 
 void features.add(__filebasename, {
@@ -70,9 +71,7 @@ void features.add(__filebasename, {
 		pageDetect.isPRFile404,
 		pageDetect.isPRCommit404
 	],
+	awaitDomReady: false,
 	init,
-	deinit: () => {
-		observer.abort();
-	},
-	awaitDomReady: false
+	deinit
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -38,6 +38,7 @@ void features.add(__filebasename, {
 	],
 	init,
 	deinit: () => {
+		selectObserver.abort();
 		resizeObserver.disconnect();
 		window.removeEventListener('resize', onResize);
 	}

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -22,7 +22,7 @@ let selectObserver: Observer;
 function init(): void {
 	selectObserver = observe(sidebarSelector, {
 		add(sidebar) {
-			observer.observe(sidebar, {box: 'border-box'});
+			resizeObserver.observe(sidebar, {box: 'border-box'});
 		}
 	});
 	window.addEventListener('resize', onResize);

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -1,7 +1,7 @@
 import './sticky-sidebar.css';
 import select from 'select-dom';
 import debounce from 'debounce-fn';
-import {observe} from 'selector-observer';
+import {observe, Observer} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -17,9 +17,10 @@ function updateStickiness(): void {
 
 const onResize = debounce(updateStickiness, {wait: 100});
 const observer = new ResizeObserver(onResize);
+let selectObserver: Observer;
 
 function init(): void {
-	observe(sidebarSelector, {
+	selectObserver = observe(sidebarSelector, {
 		add(sidebar) {
 			observer.observe(sidebar, {box: 'border-box'});
 		}
@@ -38,5 +39,6 @@ void features.add(__filebasename, {
 	init,
 	deinit: () => {
 		observer.disconnect();
+		selectObserver.abort();
 	}
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -39,6 +39,6 @@ void features.add(__filebasename, {
 	init,
 	deinit: () => {
 		resizeObserver.disconnect();
-		selectObserver.abort();
+		window.removeEventListener('resize', onResize);
 	}
 });

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -16,7 +16,7 @@ function updateStickiness(): void {
 }
 
 const onResize = debounce(updateStickiness, {wait: 100});
-const observer = new ResizeObserver(onResize);
+const resizeObserver = new ResizeObserver(onResize);
 let selectObserver: Observer;
 
 function init(): void {
@@ -38,7 +38,7 @@ void features.add(__filebasename, {
 	],
 	init,
 	deinit: () => {
-		observer.disconnect();
+		resizeObserver.disconnect();
 		selectObserver.abort();
 	}
 });


### PR DESCRIPTION
Avoids many console error.

Without this pr go from one issue to the next and the do history.back() there will be a console error. `clean-conversation-headers`
Go from the conversation tab to the files changed there will be a console error. `sticky-sidebar`

If needed I can paste all the console errors

