### PR TITLE
Meta: Add `delete_repo` scope to token generation link

### DIFF
--- a/distribution/options.html
+++ b/distribution/options.html
@@ -12,7 +12,7 @@
 
 	<p>
 		<label>
-			<strong>Personal token</strong> (optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo" target="_blank">generate one</a>)<br>
+			<strong>Personal token</strong> (optional, <a id="personal-token-link" href="https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo" target="_blank">generate one</a>)<br>
 			<!-- placeholder is set to enable use of :placeholder-shown CSS selector -->
 			<input type="text" name="personalToken" spellcheck="false" autocomplete="off" pattern="[\da-f]{40}|ghp_\w{36,251}" placeholder=" ">
 			<span id="validation"></span>


### PR DESCRIPTION
Required for the `quick-repo-deletion` feature (#3734, #3795).

| Current link ([`...&scopes=repo`](https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo)) | New link ([`...&scopes=repo,delete_repo`](https://github.com/settings/tokens/new?description=Refined%20GitHub&scopes=repo,delete_repo)) |
|-|-|
| <img src="https://user-images.githubusercontent.com/478237/125177554-b4594e00-e1d4-11eb-811b-8337b13f102f.png" width="350px" /> | <img src="https://user-images.githubusercontent.com/478237/125177551-b3c0b780-e1d4-11eb-898f-5feff21be668.png" width="350px" /> |
| ![Screenshot from 2021-07-10 23-19-51](https://user-images.githubusercontent.com/478237/125177730-22eadb80-e1d6-11eb-827a-501fadb51cab.png) | ![Screenshot from 2021-07-10 23-20-34](https://user-images.githubusercontent.com/478237/125177731-23837200-e1d6-11eb-9dbb-4359589bfce3.png) |