### PR TITLE
Only expand Checks list on PRs, not in popups

### DIFF
--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -75,10 +75,9 @@
 	color: #6a737d;
 }
 
-/* Expand merge status lists to fit more items */
-.branch-action-item-simple > .merge-status-list, /* Dropdowns */
-.branch-action-item.open > .merge-status-list { /* Pull requests */
-	max-height: 512px !important;
+/* Expand PR merge status list to fit all items */
+:root .branch-action-item.open:not(.branch-action-item-simple) > .merge-status-list {
+	max-height: none;
 }
 
 /* Make <details> visibly clickable */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -75,9 +75,10 @@
 	color: #6a737d;
 }
 
-/* Expand PR merge status list to fit all items instead of just 5 */
-:root .branch-action-item.open > .merge-status-list {
-	max-height: none;
+/* Expand merge status lists to fit more items */
+.branch-action-item-simple > .merge-status-list, /* Dropdowns */
+.branch-action-item.open > .merge-status-list { /* Pull requests */
+	max-height: 512px !important;
 }
 
 /* Make <details> visibly clickable */


### PR DESCRIPTION
## Summary

Expands only the PR merge status list (and not the popups/dropdowns) to fit all items. This can be thought of as a fix for the popups/dropdowns.

## Test URL(s)

* [dropdown(s) (main)](https://github.com/npm/arborist)
* [dropdown(s) (commit history)](https://github.com/npm/arborist/commits/main)
* [pull request](https://github.com/npm/arborist/pull/254)

## Screenshot(s)

<details>
  <summary>Long merge status list fixed</summary>

  ![Long merge status list fixed](https://user-images.githubusercontent.com/15643597/111810142-b143f600-88a3-11eb-9cac-83e5053b95b0.png)
</details>

## References

Fixes #4124.