### PR TITLE
Preserve `select-all-notifications-shortcut` after clicking Done

### DIFF
--- a/source/features/select-all-notifications-shortcut.tsx
+++ b/source/features/select-all-notifications-shortcut.tsx
@@ -8,7 +8,7 @@ async function init(): Promise<void> {
 	const selectAllNotifications = await elementReady<HTMLElement>('.js-notifications-mark-all-prompt');
 	if (selectAllNotifications) { // Notifications page may be empty
 		selectAllNotifications.dataset.hotkey = 'a';
-		await onElementRemoval(selectAllNotifications);
+		await onElementRemoval(selectAllNotifications); // "Select all" checkbox will be replaced if there's more notifications to load #4199
 		void init();
 	}
 }

--- a/source/features/select-all-notifications-shortcut.tsx
+++ b/source/features/select-all-notifications-shortcut.tsx
@@ -2,11 +2,14 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import onElementRemoval from '../helpers/on-element-removal';
 
 async function init(): Promise<void> {
 	const selectAllNotifications = await elementReady<HTMLElement>('.js-notifications-mark-all-prompt');
 	if (selectAllNotifications) { // Notifications page may be empty
 		selectAllNotifications.dataset.hotkey = 'a';
+		await onElementRemoval(selectAllNotifications);
+		void init();
 	}
 }
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4198 

## Test URLs
* https://github.com/notifications
* https://github.com/notifications?query=is%3Adone

## Screenshot
n/a

Steps to reproduce:
1. Make sure you have more than one page of notifications to select
2. Press <kbd>a</kbd> and click "Done"
3. Wait a second or two for the other notifications to load
4. Press <kbd>a</kdb>
5. Nothing happens