### PR TITLE
Meta: Drop unnecessary web-ext redirect

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -103,16 +103,14 @@ Then load or reload it into the browser to see the changes.
 
 ## Loading into the browser
 
-Once built, load it in the browser of your choice.
+Once built, load it in the browser of your choice with [web-ext](https://github.com/mozilla/web-ext):
 
 ```sh
-npm run start # Open extension in Chrome
+npx web-ext run --target=chromium # Open extension in Chrome
 ```
 
 ```sh
-npm run start:firefox # Open extension in Firefox
+npx web-ext run # Open extension in Firefox
 ```
-
-**Note**: They both require [web-ext](https://github.com/mozilla/web-ext) to be installed globally. Run `npm i -g web-ext`
 
 Or you can [load it manually in Chrome](https://www.smashingmagazine.com/2017/04/browser-extension-edge-chrome-firefox-opera-brave-vivaldi/#google-chrome-opera-vivaldi) or [Firefox](https://www.smashingmagazine.com/2017/04/browser-extension-edge-chrome-firefox-opera-brave-vivaldi/#mozilla-firefox).

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
 		"lint:css": "stylelint 'source/**/*.css'",
 		"lint:js": "xo",
 		"pack:safari": "xcodebuild -project 'safari/Refined GitHub.xcodeproj'",
-		"start": "web-ext run --target=chromium || echo 'Install it first: npm i -g web-ext'",
-		"start:firefox": "web-ext run || echo 'Install it first: npm i -g web-ext'",
 		"start:safari": "open 'safari/build/Release/Refined GitHub.app'",
 		"test": "run-p ava lint:* build:*",
 		"watch": "run-p watch:* --continue-on-error",


### PR DESCRIPTION
Using `npm run start` instead of `web-ext run --target=chromium` doesn't save a lot of time. Given I have a lot of extensions I just added shorter aliases to my shell and they work everywhere without having to check whether `start` is set. 

For new contributors it also drops the awkward command that appears to be local but requires a global dependency.