### PR TITLE
Don't run `collapse-wiki-sections` on Wiki edit pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"element-ready": "^6.0.0",
 				"fit-textarea": "^2.0.0",
 				"flat-zip": "^1.0.1",
-				"github-url-detection": "^5.2.0",
+				"github-url-detection": "^5.3.0",
 				"image-promise": "^7.0.1",
 				"indent-textarea": "^2.1.0",
 				"js-abbreviation-number": "^1.1.2",
@@ -5519,9 +5519,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"node_modules/github-url-detection": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.2.0.tgz",
-			"integrity": "sha512-Lcnz+SyIvO4VSj09Iux5kJ63HuplcS59yRQF8E57ZKKvDhwrNivNNxDMLivQAVAQkTQEzrIK3d+XVfJriPu8Aw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.3.0.tgz",
+			"integrity": "sha512-0hMs6umYBrPBE1DGPuJ5/CbL6M0y2FIYHV+YheE8tMgwX+v/jiL0/vdB0liHlNT1CH7d4ZZ68MB8YYjQ1tVa0Q==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -17894,9 +17894,9 @@
 			"integrity": "sha512-T2azXbRJTJGQc28G6x89LpzQmuVjzl0hzJXPRD2t9yMh7URYUW8Opqr5ptHvjAVDJ+hwhBtoYmVx3VyFawRoFg=="
 		},
 		"github-url-detection": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.2.0.tgz",
-			"integrity": "sha512-Lcnz+SyIvO4VSj09Iux5kJ63HuplcS59yRQF8E57ZKKvDhwrNivNNxDMLivQAVAQkTQEzrIK3d+XVfJriPu8Aw=="
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/github-url-detection/-/github-url-detection-5.3.0.tgz",
+			"integrity": "sha512-0hMs6umYBrPBE1DGPuJ5/CbL6M0y2FIYHV+YheE8tMgwX+v/jiL0/vdB0liHlNT1CH7d4ZZ68MB8YYjQ1tVa0Q=="
 		},
 		"glob": {
 			"version": "7.1.7",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"element-ready": "^6.0.0",
 		"fit-textarea": "^2.0.0",
 		"flat-zip": "^1.0.1",
-		"github-url-detection": "^5.2.0",
+		"github-url-detection": "^5.3.0",
 		"image-promise": "^7.0.1",
 		"indent-textarea": "^2.1.0",
 		"js-abbreviation-number": "^1.1.2",

--- a/source/features/collapse-wiki-sections.tsx
+++ b/source/features/collapse-wiki-sections.tsx
@@ -44,5 +44,9 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoWiki
 	],
+	exclude: [
+		pageDetect.isNewWikiPage,
+		pageDetect.isEditingWikiPage
+	],
 	init
 });

--- a/source/features/collapse-wiki-sections.tsx
+++ b/source/features/collapse-wiki-sections.tsx
@@ -45,8 +45,8 @@ void features.add(__filebasename, {
 		pageDetect.isRepoWiki
 	],
 	exclude: [
-		pageDetect.isNewWikiPage,
-		pageDetect.isEditingWikiPage
+		pageDetect.isEditingWikiPage,
+		pageDetect.isNewWikiPage
 	],
 	init
 });


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4463

## Test URLs

`collapse-wiki-sections` should run on:

- Regular wiki pages: https://github.com/lukesampson/scoop/wiki

But not:

- New page: https://github.com/tooomm/wikitest/wiki/_new
- Edit page: https://github.com/tooomm/wikitest/wiki/Getting-Started/_edit


## Screenshot

N/A
