### PR TITLE
Add more details to `useful-not-found-page` 

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -7,16 +7,10 @@ import features from '.';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 
-interface File {
-	previous_filename: string;
-	filename: string;
-	status: string;
-}
-
-async function findRename(lastCommitOnPage: string): Promise<File[]> {
+// eslint-disable-next-line import/prefer-default-export
+export async function getCommitInfo(oid: string): Promise<AnyObject> {
 	// API v4 doesn't support it: https://github.community/t/what-is-the-corresponding-object-in-graphql-api-v4-for-patch-which-is-available-in-rest-api-v3/13590
-	const {files} = await api.v3(`commits/${lastCommitOnPage}`);
-	return files;
+	return api.v3(`commits/${oid}`);
 }
 
 async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void | false> {
@@ -26,7 +20,7 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 	const toKey = isNewer ? 'filename' : 'previous_filename';
 	const sha = (isNewer ? select : select.last)('clipboard-copy[aria-label="Copy the full SHA"]')!;
 
-	const files = await findRename(sha.getAttribute('value')!);
+	const {files} = await getCommitInfo(sha.getAttribute('value')!);
 
 	for (const file of files) {
 		if (file[fromKey] === url.filePath) {

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -7,6 +7,11 @@ import features from '.';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 
+interface File {
+	previous_filename: string;
+	filename: string;
+	status: string;
+}
 // eslint-disable-next-line import/prefer-default-export
 export async function getCommitInfo(oid: string): Promise<AnyObject> {
 	// API v4 doesn't support it: https://github.community/t/what-is-the-corresponding-object-in-graphql-api-v4-for-patch-which-is-available-in-rest-api-v3/13590
@@ -22,7 +27,7 @@ async function linkify(button: HTMLButtonElement, url: GitHubURL): Promise<void 
 
 	const {files} = await getCommitInfo(sha.getAttribute('value')!);
 
-	for (const file of files) {
+	for (const file of (files as File[])) {
 		if (file[fromKey] === url.filePath) {
 			if (file.status === 'renamed') {
 				url.assign({

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -271,6 +271,7 @@ This means that the old features will still be on the page and don't need to re-
 This marks each as "processed"
 */
 void add(__filebasename, {
+	deduplicate: false,
 	init: async () => {
 		// `await` kicks it to the next tick, after the other features have checked for 'has-rgh', so they can run once.
 		await Promise.resolve();

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -117,7 +117,7 @@ async function showMissingPart(): Promise<void> {
 async function showHelpfulLinks(): Promise<void> {
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (urlToFileOnDefaultBranch) {
-		select('h2')!.after(
+		select('main > .container-lg')!.before(
 			<p className="container mt-4 text-center">
 				<a href={urlToFileOnDefaultBranch}>This {getType()}</a> exists on the default branch.
 			</p>,
@@ -132,7 +132,7 @@ async function showHelpfulLinks(): Promise<void> {
 	const url = new GitHubURL(location.href);
 
 	url.assign({route: 'commits'});
-	const commitHistory = <a href={url.toString()}>Commit history</a>;
+	const commitHistory = <a href={url.toString()}>see commit history</a>;
 	url.assign({route: 'blob', branch: commitInfo.parents[0].sha, filePath: url.filePath});
 	const lastVersionUrl = fileInfo.status === 'removed' ? fileInfo.blob_url : url.toString();
 	const lastVersion = <a href={lastVersionUrl}>This {getType()}</a>;
@@ -141,7 +141,7 @@ async function showHelpfulLinks(): Promise<void> {
 		? 'deleted'
 		: <a href={fileInfo.blob_url}>moved</a>;
 
-	select('h2')!.after(
+	select('main > .container-lg')!.before(
 		<p className="container mt-4 text-center">
 			{lastVersion} was {verb} ({permalink}) - {commitHistory}.
 		</p>,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -5,10 +5,10 @@ import elementReady from 'element-ready';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import getDefaultBranch from '../github-helpers/get-default-branch';
-import {getCleanPathname} from '../github-helpers';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
+import getDefaultBranch from '../github-helpers/get-default-branch';
+import {getCleanPathname} from '../github-helpers';
 
 function getType(): string {
 	return location.pathname.split('/').pop()!.includes('.') ? 'file' : 'object';
@@ -59,14 +59,14 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 			}
 		}
 	`);
-	const commits = commitsResponseObject.repository.ref.target.history.nodes;
-	if (!commits[0]) {
+	const [commits] = commitsResponseObject.repository.ref.target.history.nodes;
+	if (!commits) {
 		return;
 	}
 
 	// API v4 doesn't support retrieving a list of changed files for a commit:
 	// https://github.community/t/graphql-api-get-list-of-files-related-to-commit/14047/2
-	const commitInfo = await api.v3(`commits/${commits[0].oid as string}`);
+	const commitInfo = await api.v3(`commits/${commits.oid as string}`);
 	for (const fileInfo of commitInfo.files) {
 		if ([fileInfo.filename, fileInfo.previous_filename].includes(filePath)) {
 			return {fileInfo, commitInfo};

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -44,7 +44,7 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 		return;
 	}
 
-	const commitsResponseObject = await api.v4(`
+	const {repository} = await api.v4(`
 		repository() {
 			ref(qualifiedName: "${branch}") {
 				target {
@@ -59,14 +59,14 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 			}
 		}
 	`);
-	const [commits] = commitsResponseObject.repository.ref.target.history.nodes;
-	if (!commits) {
+	const [commit] = repository.ref.target.history.nodes;
+	if (!commit) {
 		return;
 	}
 
 	// API v4 doesn't support retrieving a list of changed files for a commit:
 	// https://github.community/t/graphql-api-get-list-of-files-related-to-commit/14047/2
-	const commitInfo = await api.v3(`commits/${commits.oid as string}`);
+	const commitInfo = await api.v3(`commits/${commit.oid as string}`);
 	for (const fileInfo of commitInfo.files) {
 		if ([fileInfo.filename, fileInfo.previous_filename].includes(filePath)) {
 			return {fileInfo, commitInfo};

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -134,7 +134,7 @@ async function showHelpfulLinks(): Promise<void> {
 	if (urlToFileOnDefaultBranch) {
 		select('h2')!.after(
 			<p className="container mt-4 text-center">
-				View <a href={urlToFileOnDefaultBranch}>this {getType()}</a> on the default branch.
+				<a href={urlToFileOnDefaultBranch}>This {getType()}</a> exists on the default branch.
 			</p>,
 		);
 		return;
@@ -148,7 +148,7 @@ async function showHelpfulLinks(): Promise<void> {
 		url.assign({route: 'commits'});
 		const commitHistory = <a href={url.toString()}>Commit history</a>;
 		url.assign({route: 'blob', branch: commitInfo.parents[0].sha, filePath: url.filePath});
-		const lastVersion = <a href={fileInfo.status === 'removed' ? fileInfo.blob_url : url.toString()}>The file</a>;
+		const lastVersion = <a href={fileInfo.status === 'removed' ? fileInfo.blob_url : url.toString()}>This {getType()}</a>;
 		const permalink = <a href={commitInfo.html_url}><relative-time datetime={commitInfo.commit.committer.date}/></a>;
 		const verb = fileInfo.status === 'removed'
 			? 'deleted'

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -46,20 +46,18 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 
 	const {repository} = await api.v4(`
 		repository() {
-			ref(qualifiedName: "${branch}") {
-				target {
-					... on Commit {
-						history(first: 1, path: "${filePath}") {
-							nodes {
-								oid
-							}
+			object(expression: "${branch}") {
+				... on Commit {
+					history(first: 1, path: "${filePath}") {
+						nodes {
+							oid
 						}
 					}
 				}
 			}
 		}
 	`);
-	const [commit] = repository.ref.target.history.nodes;
+	const [commit] = repository.object.history.nodes;
 	if (!commit) {
 		return;
 	}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -71,8 +71,10 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 			type: 'removed',
 			commitDetails: {
 				filePath,
-				commitSha, commitDate,
-				linkToCommit, linkToCommitHistory,
+				commitSha,
+				commitDate,
+				linkToCommit,
+				linkToCommitHistory,
 				linkToLastVersion: fileInfo.blob_url,
 			},
 		};
@@ -88,9 +90,12 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 		return {
 			type: 'renamed',
 			commitDetails: {
-				filePath: fileInfo.previous_filename, newFilePath: fileInfo.filename,
-				commitSha, commitDate,
-				linkToCommit, linkToCommitHistory,
+				filePath: fileInfo.previous_filename,
+				newFilePath: fileInfo.filename,
+				commitSha,
+				commitDate,
+				linkToCommit,
+				linkToCommitHistory,
 				linkToLastVersion: url.toString(), linkToNewVersion: fileInfo.blob_url,
 			},
 		};

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -98,8 +98,9 @@ async function getUrlToFileOnDefaultBranch(): Promise<string | void> {
 	return url.toString();
 }
 
-async function showMissingPart(bar: Element): Promise<void> {
+async function showMissingPart(): Promise<void> {
 	const parts = parseCurrentURL();
+	const bar = <h2 className="container mt-4 text-center"/>;
 
 	for (const [i, part] of parts.entries()) {
 		if (i === 2 && ['tree', 'blob', 'edit'].includes(part)) {
@@ -124,14 +125,14 @@ async function showMissingPart(bar: Element): Promise<void> {
 	}
 }
 
-async function showHelpfulLinks(bar: Element): Promise<void> {
+async function showHelpfulLinks(): Promise<void> {
 	// What we should try to do to be helpful:
 	//  1. Check if the file is on the default branch
 	//  2. Check the current branch's history for the file (was it deleted or renamed)
 
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (urlToFileOnDefaultBranch) {
-		bar.after(
+		select('h2')!.after(
 			<p className="container mt-4 text-center">
 				View <a href={urlToFileOnDefaultBranch}>this {getType()}</a> on the default branch.
 			</p>,
@@ -153,7 +154,7 @@ async function showHelpfulLinks(bar: Element): Promise<void> {
 			? 'deleted'
 			: <a href={fileInfo.status === 'renamed' ? fileInfo.blob_url : url.toString()}>moved</a>;
 
-		bar.after(
+		select('h2')!.after(
 			<p className="container mt-4 text-center">
 				{lastVersion} was {verb} ({permalink}) - {commitHistory}.
 			</p>,
@@ -167,9 +168,8 @@ function init(): false | void {
 		return false;
 	}
 
-	const bar = <h2 className="container mt-4 text-center"/>;
-	void showMissingPart(bar);
-	void showHelpfulLinks(bar);
+	void showMissingPart();
+	void showHelpfulLinks();
 }
 
 async function initPRCommit(): Promise<void | false> {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -23,9 +23,9 @@ function getStrikeThrough(text: string): HTMLElement {
 	return <del className="color-text-tertiary">{text}</del>; /* GHE #4121 */
 }
 
-async function checkIfPartExists(element: HTMLAnchorElement): Promise<void> {
-	if (await is404(element.href)) {
-		element.replaceWith(getStrikeThrough(element.textContent!));
+async function checkAnchor(anchor: HTMLAnchorElement): Promise<void> {
+	if (await is404(anchor.href)) {
+		anchor.replaceWith(getStrikeThrough(anchor.textContent!));
 	}
 }
 
@@ -47,8 +47,8 @@ async function showMissingPart(bar: Element): Promise<void> {
 			continue;
 		}
 
-		// The last part of the URL is a known 404
 		if (i === parts.length - 1) {
+			// The last part of the URL is a known 404
 			bar.append(' / ', getStrikeThrough(part));
 		} else {
 			const pathname = '/' + parts.slice(0, i + 1).join('/');
@@ -60,7 +60,7 @@ async function showMissingPart(bar: Element): Promise<void> {
 
 	// Check parts from right to left; skip the last part
 	for (let i = bar.children.length - 2; i >= 0; i--) {
-		void checkIfPartExists(bar.children[i] as HTMLAnchorElement);
+		void checkAnchor(bar.children[i] as HTMLAnchorElement);
 	}
 }
 
@@ -179,7 +179,7 @@ async function showHelpfulLinks(bar: Element): Promise<void> {
 	}
 }
 
-function initUsefulNotFoundPage(): void {
+function init(): void {
 	if (
 		parseCurrentURL().length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')
 	) {
@@ -207,7 +207,7 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.is404,
 	],
-	init: onetime(initUsefulNotFoundPage),
+	init: onetime(init),
 }, {
 	include: [
 		pageDetect.isPRCommit404,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -99,22 +99,23 @@ async function addObjectStatus(bar: Element): Promise<boolean> {
 			return false;
 		});
 
-		const commitAuthor = lastCommitInfo.author.login;
+		if (!fileInfo) {
+			return false;
+		}
+
 		const commitTime = new Date(lastCommitInfo.commit.committer.date);
 		const commitSha = lastCommitInfo.sha;
 		const shortenedCommitSha = commitSha.slice(0, 8);
 		const commitUrl = lastCommitInfo.html_url;
-
-		const urlToCommitAuthorProfile = lastCommitInfo.author.html_url;
 		const urlToLastBlob = fileInfo.blob_url;
+
+		const commitHistoryUrl = '/' + parts.join('/');
 
 		// If it was removed, tell the user
 		if (fileInfo.status === 'removed') {
 			bar.after(
 				<p className="container mt-4 text-center">
-					The file you are looking for was deleted/moved by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> <relative-time datetime={commitTime}/> with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
-					<br/>
-					You can view the last version of the file <a href={urlToLastBlob}>here</a>.
+					This {getType()} was deleted/moved by <a href={commitUrl}>{shortenedCommitSha}</a> (<relative-time datetime={commitTime}/>) - see the {getType()}&apos;s <a href={commitHistoryUrl}>commit history</a>.
 				</p>,
 			);
 
@@ -125,9 +126,7 @@ async function addObjectStatus(bar: Element): Promise<boolean> {
 		if (fileInfo.status === 'renamed') {
 			bar.after(
 				<p className="container mt-4 text-center">
-					The file you are looking for was renamed by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> <relative-time datetime={commitTime}/> with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
-					<br/>
-					You can find the renamed file <a href={urlToLastBlob}>here</a>.
+					This {getType()} was renamed by <a href={commitUrl}>{shortenedCommitSha}</a> (<relative-time datetime={commitTime}/>) - see the {getType()}&apos;s <a href={commitHistoryUrl}>commit history</a> or view the <a href={urlToLastBlob}>renamed file</a>.
 				</p>,
 			);
 

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -64,7 +64,7 @@ async function getUrlToFileOnDefaultBranch(): Promise<string | undefined> {
 
 async function getLastCommitForFile(
 	branch?: string,
-): Promise<Record<string, string | undefined> | undefined> {
+): Promise<Record<string, string | undefined> | void> {
 	// Get the current branch and file path
 	const url = new GitHubURL(location.href);
 	const currentBranch = url.branch;
@@ -155,8 +155,6 @@ async function getLastCommitForFile(
 			linkToCommitHistory,
 		};
 	}
-
-	return undefined;
 }
 
 async function getLinkToCommitHistoryOnDefaultBranch(): Promise<string | undefined> {
@@ -186,7 +184,7 @@ async function getLinkToCommitHistoryOnDefaultBranch(): Promise<string | undefin
 	return url.toString();
 }
 
-async function whatHappenedToTheFile(): Promise<Record<string, string | undefined> | undefined> {
+async function whatHappenedToTheFile(): Promise<Record<string, string | undefined> | void> {
 	// First, check if the file exists on the default branch
 	const urlOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (urlOnDefaultBranch) {
@@ -211,8 +209,6 @@ async function whatHappenedToTheFile(): Promise<Record<string, string | undefine
 			linkToCommitHistory: linkToCommitHistoryOnDefaultBranch,
 		};
 	}
-
-	return undefined;
 }
 
 async function showAdditionalInformation(bar: Element): Promise<void> {
@@ -293,8 +289,7 @@ function init(): false | void {
 
 	// Check that this is actually a 404 page for a file/folder in a repo
 	if (
-		parts.length <= 1
-		|| !select.exists('[alt*="This is not the web page you are looking for"]')
+		parts.length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')
 	) {
 		return false;
 	}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -49,21 +49,26 @@ async function displayObjectStatus(bar: Element): Promise<void> {
 async function addObjectStatusInfo(bar: Element): Promise<boolean> {
 	// Get the file path from the parts
 	const parts = parseCurrentURL();
-	const filePath = parts.slice(4).join("/")
+	const filePath = parts.slice(4).join('/');
 
 	// Get the last 2 commits that include the file
-	const previousCommitsIncludingFile = await api.v3(`commits?path=${filePath}`)
+	const previousCommitsIncludingFile = await api.v3(`commits?path=${filePath}`);
 	// The latest commit will be the first object in the array
 	if (previousCommitsIncludingFile[0]) {
 		// Get a list of changes that happened in the repo with this commit
-		const lastCommitInfo = await api.v3(`commits/${previousCommitsIncludingFile[0]['sha']}`);
-		
+		const lastCommitInfo = await api.v3(`commits/${previousCommitsIncludingFile[0].sha as string}`);
+
 		// Check what happened to this file
-		const [fileInfo] = lastCommitInfo.files.filter((file: Record<string, string>) => {
-			if (file.filename === filePath) return true
-			if (file.status === 'renamed' && file.previous_filename === filePath) return true
-			
-			return false
+		const fileInfo = lastCommitInfo.files.find((file: Record<string, string>) => {
+			if (file.filename === filePath) {
+				return true;
+			}
+
+			if (file.status === 'renamed' && file.previous_filename === filePath) {
+				return true;
+			}
+
+			return false;
 		});
 
 		const commitAuthor = lastCommitInfo.author.login;
@@ -76,7 +81,7 @@ async function addObjectStatusInfo(bar: Element): Promise<boolean> {
 			bar.after(
 				<p className="container mt-4 text-center">
 					The file you are looking for was deleted/moved by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> { twas(commitTime.getTime()) }.
-					<br />
+					<br/>
 					You can view the last version of the file <a href={urlToLastBlob}>here</a>.
 				</p>,
 			);
@@ -89,7 +94,7 @@ async function addObjectStatusInfo(bar: Element): Promise<boolean> {
 			bar.after(
 				<p className="container mt-4 text-center">
 					The file you are looking for was renamed by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> {twas(commitTime.getTime())}.
-					<br />
+					<br/>
 					You can find the renamed file <a href={urlToLastBlob}>here</a>.
 				</p>,
 			);
@@ -119,16 +124,16 @@ async function addCommitHistoryLink(bar: Element): Promise<void> {
 
 async function addBranchStatusInfo(bar: Element): Promise<void> {
 	// Get the current branch
-	const parts = parseCurrentURL()
-	const currentBranch = parts[3]
+	const parts = parseCurrentURL();
+	const currentBranch = parts[3];
 
 	// List all valid branches
-	const branches = await api.v3(`branches`)
+	const branches = await api.v3('branches');
 
 	// Check if the branch exists
-	const matchingBranches = branches.filter((branch: Record<string, string>) => (branch.name === currentBranch))
+	const matchingBranches = branches.filter((branch: Record<string, string>) => (branch.name === currentBranch));
 	if (matchingBranches.length === 0) {
-		return bar.after(
+		bar.after(
 			<p className="container mt-4 text-center">
 				The branch you are trying to view does not exist.
 			</p>,
@@ -193,7 +198,7 @@ function init(): false | void {
 	}
 
 	if (['tree', 'blob'].includes(parts[2])) {
-		void displayObjectStatus(bar)
+		void displayObjectStatus(bar);
 	}
 
 	if (['tree', 'blob', 'edit'].includes(parts[2])) {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -10,6 +10,10 @@ import {getCleanPathname} from '../github-helpers';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
 
+function getType(): string {
+	return location.pathname.split('/').pop()!.includes('.') ? 'file' : 'object';
+}
+
 async function is404(url: string): Promise<boolean> {
 	const {status} = await fetch(url, {method: 'head'});
 	return status === 404;
@@ -90,7 +94,7 @@ async function showHelpfulLinks(bar: Element): Promise<void> {
 	if (urlToFileOnDefaultBranch) {
 		bar.after(
 			<p className="container mt-4 text-center">
-				View <a href={urlToFileOnDefaultBranch}>this file</a> on the default branch.
+				View <a href={urlToFileOnDefaultBranch}>this {getType()}</a> on the default branch.
 			</p>,
 		);
 		return;
@@ -168,7 +172,7 @@ async function showHelpfulLinks(bar: Element): Promise<void> {
 		if (change.type === 'removed') {
 			bar.after(
 				<p className="container mt-4 text-center">
-					<a href={change.commitDetails.linkToLastVersion}>This file</a> was removed (<a href={change.commitDetails.linkToCommit}><relative-time datetime={change.commitDetails.commitDate}/></a>) - view the file&apos;s <a href={change.commitDetails.linkToCommitHistory}>commit history</a>.
+					<a href={change.commitDetails.linkToLastVersion}>This {getType()}</a> was removed (<a href={change.commitDetails.linkToCommit}><relative-time datetime={change.commitDetails.commitDate}/></a>) - view the file&apos;s <a href={change.commitDetails.linkToCommitHistory}>commit history</a>.
 				</p>,
 			);
 		}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -102,17 +102,7 @@ async function getLastCommitForFile(
 	);
 
 	// Check what happened to this particular file
-	const fileInfo = lastCommitInfo.files.find((file: Record<string, string>) => {
-		if (file.filename === filePath) {
-			return true;
-		}
-
-		if (file.status === 'renamed' && file.previous_filename === filePath) {
-			return true;
-		}
-
-		return false;
-	});
+	const fileInfo = lastCommitInfo.files.find((file: AnyObject) => [file.filename, file.previous_filename].includes(filePath));
 	if (!fileInfo) {
 		return;
 	}
@@ -142,8 +132,8 @@ async function getLastCommitForFile(
 	}
 
 	if (fileInfo.status === 'renamed') {
-		filePath = fileInfo.previous_filename || filePath;
-		const newFilePath = fileInfo.previous_filename;
+		const newFilePath = fileInfo.filename;
+		filePath = fileInfo.previous_filename;
 
 		const linkToNewVersion = fileInfo.blob_url;
 		url.assign({

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -260,7 +260,7 @@ async function showAdditionalInformation(bar: Element): Promise<void> {
 	if (eventThatHappened.type === 'removed') {
 		bar.after(
 			<p className="container mt-4 text-center">
-				<a href={eventThatHappened.linkToLastVersion}>This file</a> was deleted by <a href={eventThatHappened.linkToCommit}> {eventThatHappened.commitSha} </a> 	(<relative-time datetime={new Date(eventThatHappened.commitDate!)}/>) - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
+				<a href={eventThatHappened.linkToLastVersion}>This file</a> was deleted <a href={eventThatHappened.linkToCommit}><relative-time datetime={new Date(eventThatHappened.commitDate!)}/></a> - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
 			</p>,
 		);
 		return;
@@ -269,7 +269,7 @@ async function showAdditionalInformation(bar: Element): Promise<void> {
 	if (eventThatHappened.type === 'renamed') {
 		bar.after(
 			<p className="container mt-4 text-center">
-				<a href={eventThatHappened.linkToLastVersion}>This file</a> was renamed to <a href={eventThatHappened.linkToNewVersion}> {eventThatHappened.newFilePath} </a> by <a href={eventThatHappened.linkToCommit}> {eventThatHappened.commitSha} </a> (<relative-time datetime={new Date(eventThatHappened.commitDate!)}/>) - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
+				<a href={eventThatHappened.linkToLastVersion}>This file</a> was renamed to <a href={eventThatHappened.linkToNewVersion}>{eventThatHappened.newFilePath}</a> (<a href={eventThatHappened.linkToCommit}><relative-time datetime={new Date(eventThatHappened.commitDate!)}/></a>) - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
 			</p>,
 		);
 	}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -114,17 +114,20 @@ async function showMissingPart(): Promise<void> {
 	}
 }
 
-async function showHelpfulLinks(): Promise<void> {
+async function showDefaultBranchLink(): Promise<void> {
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
-	if (urlToFileOnDefaultBranch) {
-		select('main > .container-lg')!.before(
-			<p className="container mt-4 text-center">
-				<a href={urlToFileOnDefaultBranch}>This {getType()}</a> exists on the default branch.
-			</p>,
-		);
+	if (!urlToFileOnDefaultBranch) {
 		return;
 	}
 
+	select('main > .container-lg')!.before(
+		<p className="container mt-4 text-center">
+			<a href={urlToFileOnDefaultBranch}>This {getType()}</a> exists on the default branch.
+		</p>,
+	);
+}
+
+async function showAlternateLink(): Promise<void> {
 	const change = await getLatestChangeToFile();
 	if (!change) {
 		return;
@@ -157,7 +160,8 @@ function init(): false | void {
 	}
 
 	void showMissingPart();
-	void showHelpfulLinks();
+	void showDefaultBranchLink();
+	void showAlternateLink();
 }
 
 async function initPRCommit(): Promise<void | false> {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -40,15 +40,14 @@ function parseCurrentURL(): string[] {
 
 async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 	const url = new GitHubURL(location.href);
-	const currentBranch = url.branch;
-	const {filePath} = url;
-	if (!currentBranch || !filePath) {
+	const {branch, filePath} = url;
+	if (!branch || !filePath) {
 		return;
 	}
 
 	const commitsResponseObject = await api.v4(`
 		repository() {
-			ref(qualifiedName: "${currentBranch}") {
+			ref(qualifiedName: "${branch}") {
 				target {
 					... on Commit {
 						history(first: 1, path: "${filePath}") {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -1,7 +1,8 @@
 import React from 'dom-chef';
-import select from 'select-dom';
 import onetime from 'onetime';
+import select from 'select-dom';
 import elementReady from 'element-ready';
+
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -10,24 +11,8 @@ import GitHubURL from '../github-helpers/github-url';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getCleanPathname} from '../github-helpers';
 
-async function is404(url: string): Promise<boolean> {
-	const {status} = await fetch(url, {method: 'head'});
-	return status === 404;
-}
-
-function getStrikeThrough(text: string): HTMLElement {
-	return <del className="color-text-tertiary">{text}</del>; /* GHE #4121 */
-}
-
-async function checkAnchor(anchor: HTMLAnchorElement): Promise<void> {
-	if (await is404(anchor.href)) {
-		anchor.replaceWith(getStrikeThrough(anchor.textContent!));
-	}
-}
-
 function parseCurrentURL(): string[] {
 	const parts = getCleanPathname().split('/');
-	// Blob URLs are never useful
 	if (parts[2] === 'blob') {
 		parts[2] = 'tree';
 	}
@@ -35,240 +20,30 @@ function parseCurrentURL(): string[] {
 	return parts;
 }
 
-async function getUrlToFileOnDefaultBranch(): Promise<string | undefined> {
-	// Get the current branch
-	const url = new GitHubURL(location.href);
-	const currentBranch = url.branch;
-
-	if (!currentBranch) {
-		return;
-	}
-
-	const defaultBranch = await getDefaultBranch();
-	if (currentBranch === defaultBranch) {
-		return;
-	}
-
-	// Change branch
-	url.assign({
-		branch: defaultBranch
-	})
-	// Check if that path exists
-	if (await is404(url.toString())) {
-		return;
-	}
-
-	// If it does, return it
-	return url.toString();
+async function is404(url: string): Promise<boolean> {
+	const {status} = await fetch(url, {
+		method: 'head',
+	});
+	return status === 404;
 }
 
-async function getLastCommitForFile(
-	branch?: string,
-): Promise<Record<string, string | undefined> | void> {
-	// Get the current branch and file path
-	const url = new GitHubURL(location.href);
-	const currentBranch = url.branch;
-	let filePath = url.filePath;
-
-	// Get the last 2 commits that include the file
-	const commitsForFileResponse = await api.v4(`
-		repository() {
-			ref(qualifiedName: "${branch ?? currentBranch}") {
-				target {
-					... on Commit {
-						history(first: 2, path: "${filePath}") {
-							nodes {
-								oid
-							}
-						}
-					}
-				}
-			}
-		}
-	`);
-	// The latest commit will be the first object in the array
-	const previousCommitsIncludingFile
-		= commitsForFileResponse.repository.ref.target.history.nodes[0];
-	if (!previousCommitsIncludingFile) {
-		return;
-	}
-
-	// Get a list of changes that happened in the repo with this commit
-
-	// API v4 doesn't support retrieving a list of changed files for a commit:
-	// https://github.community/t/graphql-api-get-list-of-files-related-to-commit/14047/2
-	const lastCommitInfo = await api.v3(
-		`commits/${previousCommitsIncludingFile.oid as string}`,
-	);
-
-	// Check what happened to this particular file
-	const fileInfo = lastCommitInfo.files.find((file: AnyObject) => [file.filename, file.previous_filename].includes(filePath));
-	if (!fileInfo) {
-		return;
-	}
-
-	// Get info
-	const commitSha = lastCommitInfo.sha.slice(0, 8);
-	const commitDate = lastCommitInfo.commit.committer.date;
-	const linkToCommit = lastCommitInfo.html_url;
-
-	url.assign({
-		route: 'commits'
-	})
-	const linkToCommitHistory = url.toString();
-
-	if (fileInfo.status === 'removed') {
-		const linkToLastVersion = fileInfo.blob_url;
-
-		return {
-			type: 'removed',
-			filePath,
-			commitSha,
-			commitDate,
-			linkToCommit,
-			linkToLastVersion,
-			linkToCommitHistory,
-		};
-	}
-
-	if (fileInfo.status === 'renamed') {
-		const newFilePath = fileInfo.filename;
-		filePath = fileInfo.previous_filename;
-
-		const linkToNewVersion = fileInfo.blob_url;
-		url.assign({
-			route: 'blob',
-			branch: lastCommitInfo.parents[0].sha,
-			filePath
-		})
-		let linkToLastVersion = url.toString();
-
-		return {
-			type: 'renamed',
-			filePath,
-			newFilePath,
-			commitSha,
-			commitDate,
-			linkToCommit,
-			linkToLastVersion,
-			linkToNewVersion,
-			linkToCommitHistory,
-		};
+async function checkIfPartExists(element: HTMLAnchorElement): Promise<void> {
+	if (await is404(element.href)) {
+		element.replaceWith(<del className="color-text-tertiary">{element.textContent}</del>);
 	}
 }
 
-async function getLinkToCommitHistoryOnDefaultBranch(): Promise<string | undefined> {
-	// Get the current branch
-	const url = new GitHubURL(location.href);
-	const currentBranch = url.branch;
-
-	if (!currentBranch) {
-		return;
-	}
-
-	const defaultBranch = await getDefaultBranch();
-	if (currentBranch === defaultBranch) {
-		return;
-	}
-
-	url.assign({
-		route: 'commits',
-		branch: defaultBranch,
-	})
-	// Check if that path exists
-	if (await is404(url.toString())) {
-		return;
-	}
-
-	// If it does, return it
-	return url.toString();
-}
-
-async function whatHappenedToTheFile(): Promise<Record<string, string | undefined> | void> {
-	// First, check if the file exists on the default branch
-	const urlOnDefaultBranch = await getUrlToFileOnDefaultBranch();
-	if (urlOnDefaultBranch) {
-		return {
-			type: 'isOnDefaultBranch',
-			linkToLastVersion: urlOnDefaultBranch,
-		};
-	}
-
-	// Else, check if the file exists in commit history
-	const lastCommitIncludingFile = await getLastCommitForFile();
-	if (lastCommitIncludingFile) {
-		return lastCommitIncludingFile;
-	}
-
-	// Else, check if the file exists in the default branch's history
-	const linkToCommitHistoryOnDefaultBranch
-		= await getLinkToCommitHistoryOnDefaultBranch();
-	if (linkToCommitHistoryOnDefaultBranch) {
-		return {
-			type: 'wasOnDefaultBranch',
-			linkToCommitHistory: linkToCommitHistoryOnDefaultBranch,
-		};
-	}
-}
-
-async function showAdditionalInformation(bar: Element): Promise<void> {
-	// Check what happened
-	const eventThatHappened = await whatHappenedToTheFile();
-	if (!eventThatHappened) {
-		return;
-	}
-
-	// Parse that and do/show something
-	if (eventThatHappened.type === 'isOnDefaultBranch') {
-		bar.after(
-			<p className="container mt-4 text-center">
-				<a href={eventThatHappened.linkToLastVersion}>This file</a> only exists on the default branch.
-			</p>,
-		);
-		return;
-	}
-
-	if (eventThatHappened.type === 'wasOnDefaultBranch') {
-		bar.after(
-			<p className="container mt-4 text-center">
-				This file used to exist on the default branch - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
-			</p>,
-		);
-		return;
-	}
-
-	if (eventThatHappened.type === 'removed') {
-		bar.after(
-			<p className="container mt-4 text-center">
-				<a href={eventThatHappened.linkToLastVersion}>This file</a> was deleted <a href={eventThatHappened.linkToCommit}><relative-time datetime={new Date(eventThatHappened.commitDate!)}/></a> - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
-			</p>,
-		);
-		return;
-	}
-
-	if (eventThatHappened.type === 'renamed') {
-		bar.after(
-			<p className="container mt-4 text-center">
-				<a href={eventThatHappened.linkToLastVersion}>This file</a> was renamed to <a href={eventThatHappened.linkToNewVersion}>{eventThatHappened.newFilePath}</a> (<a href={eventThatHappened.linkToCommit}><relative-time datetime={new Date(eventThatHappened.commitDate!)}/></a>) - see <a href={eventThatHappened.linkToCommitHistory}>commit history</a>.
-			</p>,
-		);
-	}
-}
-
-async function showWhatIsMissingInPath(bar: Element): Promise<void> {
-	// Get the current URL
+async function showMissingPart(bar: Element): Promise<void> {
 	const parts = parseCurrentURL();
 
-	// Display the path of the file (including repo owner, repo name and branch name)
 	for (const [i, part] of parts.entries()) {
-		// Exclude parts that don't exist as standalones
 		if (i === 2 && ['tree', 'blob', 'edit'].includes(part)) {
 			continue;
 		}
 
-		// The last part of the URL is a known 404
+		// Last part caused the 404; we know that it does not exist for sure
 		if (i === parts.length - 1) {
-			bar.append(' / ', getStrikeThrough(part));
+			bar.append(' / ', <del className="color-text-tertiary">{part}</del>);
 		} else {
 			const pathname = '/' + parts.slice(0, i + 1).join('/');
 			bar.append(i ? ' / ' : '', <a href={pathname}>{part}</a>);
@@ -277,32 +52,139 @@ async function showWhatIsMissingInPath(bar: Element): Promise<void> {
 
 	select('main > :first-child, #parallax_illustration')!.after(bar);
 
-	// Check parts from right to left; skip the last part
 	for (let i = bar.children.length - 2; i >= 0; i--) {
-		void checkAnchor(bar.children[i] as HTMLAnchorElement);
+		void checkIfPartExists(bar.children[i] as HTMLAnchorElement);
 	}
 }
 
-function init(): false | void {
-	// Get the current URL
-	const parts = parseCurrentURL();
+async function showHelpfulLinks(bar: Element): Promise<void> {
+	// What we should try to do to be helpful:
+	//  1. Check if the file is on the default branch
+	//  2. Check the current branch's history for the file (was it deleted or renamed)
 
-	// Check that this is actually a 404 page for a file/folder in a repo
+	const urlToFileOnDefaultBranch = await (async () => {
+		const url = new GitHubURL(location.href);
+		const currentBranch = url.branch;
+		if (!currentBranch) {
+			return;
+		}
+
+		const defaultBranch = await getDefaultBranch();
+		if (currentBranch === defaultBranch) {
+			return;
+		}
+
+		url.assign({
+			branch: defaultBranch,
+		});
+		if (await is404(url.toString())) {
+			return;
+		}
+
+		return url.toString();
+	})();
+
+	if (urlToFileOnDefaultBranch) {
+		bar.after(
+			<p className="container mt-4 text-center">
+				View <a href={urlToFileOnDefaultBranch}>this file</a> on the default branch.
+			</p>,
+		);
+		return;
+	}
+
+	const change = await (async (): Promise<Record<string, any> | void> => {
+		const url = new GitHubURL(location.href);
+		const currentBranch = url.branch;
+		const {filePath} = url;
+		if (!currentBranch || !filePath) {
+			return;
+		}
+
+		const commits = await api.v3(`commits?path=${filePath}&sha=${currentBranch}&per_page=2`);
+		if (!commits[0]) {
+			return;
+		}
+
+		const commitInfo = await api.v3(`commits/${commits[0].sha as string}`);
+		const fileInfo = commitInfo.files.find((file: AnyObject) => [file.filename, file.previous_filename].includes(filePath));
+		if (!fileInfo) {
+			return;
+		}
+
+		const commitSha = commitInfo.sha.slice(0, 8);
+		const commitDate = commitInfo.commit.committer.date;
+		const linkToCommit = commitInfo.html_url;
+
+		url.assign({
+			route: 'commits',
+		});
+		const linkToCommitHistory = url.toString();
+
+		if (fileInfo.status === 'removed') {
+			return {
+				type: 'removed',
+				commitDetails: {
+					filePath,
+					commitSha, commitDate,
+					linkToCommit, linkToCommitHistory,
+					linkToLastVersion: fileInfo.blob_url,
+				},
+			};
+		}
+
+		if (fileInfo.status === 'renamed') {
+			url.assign({
+				route: 'blob',
+				branch: commitInfo.parents[0].sha,
+				filePath,
+			});
+
+			return {
+				type: 'renamed',
+				commitDetails: {
+					filePath: fileInfo.previous_filename, newFilePath: fileInfo.filename,
+					commitSha, commitDate,
+					linkToCommit, linkToCommitHistory,
+					linkToLastVersion: url.toString(), linkToNewVersion: fileInfo.blob_url,
+				},
+			};
+		}
+	})();
+
+	if (change) {
+		if (change.type === 'renamed') {
+			bar.after(
+				<p className="container mt-4 text-center">
+					<a href={change.commitDetails.linkToLastVersion}>This file</a> was renamed to <a href={change.commitDetails.linkToNewVersion}>{change.commitDetails.newFilePath}</a> (<a href={change.commitDetails.linkToCommit}><relative-time datetime={change.commitDetails.commitDate}/></a>) - view the file&apos;s <a href={change.commitDetails.linkToCommitHistory}>commit history</a>.
+				</p>,
+			);
+			return;
+		}
+
+		if (change.type === 'removed') {
+			bar.after(
+				<p className="container mt-4 text-center">
+					<a href={change.commitDetails.linkToLastVersion}>This file</a> was removed (<a href={change.commitDetails.linkToCommit}><relative-time datetime={change.commitDetails.commitDate}/></a>) - view the file&apos;s <a href={change.commitDetails.linkToCommitHistory}>commit history</a>.
+				</p>,
+			);
+		}
+	}
+}
+
+function initUsefulNotFoundPage(): void {
 	if (
-		parts.length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')
+		parseCurrentURL().length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')
 	) {
-		return false;
+		return;
 	}
 
-	// Create a bar to show the path of the file and which parts of it caused the 404
 	const bar = <h2 className="container mt-4 text-center"/>;
-	void showWhatIsMissingInPath(bar);
-
-	// Show more info about what happened to the file
-	void showAdditionalInformation(bar);
+	void showMissingPart(bar);
+	void showHelpfulLinks(bar);
 }
 
-async function initPRCommit(): Promise<void | false> {
+async function initPRCommitNotFoundPage(): Promise<void | false> {
 	const commitUrl = location.href.replace(/pull\/\d+\/commits/, 'commit');
 	if (await is404(commitUrl)) {
 		return false;
@@ -311,6 +193,7 @@ async function initPRCommit(): Promise<void | false> {
 	const blankSlateParagraph = await elementReady('.blankslate p', {
 		waitForChildren: false,
 	});
+
 	blankSlateParagraph!.after(
 		<p>
 			You can also try to <a href={commitUrl}>view the detached standalone commit</a>.
@@ -321,12 +204,16 @@ async function initPRCommit(): Promise<void | false> {
 void features.add(
 	__filebasename,
 	{
-		include: [pageDetect.is404],
-		init: onetime(init),
+		include: [
+			pageDetect.is404,
+		],
+		init: onetime(initUsefulNotFoundPage),
 	},
 	{
-		include: [pageDetect.isPRCommit404],
+		include: [
+			pageDetect.isPRCommit404,
+		],
 		awaitDomReady: false,
-		init: onetime(initPRCommit),
+		init: onetime(initPRCommitNotFoundPage),
 	},
 );

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -7,6 +7,7 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 import * as api from '../github-helpers/api';
 import GitHubURL from '../github-helpers/github-url';
+import {getCommitInfo} from './follow-file-renames';
 import getDefaultBranch from '../github-helpers/get-default-branch';
 import {getCleanPathname} from '../github-helpers';
 
@@ -62,9 +63,7 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 		return;
 	}
 
-	// API v4 doesn't support retrieving a list of changed files for a commit:
-	// https://github.community/t/graphql-api-get-list-of-files-related-to-commit/14047/2
-	const commitInfo = await api.v3(`commits/${commit.oid as string}`);
+	const commitInfo = await getCommitInfo(commit.oid as string);
 	for (const fileInfo of commitInfo.files) {
 		if ([fileInfo.filename, fileInfo.previous_filename].includes(filePath)) {
 			return {fileInfo, commitInfo};

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -39,7 +39,7 @@ function parseCurrentURL(): string[] {
 }
 
 async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
-	const {branch, filePath} = new GitHubURL(location.href);;
+	const {branch, filePath} = new GitHubURL(location.href);
 	if (!branch || !filePath) {
 		return;
 	}
@@ -69,7 +69,7 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 	const commitInfo = await api.v3(`commits/${commits[0].oid as string}`);
 	for (const fileInfo of commitInfo.files) {
 		if ([fileInfo.filename, fileInfo.previous_filename].includes(filePath)) {
-			return {fileInfo, commitInfo}
+			return {fileInfo, commitInfo};
 		}
 	}
 }
@@ -126,7 +126,9 @@ async function showHelpfulLinks(): Promise<void> {
 	}
 
 	const change = await getLatestChangeToFile();
-	if (!change) return;
+	if (!change) {
+		return;
+	}
 
 	const {fileInfo, commitInfo} = change;
 	const url = new GitHubURL(location.href);

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -179,11 +179,10 @@ async function showHelpfulLinks(bar: Element): Promise<void> {
 	}
 }
 
-function init(): void {
-	if (
-		parseCurrentURL().length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')
-	) {
-		return;
+function init(): false | void {
+	const parts = parseCurrentURL();
+	if (parts.length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')) {
+		return false;
 	}
 
 	const bar = <h2 className="container mt-4 text-center"/>;

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -52,7 +52,7 @@ async function addObjectStatusInfo(bar: Element): Promise<boolean> {
 	const filePath = parts.slice(4).join('/');
 
 	// Get the last 2 commits that include the file
-	const previousCommitsIncludingFile = await api.v3(`commits?path=${filePath}`);
+	const previousCommitsIncludingFile = await api.v3(`commits?path=${filePath}&per_page=2`);
 	// The latest commit will be the first object in the array
 	if (previousCommitsIncludingFile[0]) {
 		// Get a list of changes that happened in the repo with this commit

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -61,8 +61,7 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 			}
 		}
 	`);
-	const commits =
-		commitsResponseObject.repository.ref.target.history.nodes[0];
+	const commits = commitsResponseObject.repository.ref.target.history.nodes[0];
 	if (!commits[0]) {
 		return;
 	}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -77,25 +77,16 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 }
 
 async function getUrlToFileOnDefaultBranch(): Promise<string | void> {
-	const url = new GitHubURL(location.href);
-	const currentBranch = url.branch;
-	if (!currentBranch) {
+	const parsedUrl = new GitHubURL(location.href);
+	if (!parsedUrl.branch) {
 		return;
 	}
 
-	const defaultBranch = await getDefaultBranch();
-	if (currentBranch === defaultBranch) {
-		return;
+	parsedUrl.assign({branch: await getDefaultBranch()});
+	const urlOnDefault = parsedUrl.toString();
+	if (urlOnDefault !== location.href && !await is404(urlOnDefault)) {
+		return urlOnDefault;
 	}
-
-	url.assign({
-		branch: defaultBranch,
-	});
-	if (await is404(url.toString())) {
-		return;
-	}
-
-	return url.toString();
 }
 
 async function showMissingPart(): Promise<void> {

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -288,10 +288,8 @@ async function showWhatIsMissingInPath(bar: Element): Promise<void> {
 
 		// The last part of the URL is a known 404
 		if (i === parts.length - 1) {
-			// Put a strikthrough through it by default
 			bar.append(' / ', getStrikeThrough(part));
 		} else {
-			// Else just show a hyperlink to that part of the link
 			const pathname = '/' + parts.slice(0, i + 1).join('/');
 			bar.append(i ? ' / ' : '', <a href={pathname}>{part}</a>);
 		}
@@ -301,7 +299,6 @@ async function showWhatIsMissingInPath(bar: Element): Promise<void> {
 
 	// Check parts from right to left; skip the last part
 	for (let i = bar.children.length - 2; i >= 0; i--) {
-		// Strikethrough the parts that don't exist
 		void checkAnchor(bar.children[i] as HTMLAnchorElement);
 	}
 }
@@ -322,12 +319,7 @@ function init(): false | void {
 	const bar = <h2 className="container mt-4 text-center"/>;
 	void showWhatIsMissingInPath(bar);
 
-	// What happened to the file?
-	// Check if it:
-	// - exists on the default branch
-	// - exists in commit history for the current branch (got deleted/moved/renamed)
-	// - exists in commit history for the default branch (if the above 2 fail)
-	// If not, the file does not exist (wrong URL), we don't need to show any extra info
+	// Show more info about what happened to the file
 	void showAdditionalInformation(bar);
 }
 

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -58,7 +58,7 @@ async function getLatestChangeToFile(): Promise<Record<string, any> | void> {
 			}
 		}
 	`);
-	const [commit] = repository.object.history.nodes;
+	const commit = repository.object?.history.nodes[0];
 	if (!commit) {
 		return;
 	}

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -2,7 +2,6 @@ import React from 'dom-chef';
 import select from 'select-dom';
 import onetime from 'onetime';
 import elementReady from 'element-ready';
-import twas from 'twas';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
@@ -95,7 +94,7 @@ async function addObjectStatus(bar: Element): Promise<boolean> {
 		if (fileInfo.status === 'removed') {
 			bar.after(
 				<p className="container mt-4 text-center">
-					The file you are looking for was deleted/moved by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> {twas(commitTime.getTime())} with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
+					The file you are looking for was deleted/moved by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> <relative-time datetime={commitTime}/> with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
 					<br/>
 					You can view the last version of the file <a href={urlToLastBlob}>here</a>.
 				</p>,
@@ -108,7 +107,7 @@ async function addObjectStatus(bar: Element): Promise<boolean> {
 		if (fileInfo.status === 'renamed') {
 			bar.after(
 				<p className="container mt-4 text-center">
-					The file you are looking for was renamed by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> {twas(commitTime.getTime())} with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
+					The file you are looking for was renamed by <a href={urlToCommitAuthorProfile}>{commitAuthor}</a> <relative-time datetime={commitTime}/> with commit <a href={commitUrl}>{shortenedCommitSha}</a>.
 					<br/>
 					You can find the renamed file <a href={urlToLastBlob}>here</a>.
 				</p>,


### PR DESCRIPTION
## What this PR adds

This PR adds a couple of things mentioned in #4617:

- If the branch does not exist and the user is trying to view a file on that branch, tell the user that the branch was deleted.
	* In addition, check if the file exists on the default branch (existing behaviour)
- If the file was deleted/moved, show who did it, when and with which commit. Also link to the last version of the file before the commit took place.
- If the file was renamed, show who did it, when and with which commit. Also link to the renamed file.

All of the above information is added as the API calls resolve.

## Related issues

Closes #4617 (if merged).

## Example URLs

- Renamed file: https://github.com/gamemaker1/test/blob/main/rename-test/readme.txt
- Moved/deleted file: https://github.com/gorhill/uBlock/blob/master/assets/ublock/resources.txt
- Non existent branch (and file does not exist): https://github.com/gorhill/uBlock/blob/non-existent-branch/assets/ublock/resources.txt
- Non existent branch (but file exists on default branch): https://github.com/gorhill/uBlock/blob/non-existent-branch/assets/resources/scriptlets.js

## Screenshots

<details>
<summary>Renamed file</summary>

![refined-github-renamed-file](https://user-images.githubusercontent.com/34235681/128588617-5d4bede4-599a-4e4b-b102-0bd15c6c9e9d.png)

</details>

<details>
<summary>Moved/deleted file</summary>

![refined-github-moved-or-deleted-file](https://user-images.githubusercontent.com/34235681/128588699-1e886a0e-4784-406f-93c8-c60ec07ab067.png)

</details>

<details>
<summary>Non existent branch (and file does not exist)</summary>

![refined-github-non-existent-branch-and-no-file](https://user-images.githubusercontent.com/34235681/128588736-23842e75-85d6-43e0-a6ff-6db2e2d9bb79.png)

</details>

<details>
<summary>Non existent branch (but file exists on default branch)</summary>

![refined-github-non-existent-branch-and-file-on-default-branch](https://user-images.githubusercontent.com/34235681/128588754-d000609d-389f-45e8-b671-8ad957e6a7e4.png)

</details>

---

Please do let me know if there are any improvements that can be made to the changes made in this PR.

Thanks!
