### PR TITLE
fix: rename `hide-noisy-newsfeed-events` selector

### DIFF
--- a/source/features/hide-noisy-newsfeed-events.css
+++ b/source/features/hide-noisy-newsfeed-events.css
@@ -7,6 +7,6 @@ forked a repo
 followed someone
 published a release
 */
-.rgh-hide-low-quality-newsfeed-events .news :is(.push, .fork, .delete, .follow, .release) {
+.rgh-hide-noisy-newsfeed-events .news :is(.push, .fork, .delete, .follow, .release) {
 	display: none !important;
 }


### PR DESCRIPTION
That feature has been renamed recently but the selector has been renamed wrong. This PR fixes that issue to make the feature work again.