### PR TITLE
Remove `open-issue-to-latest-comment` from the dashboard

### DIFF
--- a/source/features/open-issue-to-latest-comment.tsx
+++ b/source/features/open-issue-to-latest-comment.tsx
@@ -1,11 +1,7 @@
-import React from 'dom-chef';
 import select from 'select-dom';
-import onetime from 'onetime';
-import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import {wrapAll} from '../helpers/dom-utils';
 
 function init(): void {
 	for (const link of select.all('.js-issue-row a[aria-label*="comment"], .js-pinned-issue-list-item a[aria-label*="comment"]')) {
@@ -13,24 +9,9 @@ function init(): void {
 	}
 }
 
-function initDashboard(): void {
-	observe('.js-recent-activity-container :not(a) > div > .octicon-comment', {
-		add(icon) {
-			const url = icon.closest('li')!.querySelector('a')!.pathname + '#partial-timeline';
-			icon.parentElement!.classList.remove('col-1'); // Also fix extra space added by GitHub #3174
-			wrapAll([icon, icon.nextSibling!], <a className="muted-link Link--muted" href={url}/>);
-		}
-	});
-}
-
 void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList
 	],
 	init
-}, {
-	include: [
-		pageDetect.isDashboard
-	],
-	init: onetime(initDashboard)
 });


### PR DESCRIPTION
Closes #4496

## Test URLs
https://github.com/

## Screenshot

What it looked like before (Sorry could not find a better screenshot)

![image](https://user-images.githubusercontent.com/16872793/122678626-98562400-d1b5-11eb-8fc2-b41dddaf366c.png)


Now

![image](https://user-images.githubusercontent.com/16872793/122678636-9e4c0500-d1b5-11eb-9e1e-6027487b9500.png)

@fregante title good?