### PR TITLE
Don't `follow-file-renames` when file was not renamed

### DIFF
--- a/source/features/follow-file-renames.tsx
+++ b/source/features/follow-file-renames.tsx
@@ -41,7 +41,7 @@ export async function getChangesToFileInCommit(sha: string, filePath: string): P
 
 async function linkify(button: HTMLButtonElement, filePath: string): Promise<void | false> {
 	const isNewer = button.textContent === 'Newer';
-
+	const fromKey = isNewer ? 'previous_filename' : 'filename';
 	const toKey = isNewer ? 'filename' : 'previous_filename';
 	const sha = (isNewer ? select : select.last)('clipboard-copy[aria-label="Copy the full SHA"]')!;
 
@@ -57,17 +57,20 @@ async function linkify(button: HTMLButtonElement, filePath: string): Promise<voi
 		// Clear the search from the url, so it does not get passed to the rename link
 		search: '',
 	});
-	button.replaceWith(
-		<a
-			href={String(linkifiedURL)}
-			aria-label={`Renamed ${isNewer ? 'to' : 'from'} ${fileChanges.file[toKey]!}`}
-			className="btn btn-outline BtnGroup-item tooltipped tooltipped-n tooltipped-no-delay"
-		>
-			{isNewer && <DiffRenamedIcon className="mr-1" style={{transform: 'rotate(180deg)'}}/>}
-			{button.textContent}
-			{!isNewer && <DiffRenamedIcon className="ml-1"/>}
-		</a>,
-	);
+	// Check that the file was actually renamed
+	if (fileChanges.file[fromKey] === filePath) {
+		button.replaceWith(
+			<a
+				href={String(linkifiedURL)}
+				aria-label={`Renamed ${isNewer ? 'to' : 'from'} ${fileChanges.file[toKey]!}`}
+				className="btn btn-outline BtnGroup-item tooltipped tooltipped-n tooltipped-no-delay"
+			>
+				{isNewer && <DiffRenamedIcon className="mr-1" style={{transform: 'rotate(180deg)'}}/>}
+				{button.textContent}
+				{!isNewer && <DiffRenamedIcon className="ml-1"/>}
+			</a>,
+		);
+	}
 }
 
 function init(): void | false {


### PR DESCRIPTION
Fixes #4774
Caused by https://github.com/sindresorhus/refined-github/pull/4677

## Test URLs (taken from #4677)
- https://github.com/sindresorhus/refined-github/commits/main/source/features/quick-pr-diff-options.tsx

The following URLs point to the life-cycle of a single file called `site.rb` in https://github.com/ForkAwesome/Fork-Awesome.

- https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/doc/_plugins/site.rb
- https://github.com/ForkAwesome/Fork-Awesome/commits/master/src/_plugins/site.rb
- https://github.com/ForkAwesome/Fork-Awesome/commits/master/source/_plugins/site.rb
- https://github.com/ForkAwesome/Fork-Awesome/commits/master/build/_plugins/site.rb

The first URL should have only the **Older** button linkified, the second and third URLs should have both buttons linkified and the last URL should have only the **Newer** button linkified.




## Screenshot
Before:
![image](https://user-images.githubusercontent.com/16872793/132866021-7912c8a1-d549-4ad2-b94c-9d08fb8f4f75.png)

After:

![image](https://user-images.githubusercontent.com/16872793/132866044-5bc12c19-0f3f-4e9b-9fde-0b509535a66c.png)


@gamemaker1 if you see an issue with this PR let me know. I will not be by a computer for the next while, just sat down and did some diffing to find out the issue. So I may have you take over the PR.

The code I added was there before but you removed it. So all I did was add the code back.

@fregante when reviewing view without whitespace.