### PR TITLE
`link-to-changelog-file`: Exclude non-textual files

### DIFF
--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -16,14 +16,12 @@ interface FileType {
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
-const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst)$/i
+const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst)$/i;
 function findChangelogName(files: string[]): string | false {
 	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name))!;
-	if (typeof filename !== 'undefined') {
-		return filename;
-	} else {
-		return false;
-	}
+	const result = (typeof filename === 'undefined') ? false : filename;
+
+	return result;
 }
 
 function parseFromDom(): false {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -16,12 +16,10 @@ interface FileType {
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
-const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
+const changelogFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
 function findChangelogName(files: string[]): string | false {
-	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name));
+	const filename = files.find(name => changelogFiles.test(name));
 	return filename ?? false;
-
-	return result;
 }
 
 function parseFromDom(): false {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -17,13 +17,13 @@ interface FileType {
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
 const changelogFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
-function findChangelogName(files: string[]): string | undefined {
-	return files.find(name => changelogFiles.test(name));
+function findChangelogName(files: string[]): string | false {
+	return files.find(name => changelogFiles.test(name)) ?? false;
 }
 
 function parseFromDom(): false {
 	const files = select.all('[aria-labelledby="files"] .js-navigation-open[href*="/blob/"').map(file => file.title);
-	void cache.set(getCacheKey(), findChangelogName(files) ?? '');
+	void cache.set(getCacheKey(), findChangelogName(files));
 	return false;
 }
 
@@ -48,7 +48,7 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 		}
 	}
 
-	return findChangelogName(files) ?? '';
+	return findChangelogName(files);
 }, {
 	cacheKey: getCacheKey,
 });

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -15,16 +15,15 @@ interface FileType {
 }
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
-const changelogNames = new Set(['changelog', 'news', 'changes', 'history', 'release', 'whatsnew']);
 
+const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst)$/i
 function findChangelogName(files: string[]): string | false {
-	for (const file of files) {
-		if (changelogNames.has(file.toLowerCase().split('.', 1)[0])) {
-			return file;
-		}
+	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name))!;
+	if (typeof filename !== 'undefined') {
+		return filename;
+	} else {
+		return false;
 	}
-
-	return false;
 }
 
 function parseFromDom(): false {

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -17,14 +17,13 @@ interface FileType {
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
 const changelogFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
-function findChangelogName(files: string[]): string | false {
-	const filename = files.find(name => changelogFiles.test(name));
-	return filename ?? false;
+function findChangelogName(files: string[]): string | undefined {
+	return files.find(name => changelogFiles.test(name));
 }
 
 function parseFromDom(): false {
 	const files = select.all('[aria-labelledby="files"] .js-navigation-open[href*="/blob/"').map(file => file.title);
-	void cache.set(getCacheKey(), findChangelogName(files));
+	void cache.set(getCacheKey(), findChangelogName(files) ?? '');
 	return false;
 }
 
@@ -49,7 +48,7 @@ const getChangelogName = cache.function(async (): Promise<string | false> => {
 		}
 	}
 
-	return findChangelogName(files);
+	return findChangelogName(files) ?? '';
 }, {
 	cacheKey: getCacheKey,
 });

--- a/source/features/link-to-changelog-file.tsx
+++ b/source/features/link-to-changelog-file.tsx
@@ -16,10 +16,10 @@ interface FileType {
 
 const getCacheKey = (): string => `changelog:${getRepo()!.nameWithOwner}`;
 
-const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst)$/i;
+const regexChangelogMarkdownTextFiles = /^(changelog|news|changes|history|release|whatsnew)(\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|txt|rst))?$/i;
 function findChangelogName(files: string[]): string | false {
-	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name))!;
-	const result = (typeof filename === 'undefined') ? false : filename;
+	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name));
+	return filename ?? false;
 
 	return result;
 }


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4577 (following https://github.com/sindresorhus/refined-github/issues/4577#issuecomment-881951763)

## Test URLs

Match: (as before)
https://github.com/pyca/cryptography/releases (`CHANGELOG.rst`)
https://github.com/nodeca/js-yaml/releases/tag/4.0.0  (`CHANGELOG.md`)

Not match: 
https://github.com/vercel/hyper/releases  (`release.js`)

## Screenshot

(none)

## Notes to reviewers

 - The markdown extension regex is from: [`vertical-front-matter`](https://github.com/sindresorhus/refined-github/blob/31a04dd8b43d4fe121bf5a467dbc0cdada568756/source/features/vertical-front-matter.tsx#L9) / [`view-markdown-source`](https://github.com/sindresorhus/refined-github/blob/31a04dd8b43d4fe121bf5a467dbc0cdada568756/source/features/view-markdown-source.tsx#L34)
    ```regex
    /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee)$/
    ```
    I added to it: `|txt|rst` to maintain matches from the previous related issue examples.

- I noticed that `findChangelogName()` was initially returning string or false, that's why the lengthy:

    ```js
    function findChangelogName(files: string[]): string | false {
    	const filename = files.find(name => regexChangelogMarkdownTextFiles.test(name))!;
    	const result = (typeof filename === 'undefined') ? false : filename;

    	return result;
    }
    ```

    Otherwise, if returning `false` can be omitted, I could replace it with:

    ```js
    function findChangelogName(files: string[]): string{
    	return files.find(name => regexChangelogMarkdownTextFiles.test(name))!;
    }
    ```