### PR TITLE
Fix centering and spacing of `reaction-avatars` count

### DIFF
--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -24,8 +24,6 @@
 	box-sizing: content-box;
 	display: inline-block;
 	height: var(--size);
-	margin-left: calc(var(--size) * 0.3); /* Move away from count */
-	margin-right: calc(var(--size) * -0.5);
 	margin: 0;
 	padding: 0;
 	width: var(--size);

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,23 +1,34 @@
+:root .social-button-emoji {
+	align-self: center;
+	box-sizing: content-box;
+}
+
 :root .reaction-summary-item span:nth-child(2) {
-	background: transparent;
-	border-radius: 8px;
-	border: inherit;
-	line-height: 16px;
-	margin-top: 2px;
-	min-width: 18px;
+	align-self: center;
+	box-sizing: content-box;
+	display: inline-block;
+	font-size: 1em !important;
+	height: 16px;
+	line-height: 1.25;
+	min-width: 16px;
+	vertical-align: -1px;
+}
+
+:root .reaction-summary-item span:nth-child(2):not(:last-child) {
+	margin-right: 3px;
 }
 
 :root .rgh-reactions-avatar {
 	--size: 1.3em;
+	align-self: center;
+	box-sizing: content-box;
 	display: inline-block;
-	width: var(--size);
 	height: var(--size);
-	padding: 0;
-	margin: 0;
 	margin-left: calc(var(--size) * 0.3); /* Move away from count */
 	margin-right: calc(var(--size) * -0.5);
-	box-sizing: content-box;
-	align-self: center;
+	margin: 0;
+	padding: 0;
+	width: var(--size);
 }
 
 :root .rgh-reactions-avatar:last-of-type {
@@ -26,7 +37,7 @@
 
 :root .rgh-reactions-avatar img {
 	display: block;
+	height: var(--size);
 	margin: -1px 0 0;
 	width: var(--size);
-	height: var(--size);
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -11,13 +11,13 @@
 
 :root .rgh-reactions-avatar {
 	--size: 1.3em;
-	align-self: center;
-	box-sizing: content-box;
 	display: inline-block;
-	height: var(--size);
-	margin: 0;
-	padding: 0;
 	width: var(--size);
+	height: var(--size);
+	padding: 0;
+	margin: 0;
+	box-sizing: content-box;
+	align-self: center;
 }
 
 :root .rgh-reactions-avatar:last-of-type {
@@ -26,7 +26,7 @@
 
 :root .rgh-reactions-avatar img {
 	display: block;
-	height: var(--size);
 	margin: -1px 0 0;
 	width: var(--size);
+	height: var(--size);
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,3 +1,12 @@
+:root .reaction-summary-item span:nth-child(2) {
+	background: transparent;
+	border-radius: 50%;
+	border: inherit;
+	line-height: 16px;
+	margin-top: 2px;
+	min-width: 18px;
+}
+
 :root .rgh-reactions-avatar {
 	--size: 1.3em;
 	display: inline-block;
@@ -17,7 +26,7 @@
 
 :root .rgh-reactions-avatar img {
 	display: block;
-	margin: 0;
+	margin: -1px 0 0;
 	width: var(--size);
 	height: var(--size);
 }

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,6 +1,6 @@
 :root .reaction-summary-item span:nth-child(2) {
 	background: transparent;
-	border-radius: 50%;
+	border-radius: 8px;
 	border: inherit;
 	line-height: 16px;
 	margin-top: 2px;

--- a/source/features/reactions-avatars.css
+++ b/source/features/reactions-avatars.css
@@ -1,17 +1,8 @@
-:root .social-button-emoji {
-	align-self: center;
-	box-sizing: content-box;
-}
-
+:root .social-button-emoji,
 :root .reaction-summary-item span:nth-child(2) {
 	align-self: center;
 	box-sizing: content-box;
-	display: inline-block;
-	font-size: 1em !important;
-	height: 16px;
-	line-height: 1.25;
 	min-width: 16px;
-	vertical-align: -1px;
 }
 
 :root .reaction-summary-item span:nth-child(2):not(:last-child) {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Some work to improve the rendering of reaction counts in the `reaction-avatars` feature.

## Test URLs

https://github.com/microsoft/vscode/issues/124901

## Screenshot

Before:

<img src="https://user-images.githubusercontent.com/82655227/132243466-e2c89b4e-a08b-41c6-afe0-eebc8d2a3046.png" height="136px"/>

After:

<img src="https://user-images.githubusercontent.com/82655227/132243463-ac523d68-2232-4f8d-92b4-653a775743e8.png" height="136px"/>