### PR TITLE
Fix some features appearing multiple times

### DIFF
--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -270,24 +270,15 @@ This means that the old features will still be on the page and don't need to re-
 
 This marks each as "processed"
 */
-void add(
-	__filebasename,
-	{
-		deduplicate: 'has-rgh',
-		init: async () => {
-			// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
-			await Promise.resolve();
-			select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
-		},
+void add(__filebasename, {
+	deduplicate: false,
+	init: async () => {
+		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
+		await Promise.resolve();
+		select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
+		select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #456
 	},
-	{
-		deduplicate: 'has-rgh-inner',
-		init: async () => {
-			await Promise.resolve();
-			select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #456
-		},
-	},
-);
+});
 
 const features = {
 	add,

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -270,14 +270,24 @@ This means that the old features will still be on the page and don't need to re-
 
 This marks each as "processed"
 */
-void add(__filebasename, {
-	init: async () => {
-		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
-		await Promise.resolve();
-		select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
-		select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #4567
+void add(
+	__filebasename,
+	{
+		deduplicate: 'has-rgh',
+		init: async () => {
+			// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
+			await Promise.resolve();
+			select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
+		},
 	},
-});
+	{
+		deduplicate: 'has-rgh-inner',
+		init: async () => {
+			await Promise.resolve();
+			select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #456
+		},
+	},
+);
 
 const features = {
 	add,

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -276,7 +276,7 @@ void add(__filebasename, {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();
 		select('#js-repo-pjax-container, #js-pjax-container')?.append(<has-rgh/>);
-		select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #456
+		select('#repo-content-pjax-container')?.append(<has-rgh-inner/>); // #4567
 	},
 });
 


### PR DESCRIPTION
Fixes #4622

The issue described in #4622 was caused because the `<has-rgh-inner>` element was removed on the first navigation.
So all features that checked it ran again, but the loader that would add `<has-rgh-inner>` again didn't run because the `<has-rgh>` was still present.

This PR splits them up into two loaders, I did not yet unify the code.
We could e.g. refactor it into a factory function, happy to do this if wanted.