### PR TITLE
Fix error in `next-scheduled-github-action` when no action files exist

### DIFF
--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -10,7 +10,7 @@ import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 
 const getScheduledWorkflows = cache.function(async (): Promise<Record<string, string> | false> => {
-	const {repository: {object: {entries: workflows}}} = await api.v4(`
+	const {repository: {object}} = await api.v4(`
 		repository() {
 			object(expression: "HEAD:.github/workflows") {
 				... on Tree {
@@ -25,6 +25,8 @@ const getScheduledWorkflows = cache.function(async (): Promise<Record<string, st
 			}
 		}
 	`);
+
+	const workflows = object?.entries;
 	if (!workflows) {
 		return false;
 	}

--- a/source/features/next-scheduled-github-action.tsx
+++ b/source/features/next-scheduled-github-action.tsx
@@ -10,9 +10,9 @@ import * as api from '../github-helpers/api';
 import {getRepo} from '../github-helpers';
 
 const getScheduledWorkflows = cache.function(async (): Promise<Record<string, string> | false> => {
-	const {repository: {object}} = await api.v4(`
+	const {repository: {workflowFiles}} = await api.v4(`
 		repository() {
-			object(expression: "HEAD:.github/workflows") {
+			workflowFiles: object(expression: "HEAD:.github/workflows") {
 				... on Tree {
 					entries {
 						object {
@@ -26,7 +26,7 @@ const getScheduledWorkflows = cache.function(async (): Promise<Record<string, st
 		}
 	`);
 
-	const workflows = object?.entries;
+	const workflows = workflowFiles?.entries;
 	if (!workflows) {
 		return false;
 	}


### PR DESCRIPTION
```
next-scheduled-github-action 0.0.0 → TypeError: Cannot read property 'entries' of null
    at webext_storage_cache__WEBPACK_IMPORTED_MODULE_1__.default.function.maxAge.days (refined-github.js:10401)
    at async getSet (refined-github.js:24127)
    at async init (refined-github.js:10435)
    at async runFeature (refined-github.js:8785)
    at async setupPageLoad (refined-github.js:8803)
```

## Test URLs
https://github.com/k0shk0sh/FastHub/actions


## Screenshot
None


