### PR TITLE
Meta: Don't hide final bisect message when changing tab

### DIFF
--- a/source/helpers/bisect.tsx
+++ b/source/helpers/bisect.tsx
@@ -41,6 +41,7 @@ async function onChoiceButtonClick({currentTarget: button}: React.MouseEvent<HTM
 	}
 
 	await cache.delete('bisect');
+	window.removeEventListener('visibilitychange', hideMessage);
 }
 
 async function onEndButtonClick(): Promise<void> {
@@ -59,6 +60,12 @@ function createMessageBox(message: Element | string, extraButtons?: Element): vo
 			</div>
 		</div>
 	);
+}
+
+async function hideMessage(): Promise<void> {
+	if (!await cache.get<FeatureID[]>('bisect')) {
+		createMessageBox('Process completed in another tab');
+	}
 }
 
 export default async function bisectFeatures(): Promise<Record<string, boolean> | void> {
@@ -87,11 +94,7 @@ export default async function bisectFeatures(): Promise<Record<string, boolean> 
 	});
 
 	// Hide message when the process is done elsewhere
-	window.addEventListener('visibilitychange', async () => {
-		if (!await cache.get<FeatureID[]>('bisect')) {
-			createMessageBox('Process completed in another tab');
-		}
-	});
+	window.addEventListener('visibilitychange', hideMessage);
 
 	const half = getMiddleStep(bisectedFeatures);
 	const temporaryOptions: Record<string, boolean> = {};


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4295 

## Tests

1. Complete "Find feature" wizard and remain on the last step
2. Change tab & go back
3. The bisect modal should NOT say "Process completed in another tab"

## Screenshot


https://user-images.githubusercontent.com/46634000/116893307-1b84e000-ac31-11eb-90d0-845299e65a6c.mp4