### PR TITLE
`ci-link`: Don't incorrectly show *Verified next to a repo title

### DIFF
--- a/source/features/ci-link.tsx
+++ b/source/features/ci-link.tsx
@@ -11,7 +11,7 @@ import {buildRepoURL} from '../github-helpers';
 const getIcon = onetime(async () => fetchDom(
 	buildRepoURL('commits'), [
 		'.commit-group:nth-of-type(-n+2) .commit-build-statuses', // Pre "Repository refresh" layout
-		'.TimelineItem--condensed:nth-of-type(-n+2) batch-deferred-content'
+		'.TimelineItem--condensed:nth-of-type(-n+2) batch-deferred-content[data-url$="checks-statuses-rollups"]'
 	].join()
 ));
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix https://github.com/sindresorhus/refined-github/pull/4267#issuecomment-826471250

## Test URLs

- Should show icon: this repo
- Should not show icon: https://github.com/kidonng/refined-github

## Screenshot

Before: 

![image](https://user-images.githubusercontent.com/44045911/116024037-f49e3b00-a67f-11eb-87ca-1a627b32d943.png)

After: 
![image](https://user-images.githubusercontent.com/44045911/116032825-eefe2080-a692-11eb-9d8f-c73b575c6d0d.png)
