### PR TITLE
Fix features related to repo tabs again

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -88,7 +88,12 @@ async function init(): Promise<void | false> {
 	// Update Bugs’ link
 	new SearchQuery(bugsTab).add('label:bug');
 
-	issuesTab.after(bugsTab);
+	// In case GitHub changes its layout again #4166
+	if (issuesTab.parentElement!.tagName === 'LI') {
+		issuesTab.parentElement!.after(<li className="d-flex">{bugsTab}</li>);
+	} else {
+		issuesTab.after(bugsTab);
+	}
 
 	// Update bugs count
 	try {

--- a/source/features/more-dropdown.tsx
+++ b/source/features/more-dropdown.tsx
@@ -43,11 +43,11 @@ function onlyShowInDropdown(id: string): void {
 		return;
 	}
 
-	tabItem!.closest('.UnderlineNav-item, li')!.remove();
+	(tabItem!.closest('li') ?? tabItem!.closest('.UnderlineNav-item'))!.remove();
+
 	const menuItem = select(`[data-menu-item$="${id}"]`)!;
 	menuItem.removeAttribute('data-menu-item');
 	menuItem.hidden = false;
-
 	// The item has to be moved somewhere else because the overflow nav is order-dependent
 	select('.js-responsive-underlinenav-overflow ul')!.append(menuItem);
 }

--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -69,17 +69,19 @@ async function init(): Promise<false | void> {
 	if (repoNavigationBar) {
 		// "Repository refresh" layout
 		const releasesTab = (
-			<a
-				href={buildRepoURL('releases')}
-				className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item"
-				data-hotkey="g r"
-				data-selected-links="repo_releases"
-				data-tab-item="rgh-releases-item"
-			>
-				<TagIcon className="UnderlineNav-octicon"/>
-				<span data-content="Releases">Releases</span>
-				{count && <span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>}
-			</a>
+			<li className="d-flex">
+				<a
+					href={buildRepoURL('releases')}
+					className="js-selected-navigation-item UnderlineNav-item hx_underlinenav-item no-wrap js-responsive-underlinenav-item"
+					data-hotkey="g r"
+					data-selected-links="repo_releases"
+					data-tab-item="rgh-releases-item"
+				>
+					<TagIcon className="UnderlineNav-octicon"/>
+					<span data-content="Releases">Releases</span>
+					{count && <span className="Counter" title={count > 999 ? String(count) : ''}>{abbreviateNumber(count)}</span>}
+				</a>
+			</li>
 		);
 		repoNavigationBar.append(releasesTab);
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## Test URLs
* `more-dropdown`
  * https://github.com/microsoft/TypeScript
  * https://github.com/eslint/eslint
* `bugs-tab`
  * https://github.com/microsoft/TypeScript
  * [No issue labels](https://github.com/PHPOffice/PhpSpreadsheet)
  * [Archived repo](https://github.com/PHPOffice/PHPExcel)
* `releases-tab`
  * https://github.com/atom-community/sync-settings
  * [Tags instead or releases](https://github.com/tpope/vim-unimpaired)

## Screenshot
n/a

Seems like #4180 wasn't actually needed since the `<a>` is still the one bearing the `.UnderlineNav-item` class:

![image](https://user-images.githubusercontent.com/46634000/113114022-3962bd80-920b-11eb-9b1e-c25cf1162032.png)

This PR:
  * proposes a hopefully better fix that works for both GitHub and GHE and doesn't leave empty `<li>` in the DOM
  * changes `bugs-tab` and `releases-tab` to follow the new DOM structure