### PR TITLE
Meta: Fix `lint:css` error on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"build:webpack": "webpack --mode=production",
 		"fix": "run-p 'lint:* -- --fix'",
 		"lint": "run-p lint:* --continue-on-error",
-		"lint:css": "stylelint 'source/**/*.css'",
+		"lint:css": "stylelint \"source/**/*.css\"",
 		"lint:js": "xo",
 		"pack:safari": "xcodebuild -project 'safari/Refined GitHub.xcodeproj'",
 		"start:safari": "open 'safari/build/Release/Refined GitHub.app'",


### PR DESCRIPTION
When attempting to run lint checks from the top directory, I encountered the following error:

```
C:\Repos\refined-github>npm run lint:css

> lint:css
> stylelint 'source/**/*.css'

Error: No files matching the pattern "'source/**/*.css'" were found.
    at C:\Repos\refined-github\node_modules\stylelint\lib\standalone.js:212:12
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

After this fix, lint checks run as expected without errors.

## Note for reviewers

It's very possible that this is an error that only affects me, seeing as though the code hasn't changed a year. Please let me know if the error exists on your end!

Edit: Sorry for the spam title changing. Forgot that gets added to the log.