### PR TITLE
Exclude directories from follow-file-renames

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -73,11 +73,15 @@ async function linkify(button: HTMLButtonElement, filePath: string): Promise<voi
 async function init(): Promise<void | false> {
 	const disabledPagination = select.all('.paginate-container button[disabled]');
 	const url = new GitHubURL(location.href);
-	const blobURL = `${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`;
-	const isFile = await fetch(blobURL, {method: 'HEAD'})
-		.then(response => new GitHubURL(response.url).route === 'blob' ? true : false);
 
-	if (disabledPagination.length === 0 || !url.filePath || !isFile ) {
+	const isFile = await fetch(
+		// eslint-disable-next-line restrict-template-expressions // https://github.com/Microsoft/TypeScript/issues/30239
+		`${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`,
+		{method: 'HEAD'},
+	)
+		.then(response => !!(new GitHubURL(response.url).route === 'blob'));
+
+	if (disabledPagination.length === 0 || !url.filePath || !isFile) {
 		return false;
 	}
 

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -76,7 +76,7 @@ async function init(): Promise<void | false> {
 
 	const isFile = await fetch(
 		// https://github.com/Microsoft/TypeScript/issues/30239
-		// eslint-disable-next-line restrict-template-expressions
+		// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 		`${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`,
 		{method: 'HEAD'},
 	)

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -75,11 +75,12 @@ async function init(): Promise<void | false> {
 	const url = new GitHubURL(location.href);
 
 	const isFile = await fetch(
-		// eslint-disable-next-line restrict-template-expressions // https://github.com/Microsoft/TypeScript/issues/30239
+		// https://github.com/Microsoft/TypeScript/issues/30239
+		// eslint-disable-next-line restrict-template-expressions
 		`${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`,
 		{method: 'HEAD'},
 	)
-		.then(response => !!(new GitHubURL(response.url).route === 'blob'));
+		.then(response => Boolean(new GitHubURL(response.url).route === 'blob'));
 
 	if (disabledPagination.length === 0 || !url.filePath || !isFile) {
 		return false;

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -73,18 +73,9 @@ async function linkify(button: HTMLButtonElement, filePath: string): Promise<voi
 async function init(): Promise<void | false> {
 	const disabledPagination = select.all('.paginate-container button[disabled]');
 	const url = new GitHubURL(location.href);
-
-	const isFile = await fetch(
-		`${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`,
-		{method: 'HEAD'}
-	)
-	.then(response => {
-		if (new GitHubURL(response.url).route === 'blob') {
-			return true;
-		} else {
-			return false;
-		}
-	});
+	const blobURL = `${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`;
+	const isFile = await fetch(blobURL, {method: 'HEAD'})
+		.then(response => new GitHubURL(response.url).route === 'blob' ? true : false);
 
 	if (disabledPagination.length === 0 || !url.filePath || !isFile ) {
 		return false;

--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -70,10 +70,23 @@ async function linkify(button: HTMLButtonElement, filePath: string): Promise<voi
 	);
 }
 
-function init(): void | false {
+async function init(): Promise<void | false> {
 	const disabledPagination = select.all('.paginate-container button[disabled]');
 	const url = new GitHubURL(location.href);
-	if (disabledPagination.length === 0 || !url.filePath) {
+
+	const isFile = await fetch(
+		`${location.protocol}//${location.hostname}${select('a[aria-label="View at this point in the history"]')!.getAttribute('href')}`,
+		{method: 'HEAD'}
+	)
+	.then(response => {
+		if (new GitHubURL(response.url).route === 'blob') {
+			return true;
+		} else {
+			return false;
+		}
+	});
+
+	if (disabledPagination.length === 0 || !url.filePath || !isFile ) {
 		return false;
 	}
 


### PR DESCRIPTION
resolves #4683

We cannot simply lookup the blob URL from the DOM because the `route` field for trees would still be 'blob' and we would have to make a `fetch` request and look for a redirect to determine whether the URL is a 'tree' or a 'blob'.

There is another 'tree' URL in the DOM that points to 'Browse the repository at the point in history' which is also unusable.

PS : I am sorry I took too long with this.

## Test URLs

from #4683

- file commit page : https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/doc/_plugins/site.rb
- directory commit page : https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/doc/_plugins/

## Screenshot

https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/doc/_plugins/site.rb : 
![image](https://user-images.githubusercontent.com/4771718/130501133-99d35067-1c67-431e-b47c-845805f49a21.png)

https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/doc/_plugins/ : 
![image](https://user-images.githubusercontent.com/4771718/130501255-4959abdb-4ae2-4179-ae7c-684b6ca96485.png)
