### PR TITLE
Meta: Add an `asLongAs` option to `features.add()`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -64,12 +64,16 @@ void features.add(__filebasename, {
 	// When pressing the back button, DOM changes and listeners are still there, so normally `init` isn’t called again thanks to an automatic duplicate detection.
 	// This detection however might cause problems or not work correctly in some cases #3945, so it can be disabled with `false`
 	deduplicate: false,
+	asLongAs: [
+		pageDetect.isForkedRepo,
+	],
 	include: [
-		pageDetect.isUserProfile,
-		pageDetect.isRepo
+		pageDetect.isSingleFile,
+		pageDetect.isRepoTree,
+		pageDetect.isEditingFile,
 	],
 	exclude: [
-		pageDetect.isOwnUserProfile
+		pageDetect.isRepoRoot,
 	],
 	init
 }, {

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -26,12 +26,12 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		pageDetect.isDraftPR,
+	],
 	include: [
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
-	],
-	exclude: [
-		() => !pageDetect.isDraftPR(),
 	],
 	init,
 });

--- a/source/features/comments-time-machine-links.tsx
+++ b/source/features/comments-time-machine-links.tsx
@@ -140,13 +140,13 @@ void features.add(__filebasename, {
 	deduplicate: 'has-rgh-inner',
 	init,
 }, {
+	asLongAs: [
+		() => new URLSearchParams(location.search).has('rgh-link-date'),
+	],
 	include: [
 		pageDetect.is404,
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,
-	],
-	exclude: [
-		() => !new URLSearchParams(location.search).has('rgh-link-date'),
 	],
 	awaitDomReady: false,
 	init: showTimemachineBar,

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -45,12 +45,12 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		() => select.exists('table.highlight'), // Rendered page
+	],
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isGist,
-	],
-	exclude: [
-		() => !select.exists('table.highlight'), // Rendered page
 	],
 	deduplicate: '.rgh-copy-file', // #3945
 	init,

--- a/source/features/enable-file-links-in-compare-view.tsx
+++ b/source/features/enable-file-links-in-compare-view.tsx
@@ -68,12 +68,12 @@ void features.add(__filebasename, {
 	],
 	init,
 }, {
+	asLongAs: [
+		// Only enable if you can create a PR or view an existing PR, if you can't you are probably looking at a permalink.
+		() => select.exists('.existing-pull-button, [data-ga-click*="text:Create pull request"]'),
+	],
 	include: [
 		pageDetect.isCompare,
-	],
-	exclude: [
-		// Only enable if you can create a PR or view an existing PR, if you cant you are probably looking at a permalink.
-		() => !select.exists('.existing-pull-button, [data-ga-click*="text:Create pull request"]'),
 	],
 	init,
 });

