### PR TITLE
Fix `no-useless-split-diff-view` doesn't work newly loaded files

### DIFF
--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -7,7 +7,7 @@ import {CommentIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onPrFileLoad from '../github-events/on-pr-file-load';
+import onDiffFileLoad from '../github-events/on-diff-file-load';
 import preserveScroll from '../helpers/preserve-scroll';
 
 // When an indicator is clicked, this will show comments on the current file
@@ -65,7 +65,7 @@ function observeFiles(): void {
 
 function init(): void {
 	observeFiles();
-	onPrFileLoad(observeFiles);
+	onDiffFileLoad(observeFiles);
 	delegate(document, '.rgh-comments-indicator', 'click', handleIndicatorClick);
 }
 

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -7,8 +7,8 @@ import {CommentIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onDiffFileLoad from '../github-events/on-diff-file-load';
 import preserveScroll from '../helpers/preserve-scroll';
+import onDiffFileLoad from '../github-events/on-diff-file-load';
 
 // When an indicator is clicked, this will show comments on the current file
 const handleIndicatorClick = ({delegateTarget}: delegate.Event): void => {

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -3,7 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onPrFileLoad from '../github-events/on-pr-file-load';
+import onDiffFileLoad from '../github-events/on-diff-file-load';
 
 function isUnifiedDiff(): boolean {
 	return select.exists([
@@ -34,7 +34,7 @@ void features.add(__filebasename, {
 		isUnifiedDiff
 	],
 	additionalListeners: [
-		onPrFileLoad
+		onDiffFileLoad
 	],
 	init
 });

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -13,7 +13,8 @@ function isUnifiedDiff(): boolean {
 }
 
 function init(): void {
-	for (const diffTable of select.all('.js-diff-table')) {
+	for (const diffTable of select.all('.js-diff-table:not(.rgh-no-useless-split-diff-view-visited)')) {
+		diffTable.classList.add('rgh-no-useless-split-diff-view-visited');
 		for (const side of ['left', 'right']) {
 			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
 				// eslint-disable-next-line unicorn/prefer-dom-node-dataset -- CSS file has the same selector, this can be grepped

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -3,6 +3,7 @@ import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
+import onPrFileLoad from '../github-events/on-pr-file-load';
 
 function isUnifiedDiff(): boolean {
 	return select.exists([
@@ -31,6 +32,9 @@ void features.add(__filebasename, {
 	],
 	exclude: [
 		isUnifiedDiff
+	],
+	additionalListeners: [
+		onPrFileLoad
 	],
 	init
 });

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -5,8 +5,8 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import getTextNodes from '../helpers/get-text-nodes';
-import onDiffFileLoad from '../github-events/on-diff-file-load';
 import onNewComments from '../github-events/on-new-comments';
+import onDiffFileLoad from '../github-events/on-diff-file-load';
 
 // `splitText` is used before and after each whitespace group so a new whitespace-only text node is created. This new node is then wrapped in a <span>
 function showWhiteSpacesOn(line: Element): void {

--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -5,7 +5,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import getTextNodes from '../helpers/get-text-nodes';
-import onPrFileLoad from '../github-events/on-pr-file-load';
+import onDiffFileLoad from '../github-events/on-diff-file-load';
 import onNewComments from '../github-events/on-new-comments';
 
 // `splitText` is used before and after each whitespace group so a new whitespace-only text node is created. This new node is then wrapped in a <span>
@@ -74,7 +74,7 @@ void features.add(__filebasename, {
 	],
 	additionalListeners: [
 		onNewComments,
-		onPrFileLoad
+		onDiffFileLoad
 	],
 	deduplicate: '.rgh-observing-whitespace',
 	init

--- a/source/github-events/on-diff-file-load.ts
+++ b/source/github-events/on-diff-file-load.ts
@@ -6,14 +6,14 @@ const fragmentSelector = [
 	'include-fragment.js-diff-entry-loader' // File diff loader on clicking "Load Diff"
 ].join();
 
-// This lets you call `onPrFileLoad` multiple times with the same callback but only ever a `load` listener is registered
+// This lets you call `onDiffFileLoad` multiple times with the same callback but only ever a `load` listener is registered
 const getDeduplicatedHandler = mem((callback: EventListener): delegate.EventHandler => {
 	return (event: delegate.Event) => {
 		event.delegateTarget.addEventListener('load', callback);
 	};
 });
 
-export default function onPrFileLoad(callback: EventListener): delegate.Subscription {
+export default function onDiffFileLoad(callback: EventListener): delegate.Subscription {
 	// `loadstart` is fired when the fragment is still attached so event delegation works.
 	// `load` is fired after it’s detached, so `delegate` would never listen to it.
 	// This is why we listen to a global `loadstart` and then add a specific `load` listener on the element, which is fired even when the element is detached.


### PR DESCRIPTION
This fixes #4488.

Maybe it's off-topic, but I think the listener's name should be something like `onDiffFileLoad` instead of `onPrFileLoad`. It made me wonder whether it works on non-PR pages.

## Test URLs

I've tested this at:

-   [button](https://github.com/cpeditor/cpeditor/pull/223/files?diff=split#diff-0f46ff9666ae4dc3789ffaed0f2c4a93fbd4469ab486af80f1b262cb44b7a038)

-   [long](https://github.com/cpeditor/cpeditor.github.io/commit/b349da5cefab537691e1988f74252759aff9c300?diff=split)