### PR TITLE
Hide long hunks on only one side for `no-useless-split-diff-view`

### DIFF
--- a/source/features/no-useless-split-diff-view.css
+++ b/source/features/no-useless-split-diff-view.css
@@ -2,8 +2,11 @@
 	table-layout: auto !important;
 }
 
+[data-rgh-hide-empty-split-diff-side='left'] :is([data-hunk], .blob-expanded) td:nth-child(1),
 [data-rgh-hide-empty-split-diff-side='left'] :is([data-hunk], .blob-expanded) td:nth-child(2),
-[data-rgh-hide-empty-split-diff-side='right'] :is([data-hunk], .blob-expanded) td:nth-child(4) {
+[data-rgh-hide-empty-split-diff-side='right'] :is([data-hunk], .blob-expanded) td:nth-child(3),
+[data-rgh-hide-empty-split-diff-side='right'] :is([data-hunk], .blob-expanded) td:nth-child(4),
+[data-rgh-no-useless-split-diff-view-hide-hunk] .empty-cell {
 	display: none !important;
 	width: 0 !important;
 }

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -57,7 +57,7 @@ function init(): void {
 			}
 
 			if (tds[1].classList.contains('blob-code-context')) {
-				// not in a hunk
+				// Not in a hunk
 				handleHunk(currentHunkEmpty, currentHunk);
 				currentHunkEmpty = [true, true];
 				currentHunk = [];
@@ -71,7 +71,7 @@ function init(): void {
 			}
 
 			if (!currentHunkEmpty[0] && !currentHunkEmpty[1]) {
-				// current hunk contains both sides
+				// Current hunk contains both sides
 				currentHunk = [];
 				continue;
 			}

--- a/source/features/no-useless-split-diff-view.tsx
+++ b/source/features/no-useless-split-diff-view.tsx
@@ -12,16 +12,74 @@ function isUnifiedDiff(): boolean {
 	]);
 }
 
+function handleHunk(hunkEmpty: [boolean, boolean], hunk: HTMLTableRowElement[]): void {
+	if (hunk.length > 5) {
+		for (const side of [0, 1]) {
+			if (hunkEmpty[side]) {
+				for (const tr of hunk) {
+					// eslint-disable-next-line unicorn/prefer-dom-node-dataset -- CSS file has the same selector, this can be grepped
+					tr.setAttribute('data-rgh-no-useless-split-diff-view-hide-hunk', '');
+					select(`[data-split-side=${side ? 'left' : 'right'}]`, tr)?.setAttribute('colspan', '3');
+				}
+
+				break;
+			}
+		}
+	}
+}
+
 function init(): void {
 	for (const diffTable of select.all('.js-diff-table:not(.rgh-no-useless-split-diff-view-visited)')) {
 		diffTable.classList.add('rgh-no-useless-split-diff-view-visited');
+		let wholeFileHidden = false;
 		for (const side of ['left', 'right']) {
 			if (!select.exists(`[data-split-side="${side}"]:is(.blob-code-addition, .blob-code-deletion)`, diffTable)) {
 				// eslint-disable-next-line unicorn/prefer-dom-node-dataset -- CSS file has the same selector, this can be grepped
 				diffTable.setAttribute('data-rgh-hide-empty-split-diff-side', side);
+				wholeFileHidden = true;
 				break;
 			}
 		}
+
+		if (wholeFileHidden) {
+			continue;
+		}
+
+		// Hide long hunks on one side
+
+		let currentHunkEmpty: [boolean, boolean] = [true, true];
+		let currentHunk: HTMLTableRowElement[] = [];
+
+		for (const tr of select.all('tr[data-hunk]', diffTable)) {
+			const tds = select.all('td', tr);
+			if (tds.length !== 4) {
+				continue;
+			}
+
+			if (tds[1].classList.contains('blob-code-context')) {
+				// not in a hunk
+				handleHunk(currentHunkEmpty, currentHunk);
+				currentHunkEmpty = [true, true];
+				currentHunk = [];
+				continue;
+			}
+
+			for (const side of [0, 1]) {
+				if (!tds[(side * 2) + 1].classList.contains('blob-code-empty')) {
+					currentHunkEmpty[side] = false;
+				}
+			}
+
+			if (!currentHunkEmpty[0] && !currentHunkEmpty[1]) {
+				// current hunk contains both sides
+				currentHunk = [];
+				continue;
+			}
+
+			currentHunk.push(tr);
+		}
+
+		handleHunk(currentHunkEmpty, currentHunk);
 	}
 }
 


### PR DESCRIPTION
Now for hunks that are only non-empty on a single side and contains more than 5 lines, the empty side will be hidden. The line number on the hidden side is also hidden.

The threshold "5" could be changed.

## Test URLs

[Right only](https://github.com/sindresorhus/refined-github/pull/4444/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519R713)

[Left only](https://github.com/sindresorhus/refined-github/pull/4444/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L1675)

[Short left-only](https://github.com/sindresorhus/refined-github/pull/4444/files#diff-26e829c321ccba564beb4bb33adb6e5a71106315a1e35b430d5dd1d7b383aa05L11)

[Short right-only](https://github.com/sindresorhus/refined-github/pull/4444/files#diff-26e829c321ccba564beb4bb33adb6e5a71106315a1e35b430d5dd1d7b383aa05R10)

[Both sides](https://github.com/sindresorhus/refined-github/pull/4444/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L6018)

## Screenshots

![Right only](https://user-images.githubusercontent.com/30581822/123304887-1289fe00-d552-11eb-8e94-a93ecf1d9518.png)

![Left only](https://user-images.githubusercontent.com/30581822/123304941-1e75c000-d552-11eb-9838-bb339501c2a7.png)

![Short hunks](https://user-images.githubusercontent.com/30581822/123305008-30eff980-d552-11eb-8a4b-e3676b96ae87.png)

![Both sides](https://user-images.githubusercontent.com/30581822/123305084-49f8aa80-d552-11eb-944f-51109dffcfdc.png)
