### PR TITLE
Don't hide tagged commits in `dim-bots`

### DIFF
--- a/source/features/dim-bots.css
+++ b/source/features/dim-bots.css
@@ -3,16 +3,16 @@ READ BEFORE EDITING. Some selectors match the same items ("focused" selector vs 
 Commits that have a long commit message will not be dimmed after the user uncollapses the `<details>` element.
 */
 
-.rgh-dim-bot .commit-title, /* Pre "Repository refresh" layout */
-.rgh-dim-bot .commit-meta, /* Pre "Repository refresh" layout */
-.rgh-dim-bot .mb-1,
-.rgh-dim-bot .mb-1 ~ .d-flex,
-.rgh-dim-bot > .d-md-block,
-.rgh-dim-bot .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
-.rgh-dim-bot .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
-.rgh-dim-bot .Box-row--drag-hide, /* PR row */
-.rgh-dim-bot .labels, /* PR labels */
-.rgh-dim-bot .labels + .text-small /* PR meta */ {
+.rgh-dim-bot:not(.tagged) .commit-title, /* Pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged) .commit-meta, /* Pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged) .mb-1,
+.rgh-dim-bot:not(.tagged) .mb-1 ~ .d-flex,
+.rgh-dim-bot:not(.tagged) > .d-md-block,
+.rgh-dim-bot:not(.tagged) .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged) .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged) .Box-row--drag-hide, /* PR row */
+.rgh-dim-bot:not(.tagged) .labels, /* PR labels */
+.rgh-dim-bot:not(.tagged) .labels + .text-small /* PR meta */ {
 	/* Delay the "focused" status so it's not too annoying when moving the mouse over a list of dimmed items. */
 	transition: 0.1s;
 	transition-delay: 0.3s;
@@ -23,25 +23,25 @@ Commits that have a long commit message will not be dimmed after the user uncoll
 ALL the following rules define the non-focused state
 */
 
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-title, /* Commit titles, dim, pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .mb-1, /* Commit titles, dim */
-.rgh-dim-bot:not(.navigation-focus) .Box-row--drag-hide { /* PR row, dim */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .commit-title, /* Commit titles, dim, pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .mb-1, /* Commit titles, dim */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus) .Box-row--drag-hide { /* PR row, dim */
 	opacity: 20%;
 	transition-delay: 0s;
 }
 
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-meta, /* Pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .mb-1 ~ .d-flex,
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
-.rgh-dim-bot:not(.navigation-focus):not(.Details--on) > .d-md-block {
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .commit-meta, /* Pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .mb-1 ~ .d-flex,
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .commit-links-group, /* Hash and Copy hash buttons, pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) .commit-links-group + .btn, /* Browse repository button, pre "Repository refresh" layout */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus):not(.Details--on) > .d-md-block {
 	opacity: 0%;
 	margin-bottom: -1.6em;
 	transition-delay: 0s;
 }
 
-.rgh-dim-bot:not(.navigation-focus) .labels, /* PR labels */
-.rgh-dim-bot:not(.navigation-focus) .labels + .text-small /* PR meta */ {
+.rgh-dim-bot:not(.tagged):not(.navigation-focus) .labels, /* PR labels */
+.rgh-dim-bot:not(.tagged):not(.navigation-focus) .labels + .text-small /* PR meta */ {
 	opacity: 0%;
 	margin-bottom: -2em;
 	transition-delay: 0s;

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -33,7 +33,7 @@ async function init(): Promise<void> {
 	}
 
 	for (const tag of select.all('.js-navigation-container .octicon-tag')) {
-		tag.closest('.commit, .Box-row')!.classList.remove('rgh-dim-bot');
+		tag.closest('.rgh-dim-bot')?.classList.add('tagged');
 	}
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -1,6 +1,5 @@
 import './dim-bots.css';
 import select from 'select-dom';
-import oneMutation from 'one-mutation';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -16,24 +15,12 @@ const botSelector = [
 	'.labels [href$="label%3Abot"]'
 ].join();
 
-function tagsLoaded(): boolean {
-	return select.exists('.js-navigation-container .octicon-tag');
-}
-
-async function init(): Promise<void> {
+function init(): void {
 	for (const bot of select.all(botSelector)) {
 		// Exclude co-authored commits
 		if (select.all('a', bot.parentElement!).every(link => link.matches(botSelector))) {
 			bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 		}
-	}
-
-	if (!tagsLoaded()) {
-		await oneMutation(document.body, {subtree: true, childList: true, filter: tagsLoaded});
-	}
-
-	for (const tag of select.all('.js-navigation-container .octicon-tag')) {
-		tag.closest('.rgh-dim-bot')?.classList.add('tagged');
 	}
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -1,5 +1,6 @@
 import './dim-bots.css';
 import select from 'select-dom';
+import oneMutation from 'one-mutation';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -15,12 +16,24 @@ const botSelector = [
 	'.labels [href$="label%3Abot"]'
 ].join();
 
-function init(): void {
+function tagsLoaded(): boolean {
+	return select.exists('.js-navigation-container .octicon-tag');
+}
+
+async function init(): Promise<void> {
 	for (const bot of select.all(botSelector)) {
 		// Exclude co-authored commits
 		if (select.all('a', bot.parentElement!).every(link => link.matches(botSelector))) {
 			bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 		}
+	}
+
+	if (!tagsLoaded()) {
+		await oneMutation(document.body, {subtree: true, childList: true, filter: tagsLoaded});
+	}
+
+	for (const tag of select.all('.js-navigation-container .octicon-tag')) {
+		tag.closest('.commit, .Box-row')!.classList.remove('rgh-dim-bot');
 	}
 }
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4318 

## Test URLs
https://github.com/fregante/github-url-detection/commits/master?after=e58ce98ffd6a45822d035598eda8f699e1839f06+1&branch=master

## Screenshot

<table>
<tr>
	<th>Before
	<td>

![image](https://user-images.githubusercontent.com/46634000/117278032-af88be80-ae60-11eb-9a60-378de978092c.png)
<tr>
	<th>After
	<td>

![image](https://user-images.githubusercontent.com/46634000/117277952-9ed84880-ae60-11eb-9689-d3ff1e8445d9.png)
</table>

The tags are lazy-loaded. Not sure using `oneMutation` is the best approach though.