### PR TITLE
Fix console error in `select-notifications`

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -163,5 +163,8 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isNotifications,
 	],
+	exclude: [
+		() => !select.exists('.js-notifications-mark-all-prompt'), // Notifications page may be empty
+	],
 	init,
 });

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -164,7 +164,7 @@ void features.add(__filebasename, {
 		pageDetect.isNotifications,
 	],
 	exclude: [
-		() => !select.exists('.js-notifications-mark-all-prompt'), // Notifications page may be empty
+		() => select.exists('img[src$="notifications/inbox-zero.svg"]'), // Notifications page may be empty
 	],
 	init,
 });


### PR DESCRIPTION
Happens when there are no notications.

URL: https://github.com/notifications

```
TypeError: Cannot read property 'closest' of undefined
  at init (chrome-extension://pplhppbihehddgkdedhpbfpbbbefeihl/build/refined-github.js:13715:91)
  at runFeature (chrome-extension://pplhppbihehddgkdedhpbfpbbbefeihl/build/refined-github.js:9195:17)
  at setupPageLoad (chrome-extension://pplhppbihehddgkdedhpbfpbbbefeihl/build/refined-github.js:9213:11)
  at chrome-extension://pplhppbihehddgkdedhpbfpbbbefeihl/build/refined-github.js:9265:15
```

