### PR TITLE
Fix `releases-tab` not being highlighted on release pages

### DIFF
--- a/source/features/releases-tab.tsx
+++ b/source/features/releases-tab.tsx
@@ -96,8 +96,8 @@ async function init(): Promise<false | void> {
 				selected.removeAttribute('aria-current');
 			}
 
-			releasesTab.classList.add('selected');
-			releasesTab.setAttribute('aria-current', 'page');
+			releasesTab.firstElementChild!.classList.add('selected');
+			releasesTab.firstElementChild!.setAttribute('aria-current', 'page');
 		}
 
 		appendBefore(


### PR DESCRIPTION
## Test URLs
https://github.com/sindresorhus/refined-github/releases

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/114289691-f218d000-9a47-11eb-816a-e2654bb41618.png)

