### PR TITLE
Enable `fit-textareas` on discussions

### DIFF
--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -38,7 +38,8 @@ function init(): void {
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.hasRichTextEditor
+		pageDetect.hasRichTextEditor,
+		pageDetect.isDiscussion
 	],
 	init
 }, {


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/refined-github/issues/4342

Not yet tested.

Any other pages that aren't listed here? https://github.com/fregante/github-url-detection/blob/94741eb90941a71108b6caf5f2e38ad4c05a19d0/index.ts#L492-L504