### PR TITLE
Restore `vertical-front-matter`

### DIFF
--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -9,7 +9,17 @@ import features from '.';
 const hasFrontMatter = (): boolean => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee)$/.test(location.pathname);
 
 function init(): void | false {
-	const table = select('[data-table-type="yaml-metadata"]')!;
+	const table = select('.markdown-body > table:first-child');
+	if (!table) {
+		return false;
+	}
+
+	const headRow = select(':scope > thead > tr', table)!;
+	const bodyRows = select.all(':scope > tbody > tr', table);
+	if (bodyRows.length !== 1 || headRow.childElementCount !== bodyRows[0].childElementCount) {
+		return false;
+	}
+
 	const headers = select.all(':scope > thead th', table);
 	if (headers.length <= 4) {
 		return false;
@@ -17,7 +27,7 @@ function init(): void | false {
 
 	const values = select.all(':scope > tbody > tr > td', table);
 	table.replaceWith(
-		<table className="rgh-vertical-front-matter-table" data-table-type="yaml-metadata">
+		<table className="rgh-vertical-front-matter-table">
 			<tbody>
 				{headers.map((cell, index) => (
 					<tr>

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -20,11 +20,11 @@ function init(): void | false {
 	}
 
 	const rows = select.all(':scope > tbody > tr', table);
-	const values = [...rows[0]?.children];
-	if (rows.length !== 1 || headers.length !== values.length) {
+	if (rows.length !== 1 || headers.length !== rows[0].childElementCount) {
 		return false;
 	}
 
+	const values = [...rows[0].children];
 	table.replaceWith(
 		<table className="rgh-vertical-front-matter-table">
 			<tbody>

--- a/source/features/vertical-front-matter.tsx
+++ b/source/features/vertical-front-matter.tsx
@@ -14,18 +14,17 @@ function init(): void | false {
 		return false;
 	}
 
-	const headRow = select(':scope > thead > tr', table)!;
-	const bodyRows = select.all(':scope > tbody > tr', table);
-	if (bodyRows.length !== 1 || headRow.childElementCount !== bodyRows[0].childElementCount) {
-		return false;
-	}
-
 	const headers = select.all(':scope > thead th', table);
 	if (headers.length <= 4) {
 		return false;
 	}
 
-	const values = select.all(':scope > tbody > tr > td', table);
+	const rows = select.all(':scope > tbody > tr', table);
+	const values = [...rows[0]?.children];
+	if (rows.length !== 1 || headers.length !== values.length) {
+		return false;
+	}
+
 	table.replaceWith(
 		<table className="rgh-vertical-front-matter-table">
 			<tbody>


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4273

There isn't a selector which tells us it's a front matter or not, so we are on our own.

I come up with some rules that should handle most cases:

- The table should be the first element
- The table should only have one row in the body
- The head row and the body row should have the same number of cells

Suggestions welcome. Honestly I don't want to drop this feature just because we don't have a nice way to support it :(

## Test URLs

- With front matter: https://github.com/gatsbyjs/gatsby/blob/HEAD@%7B2020-07-08T14:12:43Z%7D/docs/blog/2020-07-07-wordpress-source-beta/index.mdx
![image](https://user-images.githubusercontent.com/44045911/116033088-60d66a00-a693-11eb-9145-bef2d20003a5.png)
- Invalid table as first element: https://github.com/kidonng/refined-github/blob/8bec852e016d10a574b1a456174139d6bb9e6c99/test.md
![image](https://user-images.githubusercontent.com/44045911/116033133-78155780-a693-11eb-95a6-ec181b758b2c.png)

- Valid table, but not as first element: https://github.com/kidonng/refined-github/blob/798efec7e082531a8ed99aae5d47d06c31f8cbee/test.md

![image](https://user-images.githubusercontent.com/44045911/116033145-7ba8de80-a693-11eb-920b-88482b8ad729.png)

