### PR TITLE
Fix: `set-default-repositories-type-to-sources` changes unrelated URLs

### DIFF
--- a/source/features/set-default-repositories-type-to-sources.tsx
+++ b/source/features/set-default-repositories-type-to-sources.tsx
@@ -19,7 +19,7 @@ async function profileDropdown(): Promise<void> {
 async function init(): Promise<void> {
 	const links = select.all([
 		'[aria-label="User profile"] a[href$="tab=repositories"]', // "Repositories" tab on user profile
-		'[aria-label="Organization"] a.UnderlineNav-item:first-child', // "Repositories" tab on organization profile
+		'[aria-label="Organization"] [data-tab-item="org-header-repositories-tab"] a', // "Repositories" tab on organization profile
 		'a[data-hovercard-type="organization"]', // Organization name on repo header + organization list on user profile
 	]);
 


### PR DESCRIPTION
Currently all tabs get the `?type=source`

## Test URLs
https://github.com/microsoft


## Screenshot

None