### PR TITLE
`embed-gist-inline` fix: Exclude gist user links on Enterprise

### DIFF
--- a/source/features/embed-gist-inline.tsx
+++ b/source/features/embed-gist-inline.tsx
@@ -4,13 +4,26 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import {getCleanPathname} from '../github-helpers';
 
-const isGist = (link: HTMLAnchorElement): boolean =>
-	!link.pathname.includes('.') && // Exclude links to embed files
-	(
-		(link.hostname.startsWith('gist.') && link.pathname.includes('/', 1)) || // Exclude user links
-		link.pathname.startsWith('gist/')
+function parseGistLink(link: HTMLAnchorElement): string | void {
+	if (link.host === 'gist.github.com') {
+		return getCleanPathname(link);
+	}
+
+	if (link.host === location.host && link.pathname.startsWith('gist/')) {
+		return link.pathname.replace('/gist', '').replace(/\/$/, '');
+	}
+}
+
+function isGist(link: HTMLAnchorElement): boolean {
+	const gistUrl = parseGistLink(link);
+	return Boolean(
+		gistUrl &&
+		!gistUrl.includes('.') && // Exclude links to embed files
+		gistUrl.includes('/', 1) // Exclude user links
 	);
+}
 
 const isOnlyChild = (link: HTMLAnchorElement): boolean => link.textContent!.trim() === link.parentNode!.textContent!.trim();
 


### PR DESCRIPTION
Tested on non-GHE, still works 

## Live test URLs

### Embedded gist

https://gist.github.com/fregante/cf4d0415c4802e0c81812ae9bbb821d8

### Big file

https://gist.github.com/fregante/afa017a7c81dd5f5eeefc963593088b4

### User link

https://gist.github.com/fregante

## Screenshot

<img width="594" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/120142719-f2904480-c208-11eb-92ba-76378061685d.png">
