### PR TITLE
Add support for `rst` files to `view-markdown-source`

### DIFF
--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -33,7 +33,7 @@ async function init(): Promise<void> {
 
 void features.add(__filebasename, {
 	include: [
-		() => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee)$/.test(location.pathname),
+		() => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|rst)$/.test(location.pathname),
 	],
 	deduplicate: '.rgh-view-markdown-source', // #3945
 	init,


### PR DESCRIPTION
Related to #4244, this adds support for another common markup format that is rendered by GitHub, reStructuredText.

Should this feature be renamed to `view-markup-source` since it would now support more formats than just markdown? I'll let someone else decide.

## Test URLs

- https://github.com/github/markup/blob/46908504f5/test/markups/README.rst

## Screenshot

![image](https://user-images.githubusercontent.com/23145462/133840453-711b9fd2-c3d0-4cfc-8c24-301e70566c3c.png)

