### PR TITLE
`useful-not-found-page`: Show alternate links only if applicable

### DIFF
--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -145,7 +145,7 @@ async function showAlternateLink(): Promise<void> {
 
 function init(): false | void {
 	const parts = parseCurrentURL();
-	if (parts.length <= 1 || !select.exists('[alt*="This is not the web page you are looking for"]')) {
+	if (parts.length < 2) {
 		return false;
 	}
 

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -98,6 +98,11 @@ async function showMissingPart(): Promise<void> {
 }
 
 async function showDefaultBranchLink(): Promise<void> {
+	const parts = parseCurrentURL();
+	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
+		return
+	}
+
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (!urlToFileOnDefaultBranch) {
 		return;
@@ -111,6 +116,11 @@ async function showDefaultBranchLink(): Promise<void> {
 }
 
 async function showAlternateLink(): Promise<void> {
+	const parts = parseCurrentURL();
+	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
+		return
+	}
+
 	const url = new GitHubURL(location.href);
 	if (!url.branch || !url.filePath) {
 		return;

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -100,7 +100,7 @@ async function showMissingPart(): Promise<void> {
 async function showDefaultBranchLink(): Promise<void> {
 	const parts = parseCurrentURL();
 	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
-		return
+		return;
 	}
 
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
@@ -118,7 +118,7 @@ async function showDefaultBranchLink(): Promise<void> {
 async function showAlternateLink(): Promise<void> {
 	const parts = parseCurrentURL();
 	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
-		return
+		return;
 	}
 
 	const url = new GitHubURL(location.href);

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -98,11 +98,6 @@ async function showMissingPart(): Promise<void> {
 }
 
 async function showDefaultBranchLink(): Promise<void> {
-	const parts = parseCurrentURL();
-	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
-		return;
-	}
-
 	const urlToFileOnDefaultBranch = await getUrlToFileOnDefaultBranch();
 	if (!urlToFileOnDefaultBranch) {
 		return;
@@ -116,11 +111,6 @@ async function showDefaultBranchLink(): Promise<void> {
 }
 
 async function showAlternateLink(): Promise<void> {
-	const parts = parseCurrentURL();
-	if (!['tree', 'blob', 'edit'].includes(parts[2])) {
-		return;
-	}
-
 	const url = new GitHubURL(location.href);
 	if (!url.branch || !url.filePath) {
 		return;
@@ -160,8 +150,11 @@ function init(): false | void {
 	}
 
 	void showMissingPart();
-	void showDefaultBranchLink();
-	void showAlternateLink();
+
+	if (['tree', 'blob', 'edit'].includes(parts[2])) {
+		void showDefaultBranchLink();
+		void showAlternateLink();
+	}
 }
 
 async function initPRCommit(): Promise<void | false> {

--- a/source/github-helpers/github-url.ts
+++ b/source/github-helpers/github-url.ts
@@ -77,12 +77,8 @@ export default class GitHubURL {
 
 	set pathname(pathname: string) {
 		const [user, repository, route, ...ambiguousReference] = pathname.replace(/^\/|\/$/g, '').split('/');
-		if (route === 'blob' || route === 'tree') {
-			let { branch, filePath } = this.disambiguateReference(ambiguousReference);
-			this.assign({ user, repository, route, branch, filePath });
-		} else {
-			this.assign({ user, repository, route, branch: undefined, filePath: undefined });
-		}
+		const {branch, filePath} = this.disambiguateReference(ambiguousReference);
+		this.assign({user, repository, route, branch, filePath});
 	}
 
 	get href(): string {

--- a/source/github-helpers/github-url.ts
+++ b/source/github-helpers/github-url.ts
@@ -77,8 +77,12 @@ export default class GitHubURL {
 
 	set pathname(pathname: string) {
 		const [user, repository, route, ...ambiguousReference] = pathname.replace(/^\/|\/$/g, '').split('/');
-		const {branch, filePath} = this.disambiguateReference(ambiguousReference);
-		this.assign({user, repository, route, branch, filePath});
+		if (route === 'blob' || route === 'tree') {
+			let { branch, filePath } = this.disambiguateReference(ambiguousReference);
+			this.assign({ user, repository, route, branch, filePath });
+		} else {
+			this.assign({ user, repository, route, branch: undefined, filePath: undefined });
+		}
 	}
 
 	get href(): string {


### PR DESCRIPTION
## Related issues

Fixes #4790 if merged.

## What this PR does

Restores a check from https://github.com/sindresorhus/refined-github/commit/6047ca569d61638025a26f29a31ab9069b0dd108 that does not run the `showDefaultBranchLink` and `showAlternateLink` functions if the URL is not a `blob`/`tree`/`edit` one.

## Test URLs

From the original issue:

https://github.com/octokit/rest.js/issues/558