### PR TITLE
Align `comments-time-machine-links` banner to the site header

### DIFF
--- a/source/github-widgets/notice-bar.tsx
+++ b/source/github-widgets/notice-bar.tsx
@@ -21,8 +21,11 @@ export default function addNotice(
 ): void {
 	select('#start-of-content')!.after(
 		<div className={`flash flash-full flash-${type}`}>
-			<div className="container-lg px-3 d-flex flex-items-center flex-justify-between">
-				<div>{message}</div> {action}
+			<div className="px-2">
+				{action}
+				<div>
+					{message}
+				</div>
 			</div>
 		</div>
 	);

--- a/source/github-widgets/notice-bar.tsx
+++ b/source/github-widgets/notice-bar.tsx
@@ -20,12 +20,10 @@ export default function addNotice(
 	}: Options = {}
 ): void {
 	select('#start-of-content')!.after(
-		<div className={`flash flash-full flash-${type}`}>
-			<div className="px-2">
-				{action}
-				<div>
-					{message}
-				</div>
+		<div className={`flash flash-full flash-${type} px-4`}>
+			{action}
+			<div>
+				{message}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Fixes #4227

## Test URLs
https://github.com/sindresorhus/refined-github/blob/main/media/promo.png?rgh-link-date=2017-04-12T07%3A11%3A49Z

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/115041563-a4b1be00-9ea0-11eb-89dc-cd72892c9ce0.png)

