### PR TITLE
Meta: Open Welcome page in foreground

### DIFF
--- a/source/background.ts
+++ b/source/background.ts
@@ -53,8 +53,7 @@ browser.runtime.onInstalled.addListener(async ({reason}) => {
 		}
 
 		await browser.tabs.create({
-			url: 'https://github.com/sindresorhus/refined-github/issues/3543',
-			active: false
+			url: 'https://github.com/sindresorhus/refined-github/issues/3543'
 		});
 	}
 


### PR DESCRIPTION
I initially had it open in background because I don't like things opening automatically, but this actually causes the tab to be lost if someone has several tabs open. The welcome page contains important information to ensure every feature works (API key)