### PR TITLE
Extend `new-repo-disable-projects-and-wikis` to new repo templates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"element-ready": "^6.0.0",
 				"fit-textarea": "^3.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^4.10.0",
+				"github-url-detection": "^4.11.0",
 				"image-promise": "^7.0.1",
 				"indent-textarea": "^2.1.0",
 				"js-abbreviation-number": "^1.1.2",
@@ -5962,9 +5962,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-4.10.0.tgz",
-			"integrity": "sha512-aSow6Vcx/sS8sgV0PMGPqjrkjBwiL3iArUjCOAQ25t6UIRdR8PzzqKtnBY2K1d5CQM8u8YxSTEUDFleA0hqLzQ=="
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-4.11.0.tgz",
+			"integrity": "sha512-+s7J961DCzXHPZ7+Ad9/nOdHOmzioCnmnKIoWXtvPNn13fyxFdcvDP3W2MyFgDXyHNC+sz3+VpGmWMzeDuPh6g=="
 		},
 		"node_modules/glob": {
 			"version": "7.1.6",
@@ -19380,9 +19380,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"github-url-detection": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-4.10.0.tgz",
-			"integrity": "sha512-aSow6Vcx/sS8sgV0PMGPqjrkjBwiL3iArUjCOAQ25t6UIRdR8PzzqKtnBY2K1d5CQM8u8YxSTEUDFleA0hqLzQ=="
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-4.11.0.tgz",
+			"integrity": "sha512-+s7J961DCzXHPZ7+Ad9/nOdHOmzioCnmnKIoWXtvPNn13fyxFdcvDP3W2MyFgDXyHNC+sz3+VpGmWMzeDuPh6g=="
 		},
 		"glob": {
 			"version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"element-ready": "^6.0.0",
 		"fit-textarea": "^3.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^4.10.0",
+		"github-url-detection": "^4.11.0",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.1.0",
 		"js-abbreviation-number": "^1.1.2",

--- a/source/features/new-repo-disable-projects-and-wikis.tsx
+++ b/source/features/new-repo-disable-projects-and-wikis.tsx
@@ -33,7 +33,10 @@ function setStorage(): void {
 async function init(): Promise<void> {
 	await api.expectToken();
 
-	select.last('.js-repo-init-setting-container')!.after(
+	select.last([
+		'.js-repo-init-setting-container', // IsNewRepo
+		'.form-checkbox' // IsNewRepoTemplate
+	])!.after(
 		<div className="form-checkbox checked mt-0 mb-3">
 			<label>
 				<input
@@ -48,12 +51,13 @@ async function init(): Promise<void> {
 		</div>
 	);
 
-	delegate(document, '#new_repository', 'submit', setStorage);
+	delegate(document, '#new_repository, #new_new_repository', 'submit', setStorage);
 }
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.isNewRepo
+		pageDetect.isNewRepo,
+		pageDetect.isNewRepoTemplate
 	],
 	init
 }, {


### PR DESCRIPTION
## Test URLs

https://github.com/fregante/browser-extension-template/generate

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/115796937-b57e9a00-a3a0-11eb-9180-40aba429267f.png)

