### PR TITLE
Add "Dark dimmed" version to `night-not-found`

### DIFF
--- a/source/features/night-not-found.css
+++ b/source/features/night-not-found.css
@@ -30,71 +30,71 @@
 }
 
 /* Dark dimmed */
-[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='249'] {
+[data-color-mode='dark'][data-dark-theme='dark_dimmed'] .js-plaxify[height='249'] {
 	filter: brightness(0.5);
 }
 
-[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='230'] {
+[data-color-mode='dark'][data-dark-theme='dark_dimmed'] .js-plaxify[height='230'] {
 	filter: brightness(0.8) saturate(0.5) contrast(1.3);
 }
 
-[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='156'] {
+[data-color-mode='dark'][data-dark-theme='dark_dimmed'] .js-plaxify[height='156'] {
 	filter: brightness(0.5) saturate(0.5);
 }
 
-[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='49'] {
+[data-color-mode='dark'][data-dark-theme='dark_dimmed'] .js-plaxify[height='49'] {
 	filter: brightness(0.9) saturate(0.5);
 }
 
-[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
+[data-color-mode='dark'][data-dark-theme='dark_dimmed'] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
 	filter: brightness(0.3) saturate(0.5);
 }
 
 /* Auto mode, dark */
 @media (prefers-color-scheme: dark) {
 	/* Dark */
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='249'] {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify[height='249'] {
 		filter: invert();
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='230'] {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify[height='230'] {
 		filter: brightness(0.6) saturate(0.5) contrast(1.3);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='156'] {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify[height='156'] {
 		filter: brightness(0.3) saturate(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='49'] {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify[height='49'] {
 		filter: brightness(0.9) saturate(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify:is([height='415'], [height='75'], [height='50']) {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify:is([height='415'], [height='75'], [height='50']) {
 		filter: brightness(0.1) saturate(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='123'] {
+	[data-color-mode='auto'][data-dark-theme='dark'] .js-plaxify[height='123'] {
 		filter: brightness(0.15) saturate(0.5);
 	}
 
 	/* Dark dimmed */
-	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='249'] {
+	[data-color-mode='auto'][data-dark-theme='dark_dimmed'] .js-plaxify[height='249'] {
 		filter: brightness(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='230'] {
+	[data-color-mode='auto'][data-dark-theme='dark_dimmed'] .js-plaxify[height='230'] {
 		filter: brightness(0.8) saturate(0.5) contrast(1.3);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='156'] {
+	[data-color-mode='auto'][data-dark-theme='dark_dimmed'] .js-plaxify[height='156'] {
 		filter: brightness(0.5) saturate(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='49'] {
+	[data-color-mode='auto'][data-dark-theme='dark_dimmed'] .js-plaxify[height='49'] {
 		filter: brightness(0.9) saturate(0.5);
 	}
 
-	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
+	[data-color-mode='auto'][data-dark-theme='dark_dimmed'] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
 		filter: brightness(0.3) saturate(0.5);
 	}
 }

--- a/source/features/night-not-found.css
+++ b/source/features/night-not-found.css
@@ -3,7 +3,7 @@
 	transition: transform 0.1s, filter 1s;
 }
 
-/* These are 2 exact copies: one for dark mode and the other one for auto mode */
+/* These are 2 exact copies: one for always-dark mode and the other one for auto mode */
 
 [data-color-mode='dark'] .js-plaxify[height='249'] {
 	filter: invert();
@@ -29,30 +29,73 @@
 	filter: brightness(0.15) saturate(0.5);
 }
 
+/* Dark dimmed */
+[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='249'] {
+	filter: brightness(0.5);
+}
+
+[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='230'] {
+	filter: brightness(0.8) saturate(0.5) contrast(1.3);
+}
+
+[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='156'] {
+	filter: brightness(0.5) saturate(0.5);
+}
+
+[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify[height='49'] {
+	filter: brightness(0.9) saturate(0.5);
+}
+
+[data-color-mode='dark'][data-dark-theme="dark_dimmed"] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
+	filter: brightness(0.3) saturate(0.5);
+}
+
 /* Auto mode, dark */
 @media (prefers-color-scheme: dark) {
-	[data-color-mode='auto'] .js-plaxify[height='249'] {
+	/* Dark */
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='249'] {
 		filter: invert();
 	}
 
-	[data-color-mode='auto'] .js-plaxify[height='230'] {
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='230'] {
 		filter: brightness(0.6) saturate(0.5) contrast(1.3);
 	}
 
-	[data-color-mode='auto'] .js-plaxify[height='156'] {
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='156'] {
 		filter: brightness(0.3) saturate(0.5);
 	}
 
-	[data-color-mode='auto'] .js-plaxify[height='49'] {
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='49'] {
 		filter: brightness(0.9) saturate(0.5);
 	}
 
-	[data-color-mode='auto'] .js-plaxify:is([height='415'], [height='75'], [height='50']) {
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify:is([height='415'], [height='75'], [height='50']) {
 		filter: brightness(0.1) saturate(0.5);
 	}
 
-	[data-color-mode='auto'] .js-plaxify[height='123'] {
+	[data-color-mode='auto'][data-dark-theme="dark"] .js-plaxify[height='123'] {
 		filter: brightness(0.15) saturate(0.5);
+	}
+
+	/* Dark dimmed */
+	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='249'] {
+		filter: brightness(0.5);
+	}
+
+	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='230'] {
+		filter: brightness(0.8) saturate(0.5) contrast(1.3);
+	}
+
+	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='156'] {
+		filter: brightness(0.5) saturate(0.5);
+	}
+
+	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify[height='49'] {
+		filter: brightness(0.9) saturate(0.5);
+	}
+
+	[data-color-mode='auto'][data-dark-theme="dark_dimmed"] .js-plaxify:is([height='415'], [height='75'], [height='50'], [height='123']) {
+		filter: brightness(0.3) saturate(0.5);
 	}
 }
 


### PR DESCRIPTION
Context: https://github.blog/changelog/2021-03-16-dimmed-theme-beta-for-github-com/

Tested in both system-sync and single-theme options

![github com_404 (2)](https://user-images.githubusercontent.com/1402241/111419504-30240d80-86af-11eb-8078-057ede4b29f9.png)
![github com_404 (1)](https://user-images.githubusercontent.com/1402241/111419517-35815800-86af-11eb-9261-f82ca3b1dd6a.png)
![github com_404](https://user-images.githubusercontent.com/1402241/111419520-374b1b80-86af-11eb-8ea6-9f8cc1f5c7b3.png)
