### PR TITLE
Link to exact file in PR in `list-prs-for-file` (Chrome only)

### DIFF
--- a/source/features/list-prs-for-file.tsx
+++ b/source/features/list-prs-for-file.tsx
@@ -10,8 +10,10 @@ import getDefaultBranch from '../github-helpers/get-default-branch';
 import addAfterBranchSelector from '../helpers/add-after-branch-selector';
 import {buildRepoURL, getRepo} from '../github-helpers';
 
+let path: string;
+
 function getPRUrl(prNumber: number): string {
-	return buildRepoURL('pull', prNumber, 'files');
+	return buildRepoURL('pull', prNumber, 'files') + `#:~:text=${path}`;
 }
 
 function getDropdown(prs: number[]): HTMLElement {
@@ -102,7 +104,7 @@ const getPrsByFile = cache.function(async (): Promise<Record<string, number[]>> 
 
 async function init(): Promise<void> {
 	// `clipboard-copy` on blob page, `#blob-edit-path` on edit page
-	const path = (await elementReady('clipboard-copy, #blob-edit-path'))!.getAttribute('value')!;
+	path = (await elementReady('clipboard-copy, #blob-edit-path'))!.getAttribute('value')!;
 	let {[path]: prs} = await getPrsByFile();
 
 	if (!prs) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Via [Scroll To Text Fragment](https://github.com/WICG/scroll-to-text-fragment) we can direct the browser to the corresponding file in `list-prs-for-file`'s links, without fetching the page to get a hash.

This is not 100% accurate but should be fine most of the type, and it does nothing on a unsupported browser.

## Test URLs

https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix

## Screenshot


https://user-images.githubusercontent.com/44045911/131881041-a93830e7-bd3b-4b22-86a6-baa3cd8c41a8.mov

