### PR TITLE
Consistent button label in `quick-repo-deletion`

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -132,7 +132,7 @@ async function init(): Promise<void | false> {
 			<details className="details-reset details-overlay select-menu rgh-quick-repo-deletion">
 				<summary aria-haspopup="menu" role="button">
 					{/* This extra element is needed to keep the button above the <summary>’s lightbox */}
-					<span className="btn btn-sm btn-danger">Delete fork</span>
+					<span className="btn btn-sm btn-danger">Delete repo</span>
 				</summary>
 			</details>
 		</li>

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -61,7 +61,6 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 
 	let secondsLeft = 5;
 	const button = select('.btn', buttonContainer)!;
-	const buttonText = button.textContent;
 	try {
 		do {
 			button.style.transform = `scale(${1.2 - ((secondsLeft - 5) / 3)})`; // Dividend is zoom speed
@@ -69,7 +68,7 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 			await delay(1000, {signal: abortController.signal}); // eslint-disable-line no-await-in-loop
 		} while (--secondsLeft);
 	} catch {
-		button.textContent = buttonText;
+		button.textContent = 'Delete fork';
 		button.style.transform = '';
 	}
 

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -61,6 +61,7 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 
 	let secondsLeft = 5;
 	const button = select('.btn', buttonContainer)!;
+	const buttonText = button.textContent;
 	try {
 		do {
 			button.style.transform = `scale(${1.2 - ((secondsLeft - 5) / 3)})`; // Dividend is zoom speed
@@ -68,7 +69,7 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 			await delay(1000, {signal: abortController.signal}); // eslint-disable-line no-await-in-loop
 		} while (--secondsLeft);
 	} catch {
-		button.textContent = 'Delete repo';
+		button.textContent = buttonText;
 		button.style.transform = '';
 	}
 

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -133,7 +133,7 @@ async function init(): Promise<void | false> {
 			<details className="details-reset details-overlay select-menu rgh-quick-repo-deletion">
 				<summary aria-haspopup="menu" role="button">
 					{/* This extra element is needed to keep the button above the <summary>’s lightbox */}
-					<span className="btn btn-sm btn-danger">Delete repo</span>
+					<span className="btn btn-sm btn-danger">Delete fork</span>
 				</summary>
 			</details>
 		</li>


### PR DESCRIPTION
Respecting: 0d186f70335f1efa2dfbe213f16dbcf7dff6e50e

## Test URLs
Check your any forked repositories.

## Screenshot
### Before
!['Delete fork' action button preceding the 'Watch', 'Star', and 'Fork' buttons.](https://user-images.githubusercontent.com/3071003/117562067-0992b980-b0d7-11eb-8c48-a05071b8d327.png)

### After
!['Delete repo' action button preceding the 'Watch', 'Star', and 'Fork' buttons.](https://user-images.githubusercontent.com/3071003/117562054-fc75ca80-b0d6-11eb-9d66-443f8a662de7.png)