### PR TITLE
Check for multiple related issues in `deep-reblame`

### DIFF
--- a/source/features/deep-reblame.tsx
+++ b/source/features/deep-reblame.tsx
@@ -63,11 +63,7 @@ async function redirectToBlameCommit(event: delegate.Event<MouseEvent, HTMLAncho
 	blameElement.blur(); // Hide tooltip after click, it’s shown on :focus
 
 	const blameHunk = blameElement.closest('.blame-hunk')!;
-	const prNumbers = [];
-	for (const pr of select.all('.issue-link', blameHunk)) {
-		prNumbers.push(looseParseInt(pr));
-	}
-
+	const prNumbers = select.all('.issue-link', blameHunk).map(pr => looseParseInt(pr));
 	const prCommit = select('a.message', blameHunk)!.pathname.split('/').pop()!;
 	const blameUrl = new GitHubURL(location.href);
 


### PR DESCRIPTION
Fixes #4440 
## Test URLs
1. Visit https://github.com/pixiebrix/pixiebrix-extension/blame/69a0e85c03f57e094591865b5dcf0632c4c9e26f/browsers/chrome/webpack/webpack.dev.js#L101
2. alt-click reblame icon

Related PR in commit title: it should "enter" it https://github.com/sindresorhus/refined-github/blame/b5497da33a6c5b99eb518ecc266881780bc11877/contributing.md#L7

Unrelated PR in commit title: it should `alert()` https://github.com/sindresorhus/refined-github/blame/d1e27cb34f18b9d5d57fdbf853e5b15c3a660d85/source/features/deep-reblame.tsx#L67

Renamed file: it should `alert()` https://github.com/sindresorhus/refined-github/blame/fad67fb8d8fcf608601c9b8ae1b5f12337cbccce/source/options.html#L1


## Screenshot
![Video_2021-06-03_094736](https://user-images.githubusercontent.com/16872793/120655850-1219ae00-c451-11eb-99ca-290c975de4f8.gif)
