### PR TITLE
Link `quick-repo-deletion` button to setting page if no API token is given

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -113,6 +113,22 @@ async function start(buttonContainer: HTMLDetailsElement): Promise<void> {
 	}
 }
 
+function initWithoutAPI(): void {
+	const {nameWithOwner} = getRepo()!;
+	const deleteRepoURL = `/${nameWithOwner}/settings?confirm_delete=yes`;
+
+	select('.pagehead-actions')!.prepend(
+		<li>
+			<a
+				className="rgh-quick-repo-deletion btn btn-sm btn-danger"
+				href={deleteRepoURL}
+			>
+				Delete repo
+			</a>
+		</li>
+	);
+}
+
 async function init(): Promise<void | false> {
 	if (
 		// Only if the user can delete the repository
@@ -124,7 +140,11 @@ async function init(): Promise<void | false> {
 		return false;
 	}
 
-	await api.expectToken();
+	try {
+		await api.expectToken();
+	} catch {
+		return initWithoutAPI();
+	}
 
 	// (Ab)use the details element as state and an accessible "click-anywhere-to-cancel" utility
 	select('.pagehead-actions')!.prepend(


### PR DESCRIPTION
If no token is given, link `Delete repo` button to `/user/repo/settings?confirm_delete=yes`, which shows repository deletion confirm dialog\*.

## Test URLs
Check your any forked repositories.

## Screenshot
No (or unnoticeable) visual changes for button.

---

<details><summary>
* The repository deletion confirm dialog:
</summary>

![The GitHub's 'I understand the consequences, delete this repository' dialog.](https://user-images.githubusercontent.com/3071003/117562599-0f8a9980-b0db-11eb-9b4a-10ca5ba0fc18.png)

</details>
