### PR TITLE
Add `user-contributions-stats-in-hovercard` feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -343,6 +343,7 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.](https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png)
 - [](# "user-local-time") [Shows the user local time in their hovercard (based on their last commit).](https://user-images.githubusercontent.com/1402241/69863648-ef449180-12cf-11ea-8f36-7c92fc487f31.gif)
 - [](# "conversation-links-on-repo-lists") [Adds a link to the issues and pulls on the user profile repository tab and global search.](https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png)
+- [](# "user-contributions-stats-in-hovercard") [Adds user contributions (count of commits, merged PRs, opened issues, and contribution order) in their hovercard](https://user-images.githubusercontent.com/723651/130868890-58edf97d-01c4-453c-9829-320801b266ee.jpg)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/readme.md
+++ b/readme.md
@@ -343,7 +343,7 @@ Thanks for contributing! 🦋🙌
 - [](# "linkify-user-location") [Linkifies the user location in their hovercard and profile page.](https://user-images.githubusercontent.com/1402241/69076885-00d3a100-0a67-11ea-952a-690acec0826f.png)
 - [](# "user-local-time") [Shows the user local time in their hovercard (based on their last commit).](https://user-images.githubusercontent.com/1402241/69863648-ef449180-12cf-11ea-8f36-7c92fc487f31.gif)
 - [](# "conversation-links-on-repo-lists") [Adds a link to the issues and pulls on the user profile repository tab and global search.](https://user-images.githubusercontent.com/16872793/78712349-82c54900-78e6-11ea-8328-3c2d39a78862.png)
-- [](# "user-contributions-stats-in-hovercard") [Adds user contributions (count of commits, merged PRs, opened issues, and contribution order) in their hovercard](https://user-images.githubusercontent.com/723651/130868890-58edf97d-01c4-453c-9829-320801b266ee.jpg)
+- [](# "user-contributions-stats-in-hovercard") [Adds user contributions (count of commits, merged PRs, opened issues, and contribution order) in their hovercard](https://user-images.githubusercontent.com/723651/133829370-de1ff636-e23e-4a01-82a0-09ab625de8c1.gif)
 
 <!-- Refer to style guide above. Keep this message between sections. -->
 

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import {CodeIcon} from '@primer/octicons-react';
 
 import * as pageDetect from 'github-url-detection';
 
@@ -10,6 +11,19 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	if (!login) {
 		return;
 	}
+
+	// File: user-local-time.tsx
+	const placeholder = <span data-view-component="true" className="lh-condensed">Retrieving stats…</span>;
+	const container = (
+		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
+			<div data-view-component="true" className="mr-1 flex-shrink-0">
+				<CodeIcon/> {placeholder}
+			</div>
+		</div>
+	);
+
+	let lastline = select.last('.js-hovercard-content .color-text-secondary');
+	lastline!.after(container);
 
 	const contributorInfo = getContributorInfo(login);
 
@@ -27,13 +41,9 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	const prCount = await getIssuePRCount(repo, login, 'pr');
 
 	// Authored {commitCount} commits(#{contributionsOrder}), merged {prCount} PRs, opened {issueCount} issues
-	const message = (
-		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
-			{Number.parseInt(commitCount, 10) > 0 ? `Authored ${commitCount} commits(#${contributionsOrder},` : ''} {`merged ${prCount} PRs, opened ${issueCount} issues`}
-		</div>
-	);
-	const lastline = select.last('.js-hovercard-content .color-text-secondary');
-	lastline!.after(message);
+	const message = (Number.parseInt(commitCount, 10) > 0 ? `Authored ${commitCount} commits(#${contributionsOrder}),` : '') + `merged ${prCount} PRs, opened ${issueCount} issues`;
+	lastline = select.last('.js-hovercard-content .color-text-secondary span');
+	lastline!.textContent = message;
 }
 
 async function getContributionsCountPosition(repoPath: string, login: string): Promise<any[]> {

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -17,8 +17,9 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	const container = (
 		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
 			<div data-view-component="true" className="mr-1 flex-shrink-0">
-				<CodeIcon/> {placeholder}
+				<CodeIcon/>
 			</div>
+			{placeholder}
 		</div>
 	);
 

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -19,16 +19,17 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	const values = await getContributionsCountPosition(repo, login);
 	console.log(values);
 
-	const commitCount = values[0];
-	// Const contributionsIndex = values[1] + 1;
-	const contributionsIndex = Number.parseInt(values[1], 10) + 1;
+	const commitCount: string = values[0];
+	// Const contributionsOrder = values[1] + 1;
+	const contributionsOrder = Number.parseInt(values[1], 10) + 1;
 
 	const issueCount = await getIssuePRCount(repo, login, 'issue');
 	const prCount = await getIssuePRCount(repo, login, 'pr');
 
+	// Authored {commitCount} commits(#{contributionsOrder}), merged {prCount} PRs, opened {issueCount} issues
 	const message = (
 		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
-			Authored {commitCount} commits(#{contributionsIndex}), merged {prCount} PRs, opened {issueCount} issues
+			{Number.parseInt(commitCount, 10) > 0 ? `Authored ${commitCount} commits(#${contributionsOrder},` : ''} {`merged ${prCount} PRs, opened ${issueCount} issues`}
 		</div>
 	);
 	const lastline = select.last('.js-hovercard-content .color-text-secondary');

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -12,7 +12,6 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 		return;
 	}
 
-	// File: user-local-time.tsx
 	const placeholder = <span data-view-component="true" className="lh-condensed">Retrieving stats…</span>;
 	const container = (
 		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
@@ -28,7 +27,6 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 
 	const contributorInfo = getContributorInfo(login);
 
-	// Const access_token = await api.expectToken();
 	const repo = contributorInfo.repoPath;
 
 	const values = await getContributionsCountPosition(repo, login);
@@ -42,7 +40,7 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	const prCount = await getIssuePRCount(repo, login, 'pr');
 
 	// Authored {commitCount} commits(#{contributionsOrder}), merged {prCount} PRs, opened {issueCount} issues
-	const message = (Number.parseInt(commitCount, 10) > 0 ? `Authored ${commitCount} commits(#${contributionsOrder}),` : '') + `merged ${prCount} PRs, opened ${issueCount} issues`;
+	const message = (Number.parseInt(commitCount, 10) > 0 ? `Authored ${commitCount} commits(#${contributionsOrder}), ` : '') + `merged ${prCount} PRs, opened ${issueCount} issues`;
 	lastline = select.last('.js-hovercard-content .color-text-secondary span');
 	lastline!.textContent = message;
 }
@@ -94,9 +92,6 @@ function getContributorInfo(login: string): any {
 
 	return returnValue;
 }
-
-// https://api.github.com/search/issues?q=+author:fregante+repo:sindresorhus/refined-github+type:issue&order=asc&per_page=1&sort=created
-// https://api.github.com/search/issues?q=+author:fregante+repo:sindresorhus/refined-github+type:pr   &order=asc&per_page=1&sort=created
 
 async function getIssuePRCount(repoPath: string, login: string, type: string): Promise<string> {
 	const URL = `https://api.github.com/search/issues?q=+author:${login}+repo:${repoPath}+type:${type}&order=asc&per_page=1&sort=created`;

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -1,0 +1,110 @@
+import React from 'dom-chef';
+import select from 'select-dom';
+
+import * as pageDetect from 'github-url-detection';
+
+import features from '.';
+
+async function addContributions(baseElement: HTMLElement): Promise<void> {
+	const login = getCommenter(baseElement);
+	if (!login) {
+		return;
+	}
+
+	const contributorInfo = getContributorInfo(login);
+
+	// Const access_token = await api.expectToken();
+	const repo = contributorInfo.repoPath;
+
+	const values = await getContributionsCountPosition(repo, login);
+	console.log(values);
+
+	const commitCount = values[0];
+	// Const contributionsIndex = values[1] + 1;
+	const contributionsIndex = Number.parseInt(values[1], 10) + 1;
+
+	const issueCount = await getIssuePRCount(repo, login, 'issue');
+	const prCount = await getIssuePRCount(repo, login, 'pr');
+
+	const message = (
+		<div data-view-component="true" className="d-flex flex-items-baseline f6 mt-1 color-text-secondary">
+			Authored {commitCount} commits(#{contributionsIndex}), merged {prCount} PRs, opened {issueCount} issues
+		</div>
+	);
+	const lastline = select.last('.js-hovercard-content .color-text-secondary');
+	lastline!.after(message);
+}
+
+async function getContributionsCountPosition(repoPath: string, login: string): Promise<any[]> {
+	// Target: https://api.github.com/repos/sindresorhus/refined-github/contributors   (only the first 30 usernames)  --> This endpoint may return information that is a few hours old because the GitHub REST API v3 caches contributor data to improve performance.
+	const URL = `https://api.github.com/repos/${repoPath}/contributors`;
+	const response = await fetch(URL);
+	const commits = await response.json();
+	const isLogin = (element: any): boolean => element.login === login;
+	if (commits.findIndex((element: any) => isLogin(element)) === -1) {
+		return [0, 0];
+	}
+
+	const constributionsPosition = commits.findIndex((element: any) => isLogin(element));
+	const commitCount = commits[constributionsPosition].contributions;
+
+	return [commitCount, constributionsPosition];
+}
+
+const hovercardObserver = new MutationObserver(([mutation]) => {
+	(async () => {
+		await addContributions(mutation.target as HTMLElement);
+	})();
+});
+
+function getCommenter(baseElement: HTMLElement): string | undefined {
+	const login = select('a[data-octo-dimensions="link_type:profile"]', baseElement)?.pathname.slice(1);
+	if (typeof login !== 'undefined') {
+		return login;
+	}
+
+	return undefined;
+}
+
+function getContributorInfo(login: string): any {
+	const pathNameArray = location.pathname.split('/');
+	const org = pathNameArray[1];
+	const repo = pathNameArray[2];
+	const currentNumber = pathNameArray[4];
+	const repoPath = org + '/' + repo;
+	const contributor = login;
+
+	const returnValue = {
+		contributor,
+		currentNum: currentNumber,
+		repoPath,
+	};
+
+	return returnValue;
+}
+
+// https://api.github.com/search/issues?q=+author:fregante+repo:sindresorhus/refined-github+type:issue&order=asc&per_page=1&sort=created
+// https://api.github.com/search/issues?q=+author:fregante+repo:sindresorhus/refined-github+type:pr   &order=asc&per_page=1&sort=created
+
+async function getIssuePRCount(repoPath: string, login: string, type: string): Promise<string> {
+	const URL = `https://api.github.com/search/issues?q=+author:${login}+repo:${repoPath}+type:${type}&order=asc&per_page=1&sort=created`;
+
+	const response = await fetch(URL);
+	const result = await response.json();
+	return result.total_count;
+}
+
+function init(): void {
+	const hovercardContainer = select('.js-hovercard-content > .Popover-message');
+	if (hovercardContainer) {
+		hovercardObserver.observe(hovercardContainer, {childList: true});
+	}
+}
+
+void features.add(__filebasename, {
+	include: [
+		pageDetect.isPR,
+		pageDetect.isIssue,
+	],
+	init,
+});

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -30,7 +30,6 @@ async function addContributions(baseElement: HTMLElement): Promise<void> {
 	const repo = contributorInfo.repoPath;
 
 	const values = await getContributionsCountPosition(repo, login);
-	console.log(values);
 
 	const commitCount: string = values[0];
 	// Const contributionsOrder = values[1] + 1;

--- a/source/features/user-contributions-stats-in-hovercard.tsx
+++ b/source/features/user-contributions-stats-in-hovercard.tsx
@@ -110,8 +110,8 @@ function init(): void {
 
 void features.add(__filebasename, {
 	include: [
-		pageDetect.isPR,
 		pageDetect.isIssue,
+		pageDetect.isPR,
 	],
 	init,
 });

--- a/source/refined-github.ts
+++ b/source/refined-github.ts
@@ -218,3 +218,4 @@ import './features/cancel-wiki-edit-button';
 import './features/comment-on-draft-pr-indicator';
 import './features/select-notifications';
 import './features/clean-repo-tabs';
+import './features/user-contributions-stats-in-hovercard';


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Implements #4657 (per https://github.com/sindresorhus/refined-github/issues/4657#issuecomment-922159327)

## Test URLs

Any Issue and PR page, e.g. this one and that linked above.

## Screenshot/screen capture


![](https://user-images.githubusercontent.com/723651/133888321-73dda276-0730-4125-8696-9141f69fdfac.jpg) ![](https://user-images.githubusercontent.com/723651/133829370-de1ff636-e23e-4a01-82a0-09ab625de8c1.gif)

## Notes to reviewers:

- It's based (simplified) on the 'Contributors on Github' extension.
- It makes 3 connections:
    ```
    For commit count and contributions position: (only the first 30 usernames)
    // Target: https://api.github.com/repos/{owner}/{repo}/contributors
    
    For Issue and PR count, respectively:
    // https://api.github.com/search/issues?q=+author:{author}+repo:{owner}/{repo}+type:issue&order=asc&per_page=1&sort=created
    // https://api.github.com/search/issues?q=+author:{author}+repo:{owner}/{repo}+type:pr   &order=asc&per_page=1&sort=created
    ```
- It simply makes these connections via fetch+parse json. It doesn't make use of the RG token. Could I make use of it via using request options in `fetch()`, I mean like this: ?

    <details>
    <summary>click to expand:</summary>
    
    https://github.com/sindresorhus/refined-github/blob/b504a42cd783836b979688731a43a0a07be65bf8/source/options.tsx#L50-L57
    </details>
    I am asking, because I didn't find any such request options in other features.

    Or, could these 3 requests be combined into one via GraphQL API? I am not familiar with it, but I think it's not possible.
- It doesn't store the fetched data, i.e. repeats the requests on every new mouseover.
- If you find this PR is too lengthy/unnecessary complicated/not salvageable, feel free to close it.