### PR TITLE
modify page navigation hotkeys

### DIFF
--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -1,5 +1,5 @@
 import select from 'select-dom';
-import {isGlobalConversationList,isPRCommit} from 'github-url-detection';
+import {isRepoConversationList,isPRCommit} from 'github-url-detection';
 
 import features from '.';
 
@@ -20,14 +20,26 @@ const previousPageButtonSelectors = [
 ];
 
 function init(): void {
-	const createNextPageButton = select(nextPageButtonSelectors);
-	if (createNextPageButton) {
-		createNextPageButton.dataset.hotkey = 'n';
-	}
+	if (isRepoConversationList()) {
+		const createPreviousPageButton = select('a.previous_page');
+		if (createPreviousPageButton) {
+			createPreviousPageButton.dataset.hotkey = 'ArrowLeft';
+		}
 
-	const createPreviousPageButton = select(previousPageButtonSelectors);
-	if (createPreviousPageButton) {
-		createPreviousPageButton.dataset.hotkey = 'p';
+		const createNextPageButton = select('a.next_page');
+		if (createNextPageButton) {
+			createNextPageButton.dataset.hotkey = 'ArrowRight';
+		}
+	} else {
+		const createNextPageButton = select(nextPageButtonSelectors);
+		if (createNextPageButton) {
+			createNextPageButton.dataset.hotkey = 'n';
+		}
+
+		const createPreviousPageButton = select(previousPageButtonSelectors);
+		if (createPreviousPageButton) {
+			createPreviousPageButton.dataset.hotkey = 'p';
+		}
 	}
 }
 
@@ -41,8 +53,6 @@ void features.add(__filebasename, {
 		() => select.exists('.paginate-container'),
 	],
 	exclude: [
-		// exclude on issue and pull request lists because the `p` hotkey conflicts with the Projects filter
-		isGlobalConversationList,
 		// exclude on pull request commit pages because GitHub already supports it natively
 		isPRCommit,
 	],

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -1,5 +1,5 @@
 import select from 'select-dom';
-import {isPRCommit} from 'github-url-detection';
+import {isGlobalConversationList,isPRCommit} from 'github-url-detection';
 
 import features from '.';
 
@@ -37,6 +37,8 @@ void features.add(__filebasename, {
 		'p': 'Go to the previous page',
 	},
 	exclude: [
+		// exclude on issue and pull request lists because the `p` hotkey conflicts with the Projects filter
+		isGlobalConversationList,
 		// exclude on pull request commit pages because GitHub already supports it natively
 		isPRCommit,
 	],

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -1,9 +1,10 @@
 import select from 'select-dom';
+import {isPRCommit} from 'github-url-detection';
 
 import features from '.';
 
 const nextPageButtonSelectors = [
-	'a.next_page', // Issue/PR list, Search
+	'a.next_page', // Search
 	'.paginate-container > .BtnGroup > :last-child', // Commits
 	'.paginate-container > .pagination > :last-child', // Releases
 	'.js-notifications-list-paginator-buttons > :last-child', // Notifications
@@ -11,7 +12,7 @@ const nextPageButtonSelectors = [
 ];
 
 const previousPageButtonSelectors = [
-	'a.previous_page', // Issue/PR list, Search
+	'a.previous_page', // Search
 	'.paginate-container > .BtnGroup > :first-child', // Commits
 	'.paginate-container > .pagination > :first-child', // Releases
 	'.js-notifications-list-paginator-buttons > :first-child', // Notifications
@@ -35,5 +36,9 @@ void features.add(__filebasename, {
 		'n': 'Go to the next page',
 		'p': 'Go to the previous page',
 	},
+	exclude: [
+		// exclude on pull request commit pages because GitHub already supports it natively
+		isPRCommit,
+	],
 	init,
 });

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -21,19 +21,19 @@ const previousPageButtonSelectors = [
 function init(): void {
 	const createNextPageButton = select(nextPageButtonSelectors);
 	if (createNextPageButton) {
-		createNextPageButton.dataset.hotkey = 'ArrowRight';
+		createNextPageButton.dataset.hotkey = 'n';
 	}
 
 	const createPreviousPageButton = select(previousPageButtonSelectors);
 	if (createPreviousPageButton) {
-		createPreviousPageButton.dataset.hotkey = 'ArrowLeft';
+		createPreviousPageButton.dataset.hotkey = 'p';
 	}
 }
 
 void features.add(__filebasename, {
 	shortcuts: {
-		'→': 'Go to the next page',
-		'←': 'Go to the previous page',
+		'n': 'Go to the next page',
+		'p': 'Go to the previous page',
 	},
 	init,
 });

--- a/source/features/pagination-hotkey.tsx
+++ b/source/features/pagination-hotkey.tsx
@@ -36,6 +36,10 @@ void features.add(__filebasename, {
 		'n': 'Go to the next page',
 		'p': 'Go to the previous page',
 	},
+	include: [
+		// activate only on pages with pagination
+		() => select.exists('.paginate-container'),
+	],
 	exclude: [
 		// exclude on issue and pull request lists because the `p` hotkey conflicts with the Projects filter
 		isGlobalConversationList,

--- a/source/options-storage.ts
+++ b/source/options-storage.ts
@@ -27,6 +27,7 @@ const migrations = [
 	featureWasRenamed('more-dropdown', 'clean-repo-tabs'), // Merged in July
 	featureWasRenamed('remove-diff-signs', 'hide-diff-signs'), // Merged in August
 	featureWasRenamed('remove-label-faster', 'hide-label-faster'), // Merged in August
+	featureWasRenamed('navigate-pages-with-arrow-keys', 'pagination-hotkey'), // Merged in August
 
 	// Removed features will be automatically removed from the options as well
 	OptionsSyncPerDomain.migrations.removeUnused,

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -62,7 +62,7 @@ import './features/download-folder-button';
 import './features/linkify-branch-references';
 import './features/open-all-conversations';
 import './features/hide-useless-comments';
-import './features/navigate-pages-with-arrow-keys';
+import './features/pagination-hotkey';
 import './features/conversation-links-on-repo-lists';
 import './features/global-conversation-list-filters';
 import './features/conversation-filters';


### PR DESCRIPTION
fixes https://github.com/sindresorhus/refined-github/issues/4742

one thing that still needs fixing is :
> [it does not work] when `follow-file-renames` [~was~]is in effect because it is loaded after `navigate-pages-with-arrow-keys`.

I tried re-ordering the lines in `source/refined-github.ts` but it did not seem to have any effect. Maybe I am missing something.

## Test URLs

- Issue list : https://github.com/sindresorhus/refined-github/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
- Pull request list : https://github.com/sindresorhus/refined-github/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed
- Search page : https://github.com/sindresorhus/refined-github/search?q=navigat
- Commits Page :
  - https://github.com/sindresorhus/refined-github/commits/main/source/features/navigate-pages-with-arrow-keys.tsx
  - https://github.com/sindresorhus/refined-github/commits/main
- Releases Page : https://github.com/sindresorhus/refined-github/releases
- Notifications Page : https://github.com/notifications
- Pull Request Commits : 
  - [`d9621aa` (#4699)](https://github.com/sindresorhus/refined-github/pull/4699/commits/d9621aaf54aae286b45b8805d34d9354224412ca)
  - [`dc04365` (#4699)](https://github.com/sindresorhus/refined-github/pull/4699/commits/dc0436589007560a77db22290427d7b7898657ee)
