### PR TITLE
Add `confirm-short-comments` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ Thanks for contributing! 🦋🙌
 - [](# "table-input") [Adds a button in the text editor to quickly insert a simplified HTML table.](https://user-images.githubusercontent.com/46634000/94559114-09892c00-0261-11eb-8fb0-c5a85ea76b6f.gif)
 - [](# "unfinished-comments") [Notifies the user of unfinished comments in hidden tabs.](https://user-images.githubusercontent.com/1402241/97792086-423d5d80-1b9f-11eb-9a3a-daf716d10b0e.gif)
 - [](# "wait-for-attachments") [Wait for the attachments to finish uploading before allowing to post a comment.](https://user-images.githubusercontent.com/46634000/104294547-9b8b0c80-54bf-11eb-93e5-65ae158353b3.gif)
+- [](# "confirm-short-comments") [Displays a `confirm()` dialog when trying to submit an issue or comment with title/body of less than 3 characters](https://user-images.githubusercontent.com/723651/111637477-23fc9500-8802-11eb-8c1b-4023b7b1c371.jpg)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/confirm-short-comments.tsx
+++ b/source/features/confirm-short-comments.tsx
@@ -18,8 +18,6 @@ function handleIssueComment(event: delegate.Event<MouseEvent, KeyboardEvent, HTM
 	const textareas = select('textarea[name="comment[body]"], textarea#issue_body')!.value.length;
 	const title = select('form.new_issue input#issue_title')?.value.length;
 
-	console.log('TITLE: ' + title + ' | ' + 'TEXTAREAS: ' + textareas);
-
 	let message = '';
 	if ((title && title < 3) && (textareas < 3)) {
 		message = 'Body, title are';

--- a/source/features/confirm-short-comments.tsx
+++ b/source/features/confirm-short-comments.tsx
@@ -1,0 +1,62 @@
+import select from 'select-dom';
+import delegate from 'delegate-it';
+import * as pageDetect from 'github-url-detection';
+import * as textFieldEdit from 'text-field-edit';
+
+import features from '.';
+
+function refocus(): void {
+	const element = document.activeElement;
+	const value = element?.value;
+	textFieldEdit.set(
+		element,
+		value
+	);
+}
+
+function handleIssueComment(event: delegate.Event<MouseEvent, KeyboardEvent, HTMLAnchorElement>): void {
+	const textareas = select('textarea[name="comment[body]"], textarea#issue_body')!.value.length;
+	const title = select('form.new_issue input#issue_title')?.value.length;
+
+	console.log('TITLE: ' + title + ' | ' + 'TEXTAREAS: ' + textareas);
+
+	let message = '';
+	if ((title && title < 3) && (textareas < 3)) {
+		message = 'Body, title are';
+	} else if (title && title < 3) {
+		message += 'Title is';
+	} else if (textareas < 3) {
+		message += 'Body is';
+	}
+
+	message += ' less than 3 characters, are you sure?';
+
+	console.log(title + '/' + textareas);
+	if ((title && title < 3) && !confirm(message)) {
+		event.preventDefault();
+		refocus();
+		return;
+	}
+
+	if ((textareas < 3) && !confirm(message)) {
+		event.preventDefault();
+		if (pageDetect.isIssue()) {
+			event.stopImmediatePropagation();
+		}
+
+		refocus();
+	}
+}
+
+function init(): void {
+	delegate(document, 'form.js-new-comment-form, form.new_issue', 'submit', handleIssueComment);
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isNewIssue,
+		pageDetect.isIssue
+	],
+	awaitDomReady: false,
+	init
+});

--- a/source/features/confirm-short-comments.tsx
+++ b/source/features/confirm-short-comments.tsx
@@ -29,7 +29,6 @@ function handleIssueComment(event: delegate.Event<MouseEvent, KeyboardEvent, HTM
 
 	message += ' less than 3 characters, are you sure?';
 
-	console.log(title + '/' + textareas);
 	if ((title && title < 3) && !confirm(message)) {
 		event.preventDefault();
 		refocus();

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -216,6 +216,7 @@ import './features/collapse-markdown-sections';
 import './features/conversation-activity-filter';
 import './features/select-all-notifications-shortcut';
 import './features/no-duplicate-list-update-time';
+import './features/confirm-short-comments';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
(Second attempt, after #4123)

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #3911 

## Test URLs

Any new/existing issue page: e.g.
https://github.com/sindresorhus/refined-github/issues/new
https://github.com/sindresorhus/refined-github/issues/3911


## Screenshot

![111637477-23fc9500-8802-11eb-8c1b-4023b7b1c371](https://user-images.githubusercontent.com/723651/111687809-64c0d200-8833-11eb-9ce2-8b8e0f57eda9.jpg)


---

Currently I'm getting these 3 TypeScript errors in VSCode, which I'm unable to fix. ([screenshot](https://user-images.githubusercontent.com/723651/111886325-a4272400-89d5-11eb-9a64-56551568995f.jpg))
(I have run `npm run lint` and `npm run fix`).

> - Property 'value' does not exist on type 'Element'. (line 10)
> - Argument of type 'Element | null' is not assignable to parameter of type 'HTMLTextAreaElement | HTMLInputElement'. 
>   Type 'null' is not assignable to type 'HTMLTextAreaElement | HTMLInputElement'. (line 12)
> - Generic type 'Event' requires between 0 and 2 type arguments. (line 17)

&nbsp;
In the New Issue page it seems to be working ok.

In an existing issue page I'm having these problems:
  - If I block a submission once, then I can only submit by clicking `Submit` (the submit shortcut <kbd>Ctrl+Enter</kbd> doesn't work anymore). Additionally, sometimes I cannot submit not even via the button, unless I click somewhere away and then back in the textarea. *(My use of textFieldEdit -inside the `refocus()` function- doesn't seem to help in this case, in constrast to the New issue page)*
  - after blocking a submission, the `Close with comment` button becomes disabled. The `Comment` button remains enabled. 

Any help would be most welcome !