### PR TITLE
Meta: Add per-feature “unaffected” version in the hotfix manager

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -10,7 +10,7 @@ import {frame} from '../helpers/dom-utils';
 import onNewComments from '../github-events/on-new-comments';
 import bisectFeatures from '../helpers/bisect';
 import optionsStorage, {RGHOptions} from '../options-storage';
-import {getLocalHotfixes, updateHotfixes} from '../helpers/hotfix'
+import {getLocalHotfixes, updateHotfixes} from '../helpers/hotfix';
 
 type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -1,17 +1,16 @@
 import delay from 'delay';
 import React from 'dom-chef';
-import cache from 'webext-storage-cache';
 import select from 'select-dom';
 import domLoaded from 'dom-loaded';
 import stripIndent from 'strip-indent';
 import {Promisable} from 'type-fest';
-import compareVersions from 'tiny-version-compare';
 import * as pageDetect from 'github-url-detection';
 
 import {frame} from '../helpers/dom-utils';
 import onNewComments from '../github-events/on-new-comments';
 import bisectFeatures from '../helpers/bisect';
 import optionsStorage, {RGHOptions} from '../options-storage';
+import {getLocalHotfixes, updateHotfixes} from '../helpers/hotfix'
 
 type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;
@@ -83,9 +82,9 @@ let logError = (id: FeatureID, error: unknown): void => {
 
 // eslint-disable-next-line no-async-promise-executor -- Rule assumes we don't want to leave it pending
 const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
-	const [options, hotfix, bisectedFeatures] = await Promise.all([
+	const [options, localHotfixes, bisectedFeatures] = await Promise.all([
 		optionsStorage.getAll(),
-		version === '0.0.0' || await cache.get('hotfix'), // Ignores the cache when loaded locally
+		getLocalHotfixes(version),
 		bisectFeatures()
 	]);
 
@@ -97,8 +96,8 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 		Object.assign(options, bisectedFeatures);
 	} else {
 		// If features are remotely marked as "seriously breaking" by the maintainers, disable them without having to wait for proper updates to propagate #3529
-		void checkForHotfixes();
-		Object.assign(options, hotfix);
+		void updateHotfixes();
+		Object.assign(options, localHotfixes);
 	}
 
 	// Create logging function
@@ -180,23 +179,6 @@ const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<
 		listener(runFeature);
 	}
 };
-
-const checkForHotfixes = cache.function(async () => {
-	// The explicit endpoint is necessary because it shouldn't change on GHE
-	const request = await fetch('https://api.github.com/repos/sindresorhus/refined-github/contents/hotfix.json?ref=hotfix');
-	const response = await request.json();
-	const hotfixes: AnyObject | false = JSON.parse(atob(response.content));
-
-	// eslint-disable-next-line @typescript-eslint/prefer-optional-chain -- https://github.com/typescript-eslint/typescript-eslint/issues/1893
-	if (hotfixes && hotfixes.unaffected && compareVersions(hotfixes.unaffected, version) < 1) {
-		return {};
-	}
-
-	return hotfixes;
-}, {
-	maxAge: {hours: 6},
-	cacheKey: () => 'hotfix'
-});
 
 const shortcutMap = new Map<string, string>();
 

--- a/source/helpers/hotfix.ts
+++ b/source/helpers/hotfix.ts
@@ -1,0 +1,40 @@
+import cache from 'webext-storage-cache';
+import compareVersions from 'tiny-version-compare';
+
+import {RGHOptions} from '../options-storage';
+
+export const updateHotfixes = cache.function(async (): Promise<string[][]> => {
+	// The explicit endpoint is necessary because it shouldn't change on GHE
+	const request = await fetch('https://api.github.com/repos/sindresorhus/refined-github/contents/hotfix.csv?ref=hotfix');
+	const {content} = await request.json();
+
+	return atob(content)
+		.trim()
+		.split('\n')
+		.map(line => line.split(','));
+}, {
+	maxAge: {hours: 6},
+	cacheKey: () => 'hotfixes'
+});
+
+export async function getLocalHotfixes(version: string): Promise<Partial<RGHOptions>> {
+	// To facilitate debugging, ignore hotfixes during development
+	if (version === '0.0.0') {
+		return {};
+	}
+
+	const hotfixes = await cache.get<string[][]>('hotfixes');
+	if (!hotfixes) {
+		return {};
+	}
+
+	const options: Partial<RGHOptions> = {};
+
+	for (const [feature, unaffectedVersion] of hotfixes) {
+		if(compareVersions(unaffectedVersion, version) > 1) {
+			options[`feature:${feature}`] = false;
+		}
+	}
+
+	return options;
+}

--- a/source/helpers/hotfix.ts
+++ b/source/helpers/hotfix.ts
@@ -31,7 +31,7 @@ export async function getLocalHotfixes(version: string): Promise<Partial<RGHOpti
 	const options: Partial<RGHOptions> = {};
 
 	for (const [feature, unaffectedVersion] of hotfixes) {
-		if(compareVersions(unaffectedVersion, version) > 1) {
+		if (compareVersions(unaffectedVersion, version) > 1) {
 			options[`feature:${feature}`] = false;
 		}
 	}

--- a/source/helpers/hotfix.ts
+++ b/source/helpers/hotfix.ts
@@ -31,7 +31,7 @@ export async function getLocalHotfixes(version: string): Promise<Partial<RGHOpti
 	const options: Partial<RGHOptions> = {};
 
 	for (const [feature, unaffectedVersion] of hotfixes) {
-		if (compareVersions(unaffectedVersion, version) > 1) {
+		if (!unaffectedVersion || compareVersions(unaffectedVersion, version) > 0) {
 			options[`feature:${feature}`] = false;
 		}
 	}

--- a/source/helpers/hotfix.ts
+++ b/source/helpers/hotfix.ts
@@ -10,7 +10,7 @@ export const updateHotfixes = cache.function(async (): Promise<string[][]> => {
 
 	// Rate-limit check
 	if (!content) {
-		return {};
+		return [];
 	}
 
 	return atob(content)

--- a/source/helpers/hotfix.ts
+++ b/source/helpers/hotfix.ts
@@ -8,6 +8,11 @@ export const updateHotfixes = cache.function(async (): Promise<string[][]> => {
 	const request = await fetch('https://api.github.com/repos/sindresorhus/refined-github/contents/hotfix.csv?ref=hotfix');
 	const {content} = await request.json();
 
+	// Rate-limit check
+	if (!content) {
+		return {};
+	}
+
 	return atob(content)
 		.trim()
 		.split('\n')


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/4324

To test this PR, the manifest version needs to be manually changed. I tested it and the function correctly returns the expected option settings.