### PR TITLE
Fix `edit-comments-faster` to only when editing is allowed

### DIFF
--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -8,10 +8,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditDiscussion(): boolean {
-	return pageDetect.isDiscussion() && select.exists(`
-	.current-user span:is([title^="You are a maintainer on this repository"], [title^="You have been invited to collaborate on"]),
-	button[aria-label="Edit discussion title"]
-	`);
+	return pageDetect.isDiscussion() && select.exists('.current-user span:is([title^="You are a maintainer on this repository"], [title^="You are a collaborator on this repository"])');
 }
 
 function init(): void {

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
-import onetime from 'onetime';
 import select from 'select-dom';
+import onetime from 'onetime';
 import {observe} from 'selector-observer';
 import {PencilIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
@@ -16,7 +16,6 @@ function canEditDiscussion(): boolean {
 
 function init(): void {
 	const preSelector = !pageDetect.isDiscussion() || canEditDiscussion() ? '' : '.current-user';
-
 	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -7,11 +7,11 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditDiscussion(): boolean {
-	return document.querySelector(`
+	return select.exists(`
 	.current-user span[title^="You are the author"],
 	.current-user span[title^="You are a collaborator"],
 	button[aria-label="Edit discussion title"]
-	`) !== null;
+	`);
 }
 
 function init(): void {

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -6,11 +6,21 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
+function canEditDiscussion(): boolean {
+	return document.querySelector(`
+	.current-user span[title^="You are the author"],
+	.current-user span[title^="You are a collaborator"],
+	button[aria-label="Edit discussion title"]
+	`) !== null;
+}
+
 function init(): void {
-	// Find editable comments first, then traverse to the correct position
-	observe((document.querySelector('.current-user span[title^="You are a"]') !== null || pageDetect.hasComments() ?
-		'.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)' :
-		'.current-user.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)'), {
+	let preSelector = '';
+	if (pageDetect.isDiscussion()) {
+		preSelector = canEditDiscussion() ? '' : '.current-user';
+	}
+
+	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -8,7 +8,9 @@ import features from '.';
 
 function init(): void {
 	// Find editable comments first, then traverse to the correct position
-	observe('.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
+	observe((document.querySelector('.current-user span[title^="You are a"]') !== null || pageDetect.hasComments() ?
+		'.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)' :
+		'.current-user.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)'), {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');
 

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import onetime from 'onetime';
+import select from 'select-dom';
 import {observe} from 'selector-observer';
 import {PencilIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -8,7 +8,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditDiscussion(): boolean {
-	return pageDetect.isDiscussion() && select.exists('.current-user span:is([title^="You are a maintainer on this repository"], [title^="You are a collaborator on this repository"])');
+	return pageDetect.isDiscussion() && select.exists('[title^="You are a maintainer"], [title^="You are a collaborator"]');
 }
 
 function init(): void {

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,7 +12,9 @@ function canEditDiscussion(): boolean {
 }
 
 function init(): void {
+	// If true then the resulting selector will match all comments, otherwise it will only match made by you
 	const preSelector = !pageDetect.isDiscussion() || canEditDiscussion() ? '' : '.current-user';
+	// Find editable comments first, then traverse to the correct position
 	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
 		add(comment) {
 			comment.classList.add('rgh-edit-comment');

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -9,7 +9,7 @@ import features from '.';
 
 function canEditDiscussion(): boolean {
 	return pageDetect.isDiscussion() && select.exists(`
-	.current-user span:is([title^="You are the author"], [title^="You are a collaborator"]),
+	.current-user span:is([title^="You are a maintainer on this repository"], [title^="You have been invited to collaborate on"]),
 	button[aria-label="Edit discussion title"]
 	`);
 }

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -12,7 +12,7 @@ function canEditDiscussion(): boolean {
 }
 
 function init(): void {
-	// If true then the resulting selector will match all comments, otherwise it will only match made by you
+	// If true then the resulting selector will match all comments, otherwise it will only match those made by you
 	const preSelector = !pageDetect.isDiscussion() || canEditDiscussion() ? '' : '.current-user';
 	// Find editable comments first, then traverse to the correct position
 	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {

--- a/source/features/edit-comments-faster.tsx
+++ b/source/features/edit-comments-faster.tsx
@@ -8,18 +8,14 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditDiscussion(): boolean {
-	return select.exists(`
-	.current-user span[title^="You are the author"],
-	.current-user span[title^="You are a collaborator"],
+	return pageDetect.isDiscussion() && select.exists(`
+	.current-user span:is([title^="You are the author"], [title^="You are a collaborator"]),
 	button[aria-label="Edit discussion title"]
 	`);
 }
 
 function init(): void {
-	let preSelector = '';
-	if (pageDetect.isDiscussion()) {
-		preSelector = canEditDiscussion() ? '' : '.current-user';
-	}
+	const preSelector = !pageDetect.isDiscussion() || canEditDiscussion() ? '' : '.current-user';
 
 	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
 		add(comment) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4400

## Test URLs

Discussions where you don't have made any comments, and you are not maintainer/collaborator,
e.g. https://github.com/streetcomplete/StreetComplete/discussions/2671

## Screenshot

![2021-05-26_183553](https://user-images.githubusercontent.com/723651/119689174-4c7fbb80-be51-11eb-955e-a499f15a9aa2.jpg)

## Note to reviewers:

The issue #4400 is about this line:

https://github.com/sindresorhus/refined-github/blob/575f41a7faacd5901065cfae634ce0399658d1cb/source/features/edit-comments-faster.tsx#L11

That selector works ok in Issue pages *(it selects all your comments that you can edit)*, 
but it doesn't work ok in Discussion pages - it wrongly selects all comments).

This PR adds a check so that, if in the Discussion page there's a "`You are a (maintainer/collaborator)`" element
~~or it's in Issues page, then use the old selector,~~, or that you still can edit the page,
otherwise add to that selector this class: `.current-user` (=comments made by you) for more specificity.

