### PR TITLE
Enable `one-key-formatting` on more pages

### DIFF
--- a/source/features/esc-to-cancel.tsx
+++ b/source/features/esc-to-cancel.tsx
@@ -1,5 +1,6 @@
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import {onConversationTitleFieldKeydown} from '../github-events/on-field-keydown';
@@ -21,6 +22,10 @@ void features.add(__filebasename, {
 	shortcuts: {
 		esc: 'Cancel editing a conversation title'
 	},
+	include: [
+		pageDetect.isIssue,
+		pageDetect.isPR
+	],
 	awaitDomReady: false,
 	init
 });

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -33,8 +33,7 @@ function eventHandler(event: delegate.Event<KeyboardEvent, HTMLTextAreaElement |
 function init(): void {
 	onCommentFieldKeydown(eventHandler);
 	onConversationTitleFieldKeydown(eventHandler);
-	delegate(document, 'input[name="commit_title"]', 'keydown', eventHandler);
-	delegate(document, 'input[name="gist[description]"]', 'keydown', eventHandler);
+	delegate(document, 'input[name="commit_title"], input[name="gist[description]"], #saved-reply-title-field', 'keydown', eventHandler);
 }
 
 void features.add(__filebasename, {

--- a/source/features/one-key-formatting.tsx
+++ b/source/features/one-key-formatting.tsx
@@ -34,11 +34,13 @@ function init(): void {
 	onCommentFieldKeydown(eventHandler);
 	onConversationTitleFieldKeydown(eventHandler);
 	delegate(document, 'input[name="commit_title"]', 'keydown', eventHandler);
+	delegate(document, 'input[name="gist[description]"]', 'keydown', eventHandler);
 }
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.hasCode
+		pageDetect.hasRichTextEditor,
+		pageDetect.isGist
 	],
 	awaitDomReady: false,
 	init: onetime(init)

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -24,5 +24,5 @@ export function onCommentFieldKeydown(callback: DelegateFieldEvent): void {
 }
 
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent): void {
-	onFieldKeydown('#issue_title, #pull_request_title, #saved-reply-title-field', callback);
+	onFieldKeydown('#issue_title, #pull_request_title', callback);
 }

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -24,5 +24,5 @@ export function onCommentFieldKeydown(callback: DelegateFieldEvent): void {
 }
 
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent): void {
-	onFieldKeydown('#issue_title, #pull_request_title', callback);
+	onFieldKeydown('#issue_title, #pull_request_title, #saved-reply-title-field', callback);
 }

--- a/source/github-events/on-field-keydown.tsx
+++ b/source/github-events/on-field-keydown.tsx
@@ -24,5 +24,5 @@ export function onCommentFieldKeydown(callback: DelegateFieldEvent): void {
 }
 
 export function onConversationTitleFieldKeydown(callback: DelegateFieldEvent): void {
-	onFieldKeydown('#issue_title', callback);
+	onFieldKeydown('#issue_title, #pull_request_title', callback);
 }


### PR DESCRIPTION
Reopen of #4232. Fixes #4231.

Specifically, this PR adds one-key-formatting to:
- the title of a new issue
- the body of a new issue
- the title of a new PR (this already works for the body of a new PR)
- the title of a new gist
- the title and body of [saved replies](https://github.com/settings/replies)

Reference for the difference between `pageDetect.hasCode` and `pageDetect.hasRichTextEditor`: https://github.com/fregante/github-url-detection/blob/9aa429df7af2807ce4797c02b164f83386c453bb/index.ts#L474-L488

one-key-formatting no longer applies on the pages flagged by `pageDetect.isRepoTree` and `pageDetect.isBlame`, which is OK because there are no text inputs on these pages.

Unfortunately, one-key-formatting does not work when creating new files/gists or editing existing files/gists. This is because the GitHub code editor uses CodeMirror, which itself captures text and applies HTML around it, and so the current approach of wrapping text does not seem to work.

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs


## Screenshot

