### PR TITLE
Add `remove-actions-tabs` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,6 +142,7 @@ Thanks for contributing! 🦋🙌
 - [](# "next-scheduled-github-action") [Shows the next scheduled time of relevant GitHub Actions in the workflows sidebar.](https://user-images.githubusercontent.com/46634000/94690232-2476a180-0330-11eb-99d7-e174bb762cea.png)
 - [](# "quick-repo-deletion") [Lets you delete your repos in a click, if they have no stars, issues, or PRs.](https://user-images.githubusercontent.com/1402241/99716945-54a80a00-2a6e-11eb-9107-f3517a6ab1bc.gif)
 - [](# "useful-forks") [Helps you find the most active forks](https://user-images.githubusercontent.com/38117856/107463541-542e8500-6b2c-11eb-8b25-082f344c1587.png), via https://useful-forks.github.io.
+- [](# "remove-actions-tab") Remove actions tab if there are no workflows configured for the repository
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/remove-actions-tab.tsx
+++ b/source/features/remove-actions-tab.tsx
@@ -1,17 +1,26 @@
+import cache from 'webext-storage-cache';
 import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {getRepo} from '../github-helpers';
 import * as api from '../github-helpers/api';
+
+const getWorkflowsCount = cache.function(async (): Promise<number> => {
+	const {workflows} = await api.v3('actions/workflows');
+	return workflows.length;
+}, {
+	maxAge: {days: 1},
+	cacheKey: (): string => __filebasename + ':' + getRepo()!.nameWithOwner
+});
 
 async function removeActionsTab(): Promise<void | false> {
 	const actionsTab = await elementReady('[data-hotkey="g a"]');
-	const {workflows} = await api.v3('actions/workflows');
 
 	if (
 		!actionsTab || // Actions Tab does not exist 🎉
 		actionsTab.matches('.selected') || // User is on Actions tab 👀
-		workflows.length > 0 // Actions Workflows are configured for the repository
+		await getWorkflowsCount() > 0 // Actions Workflows are configured for the repository
 	) {
 		return false;
 	}

--- a/source/features/remove-actions-tab.tsx
+++ b/source/features/remove-actions-tab.tsx
@@ -32,6 +32,10 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepo
 	],
+	exclude: [
+		// Repo owners should see the tab. If they don't need it, they should disable actions altogether
+		pageDetect.canUserEditRepo
+	],
 	awaitDomReady: false,
 	init: removeActionsTab
 });

--- a/source/features/remove-actions-tab.tsx
+++ b/source/features/remove-actions-tab.tsx
@@ -1,0 +1,28 @@
+import elementReady from 'element-ready';
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+import * as api from '../github-helpers/api';
+
+async function removeActionsTab(): Promise<void | false> {
+	const actionsTab = await elementReady('[data-hotkey="g a"]');
+	const {workflows} = await api.v3('actions/workflows');
+
+	if (
+		!actionsTab || // Actions Tab does not exist 🎉
+		actionsTab.matches('.selected') || // User is on Actions tab 👀
+		workflows.length > 0 // Actions Workflows are configured for the repository
+	) {
+		return false;
+	}
+
+	actionsTab.remove();
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isRepo
+	],
+	awaitDomReady: false,
+	init: removeActionsTab
+});

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -221,6 +221,7 @@ import './features/global-search-filters';
 import './features/clean-header-search-field';
 import './features/avoid-accidental-submissions';
 import './features/delete-review-comments-faster';
+import './features/remove-actions-tab';
 
 // Add global for easier debugging
 (window as any).select = select;


### PR DESCRIPTION
GitHub enabled Actions and the corresponding UI tab for all repositories
even when they do not have any workflows configured. This makes it
confusing when navigating through different repositories often
misleading to think that the repository has configured Actions
workflows. This feature removes the Actions tab from view for
repositories that do not have any Actions workflows configured.

## Test URLs

- https://github.com/shinenelson/refined-github
- https://github.com/mozilla/tabzilla


## Screenshot

I am not sure this feature requires a screenshot, but I can create one
if it is required.
