### PR TITLE
Meta: Improve GHE documentation in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ We use GitHub a lot and notice many annoyances we'd like to fix. So here be drag
 
 Our hope is that GitHub will notice and implement some of these much needed improvements. So if you like any of these improvements, please email [GitHub support](https://support.github.com/contact) about doing it.
 
-GitHub Enterprise is also supported. More info in the options.
+GitHub Enterprise is also supported: [How to enable it](https://fregante.github.io/webext-domain-permission-toggle/?name=Refined%20GitHub&icon=https%3A%2F%2Fraw.githubusercontent.com%2Fsindresorhus%2Frefined-github%2Fmain%2Fdistribution%2Ficon.png). <!-- icon.png renders best -->
 
 ## Install
 


### PR DESCRIPTION
Demo URL: https://fregante.github.io/webext-domain-permission-toggle/?name=Refined%20GitHub&icon=https%3A%2F%2Fraw.githubusercontent.com%2Fsindresorhus%2Frefined-github%2Fmain%2Fdistribution%2Ficon.png

Follows https://github.com/fregante/webext-domain-permission-toggle/pull/20

No bitmaps were harmed in the making of that page 😃 

<img width="1010" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/114177856-1650b000-9967-11eb-9f1b-908c4e8ff59f.png">


- [ ] ~~Update "Welcome to RG" issue~~ the text and screenshot is already fine there, it's already a RG-specific documentation page that the options already link to.