### PR TITLE
Fix `rgh-feature-descriptions` feature

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -94,7 +94,7 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.Box-header--blue.Details, include-fragment.commit-loader'))!.parentElement!;
+	const commitInfoBox = (await elementReady('.hx_commit-tease'))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -94,7 +94,7 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.hx_commit-tease'))!.parentElement!;
+	const commitInfoBox = (await elementReady('.hx_commit-tease, .Box-header.Details, .Box-header--blue.Details, include-fragment.commit-loader'))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -94,7 +94,7 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.hx_commit-tease, .Box-header.Details, .Box-header--blue.Details, include-fragment.commit-loader'))!.parentElement!;
+	const commitInfoBox = (await elementReady('.hx_commit-tease, include-fragment.commit-loader'))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 


### PR DESCRIPTION
## Related issues

Closes #4697 if merged.

## What this PR does

Changes the CSS selector used to add the feature description box on RGH feature pages from `.Box-header--blue.Details, include-fragment.commit-loader` to `.hx_commit-tease`

## Test URLs

https://github.com/sindresorhus/refined-github/blob/main/source/features/reactions-avatars.tsx
https://github.com/sindresorhus/refined-github/blob/main/source/features/clean-conversation-headers.tsx