### PR TITLE
Cleanup `profile-hotkey`

### DIFF
--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -12,7 +12,7 @@ function init(): void {
 
 void features.add(__filebasename, {
 	shortcuts: {
-		'g m': 'Go to Profile',
+		'g m': 'Go to my profile',
 	},
 	exclude: [ isOwnUserProfile ],
 	awaitDomReady: false,

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -1,6 +1,6 @@
 import React from 'dom-chef';
 import onetime from 'onetime';
-import {isEnterprise} from 'github-url-detection';
+import {isEnterprise, isOwnUserProfile} from 'github-url-detection';
 
 import features from '.';
 import {getUsername} from '../github-helpers';
@@ -14,6 +14,7 @@ void features.add(__filebasename, {
 	shortcuts: {
 		'g m': 'Go to Profile',
 	},
+	exclude: [ isOwnUserProfile ],
 	awaitDomReady: false,
 	init: onetime(init),
 });

--- a/source/features/profile-hotkey.tsx
+++ b/source/features/profile-hotkey.tsx
@@ -14,7 +14,7 @@ void features.add(__filebasename, {
 	shortcuts: {
 		'g m': 'Go to my profile',
 	},
-	exclude: [ isOwnUserProfile ],
+	exclude: [isOwnUserProfile],
 	awaitDomReady: false,
 	init: onetime(init),
 });


### PR DESCRIPTION
There is no use for the hotkey when the user is already on their own profile.
