### PR TITLE
Fix `bugs-tab` highlighting

### DIFF
--- a/source/features/bugs-tab.tsx
+++ b/source/features/bugs-tab.tsx
@@ -12,7 +12,7 @@ import SearchQuery from '../github-helpers/search-query';
 import abbreviateNumber from '../helpers/abbreviate-number';
 
 async function highlightBugsTabOnIssuePage(): Promise<void | false> {
-	if (await countBugs() === 0 || !await elementReady('.sidebar-labels .IssueLabel[href$="/bug" i]')) {
+	if (await countBugs() === 0 || !await elementReady('#partial-discussion-sidebar .IssueLabel[href$="/bug" i]')) {
 		return false;
 	}
 


### PR DESCRIPTION
## Test URLs
https://github.com/sindresorhus/refined-github/issues/4260

## Screenshot

![image](https://user-images.githubusercontent.com/16872793/115814759-aeb54e80-a3c3-11eb-9757-4b08745dc1f3.png)
