### PR TITLE
Fix `quick-repo-deletion` not aborting on Firefox

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -58,7 +58,9 @@ async function verifyScopesWhileWaiting(abortController: AbortController): Promi
 async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boolean> {
 	// Sync AbortController and DOM state
 	const abortController = new AbortController();
-	buttonContainer.addEventListener('toggle', abortController.abort, {once: true});
+	buttonContainer.addEventListener('toggle', () => {
+		abortController.abort();
+	}, {once: true});
 	abortController.signal.addEventListener('abort', () => {
 		buttonContainer.open = false;
 	}, {once: true});

--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -56,12 +56,11 @@ async function verifyScopesWhileWaiting(abortController: AbortController): Promi
 }
 
 async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boolean> {
-	// Sync AbortController and DOM state
 	const abortController = new AbortController();
-	buttonContainer.addEventListener('toggle', () => {
+	// Add a global click listener to avoid potential future issues with z-index
+	document.addEventListener('click', event => {
+		event.preventDefault();
 		abortController.abort();
-	}, {once: true});
-	abortController.signal.addEventListener('abort', () => {
 		buttonContainer.open = false;
 	}, {once: true});
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4599 

## Test URLs
A fork you own or an empty repo with no stars

## Screenshot
https://user-images.githubusercontent.com/46634000/128853508-fdde8f28-4786-465f-ac45-6f71d6178b5e.mp4

Turns out the z-index was not the problem, rather it was the controller that wasn't aborted.\
**Tested on Firefox only**