### PR TITLE
Restore `highlight-deleted-and-added-files-in-diffs`

### DIFF
--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -20,7 +20,7 @@ async function loadDeferred(jumpList: Element): Promise<void> {
 
 async function init(): Promise<void | false> {
 	const fileList = await elementReady([
-		'.toc-select details-menu', // `isPR`
+		'.toc-select details-menu:not([src$="conversations_menu"])', // `isPR`
 		'.toc-diff-stats + .content' // `isSingleCommit` and `isCompare`
 	].join());
 

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -20,7 +20,7 @@ async function loadDeferred(jumpList: Element): Promise<void> {
 
 async function init(): Promise<void | false> {
 	const fileList = await elementReady([
-		'.toc-select details-menu:not([src$="conversations_menu"])', // `isPR`
+		'.toc-select details-menu[src*="/show_toc?"]', // `isPR`
 		'.toc-diff-stats + .content' // `isSingleCommit` and `isCompare`
 	].join());
 


### PR DESCRIPTION
See https://github.blog/changelog/2021-05-25-new-tools-to-discover-and-resolve-pull-request-conversations-beta/

Console error

```
refined-github.js:8434 Uncaught TypeError: Cannot read property 'cloneNode' of undefined
    at add (refined-github.js:8434)
    at runAdd (refined-github.js:4334)
    at applyChanges (refined-github.js:4304)
    at SelectorObserver.addRootNodes (refined-github.js:4456)
    at Array.processBatchQueue (refined-github.js:4276)
    at MutationObserver.handleMutations (refined-github.js:4293)
add @ refined-github.js:8434
runAdd @ refined-github.js:4334
applyChanges @ refined-github.js:4304
addRootNodes @ refined-github.js:4456
processBatchQueue @ refined-github.js:4276
handleMutations @ refined-github.js:4293
setTimeout (async)
handleMutations @ refined-github.js:4295
attributes (async)
scheduleMacroTask @ refined-github.js:4287
(anonymous) @ refined-github.js:4280
SelectorObserver.observe @ refined-github.js:4493
observe @ refined-github.js:4513
init @ refined-github.js:8430
async function (async)
init @ refined-github.js:8419
runFeature @ refined-github.js:1924
setupPageLoad @ refined-github.js:1937
add @ refined-github.js:1959
async function (async)
add @ refined-github.js:1944
(anonymous) @ refined-github.js:8414
(anonymous) @ refined-github.js:9289
(anonymous) @ refined-github.js:9290
```

## Test URLs

https://github.com/sindresorhus/refined-github/pull/4401/files
https://github.com/sindresorhus/refined-github/pull/4403/files

## Screenshot
![image](https://user-images.githubusercontent.com/16872793/120002260-a2b04400-bfa2-11eb-950d-2c20c0552573.png)

