### PR TITLE
Fix `reactions-avatars` conflict with new style

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ GitHub Enterprise is also supported: [How to enable it](https://fregante.github.
 	<tr>
 		<th width="50%">
 			<p><a title="reactions-avatars"></a> Adds reaction avatars showing <i>who</i> reacted to a comment
-			<p><img src="https://user-images.githubusercontent.com/1402241/34438653-f66535a4-ecda-11e7-9406-2e1258050cfa.png">
+			<p><img src="https://user-images.githubusercontent.com/1402241/130341871-6a0d69f4-8d0c-4882-a5ed-aac9b7613b0a.png">
 		<th width="50%">
 			<p><a title="wait-for-build"></a> Adds the option to wait for checks when merging a PR
 			<p><img src="https://user-images.githubusercontent.com/1402241/35192861-3f4a1bf6-fecc-11e7-8b9f-35ee019c6cdf.gif">

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -5,7 +5,8 @@
 	height: var(--size);
 	padding: 0;
 	margin: 0;
-	margin-right: calc(var(--size) / -3);
+	margin-left: calc(var(--size) * 0.3); /* Move away from count */
+	margin-right: calc(var(--size) * -0.5);
 	box-sizing: content-box;
 	align-self: center;
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,5 +1,4 @@
-
-:root:root .rgh-reactions-avatar {
+:root .rgh-reactions-avatar {
 	--size: 1.5em;
 	display: inline-block;
 	width: var(--size);
@@ -12,15 +11,15 @@
 	align-self: center;
 }
 
-:root:root .rgh-reactions-avatar:last-of-type {
+:root .rgh-reactions-avatar:last-of-type {
 	margin-right: 0 !important;
 }
 
-.review-comment .rgh-reactions-avatar {
+:root .review-comment .rgh-reactions-avatar {
 	font-size: 9px;
 }
 
-.discussion-post .rgh-reactions-avatar {
+:root .discussion-post .rgh-reactions-avatar {
 	margin-top: -1px;
 }
 

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,9 +1,8 @@
 :root .rgh-reactions-avatar {
-	--size: 1.5em;
+	--size: 1.3em;
 	display: inline-block;
 	width: var(--size);
 	height: var(--size);
-	font-size: 10px; /* Base sizer */
 	padding: 0;
 	margin: 0;
 	margin-right: calc(var(--size) / -3);
@@ -12,19 +11,10 @@
 }
 
 :root .rgh-reactions-avatar:last-of-type {
-	margin-right: 0 !important;
+	margin-right: -0.15em !important;
 }
 
-:root .review-comment .rgh-reactions-avatar {
-	font-size: 9px;
-}
-
-:root .discussion-post .rgh-reactions-avatar {
-	margin-top: -1px;
-}
-
-/* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
-.rgh-reactions-avatar img {
+:root .rgh-reactions-avatar img {
 	display: block;
 	margin: 0;
 	width: var(--size);

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,44 +1,33 @@
-.reaction-summary-item:not(.js-reaction-group-button) {
-	padding-right: 0.7em !important;
-	padding-left: 0.7em !important;
-}
 
-button.reaction-summary-item:not(.js-reaction-group-button) { /* `button` excludes the "Add reaction" icon */
-	border-top: 1px solid var(--github-border-color); /* Required when the second line is longer than the first line */
-	border-bottom: 1px solid var(--github-border-color); /* Required when the first line is longer than the second line */
-	margin-bottom: -1px; /* Makes up for `order-bottom` */
-}
-
-.comment-reactions .js-pick-reaction {
-	margin-top: -1px; /* Makes up for `.reaction-summary-item {border-top}` */
-}
-
-.reaction-summary-item:not(.js-reaction-group-button) span {
+:root:root .rgh-reactions-avatar {
+	--size: 1.5em;
 	display: inline-block;
-	width: 2em;
-	height: 2em;
-	margin-top: -0.3em;
-	margin-left: -0.5em;
-	vertical-align: middle;
-	background: var(--color-bg-canvas-inset, #efefef); /* Placeholder before the images load */
-	box-shadow: 0 0 0 2px var(--color-bg-info, #fff);
+	width: var(--size);
+	height: var(--size);
 	font-size: 10px; /* Base sizer */
+	padding: 0;
+	margin: 0;
+	margin-right: calc(var(--size) / -3);
+	box-sizing: content-box;
+	align-self: center;
 }
 
-.reaction-summary-item:not(.js-reaction-group-button) span:first-of-type {
-	margin-left: 0.5em;
+:root:root .rgh-reactions-avatar:last-of-type {
+	margin-right: 0 !important;
 }
 
-.review-comment .reaction-summary-item:not(.js-reaction-group-button) span {
+.review-comment .rgh-reactions-avatar {
 	font-size: 9px;
 }
 
-.discussion-post .reaction-summary-item:not(.js-reaction-group-button) span {
+.discussion-post .rgh-reactions-avatar {
 	margin-top: -1px;
 }
 
 /* This image will start at height:0 and will expand once loaded, covering the gray placeholder */
-.reaction-summary-item:not(.js-reaction-group-button) span img { /* `span` required for #3237 */
-	width: 100%;
-	background-color: var(--color-bg-info, #fff);
+.rgh-reactions-avatar img {
+	display: block;
+	margin: 0;
+	width: var(--size);
+	height: var(--size);
 }

--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -59,7 +59,7 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 
 	for (const {button, imageUrl} of flatParticipants) {
 		button.append(
-			<span className="rounded-1 avatar-user">
+			<span className="rounded-1 avatar-user avatar rgh-reactions-avatar">
 				<img src={imageUrl} className="avatar-user rounded-1"/>
 			</span>,
 		);


### PR DESCRIPTION
- Fix for #4674 

## Test URLs

Regular comment: https://github.com/sindresorhus/refined-github/issues/4674
Review: https://github.com/sindresorhus/refined-github/pull/4667#pullrequestreview-730139417
Review comments: https://github.com/sindresorhus/refined-github/pull/4667#discussion_r689119705

## Native


<img width="778" alt="Screen Shot 10" src="https://user-images.githubusercontent.com/1402241/130324676-c7cde102-3e5c-4319-908e-3980d50d8bdd.png">

## Refined GitHub before this PR

<img width="1206" alt="Screen Shot 11" src="https://user-images.githubusercontent.com/1402241/130324875-3680edfb-b51d-4d01-a3bc-492bc8c960f5.png">


## Refined GitHub in this PR

<img width="1326" alt="Screen Shot 9" src="https://user-images.githubusercontent.com/1402241/130324612-071757b4-cdc4-4059-aeea-1b7c2b964a6d.png">

## On white

<img width="1292" alt="Screen Shot 6" src="https://user-images.githubusercontent.com/1402241/130324616-92b5900e-f037-4f1b-8881-0483e9628a14.png">


## While loading

<img width="1285" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/130324625-23b46603-b134-4841-9d20-3783599fe2c8.png">
