### PR TITLE
Fix: `edit-comments-faster` appears on every comment

### DIFF
--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -13,7 +13,7 @@ function canEditEveryComment(): boolean {
 		'[aria-label^="You are the owner"]',
 		'[title^="You are a maintainer"]',
 		'[title^="You are a collaborator"]',
-	]) && select.exists('div.js-previewable-comment-form');
+	]) || select.exists('#settings-tab');
 }
 
 function init(): void {

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -12,7 +12,7 @@ function canEditEveryComment(): boolean {
 		'[aria-label^="You have been invited to collaborate"]',
 		'[aria-label^="You are the owner"]',
 		'[title^="You are a maintainer"]',
-		'[title^="You are a collaborator"]'
+		'[title^="You are a collaborator"]',
 	]) && select.exists('div.js-previewable-comment-form');
 }
 

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -8,7 +8,12 @@ import * as pageDetect from 'github-url-detection';
 import features from '.';
 
 function canEditEveryComment(): boolean {
-	return select.exists('[aria-label^="You have been invited to collaborate"], [aria-label^="You are the owner"], [title^="You are a maintainer"], [title^="You are a collaborator"]') && select.exists('div.js-previewable-comment-form');
+	return select.exists([
+		'[aria-label^="You have been invited to collaborate"]',
+		'[aria-label^="You are the owner"]',
+		'[title^="You are a maintainer"]',
+		'[title^="You are a collaborator"]']
+	) && select.exists('div.js-previewable-comment-form');
 }
 
 function init(): void {

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -7,13 +7,13 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-function canEditDiscussion(): boolean {
-	return pageDetect.isDiscussion() && select.exists('[title^="You are a maintainer"], [title^="You are a collaborator"]');
+function canEditEveryComment(): boolean {
+	return select.exists('[aria-label^="You have been invited to collaborate"], [aria-label^="You are the owner"], [title^="You are a maintainer"], [title^="You are a collaborator"]') && select.exists('div.js-previewable-comment-form');
 }
 
 function init(): void {
 	// If true then the resulting selector will match all comments, otherwise it will only match those made by you
-	const preSelector = !pageDetect.isDiscussion() || canEditDiscussion() ? '' : '.current-user';
+	const preSelector = canEditEveryComment() ? '' : '.current-user';
 	// Find editable comments first, then traverse to the correct position
 	observe(preSelector + '.js-comment.unminimized-comment .js-comment-update:not(.rgh-edit-comment)', {
 		add(comment) {

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -12,8 +12,8 @@ function canEditEveryComment(): boolean {
 		'[aria-label^="You have been invited to collaborate"]',
 		'[aria-label^="You are the owner"]',
 		'[title^="You are a maintainer"]',
-		'[title^="You are a collaborator"]']
-	) && select.exists('div.js-previewable-comment-form');
+		'[title^="You are a collaborator"]'
+	]) && select.exists('div.js-previewable-comment-form');
 }
 
 function init(): void {

--- a/source/features/quick-comment-edit.tsx
+++ b/source/features/quick-comment-edit.tsx
@@ -9,11 +9,15 @@ import features from '.';
 
 function canEditEveryComment(): boolean {
 	return select.exists([
+		// These are only found if you left any comments on the page
 		'[aria-label^="You have been invited to collaborate"]',
 		'[aria-label^="You are the owner"]',
 		'[title^="You are a maintainer"]',
 		'[title^="You are a collaborator"]',
-	]) || select.exists('#settings-tab');
+
+		// If you can change the repo’s settings, then can change anything
+		'#settings-tab',
+	]);
 }
 
 function init(): void {


### PR DESCRIPTION
## Related issues

Closes #4712 if merged.

This is an up-to-date version of #4749.

## What this PR does

Does not add the edit button on comments from other users if the current user is not allowed to edit them.

## Test URLs

https://github.com/facebook/jest/issues/6316 (locked issue)
https://github.com/facebook/jest/issues/11791 (regular issue)

