### PR TITLE
Extend `navigate-pages-with-arrow-keys` to pull request commit pages

### DIFF
--- a/source/features/navigate-pages-with-arrow-keys.tsx
+++ b/source/features/navigate-pages-with-arrow-keys.tsx
@@ -7,6 +7,7 @@ const nextPageButtonSelectors = [
 	'.paginate-container > .BtnGroup > :last-child', // Commits
 	'.paginate-container > .pagination > :last-child', // Releases
 	'.js-notifications-list-paginator-buttons > :last-child', // Notifications
+	'.prh-commit > .BtnGroup > :last-child', // PR Commits
 ];
 
 const previousPageButtonSelectors = [
@@ -14,6 +15,7 @@ const previousPageButtonSelectors = [
 	'.paginate-container > .BtnGroup > :first-child', // Commits
 	'.paginate-container > .pagination > :first-child', // Releases
 	'.js-notifications-list-paginator-buttons > :first-child', // Notifications
+	'.prh-commit > .BtnGroup > :first-child', // PR Commits
 ];
 
 function init(): void {


### PR DESCRIPTION
When single commits are selected on pull requests, there is a pagination that enables moving between commits.

## Test URLs

- [`1e1e070` (#4677)](https://github.com/sindresorhus/refined-github/pull/4677/commits/1e1e0707ac58d1a40543a92651c3bbfd113481bf)
- [`d5a6052` (#4677)](https://github.com/sindresorhus/refined-github/pull/4677/commits/d5a6052eeef5f57f47e1bd3aec43caa3cebb1813)

## Screenshot

![image](https://user-images.githubusercontent.com/4771718/130210706-49e80493-0596-4833-80a3-385dc63a0cbd.png)
