### PR TITLE
Fix `clean-conversation-sidebar` for triage access collaborator

### DIFF
--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -101,7 +101,6 @@ async function clean(): Promise<void> {
 
 	// Linked issues/PRs
 	select('[aria-label="Link issues"] p')!.remove(); // "Successfully merging a pull request may close this issue."
-	select('[aria-label="Link issues"] p')?.remove(); // "Successfully merging a pull request may close this issue." Not shown if issues are disabled.
 	cleanSection('[aria-label="Link issues"]');
 
 	// Projects

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -65,8 +65,9 @@ async function clean(): Promise<void> {
 	select('#partial-discussion-sidebar')!.classList.add('rgh-clean-sidebar');
 
 	// Assignees
-	const assignees = select('.js-issue-assignees, .sidebar-assignee')!; // `.sidebar-assignee` is for collaborators with only "triage access"
+	const assignees = select('.js-issue-assignees')!;
 	if (assignees.children.length === 0) {
+	if (assignees.children.length === 0 && !select('#assignees-select-menu')) {
 		assignees.closest('.discussion-sidebar-item')!.remove();
 	} else {
 		const assignYourself = select('.js-issue-assign-self');

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -65,7 +65,7 @@ async function clean(): Promise<void> {
 	select('#partial-discussion-sidebar')!.classList.add('rgh-clean-sidebar');
 
 	// Assignees
-	const assignees = select('.js-issue-assignees')!;
+	const assignees = select('.js-issue-assignees, .sidebar-assignee')!; // `.sidebar-assignee` is for collaborators with only "triage access"
 	if (assignees.children.length === 0) {
 		assignees.closest('.discussion-sidebar-item')!.remove();
 	} else {

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -66,6 +66,7 @@ async function clean(): Promise<void> {
 
 	// Assignees
 	const assignees = select('.js-issue-assignees')!;
+	// `#assignees-select-menu` check is for collaborators with only "triage access" #4238
 	if (assignees.children.length === 0 && !select('#assignees-select-menu')) {
 		assignees.closest('.discussion-sidebar-item')!.remove();
 	} else {

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -101,6 +101,7 @@ async function clean(): Promise<void> {
 
 	// Linked issues/PRs
 	select('[aria-label="Link issues"] p')!.remove(); // "Successfully merging a pull request may close this issue."
+	select('[aria-label="Link issues"] p')?.remove(); // "Successfully merging a pull request may close this issue." Not shown if issues are disabled.
 	cleanSection('[aria-label="Link issues"]');
 
 	// Projects

--- a/source/features/clean-conversation-sidebar.tsx
+++ b/source/features/clean-conversation-sidebar.tsx
@@ -66,7 +66,6 @@ async function clean(): Promise<void> {
 
 	// Assignees
 	const assignees = select('.js-issue-assignees')!;
-	if (assignees.children.length === 0) {
 	if (assignees.children.length === 0 && !select('#assignees-select-menu')) {
 		assignees.closest('.discussion-sidebar-item')!.remove();
 	} else {


### PR DESCRIPTION
Fixes #4238

## Test URLs
I tested on https://github.com/download-directory/download-directory.github.io/pull/37

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/114912044-8a6ad800-9ded-11eb-8540-fdef5d868a88.png)

