### PR TITLE
Disable `swap-branches-on-compare` in direct comparison

### DIFF
--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -28,7 +28,7 @@ void features.add(__filebasename, {
 		pageDetect.isCompare
 	],
 	exclude: [
-		() => select.exists('.range-editor .octicon-arrow-both')
+		() => location.pathname.includes('..') && !location.pathname.includes('...')
 	],
 	init
 });

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -28,7 +28,7 @@ void features.add(__filebasename, {
 		pageDetect.isCompare
 	],
 	exclude: [
-		() => location.pathname.includes('..') && !location.pathname.includes('...')
+		() => /\.\.+/.exec(location.pathname)?.[0]!.length === 2
 	],
 	init
 });

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -27,5 +27,8 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isCompare
 	],
+	exclude: [
+		() => select.exists('.range-editor .octicon-arrow-both')
+	],
 	init
 });


### PR DESCRIPTION
Closes #4390

In direct comparison, `swap-branches-on-compare` feature is not needed because of the same result after swap.

To fix this bug, `swap-branches-on-compare` should be disabled.
So check if only 2-dot exists.

## Test URLs
- https://github.com/sindresorhus/modern-normalize/compare/af8df39ff9abd290cb5ee22b7d1cc3451367f8fe..f9a9045502138c23478c2d4760dfa28e01d53e7b
