### PR TITLE
Fix very small images in `reaction-avatars`

### DIFF
--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -39,6 +39,6 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
 .reaction-summary-item a img { /* `a` required for #3237 */
-	max-width: 100%;
+	width: 100%;
 	background-color: var(--color-bg-info, #fff);
 }


### PR DESCRIPTION
There are users with a very small profile image:

![grafik](https://user-images.githubusercontent.com/202916/121957365-95e16d80-cd62-11eb-844f-cfad83be68ad.png)

GitHub scales up profile images to fill avatar circles in comments though:

![grafik](https://user-images.githubusercontent.com/202916/121957523-cc1eed00-cd62-11eb-81ad-c0dc3535d834.png)

So these two avatar circles look like two different people. Changing `max-width` to `width` in `reaction-avatars` fixes it:

![grafik](https://user-images.githubusercontent.com/202916/121957853-43ed1780-cd63-11eb-91e1-f60333c6d872.png)

## Test URLs

- user with a very small profile image: `https://github.com/Strubbl`
- that user's profile image: `https://avatars.githubusercontent.com/u/97055?v=4`
- comment with that user's reaction: `https://github.com/streetcomplete/StreetComplete/issues/2909#issuecomment-860959344`
- comment by that user: `https://github.com/streetcomplete/StreetComplete/issues/1176#issuecomment-860973960`