### PR TITLE
Use AJAX navigation for `default-branch-button`

### DIFF
--- a/source/features/default-branch-button.tsx
+++ b/source/features/default-branch-button.tsx
@@ -37,6 +37,7 @@ async function init(): Promise<false | void> {
 		<a
 			className="btn tooltipped tooltipped-ne rgh-default-branch-button"
 			href={String(url)}
+			data-pjax="#repo-content-pjax-container"
 			aria-label="See this view on the default branch"
 		>
 			<ChevronLeftIcon/>

--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -100,7 +100,11 @@ async function init(): Promise<false | void> {
 	});
 
 	const link = (
-		<a className="btn btn-sm btn-outline ml-0 flex-self-center css-truncate rgh-latest-tag-button" href={String(url)}>
+		<a
+			className="btn btn-sm btn-outline ml-0 flex-self-center css-truncate rgh-latest-tag-button"
+			href={String(url)}
+			data-pjax="#repo-content-pjax-container"
+		>
 			<TagIcon/>
 		</a>
 	);
@@ -132,6 +136,7 @@ async function init(): Promise<false | void> {
 				<a
 					className="btn btn-sm btn-outline tooltipped tooltipped-ne"
 					href={buildRepoURL(`compare/${latestTag}...${defaultBranch}`)}
+					data-pjax="#repo-content-pjax-container"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>
 					<DiffIcon className="v-align-middle"/>


### PR DESCRIPTION
Fixes #4623 

I just took the attribute from the `master` element and it worked 😅
It is also used for other elements so it seems to be the right way to trigger an AJAX navigation.

## Test URLs

https://github.com/vutran/twas/tree/v2.1.2

## Screenshot

https://user-images.githubusercontent.com/9264728/127857124-caf84808-6975-4b04-88bc-a82fe3439c1e.mp4


### Browser(s) used

Chromium 92.0.4515.107 

