### PR TITLE
Drop `emphasize-draft-pr-label` feature

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,7 +1,0 @@
-.js-issue-row [aria-label='Open draft pull request'] svg {
-	stroke: var(--color-text-secondary, #586069);
-	stroke-width: 1.2px;
-	color: var(--color-bg-canvas, #fff) !important;
-	paint-order: stroke;
-	overflow: visible !important;
-}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -19,7 +19,6 @@ import './features/sticky-conversation-list-toolbar.css';
 import './features/always-show-branch-delete-buttons.css';
 import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
-import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
 import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';


### PR DESCRIPTION
New icons might make this change unnecessary https://twitter.com/GHchangelog/status/1402312797187366914

Last related PR https://github.com/sindresorhus/refined-github/pull/2848