### PR TITLE
Fix: `select-notifications` disappears after clicking "Done"

### DIFF
--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 import {
 	CheckCircleIcon,
@@ -121,7 +122,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 function createDropdown(): JSX.Element {
 	return (
 		<details
-			className="details-reset details-overlay position-relative"
+			className="details-reset details-overlay position-relative rgh-select-notifications"
 			on-toggle={resetFilters}
 		>
 			<summary
@@ -150,10 +151,23 @@ function createDropdown(): JSX.Element {
 	);
 }
 
-function init(): false | void {
+function insertDropdown(dropdown: JSX.Element): void {
 	select('.js-notifications-mark-all-prompt')!
 		.closest('label')!
-		.after(createDropdown());
+		.after(dropdown);
+}
+
+const deinit: VoidFunction[] = [];
+function init(): false | void {
+	const dropdown = createDropdown();
+	insertDropdown(dropdown);
+
+	const selectObserver = observe('.rgh-select-notifications', {
+		remove() {
+			insertDropdown(dropdown);
+		},
+	});
+	deinit.push(selectObserver.abort);
 }
 
 void features.add(__filebasename, {
@@ -167,4 +181,5 @@ void features.add(__filebasename, {
 		() => select.exists('img[src$="notifications/inbox-zero.svg"]'), // Notifications page may be empty
 	],
 	init,
+	deinit,
 });

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -1,5 +1,6 @@
 import React from 'dom-chef';
 import select from 'select-dom';
+import onetime from 'onetime';
 import {observe} from 'selector-observer';
 import * as pageDetect from 'github-url-detection';
 import {
@@ -119,52 +120,42 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 	);
 }
 
-function createDropdown(): JSX.Element {
-	return (
-		<details
-			className="details-reset details-overlay position-relative rgh-select-notifications"
-			on-toggle={resetFilters}
+const createDropdown = onetime(() => (
+	<details
+		className="details-reset details-overlay position-relative rgh-select-notifications"
+		on-toggle={resetFilters}
+	>
+		<summary
+			className="btn btn-sm ml-3 mr-1"
+			data-hotkey="S"
+			aria-haspopup="menu"
+			role="button"
 		>
-			<summary
-				className="btn btn-sm ml-3 mr-1"
-				data-hotkey="S"
-				aria-haspopup="menu"
-				role="button"
-			>
-				Select by <span className="dropdown-caret ml-1"/>
-			</summary>
-			<details-menu
-				className="SelectMenu left-0"
-				aria-label="Select by"
-				role="menu"
-				on-details-menu-selected={handleSelection}
-			>
-				<div className="SelectMenu-modal">
-					<form id="rgh-select-notifications-form">
-						{createDropdownList('Type', ['Pull requests', 'Issues'])}
-						{createDropdownList('Status', ['Open', 'Closed', 'Merged', 'Draft'])}
-						{createDropdownList('Read', ['Read', 'Unread'])}
-					</form>
-				</div>
-			</details-menu>
-		</details>
-	);
-}
-
-function insertDropdown(dropdown: JSX.Element): void {
-	select('.js-notifications-mark-all-prompt')!
-		.closest('label')!
-		.after(dropdown);
-}
+			Select by <span className="dropdown-caret ml-1"/>
+		</summary>
+		<details-menu
+			className="SelectMenu left-0"
+			aria-label="Select by"
+			role="menu"
+			on-details-menu-selected={handleSelection}
+		>
+			<div className="SelectMenu-modal">
+				<form id="rgh-select-notifications-form">
+					{createDropdownList('Type', ['Pull requests', 'Issues'])}
+					{createDropdownList('Status', ['Open', 'Closed', 'Merged', 'Draft'])}
+					{createDropdownList('Read', ['Read', 'Unread'])}
+				</form>
+			</div>
+		</details-menu>
+	</details>
+));
 
 const deinit: VoidFunction[] = [];
 function init(): false | void {
-	const dropdown = createDropdown();
-	insertDropdown(dropdown);
-
-	const selectObserver = observe('.rgh-select-notifications', {
-		remove() {
-			insertDropdown(dropdown);
+	const selectObserver = observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
+		add(wrapper) {
+			wrapper.classList.add('rgh-select-notifications-added');
+			wrapper.closest('label')!.after(createDropdown());
 		},
 	});
 	deinit.push(selectObserver.abort);

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -157,7 +157,7 @@ function closeDropdown(): void {
 }
 
 const deinit: VoidFunction[] = [];
-function init(): false | void {
+function init(): void {
 	const selectObserver = observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
 		add(wrapper) {
 			wrapper.classList.add('rgh-select-notifications-added');

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -161,7 +161,9 @@ function init(): void {
 	const selectObserver = observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
 		add(selectAllCheckbox) {
 			selectAllCheckbox.classList.add('rgh-select-notifications-added');
-			selectAllCheckbox.closest('label')!.after(createDropdown());
+			selectAllCheckbox
+				.closest('label')!
+				.after(createDropdown());
 		},
 	});
 	deinit.push(selectObserver.abort);

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -159,9 +159,9 @@ function closeDropdown(): void {
 const deinit: VoidFunction[] = [];
 function init(): void {
 	const selectObserver = observe('.js-notifications-mark-all-prompt:not(.rgh-select-notifications-added)', {
-		add(wrapper) {
-			wrapper.classList.add('rgh-select-notifications-added');
-			wrapper.closest('label')!.after(createDropdown());
+		add(selectAllCheckbox) {
+			selectAllCheckbox.classList.add('rgh-select-notifications-added');
+			selectAllCheckbox.closest('label')!.after(createDropdown());
 		},
 	});
 	deinit.push(selectObserver.abort);

--- a/source/features/select-notifications.tsx
+++ b/source/features/select-notifications.tsx
@@ -88,7 +88,7 @@ function createDropdownList(category: Category, filters: Filter[]): JSX.Element 
 		Open: <CheckCircleIcon className="color-text-success"/>,
 		Closed: <XCircleIcon className="color-text-danger"/>,
 		Draft: <GitPullRequestDraftIcon className="color-text-tertiary"/>,
-		Merged: <GitMergeIcon className="text-purple"/>,
+		Merged: <GitMergeIcon className="color-fg-done"/>,
 		Read: <DotIcon className="color-text-link"/>,
 		Unread: <DotFillIcon className="color-text-link"/>,
 	};


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fixes #4752 

## Test URLs
https://github.com/notifications?query=repo%3Asindresorhus%2Frefined-github

## Screenshot

https://user-images.githubusercontent.com/46634000/133923470-46a61400-7abe-4a28-bd68-915dbb8c063d.mp4

GitHub fires some events when "Done" is clicked (notably two `socket:message` events from `.js-updatable` elements) but they're not correlated to the removal of the dropdown: sometimes it happens before, sometimes after.\
So in the end I went with a simple `selector-observer`.