### PR TITLE
Meta: Catch orphaned CSS files on CI

### DIFF
--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -22,6 +22,10 @@ function findError(filename: string): string | void {
 				return `ERR: \`${filename}\` should be imported by \`${correspondingTsxFile}\``;
 			}
 
+			if (entryPointSource.includes(`import './features/${filename}';`)) {
+				return `ERR: \`${filename}\` should only be imported by \`${correspondingTsxFile}\`, not by \`${entryPoint}\``;
+			}
+
 			return;
 		}
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -26,7 +26,7 @@ function findError(filename: string): string | void {
 		}
 
 		if (!entryPointSource.includes(`import './features/${filename}';`)) {
-			return `ERR: \`${filename}\` should be imported by \`${entryPoint}\``;
+			return `ERR: \`${filename}\` should be imported by \`${entryPoint}\` or removed if it is not needed`;
 		}
 
 		return;

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -48,6 +48,7 @@ function findError(filename: string): string | void {
 		return `ERR: ${featureId} should be imported by \`${entryPoint}\``;
 	}
 
+	// The previous checks apply to RGH features, but the next ones don't
 	if (filename.startsWith('rgh-')) {
 		return;
 	}

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -16,20 +16,21 @@ function findError(filename: string): string | void {
 	}
 
 	if (filename.endsWith('.css')) {
+		const isImportedByEntrypoint = entryPointSource.includes(`import './features/${filename}';`);
 		const correspondingTsxFile = `source/features/${filename.replace(/.css$/, '.tsx')}`;
 		if (existsSync(correspondingTsxFile)) {
 			if (!readFileSync(correspondingTsxFile).includes(`import './${filename}';`)) {
 				return `ERR: \`${filename}\` should be imported by \`${correspondingTsxFile}\``;
 			}
 
-			if (entryPointSource.includes(`import './features/${filename}';`)) {
+			if (isImportedByEntrypoint) {
 				return `ERR: \`${filename}\` should only be imported by \`${correspondingTsxFile}\`, not by \`${entryPoint}\``;
 			}
 
 			return;
 		}
 
-		if (!entryPointSource.includes(`import './features/${filename}';`)) {
+		if (!isImportedByEntrypoint) {
 			return `ERR: \`${filename}\` should be imported by \`${entryPoint}\` or removed if it is not needed`;
 		}
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -10,38 +10,38 @@ const entryPointSource = readFileSync(entryPoint);
 const importedFeatures = getFeatures();
 const featuresInReadme = getFeaturesMeta();
 
-function findError(fileName: string): string | void {
-	if (fileName === 'index.tsx') {
+function findError(filename: string): string | void {
+	if (filename === 'index.tsx') {
 		return;
 	}
 
-	if (fileName.endsWith('.css')) {
-		const correspondingTsxFile = `source/features/${fileName.replace(/.css$/, '.tsx')}`;
+	if (filename.endsWith('.css')) {
+		const correspondingTsxFile = `source/features/${filename.replace(/.css$/, '.tsx')}`;
 		if (existsSync(correspondingTsxFile)) {
-			if (!readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
-				return `ERR: \`${fileName}\` should be imported by \`${correspondingTsxFile}\``;
+			if (!readFileSync(correspondingTsxFile).includes(`import './${filename}';`)) {
+				return `ERR: \`${filename}\` should be imported by \`${correspondingTsxFile}\``;
 			}
 
 			return;
 		}
 
-		if (!entryPointSource.includes(`import './features/${fileName}';`)) {
-			return `ERR: \`${fileName}\` should be imported by \`${entryPoint}\``;
+		if (!entryPointSource.includes(`import './features/${filename}';`)) {
+			return `ERR: \`${filename}\` should be imported by \`${entryPoint}\``;
 		}
 
 		return;
 	}
 
-	if (!fileName.endsWith('.tsx')) {
-		return `ERR: The \`/source/features\` folder should only contain .css and .tsx files. File \`${fileName}\` violates that rule`;
+	if (!filename.endsWith('.tsx')) {
+		return `ERR: The \`/source/features\` folder should only contain .css and .tsx files. File \`${filename}\` violates that rule`;
 	}
 
-	const featureId = fileName.replace('.tsx', '');
+	const featureId = filename.replace('.tsx', '');
 	if (!importedFeatures.includes(featureId as FeatureID)) {
 		return `ERR: ${featureId} should be imported by \`${entryPoint}\``;
 	}
 
-	if (fileName.startsWith('rgh-')) {
+	if (filename.startsWith('rgh-')) {
 		return;
 	}
 

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -10,9 +10,9 @@ const entryPointSource = readFileSync(entryPoint);
 const importedFeatures = getFeatures();
 const featuresInReadme = getFeaturesMeta();
 
-function findError(fileName): string | void {
+function findError(fileName: string): string | void {
 	if (fileName === 'index.tsx') {
-		continue;
+		return;
 	}
 
 	if (fileName.endsWith('.css')) {
@@ -20,7 +20,7 @@ function findError(fileName): string | void {
 		if (existsSync(correspondingTsxFile) && !readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
 			return `ERR: \`${fileName}\` should be imported by \`${correspondingTsxFile}\``;
 		}
-		
+
 		if (!entryPointSource.includes(`import './features/${fileName}';`)) {
 			return `ERR: \`${fileName}\` should be imported by \`${entryPoint}\``;
 		}

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -17,8 +17,12 @@ function findError(fileName: string): string | void {
 
 	if (fileName.endsWith('.css')) {
 		const correspondingTsxFile = `source/features/${fileName.replace(/.css$/, '.tsx')}`;
-		if (existsSync(correspondingTsxFile) && !readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
-			return `ERR: \`${fileName}\` should be imported by \`${correspondingTsxFile}\``;
+		if (existsSync(correspondingTsxFile)) {
+			if (!readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
+				return `ERR: \`${fileName}\` should be imported by \`${correspondingTsxFile}\``;
+			}
+
+			return;
 		}
 
 		if (!entryPointSource.includes(`import './features/${fileName}';`)) {

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -10,31 +10,33 @@ const entryPointSource = readFileSync(entryPoint);
 const importedFeatures = getFeatures();
 const featuresInReadme = getFeaturesMeta();
 
+function findCssFileError(filename: string): string | void {
+	const isImportedByEntrypoint = entryPointSource.includes(`import './features/${filename}';`);
+	const correspondingTsxFile = `source/features/${filename.replace(/.css$/, '.tsx')}`;
+	if (existsSync(correspondingTsxFile)) {
+		if (!readFileSync(correspondingTsxFile).includes(`import './${filename}';`)) {
+			return `ERR: \`${filename}\` should be imported by \`${correspondingTsxFile}\``;
+		}
+
+		if (isImportedByEntrypoint) {
+			return `ERR: \`${filename}\` should only be imported by \`${correspondingTsxFile}\`, not by \`${entryPoint}\``;
+		}
+
+		return;
+	}
+
+	if (!isImportedByEntrypoint) {
+		return `ERR: \`${filename}\` should be imported by \`${entryPoint}\` or removed if it is not needed`;
+	}
+}
+
 function findError(filename: string): string | void {
 	if (filename === 'index.tsx') {
 		return;
 	}
 
 	if (filename.endsWith('.css')) {
-		const isImportedByEntrypoint = entryPointSource.includes(`import './features/${filename}';`);
-		const correspondingTsxFile = `source/features/${filename.replace(/.css$/, '.tsx')}`;
-		if (existsSync(correspondingTsxFile)) {
-			if (!readFileSync(correspondingTsxFile).includes(`import './${filename}';`)) {
-				return `ERR: \`${filename}\` should be imported by \`${correspondingTsxFile}\``;
-			}
-
-			if (isImportedByEntrypoint) {
-				return `ERR: \`${filename}\` should only be imported by \`${correspondingTsxFile}\`, not by \`${entryPoint}\``;
-			}
-
-			return;
-		}
-
-		if (!isImportedByEntrypoint) {
-			return `ERR: \`${filename}\` should be imported by \`${entryPoint}\` or removed if it is not needed`;
-		}
-
-		return;
+		return findCssFileError(filename);
 	}
 
 	if (!filename.endsWith('.tsx')) {

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -10,64 +10,45 @@ const entryPointSource = readFileSync(entryPoint);
 const importedFeatures = getFeatures();
 const featuresInReadme = getFeaturesMeta();
 
-const errors: string[] = [];
-
-function checkIfCssFileIsImported(fileName: string): string | null {
-	if (!entryPointSource.includes(`import './features/${fileName}';`)) {
-		const correspondingTsxFile = `source/features/${fileName.replace(/.css$/, '.tsx')}`;
-
-		if (existsSync(correspondingTsxFile)) {
-			if (!readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
-				return `ERR: The file \`${fileName}\` is not imported \`${correspondingTsxFile}\``;
-			}
-		} else {
-			return `ERR: The file \`${fileName}\` is not imported in \`${entryPoint}\``;
-		}
-	}
-
-	return null;
-}
-
-for (const fileName of featuresDirContents) {
+function findError(fileName): string | void {
 	if (fileName === 'index.tsx') {
 		continue;
 	}
 
 	if (fileName.endsWith('.css')) {
-		const error = checkIfCssFileIsImported(fileName);
-
-		if (error) {
-			errors.push(error);
+		const correspondingTsxFile = `source/features/${fileName.replace(/.css$/, '.tsx')}`;
+		if (existsSync(correspondingTsxFile) && !readFileSync(correspondingTsxFile).includes(`import './${fileName}';`)) {
+			return `ERR: \`${fileName}\` should be imported by \`${correspondingTsxFile}\``;
 		}
-
-		continue;
+		
+		if (!entryPointSource.includes(`import './features/${fileName}';`)) {
+			return `ERR: \`${fileName}\` should be imported by \`${entryPoint}\``;
+		}
 	}
 
 	if (!fileName.endsWith('.tsx')) {
-		errors.push(`ERR: The \`/source/features\` folder should only contain .css and .tsx files. File \`${fileName}\` violates that rule`);
-		continue;
+		return `ERR: The \`/source/features\` folder should only contain .css and .tsx files. File \`${fileName}\` violates that rule`;
 	}
 
 	const featureId = fileName.replace('.tsx', '');
 	if (!importedFeatures.includes(featureId as FeatureID)) {
-		errors.push(`ERR: ${featureId} should be imported by \`${entryPoint}\``);
+		return `ERR: ${featureId} should be imported by \`${entryPoint}\``;
 	}
 
 	if (fileName.startsWith('rgh-')) {
-		continue;
+		return;
 	}
 
 	const featureMeta = featuresInReadme.find(feature => feature.id === featureId);
 	if (!featureMeta) {
-		errors.push(`ERR: The feature ${featureId} should be described in the readme`);
-		continue;
+		return `ERR: The feature ${featureId} should be described in the readme`;
 	}
 
 	if (featureMeta.description.length < 20) {
-		errors.push(`ERR: ${featureId} should be described better in the readme (at least 20 characters)`);
+		return `ERR: ${featureId} should be described better in the readme (at least 20 characters)`;
 	}
 }
 
+const errors = featuresDirContents.map(name => findError(name)).filter(Boolean);
 console.error(errors.join('\n'));
-
 process.exitCode = errors.length;

--- a/build/verify-features.ts
+++ b/build/verify-features.ts
@@ -24,6 +24,8 @@ function findError(fileName): string | void {
 		if (!entryPointSource.includes(`import './features/${fileName}';`)) {
 			return `ERR: \`${fileName}\` should be imported by \`${entryPoint}\``;
 		}
+
+		return;
 	}
 
 	if (!fileName.endsWith('.tsx')) {

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -16,6 +16,7 @@ import './features/sticky-conversation-list-toolbar.css';
 import './features/always-show-branch-delete-buttons.css';
 import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
+import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
 import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';


### PR DESCRIPTION
This will make CI fail if we remove a feature but forget to remove its CSS file.

Note: There are currently two orphaned CSS files which are being removed in #4715, but https://github.com/sindresorhus/refined-github/pull/4715#discussion_r696328315 suggested extracting this to a separate PR to demonstrate the script failing when we expect it to.

[Example failure](https://github.com/sindresorhus/refined-github/runs/3437113085?check_suite_focus=true):

![image](https://user-images.githubusercontent.com/1863540/131034285-17628994-58b9-4355-a60b-ba621a53c215.png)