### PR TITLE
Fix extra border in `toggle-files-button`

### DIFF
--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -19,4 +19,5 @@
 
 .rgh-files-hidden .Box-header {
 	border-radius: 6px;
+	border-bottom: 0;
 }

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -19,5 +19,5 @@
 
 .rgh-files-hidden .Box-header {
 	border-radius: 6px;
-	border-bottom: 0;
+	border-bottom: none;
 }

--- a/source/features/toggle-files-button.css
+++ b/source/features/toggle-files-button.css
@@ -13,10 +13,6 @@
 	display: none;
 }
 
-.rgh-files-hidden .file-wrap {
-	border: none;
-}
-
 .rgh-files-hidden .Box-header {
 	border-radius: 6px;
 	border-bottom: none;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -5,11 +5,6 @@
 	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 
-/* Fade out the file icons */
-.file-wrap .files .octicon {
-	opacity: 60%;
-}
-
 /* Make tab indented code more readable on GitHub and Gist */
 * {
 	-moz-tab-size: 4 !important;


### PR DESCRIPTION

<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4719

I also took the chance to remove the seemingly no longer existing `.file-wrap` which is introduced in 07ecc75e81cbc466d6bc98a12505ae58fec68d59 (5 years ago) and #1017 (3 years ago).

## Test URLs

https://github.com/sindresorhus/refined-github

## Screenshot

Before:

![](https://user-images.githubusercontent.com/44045911/130956460-a3178996-2876-4520-bfd1-2bf2d19463bf.png)

After:

![image](https://user-images.githubusercontent.com/44045911/130957479-c83f899e-a75c-4f44-8ef5-26b37b5f74fd.png)
