### PR TITLE
Meta: Drop "Feature history" dropdown

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -8,84 +8,6 @@ import * as api from '../github-helpers/api';
 import {wrapAll} from '../helpers/dom-utils';
 import parseBackticks from '../github-helpers/parse-backticks';
 
-interface Commit {
-	messageHeadline: string;
-	messageHeadlineHTML: string;
-	commitUrl: string;
-	committedDate: string;
-}
-
-const getFeatureHistory = cache.function(async (fileName: string): Promise<Commit[]> => {
-	const {repository} = await api.v4(`
-		repository() {
-			defaultBranchRef {
-				target {
-					...on Commit {
-						history(first:100, path: "source/features/${fileName}") {
-							nodes {
-								messageHeadline
-								messageHeadlineHTML
-								commitUrl
-								committedDate
-							}
-						}
-					}
-				}
-			}
-		}
-	`);
-
-	// From https://github.com/notlmn/release-with-changelog/blob/5c804153ef8227047cf9bf373a704791aa3ee755/generate-release-notes.js#L6
-	const excludePreset = /^meta|^document|^lint|^refactor|readme|dependencies|^v?\d+\.\d+\.\d+/i;
-
-	return repository.defaultBranchRef.target.history.nodes.filter(
-		(commit: Commit) => !excludePreset.test(commit.messageHeadline),
-	);
-}, {
-	maxAge: {days: 1},
-	staleWhileRevalidate: {days: 4},
-	cacheKey: ([fileName]): string => __filebasename + ':' + fileName,
-});
-
-function getCommitUrl(commit: Commit): string {
-	const [, pullRequestUrl] = /<a[^>]+href="([^"]+)">/.exec(commit.messageHeadlineHTML) ?? [];
-	return pullRequestUrl ?? commit.commitUrl;
-}
-
-async function getHistoryDropdown(featureName: string): Promise<Element | void> {
-	const history = await getFeatureHistory(featureName + '.tsx');
-	if (history.length === 0) {
-		return;
-	}
-
-	return (
-		<details className="details-reset details-overlay d-inline-block ml-3 position-relative">
-			<summary className="text-gray color-text-secondary d-inline" aria-haspopup="true">
-				Feature history
-				<div className="dropdown-caret ml-1"/>
-			</summary>
-			<details-menu className="SelectMenu right-0 ws-normal" role="menu">
-				<div className="SelectMenu-modal">
-					<div className="SelectMenu-list">
-						{history.map(commit => (
-							<a
-								className="SelectMenu-item d-block"
-								role="menuitem"
-								href={getCommitUrl(commit)}
-								title={commit.messageHeadline}
-								data-pjax="#repo-content-pjax-container"
-							>
-								<h5>{parseBackticks(commit.messageHeadline)}</h5>
-								<relative-time className="text-gray color-text-secondary" datetime={commit.committedDate}/>
-							</a>
-						))}
-					</div>
-				</div>
-			</details-menu>
-		</details>
-	);
-}
-
 async function init(): Promise<void | false> {
 	const [, currentFeature] = /features\/([^.]+)/.exec(location.pathname)!;
 	const feature = features.meta.find(feature => feature.id === currentFeature);
@@ -125,11 +47,6 @@ async function init(): Promise<void | false> {
 	);
 
 	wrapAll([commitInfoBox, featureInfoBox], <div className="d-lg-flex"/>);
-
-	const historyDropdown = await getHistoryDropdown(feature.id);
-	if (historyDropdown) {
-		select('.no-wrap', featureInfoBox)!.append(historyDropdown);
-	}
 }
 
 void features.add(__filebasename, {

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -1,12 +1,8 @@
 import React from 'dom-chef';
-import cache from 'webext-storage-cache';
-import select from 'select-dom';
 import elementReady from 'element-ready';
 
 import features from '.';
-import * as api from '../github-helpers/api';
 import {wrapAll} from '../helpers/dom-utils';
-import parseBackticks from '../github-helpers/parse-backticks';
 
 async function init(): Promise<void | false> {
 	const [, currentFeature] = /features\/([^.]+)/.exec(location.pathname)!;


### PR DESCRIPTION
The dropdown is a little inconvenient because it closes every time you click on a commit, making it difficult to open more than one at a time. I think it's easier to just open the History page.

One possible meta feature in that case would be to dim every meta/lint commit in the regular commit list of Refined GitHub, using the styles of `dim-bots`
