### PR TITLE
`shorten-repo-url`: Avoid loss of images/formatting in links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"regex-join": "^1.0.0",
 				"select-dom": "^7.1.1",
 				"selector-observer": "^2.1.6",
-				"shorten-repo-url": "^2.1.0",
+				"shorten-repo-url": "^2.1.1",
 				"strip-indent": "^4.0.0",
 				"text-field-edit": "^3.1.0",
 				"tiny-version-compare": "^3.0.1",
@@ -9843,8 +9843,8 @@
 			"dev": true
 		},
 		"node_modules/shorten-repo-url": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.0.tgz",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.1.tgz",
 			"integrity": "sha512-uO9Y/ojqbWDYyJGVu4VqweXLo4SAvYrSQm3vmmLurcW6LEEwNwMzxHXedVyW/vPNRhYKHUMMVzAIfaip7mqJXQ==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.4"
@@ -19724,8 +19724,8 @@
 			"dev": true
 		},
 		"shorten-repo-url": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.0.tgz",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.1.tgz",
 			"integrity": "sha512-uO9Y/ojqbWDYyJGVu4VqweXLo4SAvYrSQm3vmmLurcW6LEEwNwMzxHXedVyW/vPNRhYKHUMMVzAIfaip7mqJXQ==",
 			"requires": {
 				"github-reserved-names": "^2.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9845,7 +9845,7 @@
 		"node_modules/shorten-repo-url": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.1.tgz",
-			"integrity": "sha512-uO9Y/ojqbWDYyJGVu4VqweXLo4SAvYrSQm3vmmLurcW6LEEwNwMzxHXedVyW/vPNRhYKHUMMVzAIfaip7mqJXQ==",
+			"integrity": "sha512-BoNW96Y24vhvHY4d9F4HwEScvB3UluKxK16mTu7HL4g3F7Q37xJkEdRNKhN42M5Elrkt2jXezgPWCKdAtR5Shg==",
 			"dependencies": {
 				"github-reserved-names": "^2.0.4"
 			},
@@ -19726,7 +19726,7 @@
 		"shorten-repo-url": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/shorten-repo-url/-/shorten-repo-url-2.1.1.tgz",
-			"integrity": "sha512-uO9Y/ojqbWDYyJGVu4VqweXLo4SAvYrSQm3vmmLurcW6LEEwNwMzxHXedVyW/vPNRhYKHUMMVzAIfaip7mqJXQ==",
+			"integrity": "sha512-BoNW96Y24vhvHY4d9F4HwEScvB3UluKxK16mTu7HL4g3F7Q37xJkEdRNKhN42M5Elrkt2jXezgPWCKdAtR5Shg==",
 			"requires": {
 				"github-reserved-names": "^2.0.4"
 			}

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"regex-join": "^1.0.0",
 		"select-dom": "^7.1.1",
 		"selector-observer": "^2.1.6",
-		"shorten-repo-url": "^2.1.0",
+		"shorten-repo-url": "^2.1.1",
 		"strip-indent": "^4.0.0",
 		"text-field-edit": "^3.1.0",
 		"tiny-version-compare": "^3.0.1",


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes [#4505](https://github.com/sindresorhus/refined-github/issues/4505)

PR that fixes bug in shorten-repo-url -[ Ignore links that contain tags/images ](https://github.com/fregante/shorten-repo-url/pull/30)

## Test URLs

https://github.com/saarahasad/egormanga 

## Screenshot

<img width="924" alt="Screenshot 2021-08-19 at 1 14 02 PM" src="https://user-images.githubusercontent.com/31311997/130028632-94781420-96c4-4678-a810-9a898bdc3090.png">
