### PR TITLE
Meta: Enable npm cache for actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
+          cache: npm
       - run: npm ci
       - run: npm run ava -- --serial
 
@@ -47,6 +48,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
+          cache: npm
       - run: npm ci
       - run: npm run build:webpack
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
Re https://github.com/sindresorhus/refined-github/issues/4008#issuecomment-873594509

See https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching


## Test URLs
NA


## Screenshot
NA

