### PR TITLE
Use system mono font stack

### DIFF
--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -6,7 +6,7 @@
 }
 
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input, textarea) {
-    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+	font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
 }
 
 .rgh-monospace-textareas textarea {

--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -6,7 +6,16 @@
 }
 
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input, textarea) {
-	font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
+	font-family: ui-monospace, 
+             Menlo, Monaco, 
+             "Cascadia Mono", "Segoe UI Mono", 
+             "Roboto Mono", 
+             "Oxygen Mono", 
+             "Ubuntu Monospace", 
+             "Source Code Pro",
+             "Fira Mono", 
+             "Droid Sans Mono", 
+             "Courier New", !important monospace;
 }
 
 .rgh-monospace-textareas textarea {

--- a/source/features/monospace-textareas.css
+++ b/source/features/monospace-textareas.css
@@ -6,16 +6,7 @@
 }
 
 .rgh-monospace-textareas :is(#merge_title_field, #commit-summary-input, textarea) {
-	font-family: ui-monospace, 
-             Menlo, Monaco, 
-             "Cascadia Mono", "Segoe UI Mono", 
-             "Roboto Mono", 
-             "Oxygen Mono", 
-             "Ubuntu Monospace", 
-             "Source Code Pro",
-             "Fira Mono", 
-             "Droid Sans Mono", 
-             "Courier New", !important monospace;
+    font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace !important;
 }
 
 .rgh-monospace-textareas textarea {

--- a/source/options.css
+++ b/source/options.css
@@ -40,7 +40,16 @@ li[data-validation] {
 
 :root [name='customCSS'],
 :root [name='personalToken'] {
-	font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+	font-family: ui-monospace, 
+             Menlo, Monaco, 
+             "Cascadia Mono", "Segoe UI Mono", 
+             "Roboto Mono", 
+             "Oxygen Mono", 
+             "Ubuntu Monospace", 
+             "Source Code Pro",
+             "Fira Mono", 
+             "Droid Sans Mono", 
+             "Courier New", monospace;
 	font-size: 11px;
 	line-height: 1.5;
 }

--- a/source/options.css
+++ b/source/options.css
@@ -40,16 +40,7 @@ li[data-validation] {
 
 :root [name='customCSS'],
 :root [name='personalToken'] {
-	font-family: ui-monospace, 
-             Menlo, Monaco, 
-             "Cascadia Mono", "Segoe UI Mono", 
-             "Roboto Mono", 
-             "Oxygen Mono", 
-             "Ubuntu Monospace", 
-             "Source Code Pro",
-             "Fira Mono", 
-             "Droid Sans Mono", 
-             "Courier New", monospace;
+	font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
 	font-size: 11px;
 	line-height: 1.5;
 }


### PR DESCRIPTION
SF Mono isn't available in Safari (or any other user installed font for
that matter). I've been using this new font[1] stack in my custom css for a
while now on macOS Safari and it works perfectly.

I am not too familiar with the code base so maybe I've overlooked something.

[1] https://qwtel.com/posts/software/the-monospaced-system-ui-css-font-stack/

## Screenshot

Before 

<img width="951" alt="ScreenShot 2021-05-25 at 10 30 15" src="https://user-images.githubusercontent.com/119219/119465761-4354f880-bd44-11eb-8dfa-85d5ab2d425d.png">

After

![ScreenShot 2021-05-25 at 10 29 29](https://user-images.githubusercontent.com/119219/119465773-46e87f80-bd44-11eb-9bbf-a5355977e1ae.png)
