### PR TITLE
Support `conversation-activity-filter` in Files Changed tab

### DIFF
--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -109,8 +109,10 @@ async function handleSelection({target}: Event): Promise<void> {
 	);
 
 	// Update the state of the other dropdown
-	select(`.${dropdownClass} [aria-checked="false"][data-value="${currentSetting}"]`)?.setAttribute('aria-checked', 'true');
-	select(`.${dropdownClass} [aria-checked="true"]:not([data-value="${currentSetting}"])`)?.setAttribute('aria-checked', 'false');
+	if (!pageDetect.isPRFiles()) {
+		select(`.${dropdownClass} [aria-checked="false"][data-value="${currentSetting}"]`)!.setAttribute('aria-checked', 'true');
+		select(`.${dropdownClass} [aria-checked="true"]:not([data-value="${currentSetting}"])`)!.setAttribute('aria-checked', 'false');
+	}
 }
 
 function createRadio(filterSettings: State): JSX.Element {

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -14,7 +14,8 @@ import onConversationHeaderUpdate from '../github-events/on-conversation-header-
 const states = {
 	default: '',
 	showOnlyComments: 'Only show comments',
-	showOnlyUnresolvedComments: 'Only show unresolved comments'
+	showOnlyUnresolvedComments: 'Only show unresolved comments',
+	hideResolvedComments: 'Hide resolved comments'
 };
 
 type State = keyof typeof states;
@@ -109,7 +110,7 @@ async function handleSelection({target}: Event): Promise<void> {
 	);
 
 	// Update the state of the other dropdown
-	if (!pageDetect.isPRFiles()) {
+	if (pageDetect.isConversation()) {
 		select(`.${dropdownClass} [aria-checked="false"][data-value="${currentSetting}"]`)!.setAttribute('aria-checked', 'true');
 		select(`.${dropdownClass} [aria-checked="true"]:not([data-value="${currentSetting}"])`)!.setAttribute('aria-checked', 'false');
 	}
@@ -154,8 +155,12 @@ async function addWidget(header: string): Promise<void> {
 				<div className="SelectMenu-modal">
 					<div className="SelectMenu-list">
 						{createRadio('default')}
-						{createRadio('showOnlyComments')}
-						{createRadio('showOnlyUnresolvedComments')}
+						{pageDetect.isPRFiles() ?
+							createRadio('hideResolvedComments') :
+							<>
+								{createRadio('showOnlyComments')}
+								{createRadio('showOnlyUnresolvedComments')}
+							</>}
 					</div>
 				</div>
 			</details-menu>
@@ -165,7 +170,9 @@ async function addWidget(header: string): Promise<void> {
 
 async function init(): Promise<void> {
 	await addWidget('#partial-discussion-header .gh-header-meta :is(clipboard-copy, .flex-auto)');
-	await addWidget('#partial-discussion-header .gh-header-sticky :is(clipboard-copy, relative-time)');
+	if (pageDetect.isConversation()) {
+		await addWidget('#partial-discussion-header .gh-header-sticky :is(clipboard-copy, relative-time)');
+	}
 }
 
 void features.add(__filebasename, {

--- a/source/features/conversation-activity-filter.tsx
+++ b/source/features/conversation-activity-filter.tsx
@@ -46,6 +46,14 @@ function processSimpleComment(item: HTMLElement): void {
 	}
 }
 
+function processReviewsInFiles(review: HTMLElement): void {
+	if (currentSetting === 'showOnlyComments') {
+		return;
+	}
+
+	review.classList.add(hiddenClassName);
+}
+
 function processReview(review: HTMLElement): void {
 	if (currentSetting === 'showOnlyComments') {
 		return;
@@ -69,8 +77,10 @@ function processPage(): void {
 		return;
 	}
 
-	for (const item of select.all('.js-timeline-item')) {
-		if (select.exists('.js-comment[id^=pullrequestreview]', item)) {
+	for (const item of select.all('.js-timeline-item, .js-inline-comments-container')) {
+		if (select.exists('.js-line-comments', item)) {
+			processReviewsInFiles(item);
+		} else if (select.exists('.js-comment[id^=pullrequestreview]', item)) {
 			processReview(item);
 		} else if (select.exists('.comment-body', item)) {
 			processSimpleComment(item);
@@ -99,8 +109,8 @@ async function handleSelection({target}: Event): Promise<void> {
 	);
 
 	// Update the state of the other dropdown
-	select(`.${dropdownClass} [aria-checked="false"][data-value="${currentSetting}"]`)!.setAttribute('aria-checked', 'true');
-	select(`.${dropdownClass} [aria-checked="true"]:not([data-value="${currentSetting}"])`)!.setAttribute('aria-checked', 'false');
+	select(`.${dropdownClass} [aria-checked="false"][data-value="${currentSetting}"]`)?.setAttribute('aria-checked', 'true');
+	select(`.${dropdownClass} [aria-checked="true"]:not([data-value="${currentSetting}"])`)?.setAttribute('aria-checked', 'false');
 }
 
 function createRadio(filterSettings: State): JSX.Element {
@@ -158,7 +168,8 @@ async function init(): Promise<void> {
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.isConversation
+		pageDetect.isConversation,
+		pageDetect.isPRFiles
 	],
 	additionalListeners: [
 		onConversationHeaderUpdate


### PR DESCRIPTION
closes #4506

@fregante said
> It would be nice, but the feature is too complex to be adjusted to a page where it only hides something that it’s already small and usually disappears once outdated.
GitHub also added a Conversation dropdown that makes it easier to see what’s still unresolved


It is too complicated. 

However, I think that implementation with supporting in files is quite easy. so I make a draft PR.

Can you check this task? @fregante 

That issue I made, it was so lack of description.



## Test URLs
- https://github.com/sindresorhus/refined-github/pull/4395/files


## Screenshot
**Normal state**<img width="888" alt="스크린샷 2021-06-23 오후 11 03 27" src="https://user-images.githubusercontent.com/29705162/123110762-5825c880-d477-11eb-95c5-988d128e3c4e.png">

**Dropdown**
<img width="767" alt="스크린샷 2021-06-23 오후 11 03 34" src="https://user-images.githubusercontent.com/29705162/123110778-5d831300-d477-11eb-9f68-a2111490b94c.png">

**Only unresolved comments**
<img width="921" alt="스크린샷 2021-06-23 오후 11 03 37" src="https://user-images.githubusercontent.com/29705162/123110810-64aa2100-d477-11eb-95c8-c1c84c9d4c2f.png">

**Show comments**
<img width="1326" alt="스크린샷 2021-06-23 오후 11 03 45" src="https://user-images.githubusercontent.com/29705162/123110910-7a1f4b00-d477-11eb-87d6-2c3640e09199.png">
