### PR TITLE
Fix `no-useless-split-diff-view` on GitHub Enterprise

### DIFF
--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -15,6 +15,10 @@ function isUnifiedDiff(): boolean {
 function init(): void {
 	for (const diffTable of select.all('.js-diff-table:not(.rgh-no-useless-split-diff-view-visited)')) {
 		diffTable.classList.add('rgh-no-useless-split-diff-view-visited');
+		if (!select.exists('.blob-code-addition, .blob-code-deletion', diffTable)) {
+			continue;
+		}
+
 		for (const side of ['left', 'right']) {
 			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
 				// eslint-disable-next-line unicorn/prefer-dom-node-dataset -- CSS file has the same selector, this can be grepped

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -15,10 +15,6 @@ function isUnifiedDiff(): boolean {
 function init(): void {
 	for (const diffTable of select.all('.js-diff-table:not(.rgh-no-useless-split-diff-view-visited)')) {
 		diffTable.classList.add('rgh-no-useless-split-diff-view-visited');
-		if (!select.exists('.blob-code-addition, .blob-code-deletion', diffTable)) {
-			continue;
-		}
-
 		for (const side of ['left', 'right']) {
 			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
 				// eslint-disable-next-line unicorn/prefer-dom-node-dataset -- CSS file has the same selector, this can be grepped
@@ -36,7 +32,9 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles
 	],
 	exclude: [
-		isUnifiedDiff
+		isUnifiedDiff,
+		// Make sure the class names we need exist on the page #4483
+		() => !select.exists('.js-diff-table :is([data-split-side="left"], [data-split-side="right"]):is(.blob-code-addition, .blob-code-deletion)')
 	],
 	additionalListeners: [
 		onDiffFileLoad


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4483 

## Test URLs
* [Diff should be collapsed](https://github.com/sindresorhus/refined-github/commit/f60cb71e0bc2708ebda622d6c684489241fd367a?diff=split)
* [Diff should be untouched](https://github.com/sindresorhus/refined-github/commit/26e778fd85f7db6c3d5bc6f508e23c77f3ed4a20?diff=split)

## Screenshot
n/a

This needs to be tested on GHE 2.22.10 or lower (both diffs should be left untouched).