### PR TITLE
Fix: `sticky-conversation-sidebar` overlaps "Open with" dropdown

### DIFF
--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -4,9 +4,6 @@
 
 .rgh-sticky-sidebar {
 	position: sticky;
-}
-
-:not(#partial-discussion-sidebar).rgh-sticky-sidebar {
 	top: 0;
 
 	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -23,3 +23,8 @@
 .rgh-sticky-sidebar + .border-top {
 	display: none;
 }
+
+.gh-header-actions tab-container {
+	/* Needed so the "Open with" PR dropdown is over the sidebar #4490 */
+	z-index: 91 !important;
+}

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -18,8 +18,7 @@
 	top: 76px !important; /* Sticky header's height + sidebar item's margin */
 
 	/* Needed so the backdrop of notification modal is over the other elements in the conversation */
-	/* Lower than "Open with" PR dropdown #4490 */
-	z-index: 80;
+	z-index: 1;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -7,6 +7,10 @@
 	top: 0;
 
 	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
+	z-index: 1;
+}
+
+:not(#partial-discussion-sidebar).rgh-sticky-sidebar {
 	/* Higher than sticky readme header #4192 */
 	z-index: 90;
 }
@@ -15,16 +19,11 @@
 	top: 76px !important; /* Sticky header's height + sidebar item's margin */
 
 	/* Needed so the backdrop of notification modal is over the other elements in the conversation */
-	/* Higher than sticky readme header #4192 */
-	z-index: 90;
+	/* Lower than "Open with" PR dropdown #4490 */
+	z-index: 80;
 }
 
 /* Hides the last divider (on pull requests) to avoid https://user-images.githubusercontent.com/10238474/62282128-af6fb980-b457-11e9-8b18-c29687b88da1.gif */
 .rgh-sticky-sidebar + .border-top {
 	display: none;
-}
-
-.gh-header-actions tab-container {
-	/* Needed so the "Open with" PR dropdown is over the sidebar #4490 */
-	z-index: 91 !important;
 }

--- a/source/features/sticky-sidebar.css
+++ b/source/features/sticky-sidebar.css
@@ -4,13 +4,12 @@
 
 .rgh-sticky-sidebar {
 	position: sticky;
-	top: 0;
-
-	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
-	z-index: 1;
 }
 
 :not(#partial-discussion-sidebar).rgh-sticky-sidebar {
+	top: 0;
+
+	/* `sticky` will trap the `fixed` dialog’s z-index in some sidebars #3732 */
 	/* Higher than sticky readme header #4192 */
 	z-index: 90;
 }

--- a/source/features/sticky-sidebar.tsx
+++ b/source/features/sticky-sidebar.tsx
@@ -8,7 +8,7 @@ import features from '.';
 
 const deinit: VoidFunction[] = [];
 // Both selectors are present on conversation pages so we need to discriminate
-const sidebarSelector = pageDetect.isRepoRoot() ? '.repository-content .flex-column > :last-child [data-pjax]' : '#partial-discussion-sidebar';
+const sidebarSelector = pageDetect.isRepoRoot() ? '.repository-content .flex-column > .flex-shrink-0 > [data-pjax]' : '#partial-discussion-sidebar';
 
 function updateStickiness(): void {
 	const sidebar = select(sidebarSelector)!;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4490 
Related: #3754, #4364 

## Test URLs
- On this page:
  * click the "Open with" button → the dropdown should be over the sidebar
  * click the "Customize" button next to "Notifications" → the modal's background should cover everything (except the sticky header)
- On a repo root where you can edit the sidebar
  * click the gear icon → the modal's background should cover everything

## Screenshot
![image](https://user-images.githubusercontent.com/46634000/123646367-6ed97000-d827-11eb-900e-d010dc79799b.png)