### PR TITLE
Feat/2673 load rich diff for images

### DIFF
--- a/source/features/rich-diff-for-images.tsx
+++ b/source/features/rich-diff-for-images.tsx
@@ -1,0 +1,133 @@
+import * as pageDetect from "github-url-detection";
+
+import features from ".";
+import fetchDom from "../helpers/fetch-dom";
+import delegate from "delegate-it";
+
+const MAX_IMAGES_TO_BE_FETCHED_CONCURRENTLY = 20;
+// @see https://docs.github.com/en/github/managing-files-in-a-repository/working-with-non-code-files/rendering-and-diffing-images
+const IMAGE_FILE_TYPES = [".jpg", ".png", ".gif", ".psd", ".svg"];
+
+void features.add(__filebasename, {
+	include: [pageDetect.isCommit, pageDetect.isPRFiles],
+	init,
+});
+
+async function init(): Promise<void> {
+	window.setTimeout(run, 1000);
+
+	delegate(
+		document.body,
+		"include-fragment.diff-progressive-loader",
+		"load",
+		run
+	);
+}
+
+const run = () => {
+	const imageFiletypeCssSelector = IMAGE_FILE_TYPES.map((imageFileType) => {
+		return `.show-inline-notes[data-file-type="${imageFileType}"][data-file-deleted="false"] .js-rendered`;
+	}).join(", ");
+
+	const richDiffButtons = Array.from(
+		document.querySelectorAll(imageFiletypeCssSelector)
+	);
+
+	const unselectedRichDiffButtons = richDiffButtons.filter(
+		(button) => !button.classList.contains("selected")
+	);
+
+	if (unselectedRichDiffButtons.length === 0) return;
+
+	const richDiffButtonsForNextConcurrentFetch = unselectedRichDiffButtons.slice(
+		0,
+		MAX_IMAGES_TO_BE_FETCHED_CONCURRENTLY
+	);
+
+	richDiffButtonsForNextConcurrentFetch.forEach(
+		async (richDiffButton: Element) => {
+			await loadRichDiffAndSwitchButtonStates(richDiffButton);
+		}
+	);
+
+	const lastButton =
+		richDiffButtonsForNextConcurrentFetch[
+			richDiffButtonsForNextConcurrentFetch.length - 1
+		];
+	displayLoadMoreContainer(lastButton);
+};
+
+async function loadRichDiffAndSwitchButtonStates(richDiffButton: Element) {
+	const detailsContainer = richDiffButton.closest(".js-details-container");
+	const richDiffForm = richDiffButton.closest(".BtnGroup-parent");
+
+	if (detailsContainer === null || richDiffForm === null) return;
+
+	const sourceButton = detailsContainer.querySelector("button.js-source");
+	const fileContentContainer =
+		detailsContainer.querySelector(".js-file-content");
+	if (sourceButton === null || fileContentContainer === null) return;
+
+	const richDiffFormAction = richDiffForm.getAttribute("action");
+	if (richDiffFormAction === null) return;
+
+	// wait some time between fetches
+	const imagePreviewDocumentFragment = await fetchDom(richDiffFormAction);
+
+	const sourceFileContent = fileContentContainer.firstElementChild;
+	if (sourceFileContent === null || !(sourceFileContent instanceof HTMLElement))
+		return;
+
+	hideSourceFileContentInsteadOfReplaceToPreserveContainerFunctionality(
+		sourceFileContent
+	);
+	fileContentContainer.append(imagePreviewDocumentFragment);
+
+	setRichDiffButtonAsSelected(sourceButton, richDiffButton);
+}
+
+function setRichDiffButtonAsSelected(
+	sourceButton: Element,
+	richDiffButton: Element
+) {
+	sourceButton.classList.remove("selected");
+	sourceButton.removeAttribute("aria-current");
+	richDiffButton.classList.add("selected");
+	richDiffButton.setAttribute("aria-current", "true");
+}
+
+function hideSourceFileContentInsteadOfReplaceToPreserveContainerFunctionality(
+	sourceFileContent: HTMLElement
+) {
+	sourceFileContent.style["display"] = "none";
+}
+
+function displayLoadMoreContainer(lastButton: Element) {
+	const lastDetailsContainer = lastButton.closest(".js-details-container");
+
+	if (lastDetailsContainer === null) return;
+
+	let lastDetailsContainerParent = lastDetailsContainer.parentNode;
+	if (lastDetailsContainerParent === null) return;
+
+	let loadMoreContainer = createLoadMoreContainer();
+
+	lastDetailsContainerParent.insertBefore(
+		loadMoreContainer,
+		lastDetailsContainer.nextSibling
+	);
+}
+
+function createLoadMoreContainer(): HTMLDivElement {
+	let loadMoreContainer = document.createElement("div");
+	loadMoreContainer.classList.add("d-flex", "flex-justify-center", "mb-4");
+	let btn = document.createElement("button");
+	btn.innerHTML = `Load more rich diffs`;
+	btn.classList.add("btn", "ml-2", "d-none", "d-md-block");
+	btn.addEventListener("click", function () {
+		run();
+		loadMoreContainer.remove();
+	});
+	loadMoreContainer.appendChild(btn);
+	return loadMoreContainer;
+}

--- a/source/features/rich-diff-for-images.tsx
+++ b/source/features/rich-diff-for-images.tsx
@@ -71,7 +71,6 @@ async function loadRichDiffAndSwitchButtonStates(richDiffButton: Element) {
 	const richDiffFormAction = richDiffForm.getAttribute("action");
 	if (richDiffFormAction === null) return;
 
-	// wait some time between fetches
 	const imagePreviewDocumentFragment = await fetchDom(richDiffFormAction);
 
 	const sourceFileContent = fileContentContainer.firstElementChild;

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -35,6 +35,7 @@ import './features/minimize-upload-bar';
 import './features/monospace-textareas';
 import './features/remove-diff-signs';
 
+import './features/rich-diff-for-images';
 import './features/useful-not-found-page';
 import './features/trending-menu-item';
 import './features/more-dropdown-links';


### PR DESCRIPTION
**1. Does this PR close/fix an existing issue? Write something like `Closes #10`**

Closes #2673  - even more it is configured to load rich diffs for all image types supported by github as stated in https://docs.github.com/en/github/managing-files-in-a-repository/working-with-non-code-files/rendering-and-diffing-images

**2. What pages does this PR affect? Include some REAL URLs where you tested the code**

This PR automatically loads the first 20 (configurable) rich diffs for images in the PR-Files and commit tab. If there are more files a load more button is introduced after the last loaded rich diff. I built this solution because I experienced some loading problems when loading more than 20 rich-diffs simultaneously in my PRs.

Test-Urls:
https://github.com/pcode-at/pcode-web-next/pull/153/files
https://github.com/xcp-ng/xcp-ng-release/pull/7/files

**3. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.**

I was having some timing problems with large PRs and include_fragments (I think so) so I just made a hacky "solution" with window.setTimeout(run, 1000); - I would need some guidance what would be a more approriate so everything needed is loaded and ready. cc @fregante 

## Test URLs
https://github.com/xcp-ng/xcp-ng-release/pull/7/files
https://github.com/pcode-at/pcode-web-next/pull/153/files

## Screenshot

![image](https://user-images.githubusercontent.com/9039956/127633924-2a826cc7-633d-4aa1-a817-519cab5c05c9.png)

