### PR TITLE
Stop linking avatars in `reactions-avatars`

### DIFF
--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -13,7 +13,7 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	margin-top: -1px; /* Makes up for `.reaction-summary-item {border-top}` */
 }
 
-.reaction-summary-item a {
+.reaction-summary-item span {
 	display: inline-block;
 	width: 2em;
 	height: 2em;
@@ -25,20 +25,20 @@ button.reaction-summary-item { /* `button` excludes the "Add reaction" icon */
 	font-size: 10px; /* Base sizer */
 }
 
-.reaction-summary-item a:first-of-type {
+.reaction-summary-item span:first-of-type {
 	margin-left: 0.5em;
 }
 
-.review-comment .reaction-summary-item a {
+.review-comment .reaction-summary-item span {
 	font-size: 9px;
 }
 
-.discussion-post .reaction-summary-item a {
+.discussion-post .reaction-summary-item span {
 	margin-top: -1px;
 }
 
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
-.reaction-summary-item a img { /* `a` required for #3237 */
+.reaction-summary-item span img { /* `span` required for #3237 */
 	width: 100%;
 	background-color: var(--color-bg-info, #fff);
 }

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -59,9 +59,9 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 
 	for (const {container, imageUrl} of flatParticipants) {
 		container.append(
-			<a className="rounded-1 avatar-user">
+			<span className="rounded-1 avatar-user">
 				<img src={imageUrl} className="avatar-user rounded-1"/>
-			</a>,
+			</span>,
 		);
 	}
 

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -13,7 +13,6 @@ const approximateHeaderLength = 3; // Each button header takes about as much as 
 
 interface Participant {
 	container: HTMLElement;
-	username: string;
 	imageUrl: string;
 }
 
@@ -36,14 +35,14 @@ function getParticipants(container: HTMLElement): Participant[] {
 		// Find image on page. Saves a request and a redirect + add support for bots
 		const existingAvatar = select<HTMLImageElement>(`[alt="@${cleanName}"]`);
 		if (existingAvatar) {
-			participants.push({container, username, imageUrl: existingAvatar.src});
+			participants.push({container, imageUrl: existingAvatar.src});
 			continue;
 		}
 
 		// If it's not a bot, use a shortcut URL #2125
 		if (cleanName === username) {
 			const imageUrl = `/${username}.png?size=${window.devicePixelRatio * 20}`;
-			participants.push({container, username, imageUrl});
+			participants.push({container, imageUrl});
 		}
 	}
 
@@ -58,7 +57,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 		.map(getParticipants);
 	const flatParticipants = flatZip(participantByReaction, avatarLimit);
 
-	for (const {container, username, imageUrl} of flatParticipants) {
+	for (const {container, imageUrl} of flatParticipants) {
 		container.append(
 			<a className="rounded-1 avatar-user">
 				<img src={imageUrl} className="avatar-user rounded-1"/>

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -6,7 +6,7 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 import onReplacedElement from '../helpers/on-replaced-element';
-import {getUsername, isFirefox} from '../github-helpers';
+import {getUsername} from '../github-helpers';
 
 const arbitraryAvatarLimit = 36;
 const approximateHeaderLength = 3; // Each button header takes about as much as 3 avatars
@@ -60,8 +60,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 
 	for (const {container, username, imageUrl} of flatParticipants) {
 		container.append(
-			// Without this, Firefox will follow the link instead of submitting the reaction button
-			<a href={isFirefox ? undefined : `/${username}`} className="rounded-1 avatar-user">
+			<a className="rounded-1 avatar-user">
 				<img src={imageUrl} className="avatar-user rounded-1"/>
 			</a>,
 		);


### PR DESCRIPTION
I think that having links in here doesn't make much sense and it's just problematic (the browser will _occasionally(!)_ follow the link when clicking the button) so let's just drop it.

~I should probably also replace the A with a SPAN, that requires changes in the CSS file as well~ _Done_

## Test URLs

This PR

## Screenshot

### Before feature
<img width="315" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/127300547-fa40d5fa-dead-4ab3-b5e4-2a5ceac4bb1f.png">

### Loading 
<img width="534" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/127300571-88ed203e-7567-4dba-9334-0d04da1193c4.png">

### Loaded
<img width="527" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/127300580-b9cf676f-848a-46ff-8186-bbbf3ee3ce5c.png">
