### PR TITLE
`clean-repo-sidebar` fix: Section disappears if URL includes “releases”

### DIFF
--- a/source/features/clean-repo-sidebar.tsx
+++ b/source/features/clean-repo-sidebar.tsx
@@ -20,7 +20,7 @@ async function cleanLicenseText(): Promise<void> {
 }
 
 async function cleanReleases(): Promise<void> {
-	const sidebarReleases = await elementReady('.BorderGrid-cell a[href$="/releases"]', {waitForChildren: false});
+	const sidebarReleases = await elementReady('.BorderGrid-cell h2 a[href$="/releases"]', {waitForChildren: false});
 	if (!sidebarReleases) {
 		return;
 	}


### PR DESCRIPTION
From #4424