### PR TITLE
Fix: Extension may fail to load if custom CSS is specified

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -1,4 +1,3 @@
-import delay from 'delay';
 import React from 'dom-chef';
 import select from 'select-dom';
 import domLoaded from 'dom-loaded';
@@ -6,6 +5,7 @@ import stripIndent from 'strip-indent';
 import {Promisable} from 'type-fest';
 import * as pageDetect from 'github-url-detection';
 
+import waitFor from '../helpers/wait-for';
 import onNewComments from '../github-events/on-new-comments';
 import bisectFeatures from '../helpers/bisect';
 import optionsStorage, {RGHOptions} from '../options-storage';
@@ -88,6 +88,7 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 	]);
 
 	if (options.customCSS.trim().length > 0) {
+		await waitFor(() => document.head);
 		document.head.append(<style>{options.customCSS}</style>);
 	}
 
@@ -102,10 +103,7 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 	// Create logging function
 	log = options.logging ? console.log : () => {/* No logging */};
 
-	while (!document.body) {
-		// eslint-disable-next-line no-await-in-loop
-		await delay(10);
-	}
+	await waitFor(() => document.body);
 
 	if (pageDetect.is500() || pageDetect.isPasswordConfirmation()) {
 		return;

--- a/source/helpers/wait-for.ts
+++ b/source/helpers/wait-for.ts
@@ -1,7 +1,7 @@
 import delay from 'delay';
 
-export default async function waitFor(booleanFunction: () => any): Promise<void> {
-	while (!booleanFunction()) {
+export default async function waitFor(condition: () => any): Promise<void> {
+	while (!condition()) {
 		// eslint-disable-next-line no-await-in-loop
 		await delay(10);
 	}

--- a/source/helpers/wait-for.ts
+++ b/source/helpers/wait-for.ts
@@ -1,0 +1,8 @@
+import delay from 'delay';
+
+export default async function waitFor(booleanFunction: () => any): Promise<void> {
+	while (!booleanFunction()) {
+		// eslint-disable-next-line no-await-in-loop
+		await delay(10);
+	}
+}


### PR DESCRIPTION
Fixes #4376

This is hard to test since it's a rare occurrence.

1. Specify CSS in the options
2. Reload the page a million times