### PR TITLE
Make `follow-file-renames` more noticeable by adding icons

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -1,7 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
-import {ArrowLeftIcon, ArrowRightIcon} from '@primer/octicons-react';
+import {DiffRenamedIcon} from '@primer/octicons-react';
 
 import features from '.';
 import * as api from '../github-helpers/api';
@@ -41,7 +41,7 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 						aria-label={`Renamed ${isNewer ? 'to' : 'from'} ${file[toKey]}`}
 						className="btn btn-outline BtnGroup-item tooltipped tooltipped-n tooltipped-no-delay"
 					>
-						{isNewer && <ArrowLeftIcon className="mr-1"/>}{button.textContent}{!isNewer && <ArrowRightIcon className="ml-1"/>}
+						{isNewer && <DiffRenamedIcon className="mr-1" transform="rotate(180)"/>}{button.textContent}{!isNewer && <DiffRenamedIcon className="ml-1"/>}
 					</a>,
 				);
 			}

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -1,6 +1,7 @@
 import React from 'dom-chef';
 import select from 'select-dom';
 import * as pageDetect from 'github-url-detection';
+import {ArrowLeftIcon, ArrowRightIcon} from '@primer/octicons-react';
 
 import features from '.';
 import * as api from '../github-helpers/api';
@@ -15,7 +16,7 @@ interface File {
 async function findRename(lastCommitOnPage: string): Promise<File[]> {
 	// API v4 doesn't support it: https://github.community/t/what-is-the-corresponding-object-in-graphql-api-v4-for-patch-which-is-available-in-rest-api-v3/13590
 	const {files} = await api.v3(`commits/${lastCommitOnPage}`);
-	return files;
+	return files as File[];
 }
 
 async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void | false> {
@@ -40,7 +41,7 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 						aria-label={`Renamed ${isNewer ? 'to' : 'from'} ${file[toKey]}`}
 						className="btn btn-outline BtnGroup-item tooltipped tooltipped-n tooltipped-no-delay"
 					>
-						{button.textContent}
+						{isNewer && <ArrowLeftIcon className="mr-1"/>}{button.textContent}{!isNewer && <ArrowRightIcon className="ml-1"/>}
 					</a>,
 				);
 			}

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -16,7 +16,7 @@ interface File {
 async function findRename(lastCommitOnPage: string): Promise<File[]> {
 	// API v4 doesn't support it: https://github.community/t/what-is-the-corresponding-object-in-graphql-api-v4-for-patch-which-is-available-in-rest-api-v3/13590
 	const {files} = await api.v3(`commits/${lastCommitOnPage}`);
-	return files as File[];
+	return files;
 }
 
 async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void | false> {
@@ -41,7 +41,9 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 						aria-label={`Renamed ${isNewer ? 'to' : 'from'} ${file[toKey]}`}
 						className="btn btn-outline BtnGroup-item tooltipped tooltipped-n tooltipped-no-delay"
 					>
-						{isNewer && <DiffRenamedIcon className="mr-1" transform="rotate(180)"/>}{button.textContent}{!isNewer && <DiffRenamedIcon className="ml-1"/>}
+						{isNewer && <DiffRenamedIcon className="mr-1" transform="rotate(180)"/>}
+						{button.textContent}
+						{!isNewer && <DiffRenamedIcon className="ml-1"/>}
 					</a>,
 				);
 			}


### PR DESCRIPTION
Closes #4477 


## Test URLs
https://github.com/sindresorhus/refined-github/commits/main?after=285eaec360f21431757236c6c39cdbe6f303f6e2+34&branch=main&path%5B%5D=source&path%5B%5D=background.ts

## Screenshot


# Before
![image](https://user-images.githubusercontent.com/16872793/125291988-ff1bb880-e2ef-11eb-8d67-616834a376a7.png)
<hr>

# After
![image](https://user-images.githubusercontent.com/16872793/125452976-09ba7093-bb45-4fda-94a9-6bc19167e89c.png)


