### PR TITLE
Fix `global-conversation-list-filters` creates faulty links

### DIFF
--- a/source/features/global-conversation-list-filters.tsx
+++ b/source/features/global-conversation-list-filters.tsx
@@ -22,7 +22,7 @@ function init(): void {
 
 	for (const [label, title, query] of links) {
 		// Create link
-		const url = new URL(location.pathname, location.origin);
+		const url = new URL(isIssues ? '/issues' : '/pulls', location.origin);
 		url.searchParams.set('q', `${typeQuery} ${defaultQuery} ${query}`);
 		const link = <a href={String(url)} title={title} className="subnav-item">{label}</a>;
 


### PR DESCRIPTION

Closes #3731



1. if sort by Recently updated is disabled, Github url will be changed as short automatically after clicking review requests tab, mentioned or something.
2. then click Commented tab, the bug occurs.
