### PR TITLE
Fix `dim-bots` with multiple PR labels

### DIFF
--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -4,23 +4,29 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-const botSelector = [
+const commitSelector = [
 	/* Commits */
 	'.commit-author[href$="%5Bbot%5D"]',
 	'.commit-author[href$="renovate-bot"]',
-	'.commit-author[href$="scala-steward"]',
+	'.commit-author[href$="scala-steward"]'
+].join();
 
+const prSelector = [
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
 	'.labels [href$="label%3Abot"]'
 ].join();
 
 function init(): void {
-	for (const bot of select.all(botSelector)) {
+	for (const bot of select.all(commitSelector)) {
 		// Exclude co-authored commits
-		if (select.all('a', bot.parentElement!).every(link => link.matches(botSelector))) {
+		if (select.all('a', bot.parentElement!).every(link => link.matches(commitSelector))) {
 			bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 		}
+	}
+
+	for (const bot of select.all(prSelector)) {
+		bot.closest('.commit, .Box-row')!.classList.add('rgh-dim-bot');
 	}
 }
 

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -27,7 +27,8 @@ function init(): void {
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommitList,
-		pageDetect.isConversationList
+		pageDetect.isConversationList,
+		pageDetect.isPRList
 	],
 	init
 });

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -33,8 +33,7 @@ function init(): void {
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isCommitList,
-		pageDetect.isConversationList,
-		pageDetect.isPRList
+		pageDetect.isConversationList
 	],
 	init
 });

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -15,7 +15,7 @@ const prSelector = [
 	/* Issues/PRs */
 	'.opened-by [href*="author%3Aapp%2F"]',
 	'.labels [href$="label%3Abot"]'
-].join();
+];
 
 function init(): void {
 	for (const bot of select.all(commitSelector)) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4354
Fixes a regression from #3921 causing the PRs with more than just the `bot` label not to be dimmed anymore.


## Test URLs

1. Create a pull request with a `bot` label and any other one.
2. Browse to https://github.com/pulls

## Screenshot

|     | normal | hover |
| --- | ------ | ----- |
| Before | ![image](https://user-images.githubusercontent.com/47184027/118136965-a94f9080-b3d2-11eb-815e-e0778f621fb8.png) | N/A |
| After | ![image](https://user-images.githubusercontent.com/47184027/118136665-5b3a8d00-b3d2-11eb-863e-4ceaec5c67ab.png) | ![image](https://user-images.githubusercontent.com/47184027/118136710-67264f00-b3d2-11eb-8c66-4512152c5793.png) |




