### PR TITLE
Fix `prevent-link-loss` warning message copy

### DIFF
--- a/source/features/prevent-link-loss.tsx
+++ b/source/features/prevent-link-loss.tsx
@@ -28,7 +28,7 @@ function handleButtonClick({delegateTarget: fixButton}: delegate.Event<MouseEven
 function getUI(field: HTMLTextAreaElement): HTMLElement {
 	return select('.rgh-prevent-link-loss-container', field.form!) ?? (
 		<div className="flash flash-warn mb-2 rgh-prevent-link-loss-container">
-			<AlertIcon/> Your link may be misinterpreted by GitHub (see {createRghIssueLink(2327)}.
+			<AlertIcon/> Your link may be misinterpreted by GitHub (see {createRghIssueLink(2327)}).
 			<button type="button" className="btn btn-sm primary flash-action rgh-prevent-link-loss">Fix link</button>
 		</div>
 	);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->



## Test URLs

Try adding this URL to a new comment (e.g. in this PR):

    https://github.com/github/choosealicense.com/compare/gh-pages...Pukimaa:gh-pages#diff-c0311c1df17d5d714db46ca1401ad374a35de861a461d211c6c947f1b2194034R8

## Screenshot

![Screenshot 2021-06-14 at 18 16 38](https://user-images.githubusercontent.com/478237/121932523-e04ff380-cd3c-11eb-8e7a-5f4fdc8dd392.png)

After

![image](https://user-images.githubusercontent.com/16872793/121985141-2ff4e600-cd62-11eb-9368-13a6f666ded1.png)

