### PR TITLE
Fix `swap-branches-on-compare` is not operated in direct comparison

### DIFF
--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -7,10 +7,13 @@ import features from '.';
 import {buildRepoURL, getRepo} from '../github-helpers';
 
 function init(): void {
-	const references = getRepo()!
+	const referencePath = getRepo()!
 		.path
-		.replace('compare/', '')
-		.split('...')
+		.replace('compare/', '');
+	const isDirectComparision: boolean = referencePath.includes('..');
+	const branchDelimiter: string = isDirectComparision ? '..' : '...';
+	const references: string[] = referencePath
+		.split(branchDelimiter)
 		.reverse();
 
 	// Compares against the "base" branch if the URL only has one reference
@@ -18,9 +21,9 @@ function init(): void {
 		references.unshift(select('.branch span')!.textContent!);
 	}
 
-	const icon = select('.range-editor .octicon-arrow-left')!;
+	const icon = select('.range-editor .octicon-arrow-left,.octicon-arrow-both')!;
 	icon.parentElement!.attributes['aria-label'].value += '.\nClick to swap.';
-	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
+	wrap(icon, <a href={buildRepoURL('compare/' + references.join(branchDelimiter))}/>);
 }
 
 void features.add(__filebasename, {


### PR DESCRIPTION
Closes #4390

The double dotted delimiter is used with direct comparison.

So need to check if path includes how many there is dot.

And then reuse the delimiter at replacement and also find element by `.octicon-arrow-both`. because, in direct comparison, arrow is both directional.



## Test URLs
- https://github.com/sindresorhus/modern-normalize/compare/af8df39ff9abd290cb5ee22b7d1cc3451367f8fe..f9a9045502138c23478c2d4760dfa28e01d53e7b