### PR TITLE
Add `no-duplicate-list-update-time` feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2613,6 +2613,7 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
+				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
@@ -4193,7 +4194,8 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -7359,6 +7361,7 @@
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
 			"dev": true,
 			"dependencies": {
+				"graceful-fs": "^4.1.6",
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -204,6 +204,7 @@ Thanks for contributing! 🦋🙌
 - [](# "clean-conversation-headers") [Removes duplicate information in the header of issues and PRs ("User wants to merge X commits from Y into Z")](https://user-images.githubusercontent.com/44045911/89736767-686ec800-da9e-11ea-81c3-252e9813140b.png)
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif)
 - [](# "esc-to-cancel") [Adds a shortcut to cancel editing a conversation title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
+- [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](TODO)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -204,7 +204,7 @@ Thanks for contributing! 🦋🙌
 - [](# "clean-conversation-headers") [Removes duplicate information in the header of issues and PRs ("User wants to merge X commits from Y into Z")](https://user-images.githubusercontent.com/44045911/89736767-686ec800-da9e-11ea-81c3-252e9813140b.png)
 - [](# "dim-bots") [Dims commits and PRs by bots to reduce noise.](https://user-images.githubusercontent.com/1402241/65263190-44c52b00-db36-11e9-9b33-d275d3c8479d.gif)
 - [](# "esc-to-cancel") [Adds a shortcut to cancel editing a conversation title: <kbd>esc</kbd>.](https://user-images.githubusercontent.com/35100156/98303086-d81d2200-1fbd-11eb-8529-70d48d889bcf.gif)
-- [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](TODO)
+- [](# "no-duplicate-list-update-time") [Hides the update time of conversations in lists when it matches the open/closed/merged time.](https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/no-duplicate-list-update-time.tsx
+++ b/source/features/no-duplicate-list-update-time.tsx
@@ -1,0 +1,31 @@
+import select from 'select-dom';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+function parseTime(element: HTMLElement): number {
+	return new Date(element.getAttribute('datetime')!).getTime();
+}
+
+function init(): void {
+	for (const issue of select.all('.js-navigation-item[id^="issue_"]')) {
+		const [stateChangeTime, updateTime] = select.all('relative-time', issue);
+		console.log(issue, (parseTime(updateTime) - parseTime(stateChangeTime))/1000);
+
+		if (parseTime(updateTime) - parseTime(stateChangeTime) < 10000) { // Hide if within 10 seconds
+			updateTime.parentElement!.remove()
+		}
+	}
+}
+
+console.log(33);
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isConversationList
+	],
+	exclude: [
+		() => !location.search.includes('sort%3Aupdated-desc')
+	],
+	init
+});

--- a/source/features/no-duplicate-list-update-time.tsx
+++ b/source/features/no-duplicate-list-update-time.tsx
@@ -10,22 +10,18 @@ function parseTime(element: HTMLElement): number {
 function init(): void {
 	for (const issue of select.all('.js-navigation-item[id^="issue_"]')) {
 		const [stateChangeTime, updateTime] = select.all('relative-time', issue);
-		console.log(issue, (parseTime(updateTime) - parseTime(stateChangeTime))/1000);
-
 		if (parseTime(updateTime) - parseTime(stateChangeTime) < 10000) { // Hide if within 10 seconds
-			updateTime.parentElement!.remove()
+			updateTime.parentElement!.remove();
 		}
 	}
 }
-
-console.log(33);
 
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],
 	exclude: [
-		() => !location.search.includes('sort%3Aupdated-desc')
+		() => !location.search.includes('sort%3Aupdated-')
 	],
 	init
 });

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -214,6 +214,7 @@ import './features/rgh-sponsor-button';
 import './features/rgh-linkify-features';
 import './features/collapse-markdown-sections';
 import './features/conversation-activity-filter';
+import './features/no-duplicate-list-update-time';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
Closes https://github.com/sindresorhus/refined-github/issues/3948

This feature applies to conversation lists sorted by updated time

- https://github.com/sindresorhus/refined-github/pulls?q=sort%3Aupdated-asc+is%3Aclosed
- https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+sort%3Aupdated-desc+is%3Aclosed+comments%3A0
- [github.com/issues (is:issue is:open author:fregante archived:false sort:updated-desc)](https://github.com/issues?q=is%3Aissue+is%3Aopen+author%3Afregante+archived%3Afalse+sort%3Aupdated-desc)

## Screenshot

<img width="625" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/111360126-fb359d80-8651-11eb-96d4-4fe1d003a48f.png">



## Demo mockup

<img width="701" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/111357166-ac3a3900-864e-11eb-884a-d6d6da88f7e2.png">