### PR TITLE
Fix: "Done" click is ignored when `select-notifications` is open

### DIFF
--- a/source/features/select-notifications.css
+++ b/source/features/select-notifications.css
@@ -1,4 +1,4 @@
 .js-notifications-mark-selected-actions > * {
-	/* Allow clicking on "Done" and other toolbar buttons even when the dropdown (z-index of 99) is still open #4753 */
+	/* Allow clicking on "Done" and other toolbar buttons even when the dropdown (z-index of 99) is open #4753 */
 	z-index: 100;
 }

--- a/source/features/select-notifications.css
+++ b/source/features/select-notifications.css
@@ -1,0 +1,4 @@
+.js-notifications-mark-selected-actions > * {
+	/* Allow clicking on "Done" and other toolbar buttons even when the dropdown (z-index of 99) is still open #4753 */
+	z-index: 100;
+}

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -153,7 +153,7 @@ function createDropdown(): JSX.Element {
 }
 
 function closeDropdown(): void {
-	select('.rgh-select-notifications[open] summary')?.dispatchEvent(new MouseEvent('click'));
+	select('.rgh-select-notifications')?.removeAttribute('open');
 }
 
 function init(): false | void {

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -1,5 +1,7 @@
+import './select-notifications.css';
 import React from 'dom-chef';
 import select from 'select-dom';
+import delegate from 'delegate-it';
 import * as pageDetect from 'github-url-detection';
 import {
 	CheckCircleIcon,
@@ -121,7 +123,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 function createDropdown(): JSX.Element {
 	return (
 		<details
-			className="details-reset details-overlay position-relative"
+			className="details-reset details-overlay position-relative rgh-select-notifications"
 			on-toggle={resetFilters}
 		>
 			<summary
@@ -150,10 +152,17 @@ function createDropdown(): JSX.Element {
 	);
 }
 
+function closeDropdown(): void {
+	select('.rgh-select-notifications[open] summary')?.dispatchEvent(new MouseEvent('click'));
+}
+
 function init(): false | void {
 	select('.js-notifications-mark-all-prompt')!
 		.closest('label')!
 		.after(createDropdown());
+
+	// Close the dropdown when one of the toolbar buttons is clicked
+	delegate(document, '.js-notifications-mark-selected-actions > *', 'click', closeDropdown);
 }
 
 void features.add(__filebasename, {


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4753 

## Test URLs
https://github.com/notifications

## Screenshot

https://user-images.githubusercontent.com/46634000/133922795-289fb9b2-1ea9-4b03-b3b7-b3cac7152e36.mp4