### PR TITLE
`one-click-pr-or-gist`: Make the Create PR buttons be disabled when the title field is empty

### DIFF
--- a/source/features/one-click-pr-or-gist.tsx
+++ b/source/features/one-click-pr-or-gist.tsx
@@ -29,6 +29,7 @@ function init(): void | false {
 
 		initialGroupedButtons.after(
 			<button
+				data-disable-invalid
 				className={classList.join(' ')}
 				aria-label={description}
 				type="submit"


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #4565.

## Test URLs

`https://github.com/darkred/test/compare/main...t2?expand=1`

## Screenshots

<details>
<summary>Before:</summary>

![](https://user-images.githubusercontent.com/723651/125519216-f738dde9-7449-42d0-8e26-1d8623000ce8.gif)</details>

<details>
<summary>After:</summary>

![](https://user-images.githubusercontent.com/723651/127389329-31ba57d9-f152-4989-9c7f-0842736967c9.gif)
</details>

