### PR TITLE
`repo-wide-file-finder`: Use current branch/tag when possible

### DIFF
--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -3,8 +3,8 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
+import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 
 async function init(): Promise<void> {
 	document.body.append(

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {buildRepoURL} from '../github-helpers';
+import {buildRepoURL, getCurrentCommittish} from '../github-helpers';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 
 async function init(): Promise<void> {
@@ -12,7 +12,7 @@ async function init(): Promise<void> {
 			hidden
 			data-hotkey="t"
 			data-pjax="true"
-			href={buildRepoURL('find', await getDefaultBranch())}
+			href={buildRepoURL('find', await (getCurrentCommittish() ?? getDefaultBranch()))}
 		/>
 	);
 }

--- a/source/features/repo-wide-file-finder.tsx
+++ b/source/features/repo-wide-file-finder.tsx
@@ -12,7 +12,7 @@ async function init(): Promise<void> {
 			hidden
 			data-hotkey="t"
 			data-pjax="true"
-			href={buildRepoURL('find', await (getCurrentCommittish() ?? getDefaultBranch()))}
+			href={buildRepoURL('find', getCurrentCommittish() ?? await getDefaultBranch())}
 		/>
 	);
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

The repo wide file finder was always loading the finder for the repo's default branch, even if a different branch/tag was selected. This updates the logic to try to get the current branch from the URL before falling back to the default.

## Test URLs

https://github.com/optics-dev/Monocle/tree/v3.0.0-RC2
https://github.com/optics-dev/monocle/commits/v3.0.0-RC2

## Screenshot

### Before

Note `master` in the find URL

<details>
  <summary>expand GIF</summary>
  
  ![before](https://user-images.githubusercontent.com/4718399/120906674-5fe90e80-c629-11eb-8bb3-bca763417dda.gif)

</details>

### After

Note `v3.0.0-RC2`, the selected tag, in the find URL

<details>
  <summary>expand GIF</summary>
  
  ![after](https://user-images.githubusercontent.com/4718399/120906695-8ad36280-c629-11eb-80d0-d5f5e97b0e42.gif)

</details>