### PR TITLE
Fix console error in `set-default-repositories-type-to-sources`

### DIFF
--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -1,5 +1,6 @@
 import select from 'select-dom';
 import onetime from 'onetime';
+import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onProfileDropdownLoad from '../github-events/on-profile-dropdown-load';
@@ -8,6 +9,11 @@ function addSourceTypeToLink(link: HTMLAnchorElement): void {
 	const search = new URLSearchParams(link.search);
 	search.set('type', 'source');
 	link.search = String(search);
+}
+
+async function profileDropdown(): Promise<void> {
+	await onProfileDropdownLoad();
+	addSourceTypeToLink(select('.header-nav-current-user ~ a[href$="tab=repositories"]')!); // "Your repositories" in header dropdown
 }
 
 async function init(): Promise<void> {
@@ -26,13 +32,11 @@ async function init(): Promise<void> {
 	}
 }
 
-async function profileDropdown(): Promise<void> {
-	await onProfileDropdownLoad();
-	addSourceTypeToLink(select('.header-nav-current-user ~ a[href$="tab=repositories"]')!); // "Your repositories" in header dropdown
-}
-
 void features.add(__filebasename, {
-	init: onetime(profileDropdown)
-}, {
 	init
+}, {
+	exclude: [
+		pageDetect.isGist // "Your repositories" does not exist
+	],
+	init: onetime(profileDropdown)
 });


### PR DESCRIPTION
"Your repositories"  does not exist on gists

```js
❌ set-default-repositories-type-to-sources 0.0.0 → TypeError: Cannot read property 'search' of undefined
    at addSourceTypeToLink (refined-github.js:13332)
    at profileDropdown (refined-github.js:13350)
    at async runFeature (refined-github.js:8785)
    at async setupPageLoad (refined-github.js:8803)
    at async chrome-extension:/pplhppbihehddgkdedhpbfpbbbefeihl/build/refined-github.js:8867
```

## Test URLs
https://gist.github.com/sindresorhus


## Screenshot
![image](https://user-images.githubusercontent.com/16872793/116724093-372c8400-a9ae-11eb-9080-b557a31ecd6c.png)


