### PR TITLE
Enable `edit-comments-faster` on Discussions

### DIFF
--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -24,7 +24,7 @@ function init(): void {
 					<button
 						type="button"
 						role="menuitem"
-						className={`"timeline-comment-action btn-link js-comment-edit-button ${discussionsClassname} rgh-edit-comments-faster-button"`}
+						className={`timeline-comment-action btn-link js-comment-edit-button ${discussionsClassname} rgh-edit-comments-faster-button`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -19,7 +19,7 @@ function init(): void {
 					<button
 						type="button"
 						role="menuitem"
-						className={`timeline-comment-action btn-link ${pageDetect.isDiscussion() ? 'js-comment-edit-button js-discussions-comment-edit-button' : 'js-comment-edit-button'} rgh-edit-comments-faster-button`}
+						className={`timeline-comment-action btn-link js-comment-edit-button ${pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : ''} rgh-edit-comments-faster-button`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,9 +12,9 @@ function init(): void {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 
-			let toAdd = '';
+			let discussionsClassname = '';
 			if (pageDetect.isDiscussion()) {
-				toAdd = 'js-discussions-comment-edit-button';
+				discussionsClassname = 'js-discussions-comment-edit-button';
 			}
 
 			comment
@@ -24,7 +24,7 @@ function init(): void {
 					<button
 						type="button"
 						role="menuitem"
-						className={`"timeline-comment-action btn-link js-comment-edit-button ${toAdd} rgh-edit-comments-faster-button"`}
+						className={`"timeline-comment-action btn-link js-comment-edit-button ${discussionsClassname} rgh-edit-comments-faster-button"`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -19,7 +19,7 @@ function init(): void {
 					<button
 						type="button"
 						role="menuitem"
-						className={`timeline-comment-action btn-link js-comment-edit-button ${pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : ''} rgh-edit-comments-faster-button`}
+						className={`timeline-comment-action btn-link js-comment-edit-button rgh-edit-comments-faster-button ${pageDetect.isDiscussion() ? 'js-discussions-comment-edit-button' : ''}`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -14,7 +14,7 @@ function init(): void {
 
 			comment
 				.closest('.js-comment')!
-				.querySelector('.timeline-comment-actions > details:last-child, .timeline-comment-actions details:last-child')! // The dropdown
+				.querySelector('.timeline-comment-actions details:last-child')! // The dropdown
 				.before(
 					<button
 						type="button"

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,14 +12,19 @@ function init(): void {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 
+			let toAdd = '';
+			if (pageDetect.isDiscussion()) {
+				toAdd = 'js-discussions-comment-edit-button';
+			}
+
 			comment
 				.closest('.js-comment')!
-				.querySelector('.timeline-comment-actions > details:last-child')! // The dropdown
+				.querySelector('.timeline-comment-actions > details:last-child, .timeline-comment-actions details:last-child')! // The dropdown
 				.before(
 					<button
 						type="button"
 						role="menuitem"
-						className="timeline-comment-action btn-link js-comment-edit-button rgh-edit-comments-faster-button"
+						className={`"timeline-comment-action btn-link js-comment-edit-button ${toAdd} rgh-edit-comments-faster-button"`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>
@@ -31,7 +36,8 @@ function init(): void {
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.hasComments
+		pageDetect.hasComments,
+		pageDetect.isDiscussion
 	],
 	init: onetime(init)
 });

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,11 +12,6 @@ function init(): void {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 
-			let discussionsClassname = '';
-			if (pageDetect.isDiscussion()) {
-				discussionsClassname = 'js-discussions-comment-edit-button';
-			}
-
 			comment
 				.closest('.js-comment')!
 				.querySelector('.timeline-comment-actions > details:last-child, .timeline-comment-actions details:last-child')! // The dropdown
@@ -24,7 +19,7 @@ function init(): void {
 					<button
 						type="button"
 						role="menuitem"
-						className={`timeline-comment-action btn-link js-comment-edit-button ${discussionsClassname} rgh-edit-comments-faster-button`}
+						className={`timeline-comment-action btn-link ${pageDetect.isDiscussion() ? 'js-comment-edit-button js-discussions-comment-edit-button' : 'js-comment-edit-button'} rgh-edit-comments-faster-button`}
 						aria-label="Edit comment"
 					>
 						<PencilIcon/>


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4334


## Test URLs

https://github.com/tophf/mpiv/discussions/50

## Screenshot

![](https://user-images.githubusercontent.com/723651/117574971-75315280-b0e8-11eb-9c51-7e95dbec91fb.gif)

## Note to reviewers

- The added selector `.timeline-comment-actions details:last-child` (or `.timeline-comment-actions > div > details:last-child` ) is for discussions