### PR TITLE
`hide-useless-newsfeed-events`: Hide releases too

### DIFF
--- a/source/features/hide-useless-newsfeed-events.css
+++ b/source/features/hide-useless-newsfeed-events.css
@@ -5,7 +5,8 @@ deleted a branch
 added someone as a collaborator
 forked a repo
 followed someone
+published a release
 */
-.rgh-hide-useless-newsfeed-events .news :is(.push, .fork, .delete, .follow) {
+.rgh-hide-useless-newsfeed-events .news :is(.push, .fork, .delete, .follow, .release) {
 	display: none !important;
 }


### PR DESCRIPTION
This PR adds releases to `hide-useless-newsfeed-events`. Since recently, published releases appear in the newsfeed. They take a lot of place, and I can even see some bots' releases. I figured it was pretty much useless and could belong in this feature.


## Test URLs

- https://github.com/ (when logged in, newsfeed)

## Screenshot

### Before

![image](https://user-images.githubusercontent.com/16060559/115672604-031ce780-a34c-11eb-9e61-d9288e193003.png)

### After

![image](https://user-images.githubusercontent.com/16060559/115672684-16c84e00-a34c-11eb-8ad7-ceaf50b71894.png)
