### PR TITLE
Vertically center text of `clean-pinned-issues`

### DIFF
--- a/source/features/clean-pinned-issues.css
+++ b/source/features/clean-pinned-issues.css
@@ -25,6 +25,7 @@
 	.rgh-clean-pinned-issues .pinned-issue-item > * {
 		display: table-cell !important;
 		padding: 6px 12px;
+		vertical-align: middle;
 	}
 
 	/* Move `x` before the title and align both icons */


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->
Closes #4598. Fix for vertical misalignment in `clean-pinned-issues` info.

## Test URLs

https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

## Screenshot

<b>Before:</b>

<p align="center"><img alt="github com_sindresorhus_refined-github_issues_q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" src="https://user-images.githubusercontent.com/82655227/126626685-ebf284df-2027-4fae-8b44-15c713103f82.png" width="512px" /></p>

<b>After:</b>

<p align="center"><img alt="github com_sindresorhus_refined-github_issues_q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" src="https://user-images.githubusercontent.com/82655227/126626693-5f5eb415-ecd1-47b1-b74c-bc200bad4289.png" width="512px" /></p>