### PR TITLE
Fix `z-index` bug in `quick-repo-deletion` and `sticky-sidebar`

### DIFF
--- a/source/features/quick-repo-deletion.css
+++ b/source/features/quick-repo-deletion.css
@@ -1,11 +1,11 @@
 :root .rgh-quick-repo-deletion[open] span {
 	position: relative;
-	z-index: 91; /* Higher than sticky readme header #4192 */
+	z-index: 91; /* Higher than sticky readme header and `sticky-sidebar` #4192 */
 	transform-origin: top;
 }
 
 :root .rgh-quick-repo-deletion[open] summary::before {
 	background-color: var(--color-scale-red-6);
 	opacity: 30%;
-	z-index: 91; /* Higher than sticky readme header #4192 */
+	z-index: 91; /* Higher than sticky readme header and `sticky-sidebar` #4192 */
 }

--- a/source/features/quick-repo-deletion.css
+++ b/source/features/quick-repo-deletion.css
@@ -1,10 +1,11 @@
 :root .rgh-quick-repo-deletion[open] span {
 	position: relative;
-	z-index: 81;
+	z-index: 91; /* Higher than sticky readme header #4192 */
 	transform-origin: top;
 }
 
 :root .rgh-quick-repo-deletion[open] summary::before {
 	background-color: var(--color-scale-red-6);
 	opacity: 30%;
+	z-index: 91; /* Higher than sticky readme header #4192 */
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -5,12 +5,18 @@
 .rgh-sticky-sidebar {
 	position: sticky;
 	top: 0;
-	z-index: 1; /* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
+
+	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
+	/* Higher than sticky readme header #4192 */
+	z-index: 91;
 }
 
 #partial-discussion-sidebar.rgh-sticky-sidebar {
 	top: 76px !important; /* Sticky header's height + sidebar item's margin */
-	z-index: 1; /* Needed so the backdrop of notification modal is over the other elements in the conversation */
+
+	/* Needed so the backdrop of notification modal is over the other elements in the conversation */
+	/* Higher than sticky readme header #4192 */
+	z-index: 91;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -8,7 +8,7 @@
 
 	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
 	/* Higher than sticky readme header #4192 */
-	z-index: 91;
+	z-index: 90;
 }
 
 #partial-discussion-sidebar.rgh-sticky-sidebar {
@@ -16,7 +16,7 @@
 
 	/* Needed so the backdrop of notification modal is over the other elements in the conversation */
 	/* Higher than sticky readme header #4192 */
-	z-index: 91;
+	z-index: 90;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */


### PR DESCRIPTION
Fixes #4363 
Fixes #4192 

Preserves https://github.com/sindresorhus/refined-github/pull/3754

## Test

1. Find own fork that can be deleted by `quick-repo-deletion`, like https://github.com/fregante/xo for me
2. Click "Delete fork" button

1. Find own repo (can be the same as above), like https://github.com/fregante/xo for me
2. Click gear icon in sidebar

## Before

<img width="970" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/118349236-b8bd0e00-b579-11eb-9676-ba74ade0590e.png">


## After

<img width="1010" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/118349237-bbb7fe80-b579-11eb-827e-49074a70deb6.png">



<img width="1331" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/118349389-98da1a00-b57a-11eb-8359-4d681f43a7ac.png">
