### PR TITLE
Ensure the dropdown loaded in `git-checkout-pr`

### DIFF
--- a/source/features/git-checkout-pr.tsx
+++ b/source/features/git-checkout-pr.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import delegate from 'delegate-it';
+import oneMutation from 'one-mutation';
 import {ClippyIcon} from '@primer/octicons-react';
 import * as pageDetect from 'github-url-detection';
 
@@ -63,8 +64,12 @@ function checkoutOption(remote?: string, remoteType?: 'HTTPS' | 'SSH'): JSX.Elem
 	);
 }
 
-function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): void {
+async function handleMenuOpening({delegateTarget: dropdown}: delegate.Event): Promise<void> {
 	dropdown.classList.add('rgh-git-checkout'); // Mark this as processed
+	if (select.exists('.SelectMenu-loading', dropdown)) { // The dropdown may still be loading
+		await oneMutation(dropdown, {childList: true, subtree: true});
+	}
+
 	const tabContainer = select('[action="/users/checkout-preference"]', dropdown)!.closest<HTMLElement>('tab-container')!;
 	tabContainer.style.minWidth = '370px';
 	select('.UnderlineNav-body', tabContainer)!.append(


### PR DESCRIPTION
Closes #4489 
If you click on the dropdown before the page has fully loaded you will get the error.

## Test URLs
https://github.com/sindresorhus/refined-github/pull/4448 or this PR

## Screenshot
![Video_2021-06-21_231721](https://user-images.githubusercontent.com/16872793/122858139-c89ddf80-d2e7-11eb-96f9-8f46f264f5c7.gif)


