### PR TITLE
Fix `more-dropdown` removing repo tabs container

### DIFF
--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -43,7 +43,7 @@ function onlyShowInDropdown(id: string): void {
 		return;
 	}
 
-	tabItem!.parentElement!.remove();
+	tabItem!.remove();
 	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -43,7 +43,7 @@ function onlyShowInDropdown(id: string): void {
 		return;
 	}
 
-	tabItem!.remove();
+	tabItem!.closest('.UnderlineNav-item')!.remove();
 	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;


### PR DESCRIPTION
Fixes []() #4166 

Looks like GitHub changed their layout:
The `[data-tab-item$="${id}"]` selector now points to the tab anchor/link.

![image](https://user-images.githubusercontent.com/10238474/112875964-8c365b00-90cd-11eb-9e58-c814b0521735.png)