--- a/source/features/fork-source-link-same-view.tsx
+++ b/source/features/fork-source-link-same-view.tsx
@@ -22,13 +22,15 @@ async function init(): Promise<void> {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		pageDetect.isForkedRepo,
+	],
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
 	exclude: [
-		() => !pageDetect.isForkedRepo(),
 		pageDetect.isRepoRoot,
 	],
 	deduplicate: false,

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -141,7 +141,7 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<void> => {
 	const {asLongAs, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
 
-	// If any asLongAs is false, every `include` is false or no `exclude` is true, don’t run the feature
+	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
 	if (!asLongAs.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
 		return;
 	}

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -34,7 +34,7 @@ interface FeatureLoader extends Partial<InternalRunConfig> {
 }
 
 interface InternalRunConfig {
-	always: BooleanFunction[];
+	asLongAs: BooleanFunction[];
 	include: BooleanFunction[];
 	exclude: BooleanFunction[];
 	init: FeatureInit;
@@ -139,10 +139,10 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 });
 
 const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<void> => {
-	const {always, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
+	const {asLongAs, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
 
-	// If any always is false, every `include` is false or no `exclude` is true, don’t run the feature
-	if (!always.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
+	// If any asLongAs is false, every `include` is false or no `exclude` is true, don’t run the feature
+	if (!asLongAs.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
 		return;
 	}
 
@@ -219,7 +219,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		// Input defaults and validation
 		const {
 			shortcuts = {},
-			always = [], // Default: nothing
+			asLongAs = [], // Default: nothing
 			include = [() => true], // Default: every page
 			exclude = [], // Default: nothing
 			init,
@@ -236,13 +236,13 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		}
 
 		// 404 pages should only run 404-only features
-		if (pageDetect.is404() && !include.includes(pageDetect.is404) && !always.includes(pageDetect.is404)) {
+		if (pageDetect.is404() && !include.includes(pageDetect.is404) && !asLongAs.includes(pageDetect.is404)) {
 			continue;
 		}
 
 		enforceDefaults(id, include, additionalListeners);
 
-		const details = {always, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners};
+		const details = {asLongAs, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners};
 		if (awaitDomReady) {
 			(async () => {
 				await domLoaded;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -35,9 +35,9 @@ interface FeatureLoader extends Partial<InternalRunConfig> {
 }
 
 interface InternalRunConfig {
-	asLongAs: BooleanFunction[];
-	include: BooleanFunction[];
-	exclude: BooleanFunction[];
+	asLongAs: BooleanFunction[] | undefined;
+	include: BooleanFunction[] | undefined;
+	exclude: BooleanFunction[] | undefined;
 	init: FeatureInit;
 	deinit?: VoidFunction | VoidFunction[];
 	additionalListeners: CallerFunction[];
@@ -193,7 +193,7 @@ function enforceDefaults(
 	additionalListeners: InternalRunConfig['additionalListeners'],
 ): void {
 	for (const [detection, listener] of defaultPairs) {
-		if (!include.includes(detection)) {
+		if (!include?.includes(detection)) {
 			continue;
 		}
 
@@ -219,9 +219,9 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		// Input defaults and validation
 		const {
 			shortcuts = {},
-			asLongAs = [], // Default: nothing
-			include = [() => true], // Default: every page
-			exclude = [], // Default: nothing
+			asLongAs,
+			include,
+			exclude,
 			init,
 			deinit,
 			awaitDomReady = true,
@@ -236,7 +236,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		}
 
 		// 404 pages should only run 404-only features
-		if (pageDetect.is404() && !include.includes(pageDetect.is404) && !asLongAs.includes(pageDetect.is404)) {
+		if (pageDetect.is404() && !include?.includes(pageDetect.is404) && !asLongAs?.includes(pageDetect.is404)) {
 			continue;
 		}
 
@@ -260,7 +260,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 	}
 };
 
-const addCssFeature = async (id: FeatureID, include: BooleanFunction[], deduplicate?: false | string): Promise<void> => {
+const addCssFeature = async (id: FeatureID, include: BooleanFunction[] | undefined, deduplicate?: false | string): Promise<void> => {
 	void add(id, {
 		include,
 		deduplicate,

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -10,6 +10,7 @@ import onNewComments from '../github-events/on-new-comments';
 import bisectFeatures from '../helpers/bisect';
 import optionsStorage, {RGHOptions} from '../options-storage';
 import {getLocalHotfixesAsOptions, updateHotfixes} from '../helpers/hotfix';
+import {shouldFeatureRun} from '../github-helpers';
 
 type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;
@@ -141,8 +142,7 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<void> => {
 	const {asLongAs, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
 
-	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
-	if (!asLongAs.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
+	if (!shouldFeatureRun({asLongAs, include, exclude})) {
 		return;
 	}
 

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -34,6 +34,7 @@ interface FeatureLoader extends Partial<InternalRunConfig> {
 }
 
 interface InternalRunConfig {
+	always: BooleanFunction[];
 	include: BooleanFunction[];
 	exclude: BooleanFunction[];
 	init: FeatureInit;
@@ -138,10 +139,10 @@ const globalReady: Promise<RGHOptions> = new Promise(async resolve => {
 });
 
 const setupPageLoad = async (id: FeatureID, config: InternalRunConfig): Promise<void> => {
-	const {include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
+	const {always, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners} = config;
 
-	// If every `include` is false and no `exclude` is true, don’t run the feature
-	if (include.every(c => !c()) || exclude.some(c => c())) {
+	// If any always is false, every `include` is false or no `exclude` is true, don’t run the feature
+	if (!always.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
 		return;
 	}
 
@@ -218,6 +219,7 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		// Input defaults and validation
 		const {
 			shortcuts = {},
+			always = [], // Default: nothing
 			include = [() => true], // Default: every page
 			exclude = [], // Default: nothing
 			init,
@@ -234,13 +236,13 @@ const add = async (id: FeatureID, ...loaders: FeatureLoader[]): Promise<void> =>
 		}
 
 		// 404 pages should only run 404-only features
-		if (pageDetect.is404() && !include.includes(pageDetect.is404)) {
+		if (pageDetect.is404() && !include.includes(pageDetect.is404) && !always.includes(pageDetect.is404)) {
 			continue;
 		}
 
 		enforceDefaults(id, include, additionalListeners);
 
-		const details = {include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners};
+		const details = {always, include, exclude, init, deinit, additionalListeners, onlyAdditionalListeners};
 		if (awaitDomReady) {
 			(async () => {
 				await domLoaded;

--- a/source/features/index.tsx
+++ b/source/features/index.tsx
@@ -8,9 +8,9 @@ import * as pageDetect from 'github-url-detection';
 import waitFor from '../helpers/wait-for';
 import onNewComments from '../github-events/on-new-comments';
 import bisectFeatures from '../helpers/bisect';
+import {shouldFeatureRun} from '../github-helpers';
 import optionsStorage, {RGHOptions} from '../options-storage';
 import {getLocalHotfixesAsOptions, updateHotfixes} from '../helpers/hotfix';
-import {shouldFeatureRun} from '../github-helpers';
 
 type BooleanFunction = () => boolean;
 type CallerFunction = (callback: VoidFunction) => void;

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -42,8 +42,8 @@ async function initRepo(): Promise<void> {
 }
 
 void features.add(__filebasename, {
-	exclude: [
-		() => !getRepo()?.name.endsWith('.github.io'),
+	asLongAs: [
+		() => getRepo()?.name.endsWith('.github.io') ?? false,
 	],
 	init: initRepo,
 }, {

--- a/source/features/link-to-github-io.tsx
+++ b/source/features/link-to-github-io.tsx
@@ -43,7 +43,7 @@ async function initRepo(): Promise<void> {
 
 void features.add(__filebasename, {
 	asLongAs: [
-		() => getRepo()?.name.endsWith('.github.io') ?? false,
+		() => Boolean(getRepo()?.name.endsWith('.github.io')),
 	],
 	init: initRepo,
 }, {

--- a/source/features/no-duplicate-list-update-time.tsx
+++ b/source/features/no-duplicate-list-update-time.tsx
@@ -17,11 +17,11 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		() => location.search.includes('sort%3Aupdated-'),
+	],
 	include: [
 		pageDetect.isConversationList,
-	],
-	exclude: [
-		() => !location.search.includes('sort%3Aupdated-'),
 	],
 	init,
 });

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -26,6 +26,10 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		// Make sure the class names we need exist on the page #4483
+		() => select.exists('.js-diff-table :is([data-split-side="left"], [data-split-side="right"]):is(.blob-code-addition, .blob-code-deletion)'),
+	],
 	include: [
 		pageDetect.isCommit,
 		pageDetect.isCompare,
@@ -33,8 +37,6 @@ void features.add(__filebasename, {
 	],
 	exclude: [
 		isUnifiedDiff,
-		// Make sure the class names we need exist on the page #4483
-		() => !select.exists('.js-diff-table :is([data-split-side="left"], [data-split-side="right"]):is(.blob-code-addition, .blob-code-deletion)'),
 	],
 	additionalListeners: [
 		onDiffFileLoad,

--- a/source/features/show-associated-branch-prs-on-fork.tsx
+++ b/source/features/show-associated-branch-prs-on-fork.tsx
@@ -105,11 +105,11 @@ async function init(): Promise<void> {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		pageDetect.isForkedRepo,
+	],
 	include: [
 		pageDetect.isBranches,
-	],
-	exclude: [
-		() => !pageDetect.isForkedRepo(),
 	],
 	awaitDomReady: false,
 	init: onetime(init),

--- a/source/features/show-open-prs-of-forks.tsx
+++ b/source/features/show-open-prs-of-forks.tsx
@@ -89,20 +89,20 @@ async function initDeleteHint(): Promise<void | false> {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		pageDetect.isForkedRepo,
+	],
 	include: [
 		pageDetect.isRepo,
-	],
-	exclude: [
-		() => !pageDetect.isForkedRepo(),
 	],
 	awaitDomReady: false,
 	init: initHeadHint,
 }, {
+	asLongAs: [
+		pageDetect.isForkedRepo,
+	],
 	include: [
 		pageDetect.isRepoMainSettings,
-	],
-	exclude: [
-		() => !pageDetect.isForkedRepo(),
 	],
 	awaitDomReady: false,
 	init: initDeleteHint,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -156,7 +156,9 @@ async function initPRCommit(): Promise<void | false> {
 }
 
 void features.add(__filebasename, 	{
-	always: [pageDetect.is404],
+	always: [
+		pageDetect.is404
+	],
 	include: [() => parseCurrentURL().length > 1],
 	init: showMissingPart,
 },

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -161,14 +161,16 @@ async function initPRCommit(): Promise<void | false> {
 }
 
 void features.add(__filebasename, 	{
-	always: [
+	asLongAs: [
 		pageDetect.is404,
+		() => parseCurrentURL().length > 1,
 	],
-	include: [() => parseCurrentURL().length > 1],
 	init: showMissingPart,
 },
 {
-	always: [pageDetect.is404],
+	asLongAs: [
+		pageDetect.is404,
+	],
 	include: [
 		pageDetect.isSingleFile,
 		pageDetect.isRepoTree,

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -143,20 +143,6 @@ async function showAlternateLink(): Promise<void> {
 	);
 }
 
-function init(): false | void {
-	const parts = parseCurrentURL();
-	if (parts.length < 2) {
-		return false;
-	}
-
-	void showMissingPart();
-
-	if (['tree', 'blob', 'edit'].includes(parts[2])) {
-		void showDefaultBranchLink();
-		void showAlternateLink();
-	}
-}
-
 async function initPRCommit(): Promise<void | false> {
 	const commitUrl = location.href.replace(/pull\/\d+\/commits/, 'commit');
 	if (await is404(commitUrl)) {
@@ -169,12 +155,20 @@ async function initPRCommit(): Promise<void | false> {
 	);
 }
 
-void features.add(__filebasename, {
-	include: [
-		pageDetect.is404,
-	],
-	init: onetime(init),
-}, {
+void features.add(__filebasename, 	{
+		always: [pageDetect.is404],
+		include: [() => parseCurrentURL().length > 1],
+		init: showMissingPart
+	},
+	{
+		always: [pageDetect.is404],
+		include: [
+			pageDetect.isSingleFile,
+			pageDetect.isRepoTree,
+			pageDetect.isEditingFile,
+		],
+		init: () => {showDefaultBranchLink(); showAlternateLink() }
+	}, {
 	include: [
 		pageDetect.isPRCommit404,
 	],

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -156,19 +156,21 @@ async function initPRCommit(): Promise<void | false> {
 }
 
 void features.add(__filebasename, 	{
-		always: [pageDetect.is404],
-		include: [() => parseCurrentURL().length > 1],
-		init: showMissingPart
+	always: [pageDetect.is404],
+	include: [() => parseCurrentURL().length > 1],
+	init: showMissingPart,
+},
+{
+	always: [pageDetect.is404],
+	include: [
+		pageDetect.isSingleFile,
+		pageDetect.isRepoTree,
+		pageDetect.isEditingFile,
+	],
+	init: () => {
+		showDefaultBranchLink(); showAlternateLink();
 	},
-	{
-		always: [pageDetect.is404],
-		include: [
-			pageDetect.isSingleFile,
-			pageDetect.isRepoTree,
-			pageDetect.isEditingFile,
-		],
-		init: () => {showDefaultBranchLink(); showAlternateLink() }
-	}, {
+}, {
 	include: [
 		pageDetect.isPRCommit404,
 	],

--- a/source/features/useful-not-found-page.tsx
+++ b/source/features/useful-not-found-page.tsx
@@ -143,6 +143,11 @@ async function showAlternateLink(): Promise<void> {
 	);
 }
 
+function init(): void {
+	void showDefaultBranchLink();
+	void showAlternateLink();
+}
+
 async function initPRCommit(): Promise<void | false> {
 	const commitUrl = location.href.replace(/pull\/\d+\/commits/, 'commit');
 	if (await is404(commitUrl)) {
@@ -157,7 +162,7 @@ async function initPRCommit(): Promise<void | false> {
 
 void features.add(__filebasename, 	{
 	always: [
-		pageDetect.is404
+		pageDetect.is404,
 	],
 	include: [() => parseCurrentURL().length > 1],
 	init: showMissingPart,
@@ -169,9 +174,7 @@ void features.add(__filebasename, 	{
 		pageDetect.isRepoTree,
 		pageDetect.isEditingFile,
 	],
-	init: () => {
-		showDefaultBranchLink(); showAlternateLink();
-	},
+	init: onetime(init),
 }, {
 	include: [
 		pageDetect.isPRCommit404,

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -27,11 +27,11 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		() => select.exists(deploymentSelector),
+	],
 	include: [
 		pageDetect.isPRConversation,
-	],
-	exclude: [
-		() => !select.exists(deploymentSelector),
 	],
 	additionalListeners: [
 		onConversationHeaderUpdate,

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -99,12 +99,12 @@ function init(): void {
 }
 
 void features.add(__filebasename, {
+	asLongAs: [
+		// The user cannot merge
+		() => select.exists('[data-details-container=".js-merge-pr"]:not(:disabled)'),
+	],
 	include: [
 		pageDetect.isPRConversation,
-	],
-	exclude: [
-		// The user cannot merge
-		() => !select.exists('[data-details-container=".js-merge-pr"]:not(:disabled)'),
 	],
 	init,
 });

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -116,3 +116,17 @@ export async function isPermalink(): Promise<boolean> {
 export function isNotRefinedGitHubRepo(): boolean {
 	return !location.pathname.startsWith('/sindresorhus/refined-github/');
 }
+
+type BooleanFunction = () => boolean;
+export function shouldFeatureRun(conditions: {
+	include: BooleanFunction[];
+	exclude: BooleanFunction[];
+	asLongAs: BooleanFunction[];
+}): boolean {
+	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
+	if (!conditions.asLongAs.every(c => c()) || conditions.include.every(c => !c()) || conditions.exclude.some(c => c())) {
+		return false;
+	}
+
+	return true;
+}

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -118,14 +118,14 @@ export function isNotRefinedGitHubRepo(): boolean {
 }
 
 export function shouldFeatureRun({
-	asLongAs = [() => true],
+	/** Every condition must be true */
+	asLongAs = [],
+	
+	/** At least one condition must be true */
 	include = [() => true],
-	exclude = [() => false],
+	
+	/** No conditions must be true */
+	exclude = [],
 }): boolean {
-	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
-	if (!asLongAs.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
-		return false;
-	}
-
-	return true;
+	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c()))
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -119,10 +119,22 @@ export function isNotRefinedGitHubRepo(): boolean {
 
 type BooleanFunction = () => boolean;
 export function shouldFeatureRun(conditions: {
-	include: BooleanFunction[];
-	exclude: BooleanFunction[];
-	asLongAs: BooleanFunction[];
+	include?: BooleanFunction[];
+	exclude?: BooleanFunction[];
+	asLongAs?: BooleanFunction[];
 }): boolean {
+	if (!conditions.asLongAs) {
+		conditions.asLongAs = [];
+	}
+
+	if (!conditions.include) {
+		conditions.include = [() => true];
+	}
+
+	if (!conditions.exclude) {
+		conditions.exclude = [];
+	}
+
 	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
 	if (!conditions.asLongAs.every(c => c()) || conditions.include.every(c => !c()) || conditions.exclude.some(c => c())) {
 		return false;

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -117,26 +117,13 @@ export function isNotRefinedGitHubRepo(): boolean {
 	return !location.pathname.startsWith('/sindresorhus/refined-github/');
 }
 
-type BooleanFunction = () => boolean;
-export function shouldFeatureRun(conditions: {
-	include?: BooleanFunction[];
-	exclude?: BooleanFunction[];
-	asLongAs?: BooleanFunction[];
+export function shouldFeatureRun({
+	asLongAs = [() => true],
+	include = [() => true],
+	exclude = [() => false],
 }): boolean {
-	if (!conditions.asLongAs) {
-		conditions.asLongAs = [];
-	}
-
-	if (!conditions.include) {
-		conditions.include = [() => true];
-	}
-
-	if (!conditions.exclude) {
-		conditions.exclude = [];
-	}
-
 	// Features are enabled if every `asLongAs` matches, at least one `include` matches, none of `exclude` matches
-	if (!conditions.asLongAs.every(c => c()) || conditions.include.every(c => !c()) || conditions.exclude.some(c => c())) {
+	if (!asLongAs.every(c => c()) || include.every(c => !c()) || exclude.some(c => c())) {
 		return false;
 	}
 

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -127,5 +127,5 @@ export function shouldFeatureRun({
 	/** No conditions must be true */
 	exclude = [],
 }): boolean {
-	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c()))
+	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c());
 }

--- a/source/github-helpers/index.ts
+++ b/source/github-helpers/index.ts
@@ -119,13 +119,13 @@ export function isNotRefinedGitHubRepo(): boolean {
 
 export function shouldFeatureRun({
 	/** Every condition must be true */
-	asLongAs = [],
-	
+	asLongAs = [() => true],
+
 	/** At least one condition must be true */
 	include = [() => true],
-	
+
 	/** No conditions must be true */
-	exclude = [],
+	exclude = [() => false],
 }): boolean {
 	return asLongAs.every(c => c()) && include.some(c => c()) && exclude.every(c => !c());
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -176,4 +176,10 @@ test('shouldFeatureRun', t => {
 		asLongAs: [yes],
 		exclude: yesNo,
 	}), 'If any `exclude` is true, then it should not run, regardless of `asLongAs`');
+
+	t.false(shouldFeatureRun({
+		asLongAs: [yes],
+		include: yesYes,
+		exclude: yesNo,
+	}), 'If any `exclude` is true, then it should not run, regardless of `asLongAs` and `include`');
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -138,54 +138,42 @@ test('getLatestVersionTag', t => {
 });
 
 test('shouldFeatureRun', t => {
-	const returnsTrue = (): boolean => true;
-	const returnsFalse = (): boolean => false;
+	const yes = (): boolean => true;
+	const no = (): boolean => false;
+	const yesYes = [yes, yes];
+	const yesNo = [yes, no];
+	const noNo = [no, no];
 
-	t.is(shouldFeatureRun({
-		asLongAs: [],
-		include: [],
-		exclude: [],
-	}), false, 'Feature should not run if no conditions are passed');
+	t.true(shouldFeatureRun({}), 'A lack of conditions should mean "run everywhere"');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [returnsTrue, returnsFalse],
-		include: [],
-		exclude: [],
-	}), false, 'Feature should not run when any `asLongAs` condition returns false');
+	t.false(shouldFeatureRun({
+		asLongAs: yesNo,
+	}), 'Every `asLongAs` should be true to run');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [returnsFalse, returnsTrue],
-		include: [returnsTrue, returnsFalse],
-		exclude: [],
-	}), false, 'Feature should not run when any `asLongAs` condition returns false, even if any `include` condition returns true');
+	t.false(shouldFeatureRun({
+		asLongAs: yesNo,
+		include: [yes],
+	}), 'Every `asLongAs` should be true to run, regardless of `include`');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [],
-		include: [returnsFalse, returnsFalse],
-		exclude: [],
-	}), false, 'Feature should not run when all `include` condition returns false');
+	t.false(shouldFeatureRun({
+		include: noNo,
+	}), 'At least one `include` should be true to run');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [],
-		include: [returnsTrue, returnsFalse],
-		exclude: [],
-	}), true, 'Feature should run even if only one `include` condition returns true');
+	t.true(shouldFeatureRun({
+		include: yesNo,
+	}), 'If one `include` is true, then it should run');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [],
-		include: [],
-		exclude: [returnsTrue, returnsFalse],
-	}), false, 'Feature should not run when any `exclude` condition returns true');
+	t.false(shouldFeatureRun({
+		exclude: yesNo,
+	}), 'If any `exclude` is true, then it should not run');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [returnsTrue],
-		include: [],
-		exclude: [returnsTrue, returnsFalse],
-	}), false, 'Feature should not run when any `exclude` condition returns true, even if all `asLongAs` conditions return true');
+	t.false(shouldFeatureRun({
+		include: [yes],
+		exclude: yesNo,
+	}), 'If any `exclude` is true, then it should not run, regardless of `include`');
 
-	t.is(shouldFeatureRun({
-		asLongAs: [],
-		include: [returnsTrue],
-		exclude: [returnsTrue, returnsFalse],
-	}), false, 'Feature should not run when any `exclude` condition returns true, even if all `include` conditions return true');
+	t.false(shouldFeatureRun({
+		asLongAs: [yes],
+		exclude: yesNo,
+	}), 'If any `exclude` is true, then it should not run, regardless of `asLongAs`');
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -8,6 +8,7 @@ import {
 	parseTag,
 	compareNames,
 	getLatestVersionTag,
+	shouldFeatureRun,
 } from '../source/github-helpers';
 
 test('getConversationNumber', t => {
@@ -134,4 +135,57 @@ test('getLatestVersionTag', t => {
 		'2020-10-10',
 		'v1.0-1',
 	]), 'lol v0.0.0', 'Non-version tags should short-circuit the sorting and return the first tag');
+});
+
+test('shouldFeatureRun', t => {
+	const returnsTrue = (): boolean => true;
+	const returnsFalse = (): boolean => false;
+
+	t.is(shouldFeatureRun({
+		asLongAs: [],
+		include: [],
+		exclude: [],
+	}), false, 'Feature should not run if no conditions are passed');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [returnsTrue, returnsFalse],
+		include: [],
+		exclude: [],
+	}), false, 'Feature should not run when any `asLongAs` condition returns false');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [returnsFalse, returnsTrue],
+		include: [returnsTrue, returnsFalse],
+		exclude: [],
+	}), false, 'Feature should not run when any `asLongAs` condition returns false, even if any `include` condition returns true');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [],
+		include: [returnsFalse, returnsFalse],
+		exclude: [],
+	}), false, 'Feature should not run when all `include` condition returns false');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [],
+		include: [returnsTrue, returnsFalse],
+		exclude: [],
+	}), true, 'Feature should run even if only one `include` condition returns true');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [],
+		include: [],
+		exclude: [returnsTrue, returnsFalse],
+	}), false, 'Feature should not run when any `exclude` condition returns true');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [returnsTrue],
+		include: [],
+		exclude: [returnsTrue, returnsFalse],
+	}), false, 'Feature should not run when any `exclude` condition returns true, even if all `asLongAs` conditions return true');
+
+	t.is(shouldFeatureRun({
+		asLongAs: [],
+		include: [returnsTrue],
+		exclude: [returnsTrue, returnsFalse],
+	}), false, 'Feature should not run when any `exclude` condition returns true, even if all `include` conditions return true');
 });


### PR DESCRIPTION
## What this PR does

Adds the `required` variable from https://github.com/sindresorhus/refined-github/issues/4008#issuecomment-812843149 as the `always` variable. Also move negative `exclude`s to their own list of `always` tests.

> https://github.com/sindresorhus/refined-github/blob/936eedbb0bb37a30fc44a2cc7e5f3af31f24a3fc/source/features/fork-source-link-same-view.tsx#L24-L32
> 
> Could be
> 
> ```js
> 	required: [ // name TBD
>		pageDetect.isForkedRepo
>	],
>	include: [
>		pageDetect.isSingleFile,
>		pageDetect.isRepoTree,
>		pageDetect.isEditingFile
>	],
>	exclude: [
>		pageDetect.isRepoRoot
>	],
>```
>
> Side note: https://github.com/sindresorhus/refined-github/pull/4797/files#r711719028

---

I will be changing all the instances of negative exclusions to their own list of `always` tests, until then, the PR will stay a draft. Please do review the changes I made to `source/features/index.ts` while adding the `always` test though.
