### PR TITLE
Exclude gists from `comments-time-machine-links`

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -132,6 +132,9 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.hasComments
 	],
+	exclude: [
+		pageDetect.isGist
+	],
 	init
 }, {
 	include: [


### PR DESCRIPTION
## Test URLs
https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c

## Screenshot

