### PR TITLE
Fix `mark-merge-commits-in-list` commit hash selector

### DIFF
--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -34,7 +34,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	return commit.querySelector('a[href]:not(.js-issue-link)')!.pathname.split('/').pop()!;
+	return select('[aria-label="Copy the full SHA"]', commit)!.getAttribute('value');
 }
 
 async function init(): Promise<void> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -34,7 +34,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	return select('[aria-label="Copy the full SHA"]', commit)!.getAttribute('value');
+	return select('[aria-label="Copy the full SHA"]', commit)!.getAttribute('value')!;
 }
 
 async function init(): Promise<void> {

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -34,7 +34,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	return commit.querySelector('a[href]')!.pathname.split('/').pop()!;
+	return commit.querySelector('a[href]:not(.js-issue-link)')!.pathname.split('/').pop()!;
 }
 
 async function init(): Promise<void> {


### PR DESCRIPTION
Closes #4468 


## Test URLs
https://github.com/pixiebrix/pixiebrix-extension/commits/main
https://github.com/babel/babel/commits/master?after=ddd40bf5c7ad8565fc990f26142f85613958a329+104

##Screenshot 

![image](https://user-images.githubusercontent.com/16872793/121796975-272dd400-cbeb-11eb-9048-6fdfefd22a25.png)
