### PR TITLE
Fix `unwrap-useless-dropdowns`'s button size on actions page

### DIFF
--- a/source/features/unwrap-useless-dropdowns.tsx
+++ b/source/features/unwrap-useless-dropdowns.tsx
@@ -50,7 +50,7 @@ async function unwrapActionRun(): Promise<void | false> {
 
 	// Fix button’s style
 	const button = select('button', desiredForm)!;
-	button.className = 'btn btn-sm';
+	button.className = 'btn';
 	button.prepend(select('.octicon-sync')!);
 
 	// Replace dropdown


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4512

## Test URLs

https://github.com/sindresorhus/refined-github/actions/runs/967719800


## Screenshot

Before:

![image](https://user-images.githubusercontent.com/44045911/123257708-194e4c00-d525-11eb-8797-8857ee0692fa.png)

After:

![image](https://user-images.githubusercontent.com/44045911/123257714-1d7a6980-d525-11eb-990d-dafe7d6925bf.png)

