### PR TITLE
Fix `latest-tag-button` on repo home page

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -133,7 +133,7 @@ async function init(): Promise<false | void> {
 	}
 
 	const defaultBranch = await getDefaultBranch();
-	if (currentBranch === defaultBranch) {
+	if (pageDetect.isRepoHome() || currentBranch === defaultBranch) {
 		link.append(<sup> +{aheadBy}</sup>);
 		link.setAttribute(
 			'aria-label',


### PR DESCRIPTION
Partially replaces https://github.com/sindresorhus/refined-github/pull/4187
Re #4196. Currently we cannot determine the branch. However this change should happen anyways. 

## Test URLs

https://github.com/sindresorhus/refined-github

## Screenshot

![image](https://user-images.githubusercontent.com/16872793/116723120-2596ac80-a9ad-11eb-9603-d02d4dff7870.png)
