### PR TITLE
Fix backticks conflict in `sync-pr-commit-title`

### DIFF
--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -18,7 +18,7 @@ function getCommitTitleField(): HTMLInputElement | undefined {
 }
 
 function createCommitTitle(): string {
-	const prTitle = select('.js-issue-title')!.textContent!.trim();
+	const prTitle = select(prTitleFieldSelector)!.value.trim();
 	return `${prTitle} (#${getConversationNumber()!})`;
 }
 


### PR DESCRIPTION
Fixes #4139 

## Test URLs
This PR

## Screenshot
None

