### PR TITLE
Fix `mark-merge-commits-in-list` feature

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -24,7 +24,7 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 
 	const fromKey = isNewer ? 'previous_filename' : 'filename';
 	const toKey = isNewer ? 'filename' : 'previous_filename';
-	const sha = (isNewer ? select : select.last)('[aria-label="Copy the full SHA"]')!;
+	const sha = (isNewer ? select : select.last)('clipboard-copy[aria-label="Copy the full SHA"]')!;
 
 	const files = await findRename(sha.getAttribute('value')!);
 

--- a/source/features/mark-merge-commits-in-list.tsx
+++ b/source/features/mark-merge-commits-in-list.tsx
@@ -34,7 +34,7 @@ const filterMergeCommits = async (commits: string[]): Promise<string[]> => {
 
 // eslint-disable-next-line import/prefer-default-export
 export function getCommitHash(commit: HTMLElement): string {
-	return select('[aria-label="Copy the full SHA"]', commit)!.getAttribute('value')!;
+	return select('clipboard-copy[aria-label="Copy the full SHA"]', commit)!.getAttribute('value')!;
 }
 
 async function init(): Promise<void> {


### PR DESCRIPTION
GitHub add the `[aria-label="Copy the full SHA"]` to the div above it too (WHY?!)
Edit: I see why they did it, the tooltip does not work on the `clipboard-copy`


## Test URLs
https://github.com/sindresorhus/refined-github/pull/4530/commits

## Console Error
```
mark-merge-commits-in-list 0.0.0 → TypeError: Cannot read property 'parents' of null
    at refined-github.js:5892
    at async init (refined-github.js:5890)
    at async runFeature (refined-github.js:1932)
    at async setupPageLoad (refined-github.js:1945)
    at async refined-github.js:1966
````
