### PR TITLE
Meta: Add collaborators guide

### DIFF
--- a/collaborators.md
+++ b/collaborators.md
@@ -1,0 +1,17 @@
+# Collaborator guide
+
+## Creating releases
+
+Releases are done semi-automatically through GitHub Actions. See the full workflow: [release.yml](.github/workflows/release.yml)
+
+Every first of the month, it attempts to create a release, if there are any unreleased commits on the `main` branch.
+
+To create a release manually, visit the [Release workflow page](https://github.com/sindresorhus/refined-github/actions/workflows/release.yml) and click "Run the workflow". This can be done approximately once a week, if worth it, or earlier if there are bugs of medium severity.
+
+## Hot fixes
+
+When features are breaking GitHub altogether, they can be disabled immediately for everyone without going through the release/update process.
+
+Refined GitHub fetches a list of buggy features at most every 4 hours, if the user visits GitHub.
+
+This list of disabled features lives on the [`hotfixes` branch](https://github.com/sindresorhus/refined-github/tree/hotfix), together with more detailed instructions on how to properly use it.

--- a/collaborators.md
+++ b/collaborators.md
@@ -4,14 +4,14 @@
 
 Releases are done semi-automatically through GitHub Actions. See the full workflow: [release.yml](.github/workflows/release.yml)
 
-Every first of the month, it attempts to create a release, if there are any unreleased commits on the `main` branch.
+On the first of every month, it attempts to create a release if there are any unreleased commits on the `main` branch.
 
-To create a release manually, visit the [Release workflow page](https://github.com/sindresorhus/refined-github/actions/workflows/release.yml) and click "Run the workflow". This can be done approximately once a week, if worth it, or earlier if there are bugs of medium severity.
+To create a release manually, visit the [Release workflow page](https://github.com/sindresorhus/refined-github/actions/workflows/release.yml) and click “Run the workflow”. This can be done approximately once a week, if worth it, or earlier if there are bugs of medium severity.
 
-## Hot fixes
+## Hotfixes
 
 When features are breaking GitHub altogether, they can be disabled immediately for everyone without going through the release/update process.
 
-Refined GitHub fetches a list of buggy features at most every 4 hours, if the user visits GitHub.
+Refined GitHub fetches a list of buggy features at most every 6 hours if the user visits GitHub.
 
 This list of disabled features lives on the [`hotfixes` branch](https://github.com/sindresorhus/refined-github/tree/hotfix), together with more detailed instructions on how to properly use it.


### PR DESCRIPTION
What else should we include? This is different from the generic contributors guide, which is more of an entry point and doesn't need to include a lot of details about the codebase.

This file could include instructions on how the codebase is organized and nitpicks to ensure consistency when reviewing, which currently are "unwritten rules" and lints like:

- [ ] how to cache API calls correctly
- [ ] sort imports a certain way
- [ ] when to use elementReady and what it is
- [ ] keep in mind GHE when using absolute URLs
- [ ] use `// TODO[2021-10-01]: GHE #1234` comments to remind us to drop old code after a year
- [ ] GHE support policy: I suggest dropping code a year after it has changed on GitHub.com
- [ ] GHE code: preserve unchanged instead of mixing it with new code, unless it's a single selector change. When dropping it, it'll be as easy as deleting whole lines instead of untangling it from live code.

Also in the contributors guide we could add:
- general code instructions (e.g. use this listener instead of that)
- how to reverse engineer GitHub

Reviews and additional draft PRs welcome for this document and the other