### PR TITLE
Restore `emphasize-draft-pr-label` feature

### DIFF
--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,7 +1,11 @@
-.js-issue-row [aria-label='Open draft pull request'] svg {
-	stroke: var(--color-text-secondary, #586069);
-	stroke-width: 1.2px;
-	color: var(--color-bg-canvas, #fff) !important;
-	paint-order: stroke;
-	overflow: visible !important;
+// Details in https://github.com/sindresorhus/refined-github/pull/4728/files
+
+@media (-webkit-min-device-pixel-ratio: 2) {
+	.js-issue-row [aria-label='Open draft pull request'] svg {
+		stroke: var(--color-text-secondary, #586069);
+		stroke-width: 1.2px;
+		color: var(--color-bg-canvas, #fff) !important;
+		paint-order: stroke;
+		overflow: visible !important;
+	}
 }

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,6 +1,6 @@
 /* Details in https://github.com/sindresorhus/refined-github/pull/4728/files */
 
-/* stylelint-disable-next-line media-feature-name-no-vendor-prefix -- It's the only cross-browser media query */ 
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix -- It's the only cross-browser media query */
 @media (-webkit-min-device-pixel-ratio: 2) {
 	.js-issue-row [aria-label='Open draft pull request'] svg {
 		stroke: var(--color-text-secondary, #586069);

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,5 +1,6 @@
 /* Details in https://github.com/sindresorhus/refined-github/pull/4728/files */
 
+/* stylelint-disable-next-line media-feature-name-no-vendor-prefix -- It's the only cross-browser media query */ 
 @media (-webkit-min-device-pixel-ratio: 2) {
 	.js-issue-row [aria-label='Open draft pull request'] svg {
 		stroke: var(--color-text-secondary, #586069);

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,4 +1,4 @@
-// Details in https://github.com/sindresorhus/refined-github/pull/4728/files
+/* Details in https://github.com/sindresorhus/refined-github/pull/4728/files */
 
 @media (-webkit-min-device-pixel-ratio: 2) {
 	.js-issue-row [aria-label='Open draft pull request'] svg {

--- a/source/features/emphasize-draft-pr-label.css
+++ b/source/features/emphasize-draft-pr-label.css
@@ -1,0 +1,7 @@
+.js-issue-row [aria-label='Open draft pull request'] svg {
+	stroke: var(--color-text-secondary, #586069);
+	stroke-width: 1.2px;
+	color: var(--color-bg-canvas, #fff) !important;
+	paint-order: stroke;
+	overflow: visible !important;
+}

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -16,6 +16,7 @@ import './features/sticky-conversation-list-toolbar.css';
 import './features/always-show-branch-delete-buttons.css';
 import './features/easier-pr-sha-copy.css';
 import './features/repo-stats-spacing.css';
+import './features/emphasize-draft-pr-label.css';
 import './features/clean-notifications.css';
 import './features/fix-first-tab-length.css';
 import './features/align-repository-header.css';


### PR DESCRIPTION
- Reverts sindresorhus/refined-github#4450

On second thought… the contrast between the two is still too low.

<img width="144" alt="Screen Shot 4" src="https://user-images.githubusercontent.com/1402241/131117798-0ac14356-ddfd-4fbd-b30b-63908689ca8b.png"> <img width="89" alt="Screen Shot 5"  align="right" src="https://user-images.githubusercontent.com/1402241/131125020-178dc6c8-adc0-4312-b8a2-ad937049d48a.png"><img width="148" alt="Screen Shot" align="right" src="https://user-images.githubusercontent.com/1402241/131117969-0c72059e-3266-4ce6-b165-0c1842518454.png">