### PR TITLE
Don't `collapse-markdown-sections` when clicking links

### DIFF
--- a/source/features/collapse-markdown-sections.ts
+++ b/source/features/collapse-markdown-sections.ts
@@ -3,12 +3,18 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function onHeadingClick({delegateTarget: sectionHeading}: delegate.Event<MouseEvent, HTMLElement>): void {
+function onHeadingClick(event: delegate.Event<MouseEvent, HTMLElement>): void {
 	// Don't toggle the section if the title text is being selected instead of clicked
 	if (document.getSelection()?.type === 'Range') {
 		return;
 	}
 
+	// Don't toggle the section if a link in the heading is clicked (either the content or the anchor)
+	if ((event.target as HTMLElement).closest('h1, h2, h3, h4, h5, h6, a')!.tagName === 'A') {
+		return;
+	}
+
+	const sectionHeading = event.delegateTarget;
 	const isSectionHidden = sectionHeading.classList.toggle('rgh-markdown-section-collapsed');
 	let element = sectionHeading.tagName === 'H1' ?
 		sectionHeading.parentElement!.firstElementChild as HTMLElement :

--- a/source/features/collapse-markdown-sections.ts
+++ b/source/features/collapse-markdown-sections.ts
@@ -10,7 +10,7 @@ function onHeadingClick(event: delegate.Event<MouseEvent, HTMLElement>): void {
 	}
 
 	// Don't toggle the section if a link in the heading is clicked (either the content or the anchor)
-	if ((event.target as HTMLElement).closest('h1, h2, h3, h4, h5, h6, a')!.tagName === 'A') {
+	if ((event.target as HTMLElement).closest('a')) {
 		return;
 	}
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4126 

## Test URLs
- [Links in headings](https://github.com/kidonng/api)
- [Links inside `<code>` elements in headings](https://github.com/cheap-glitch/git-grapnel)

## Screenshot
n/a

Note that the sections can still be toggled by clicking on the "side" of the links (since headings are blocks).

This fix also prevents the toggling of a section when the "anchor links" are clicked (which happens otherwise since they are inside the heading elements).