### PR TITLE
Fix style of `hide-readme-header` on GitHub Enterprise

### DIFF
--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -4,6 +4,9 @@
 
 .repository-content #readme:not(.blob) .Box-header {
 	margin-bottom: -40px;
+	/* fix for older Github Enterprise versions */
+	background-color: transparent !important;
+	border-bottom: none;
 }
 
 .repository-content #readme:not(.blob) .Box-header .btn-octicon {

--- a/source/features/hide-readme-header.css
+++ b/source/features/hide-readme-header.css
@@ -4,9 +4,8 @@
 
 .repository-content #readme:not(.blob) .Box-header {
 	margin-bottom: -40px;
-	/* fix for older Github Enterprise versions */
-	background-color: transparent !important;
-	border-bottom: none;
+	background-color: transparent !important; /* GHE #4137 */
+	border-bottom: none; /* GHE #4137 */
 }
 
 .repository-content #readme:not(.blob) .Box-header .btn-octicon {


### PR DESCRIPTION
relates to https://github.com/sindresorhus/refined-github/pull/4046

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs


## Screenshot
<img width="1018" alt="Screen Shot 2021-03-19 at 2 36 07 PM" src="https://user-images.githubusercontent.com/12237902/111827609-514f4e80-88a7-11eb-8220-caace7078deb.png">
(from Github Enterprise v2.21.14)

