### PR TITLE
Restore `parse-backticks` on Discussions

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -42,6 +42,7 @@ function init(): void {
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
 		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard (GHE #4021)
 		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard
+		'.js-discussions-title-container h1 > .js-issue-title', // `isDiscussion`
 		'a[data-hovercard-type="discussion"]', // `isDiscussionList`
 	].map(selector => selector + ':not(.rgh-backticks-already-parsed)').join(',');
 


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Closes #3975 finally



## Test URLs

https://github.com/tophf/mpiv/discussions/50

## Screenshot

![2021-09-06_200921](https://user-images.githubusercontent.com/723651/132247911-bc07fce6-3275-4e10-b2be-cfec26ebf212.jpg)

## Notes to reviewers:

The `.js-issue-title` selector for Discussion page titles of my PR #3977 had to be removed, in PR [#4136 (comment)](https://github.com/sindresorhus/refined-github/pull/4136#issuecomment-805101315).

Following https://github.com/sindresorhus/refined-github/issues/3975#issuecomment-815975667, the selector in this PR, `.js-discussions-title-container h1 > .js-issue-title` 
matches (*once*) in discussion pages, and it doesn't matches in issue pages.

If I remove the `h1 >` part then it matches *twice* in discussion pages (i.e. also in a hidden element).