### PR TITLE
Make some feature-generated links load via AJAX

### DIFF
--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -105,7 +105,18 @@ async function showTimemachineBar(): Promise<void | false> {
 	}
 
 	addNotice(
-		<>You can also <a className="rgh-link-date" href={String(url)} data-pjax="#repo-content-pjax-container">view this object as it appeared at the time of the comment</a> (<relative-time datetime={date}/>)</>,
+		<>
+			You can also
+			{' '}
+			<a
+				className="rgh-link-date"
+				href={String(url)}
+				data-pjax="#repo-content-pjax-container"
+			>
+				view this object as it appeared at the time of the comment
+			</a>
+			(<relative-time datetime={date}/>)
+		</>,
 	);
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -104,19 +104,13 @@ async function showTimemachineBar(): Promise<void | false> {
 		url.pathname = parsedUrl.pathname;
 	}
 
+	const link = (
+		<a className="rgh-link-date" href={String(url)} data-pjax="#repo-content-pjax-container">
+			view this object as it appeared at the time of the comment
+		</a>
+	);
 	addNotice(
-		<>
-			You can also
-			{' '}
-			<a
-				className="rgh-link-date"
-				href={String(url)}
-				data-pjax="#repo-content-pjax-container"
-			>
-				view this object as it appeared at the time of the comment
-			</a>
-			(<relative-time datetime={date}/>)
-		</>,
+		<>You can also {link} (<relative-time datetime={date}/>)</>,
 	);
 }
 

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -105,7 +105,7 @@ async function showTimemachineBar(): Promise<void | false> {
 	}
 
 	addNotice(
-		<>You can also <a className="rgh-link-date" href={String(url)}>view this object as it appeared at the time of the comment</a> (<relative-time datetime={date}/>)</>,
+		<>You can also <a className="rgh-link-date" href={String(url)} data-pjax="#repo-content-pjax-container">view this object as it appeared at the time of the comment</a> (<relative-time datetime={date}/>)</>,
 	);
 }
 

--- a/source/features/linkify-branch-references.tsx
+++ b/source/features/linkify-branch-references.tsx
@@ -13,7 +13,7 @@ async function init(): Promise<void | false> {
 	}
 
 	const branchUrl = buildRepoURL('tree', element.textContent!);
-	wrap(element.closest('.branch-name')!, <a href={branchUrl}/>);
+	wrap(element.closest('.branch-name')!, <a href={branchUrl} data-pjax="#repo-content-pjax-container"/>);
 }
 
 void features.add(__filebasename, {

--- a/source/features/linkify-symbolic-links.tsx
+++ b/source/features/linkify-symbolic-links.tsx
@@ -8,7 +8,7 @@ import features from '.';
 function init(): void {
 	if (select('.file-mode')?.textContent === 'symbolic link') {
 		const line = select('.js-file-line')!;
-		wrap(line.firstChild!, <a href={line.textContent!}/>);
+		wrap(line.firstChild!, <a href={line.textContent!} data-pjax="#repo-content-pjax-container"/>);
 	}
 }
 

--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -34,7 +34,7 @@ function getDropdown(prs: number[]): HTMLElement {
 						data-url={buildRepoURL('issues', prNumber)}
 						data-id={`rgh-pr-${prNumber}`}
 					>
-						<a className="dropdown-item" href={getPRUrl(prNumber)}>
+						<a className="dropdown-item" href={getPRUrl(prNumber)} data-pjax="#js-repo-pjax-container">
 							#{prNumber}
 						</a>
 					</li>
@@ -49,6 +49,7 @@ function getSingleButton(prNumber: number, _?: number, prs?: number[]): HTMLElem
 		<a
 			href={getPRUrl(prNumber)}
 			className={'btn btn-sm btn-outline flex-self-center rgh-list-prs-for-file' + (prs ? ' BtnGroup-item' : '')}
+			data-pjax="#js-repo-pjax-container"
 		>
 			<GitPullRequestIcon/> #{prNumber}
 		</a>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -73,6 +73,7 @@ async function getHistoryDropdown(featureName: string): Promise<Element | void> 
 								role="menuitem"
 								href={getCommitUrl(commit)}
 								title={commit.messageHeadline}
+								data-pjax="#repo-content-pjax-container"
 							>
 								<h5>{parseBackticks(commit.messageHeadline)}</h5>
 								<relative-time className="text-gray color-text-secondary" datetime={commit.committedDate}/>
@@ -116,7 +117,7 @@ async function init(): Promise<void | false> {
 					{ /* eslint-disable-next-line react/no-danger */ }
 					<div dangerouslySetInnerHTML={{__html: feature.description}} className="text-bold"/>
 					<div className="no-wrap">
-						<a href={conversationsUrl}>Conversations</a>
+						<a href={conversationsUrl} data-pjax="#repo-content-pjax-container">Conversations</a>
 					</div>
 				</div>
 			</div>

--- a/source/features/swap-branches-on-compare.tsx
+++ b/source/features/swap-branches-on-compare.tsx
@@ -20,7 +20,7 @@ function init(): void {
 
 	const icon = select('.range-editor .octicon-arrow-left')!;
 	icon.parentElement!.attributes['aria-label'].value += '.\nClick to swap.';
-	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))}/>);
+	wrap(icon, <a href={buildRepoURL('compare/' + references.join('...'))} data-pjax="#repo-content-pjax-container"/>);
 }
 
 void features.add(__filebasename, {

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -11,6 +11,7 @@ async function init(): Promise<void> {
 		<div className="BtnGroup rgh-view-markdown-source mr-1">
 			<a
 				href="?plain=1"
+				data-pjax="#repo-content-pjax-container"
 				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
 				aria-label="Display the source"
 			>
@@ -18,6 +19,7 @@ async function init(): Promise<void> {
 			</a>
 			<a
 				href={location.pathname}
+				data-pjax="#repo-content-pjax-container"
 				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
 				aria-label="Display the rendered file"
 			>


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Motivation: https://github.com/sindresorhus/refined-github/pull/4631#issuecomment-891201750

This PR will continue for a few days in case anyone find something new, but hopefully searching for `<a` will give not too much results to check.

Ajaxed features and Test URLS:

- `comments-time-machine-links`: https://github.com/sindresorhus/refined-github/blob/main/.gitattributes?rgh-link-date=2021-08-01
- `linkify-branch-references`: 🤷‍♀️ Something like https://github.com/sindresorhus/refined-github/compare/main...test?quick_pull=1
- `linkify-symbolic-links`: https://github.com/lxqt/lxqt/blob/master/CONTRIBUTING
- `list-prs-for-file`: https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix
- `rgh-feature-descriptions`: https://github.com/sindresorhus/refined-github/blob/main/source/features/ci-link.tsx
- `swap-branches-on-compare`: https://github.com/sindresorhus/refined-github/compare/hotfix...main
- `view-markdown-source`: https://github.com/sindresorhus/refined-github/blob/main/readme.md


## Screenshot

