### PR TITLE
Don't run `comments-time-machine-links` if comment is after latest commit

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -91,7 +91,7 @@ async function showTimemachineBar(): Promise<void | false> {
 			return false;
 		}
 
-		const lastCommitDate = await elementReady('[itemprop="dateModified"] relative-time', {waitForChildren: false});
+		const lastCommitDate = await elementReady('.repository-content .Box.Box--condensed relative-time', {waitForChildren: false});
 		if (lastCommitDate && date > lastCommitDate.getAttribute('datetime')!) {
 			return false;
 		}


### PR DESCRIPTION
1. LINKED ISSUES:
   Closes #3244

2. TEST URLS:
Should not show
	https://github.com/sindresorhus/refined-github/blob/main/source/features/comments-time-machine-links.tsx

Should show
```
https://github.com/sindresorhus/refined-github/blob/main/source/features/comments-time-machine-links.tsx?rgh-link-date=2019-12-11T10%3A12%3A11Z
```

3. SCREENSHOT:
   None. If needed let me know


Fixes my mess-up in #3951 