### PR TITLE
Disable `fit-textarea` in Safari

### DIFF
--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
+import isSafari from '../helpers/browser-detection';
 
 import features from '.';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
@@ -40,10 +41,16 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor
 	],
+	exclude: [
+		isSafari
+	],
 	init
 }, {
 	include: [
 		pageDetect.isPRConversation
+	],
+	exclude: [
+		isSafari
 	],
 	init() {
 		onPrMergePanelOpen(fitPrCommitMessageBox);

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -3,9 +3,9 @@ import select from 'select-dom';
 import delegate from 'delegate-it';
 import fitTextarea from 'fit-textarea';
 import * as pageDetect from 'github-url-detection';
-import isSafari from '../helpers/browser-detection';
 
 import features from '.';
+import isSafari from '../helpers/browser-detection';
 import onPrMergePanelOpen from '../github-events/on-pr-merge-panel-open';
 
 function inputListener({target}: Event): void {


### PR DESCRIPTION
[fit-textarea](https://github.com/fregante/fit-textarea) v2 is slow on Safari (https://github.com/sindresorhus/refined-github/issues/4266) and v3 is slow on Chrome (https://github.com/sindresorhus/refined-github/issues/4275)

To re-enable v3, I need to figure out why it's so slow on Chrome