### PR TITLE
Fix AJAX navigation for compare link in `latest-tag-button` and add it to `view-markdown-source`

### DIFF
--- a/source/features/latest-tag-button.tsx
+++ b/source/features/latest-tag-button.tsx
@@ -136,7 +136,7 @@ async function init(): Promise<false | void> {
 				<a
 					className="btn btn-sm btn-outline tooltipped tooltipped-ne"
 					href={buildRepoURL(`compare/${latestTag}...${defaultBranch}`)}
-					data-pjax="#repo-content-pjax-container"
+					data-pjax="#js-repo-pjax-container"
 					aria-label={`Compare ${latestTag}...${defaultBranch}`}
 				>
 					<DiffIcon className="v-align-middle"/>

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -11,6 +11,7 @@ async function init(): Promise<void> {
 		<div className="BtnGroup rgh-view-markdown-source mr-1">
 			<a
 				href="?plain=1"
+				data-pjax="#repo-content-pjax-container"
 				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
 				aria-label="Display the source"
 			>
@@ -18,6 +19,7 @@ async function init(): Promise<void> {
 			</a>
 			<a
 				href={location.pathname}
+				data-pjax="#repo-content-pjax-container"
 				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
 				aria-label="Display the rendered file"
 			>


### PR DESCRIPTION

As pointed out by @kidonng in https://github.com/sindresorhus/refined-github/pull/4631#discussion_r682548229
The `#repo-content-pjax-container` did not work correctly for the compare link.

As a reparation I added the AJAX navigation to the `view-markdown-source` feature. 😄
I hope this will not conflict with #4639

## Test URLs

- Compare Link: https://github.com/sindresorhus/got
- `view-markdown-source`: https://github.com/sindresorhus/refined-github/blob/main/readme.md

## Screenshot


https://user-images.githubusercontent.com/9264728/128202068-c22975f2-f423-43dd-b0dd-0aafa2bee955.mp4


https://user-images.githubusercontent.com/9264728/128202284-cdce99f0-8345-4c95-b4bf-3829f7ba5519.mp4



