### PR TITLE
Support for dark mode in `remove-label-faster`

### DIFF
--- a/source/features/remove-label-faster.css
+++ b/source/features/remove-label-faster.css
@@ -19,6 +19,10 @@
 	fill: rgb(var(--label-r) var(--label-g) var(--label-b));
 }
 
+[data-color-mode='dark'][data-dark-theme*='dark'] .rgh-remove-label-faster:is(:focus, :hover) svg {
+	fill: var(--color-bg-canvas);
+}
+
 :root:root .rgh-remove-label-faster-already-added {
 	display: inline-flex !important;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

## What's this?
Following the PR for fixing the hover color on labels https://github.com/sindresorhus/refined-github/commit/074b2b8c2f0a12d82e6b528db1b6366f017148fa, I forgot to consider dark mode:

https://user-images.githubusercontent.com/43481548/117852277-10f4c700-b27f-11eb-9166-bb02a6287ffc.mov

Sorry this is not a gif, Gifski didn't like this video.

# The fix
In previous versions it looks like in dark mode the X was just black.

I attempted to make the X the background color of the label, however this did not work as the background color has transparency and is made dark by the body background.

To avoid overcomplication my fix/suggestion is to set the X to the body background color.

## Tests / Gifs

Tested on Firefox and Chrome

Dark
![dark](https://user-images.githubusercontent.com/43481548/117852895-ba3bbd00-b27f-11eb-95ed-d73e24a073af.gif)
Dark Dimmed
![dark-dim](https://user-images.githubusercontent.com/43481548/117852915-bf007100-b27f-11eb-8a7e-98f43d3c2b88.gif)




