### PR TITLE
Improve error handling for the Safari extension app

### DIFF
--- a/safari/Refined GitHub.xcodeproj/project.pbxproj
+++ b/safari/Refined GitHub.xcodeproj/project.pbxproj
@@ -106,12 +106,12 @@
 		1FE2B2132540F6EE00A5D543 /* Refined GitHub */ = {
 			isa = PBXGroup;
 			children = (
-				1FE2B2142540F6EE00A5D543 /* Refined_GitHub.entitlements */,
 				1FE2B2152540F6EE00A5D543 /* AppDelegate.swift */,
 				1FE2B21A2540F6EE00A5D543 /* ViewController.swift */,
 				1FE2B2172540F6EE00A5D543 /* Main.storyboard */,
 				1FE2B21C2540F6EF00A5D543 /* Assets.xcassets */,
 				1FE2B21E2540F6EF00A5D543 /* Info.plist */,
+				1FE2B2142540F6EE00A5D543 /* Refined_GitHub.entitlements */,
 			);
 			path = "Refined GitHub";
 			sourceTree = "<group>";

--- a/safari/Refined GitHub/ViewController.swift
+++ b/safari/Refined GitHub/ViewController.swift
@@ -6,7 +6,7 @@ let appName = "Refined GitHub"
 let extensionBundleIdentifier = "com.sindresorhus.Refined-GitHub.Extension"
 
 final class ViewController: NSViewController {
-	@IBOutlet var appNameLabel: NSTextField!
+	@IBOutlet private var appNameLabel: NSTextField!
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -14,11 +14,17 @@ final class ViewController: NSViewController {
 		appNameLabel.stringValue = appName
 
 		SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionBundleIdentifier) { state, error in
-			guard
-				let state = state,
-				error == nil
-			else {
-				// Insert code to inform the user that something went wrong.
+			if let error = error {
+				NSLog("%@", error.localizedDescription)
+				DispatchQueue.main.async {
+					NSApp.presentError(error)
+				}
+				return
+			}
+
+			guard let state = state else {
+				// This should in theory not be hit.
+				NSLog("Could not get state.")
 				return
 			}
 
@@ -32,11 +38,27 @@ final class ViewController: NSViewController {
 		}
 	}
 
+	override func viewDidAppear() {
+		super.viewDidAppear()
+
+		if let window = view.window {
+			window.title = appName
+			window.level = .floating
+			window.styleMask = [.titled]
+			window.center()
+		}
+
+		NSApp.activate(ignoringOtherApps: true)
+	}
+
 	@IBAction
-	func openSafariExtensionPreferences(_ sender: AnyObject?) {
+	private func openSafariExtensionPreferences(_ sender: AnyObject?) {
 		SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
-			guard error == nil else {
-				// Insert code to inform the user that something went wrong.
+			if let error = error {
+				NSLog("%@", error.localizedDescription)
+				DispatchQueue.main.async {
+					NSApp.presentError(error)
+				}
 				return
 			}
 


### PR DESCRIPTION
I also slightly improved the look of the wrapper app:

<img width="526" alt="Screen Shot 2021-04-10 at 15 27 41" src="https://user-images.githubusercontent.com/170270/114263684-4b194180-9a11-11eb-8d34-7160dd342165.png">
