### PR TITLE
Add `hide-empty-profile-status` feature

### DIFF
--- a/source/features/hide-empty-profile-status.css
+++ b/source/features/hide-empty-profile-status.css
@@ -1,4 +1,4 @@
-/* Hide empty profile status on hover #4160 */
+/* GitHub adds unnecessary spacing on empty profile status labels when hovering #4160 */
 .user-status-circle-badge-container:hover .user-status-emoji-container {
 	margin-right: 0 !important;
 }

--- a/source/features/hide-empty-profile-status.css
+++ b/source/features/hide-empty-profile-status.css
@@ -1,0 +1,8 @@
+/* Hide empty profile status on hover #4160 */
+.user-status-circle-badge-container:hover .user-status-emoji-container {
+	margin-right: 0 !important;
+}
+
+.user-status-circle-badge-container:hover .user-status-message-wrapper > div {
+	margin-left: 8px !important;
+}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -138,12 +138,3 @@ pr-branches
 .select-menu-item-text .diffstat {
 	display: inline !important;
 }
-
-/* Hide empty profile status on hover #4160 */
-.user-status-circle-badge-container:hover .user-status-emoji-container {
-	margin-right: 0 !important;
-}
-
-.user-status-circle-badge-container:hover .user-status-message-wrapper > div {
-	margin-left: 8px !important;
-}

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -138,3 +138,12 @@ pr-branches
 .select-menu-item-text .diffstat {
 	display: inline !important;
 }
+
+/* Hide empty profile status on hover #4160 */
+.user-status-circle-badge-container:hover .user-status-emoji-container {
+	margin-right: 0 !important;
+}
+
+.user-status-circle-badge-container:hover .user-status-message-wrapper > div {
+	margin-left: 8px !important;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -22,6 +22,7 @@ import './features/clean-notifications.css';
 import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';
 import './features/night-not-found.css';
+import './features/hide-empty-profile-status.css';
 
 // DO NOT add CSS files here if they are part of a JavaScript feature.
 // Import the `.css` file from the `.tsx` instead.


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4160

## Test URLs

* [Profile with empty status](https://github.com/Krausso)
* [Profile with status](https://github.com/notlmn)

## Screenshot
![image](https://user-images.githubusercontent.com/46634000/113003955-809d6f80-9173-11eb-9fa0-8f476d740d24.png)
