### PR TITLE
Fix: Milestone is shown red on PR lists when it contains word "changes"

### DIFF
--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -1,11 +1,11 @@
 /* Show approvals count in PR list */
-.js-issue-row .text-gray [aria-label*='approval'], /* GHE #4021 */
-.js-issue-row .color-text-secondary [aria-label*='approval'] {
+.js-issue-row .text-gray [href$='#partial-pull-merging'][aria-label*='approval'], /* GHE #4021 */
+.js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='approval'] {
 	font-size: 0;
 }
 
 .js-issue-row .text-gray [aria-label*='approval']::before, /* GHE #4021 */
-.js-issue-row .color-text-secondary [aria-label*='approval']::before {
+.js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='approval']::before {
 	all: unset;
 	content: attr(aria-label);
 	display: inline !important;
@@ -14,11 +14,11 @@
 }
 
 .js-issue-row .text-gray [aria-label*='changes'], /* GHE #4021 */
-.js-issue-row .color-text-secondary [aria-label*='changes'] {
+.js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='changes'] {
 	color: var(--github-red) !important;
 }
 
 /* Disable now-duplicate tooltip */
-.js-issue-row .color-text-secondary [aria-label*='approval']::after {
+.js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='approval']::after {
 	content: none;
 }

--- a/source/features/pr-approvals-count.css
+++ b/source/features/pr-approvals-count.css
@@ -4,7 +4,7 @@
 	font-size: 0;
 }
 
-.js-issue-row .text-gray [aria-label*='approval']::before, /* GHE #4021 */
+.js-issue-row .text-gray [href$='#partial-pull-merging'][aria-label*='approval']::before, /* GHE #4021 */
 .js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='approval']::before {
 	all: unset;
 	content: attr(aria-label);
@@ -13,7 +13,7 @@
 	font-size: 12px;
 }
 
-.js-issue-row .text-gray [aria-label*='changes'], /* GHE #4021 */
+.js-issue-row .text-gray [href$='#partial-pull-merging'][aria-label*='changes'], /* GHE #4021 */
 .js-issue-row .color-text-secondary [href$='#partial-pull-merging'][aria-label*='changes'] {
 	color: var(--github-red) !important;
 }


### PR DESCRIPTION
Closes #4517

## Test URLs
https://github.com/Cog-Creators/Red-DiscordBot/pulls?page=2&q=is%3Apr+is%3Aopen+sort%3Aupdated-desc
https://github.com/Cog-Creators/Red-DiscordBot/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed

## Screenshot
**Before**
![image](https://user-images.githubusercontent.com/16872793/123548175-b2ea4900-d731-11eb-811a-8663c405a66b.png)


**After** 
![image](https://user-images.githubusercontent.com/16872793/123548142-98b06b00-d731-11eb-928e-a6061fb00244.png)


