### PR TITLE
Restore `linkify-full-profile-readme-title` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -351,7 +351,7 @@ Thanks for contributing! 🦋🙌
 - [](# "prevent-duplicate-pr-submission") [Avoids creating duplicate PRs when mistakenly clicking "Create pull request" more than once.](https://user-images.githubusercontent.com/16872793/89589967-e029c200-d814-11ea-962b-3ff1f6236781.gif)
 - [](# "stop-pjax-loading-with-esc") [After you click on an ajaxed link, this lets you stop loading a page by pressing the <kbd>esc</kbd> key, like the browser does for regular page loads.](https://user-images.githubusercontent.com/36174850/90323385-3c08ef00-df69-11ea-8c0e-c85241888a7b.gif)
 - [](# "same-page-definition-jump") [Avoids re-loading the page when jumping to function definition in the current file.](https://user-images.githubusercontent.com/16872793/90833649-7a5e2f80-e316-11ea-827d-a4e3ac8ced69.png)
-- [](# "linkify-full-profile-readme-title") [Linkify the readme text on profile pages.](https://user-images.githubusercontent.com/16872793/90910173-ebe4bf00-e3a4-11ea-8fc5-aea3d1a2e5e5.png)
+- [](# "linkify-full-profile-readme-title") [Linkifies the readme text on profile pages.](https://user-images.githubusercontent.com/16872793/90910173-ebe4bf00-e3a4-11ea-8fc5-aea3d1a2e5e5.png)
 - [](# "convert-pr-to-draft-improvements") [Moves the "Convert PR to Draft" button to the mergeability box and adds visual feedback to its confirm button.](https://user-images.githubusercontent.com/1402241/95644892-885f3f80-0a7f-11eb-8428-8e0fb0c8dfa5.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->

--- a/source/features/linkify-full-profile-readme-title.tsx
+++ b/source/features/linkify-full-profile-readme-title.tsx
@@ -4,7 +4,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function init(): void {
-	const link = select('.user-profile-nav + div .octicon-smiley + a');
+	const link = select('.user-profile-nav + div .octicon-octoface + a');
 	while (link?.nextSibling) {
 		link.append(link.nextSibling);
 	}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4122

## Test URLs

https://github.com/sindresorhus

## Screenshot

Unnecessary I guess?

P.S. Coincidently, I noticed this icon change a few days ago, but I can't remember this feature existing.