### PR TITLE
Meta: Fix `rgh-feature-descriptions` feature

### DIFF
--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -13,13 +13,13 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady([
-		'.hx_commit-tease', // Selector for commit message
-		'.Box-header.Details', // Generic selector for entire commit box
-		'include-fragment.commit-loader', // Required according to 2683e30
-	].join(',')))!.parentElement!;
-	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
-	commitInfoBox.classList.remove('flex-shrink-0');
+	const commit = await elementReady([
+		'.Box-header.Details', // Already loaded
+		'include-fragment.commit-loader', // Deferred loading
+	].join(','));
+	
+	commit!.parentElement!.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
+	commit!.parentElement!.classList.remove('flex-shrink-0');
 
 	const featureInfoBox = (
 		<div className="Box rgh-feature-description" style={{flex: '0 1 544px'}}>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -17,9 +17,11 @@ async function init(): Promise<void | false> {
 		'.Box-header.Details', // Already loaded
 		'include-fragment.commit-loader', // Deferred loading
 	].join(','));
-	
-	commit!.parentElement!.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
-	commit!.parentElement!.classList.remove('flex-shrink-0');
+
+	const commitInfoBox = commit!.parentElement!;
+
+	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
+	commitInfoBox.classList.remove('flex-shrink-0');
 
 	const featureInfoBox = (
 		<div className="Box rgh-feature-description" style={{flex: '0 1 544px'}}>

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -13,7 +13,7 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.Box-header.Details, include-fragment.commit-loader'))!.parentElement!;
+	const commitInfoBox = (await elementReady('.hx_commit-tease, .Box-header.Details, include-fragment.commit-loader'))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -13,7 +13,11 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.hx_commit-tease, .Box-header.Details, include-fragment.commit-loader'))!.parentElement!;
+	const commitInfoBox = (await elementReady([
+		'.hx_commit-tease', // Selector for commit message
+		'.Box-header.Details', // Generic selector for entire commit box
+		'include-fragment.commit-loader', // Required according to 2683e30
+	].join(',')))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 

--- a/source/features/rgh-feature-descriptions.tsx
+++ b/source/features/rgh-feature-descriptions.tsx
@@ -13,7 +13,7 @@ async function init(): Promise<void | false> {
 
 	const conversationsUrl = '/sindresorhus/refined-github/issues?q=' + encodeURIComponent(`"${feature.id}" sort:updated-desc`);
 
-	const commitInfoBox = (await elementReady('.hx_commit-tease, include-fragment.commit-loader'))!.parentElement!;
+	const commitInfoBox = (await elementReady('.Box-header.Details, include-fragment.commit-loader'))!.parentElement!;
 	commitInfoBox.classList.add('width-fit', 'min-width-0', 'flex-auto', 'mb-lg-0', 'mr-lg-3');
 	commitInfoBox.classList.remove('flex-shrink-0');
 


### PR DESCRIPTION
Changes the selector to select the commit box to `.Box-header.Details`, as suggested in https://github.com/sindresorhus/refined-github/issues/4815#issuecomment-927072107.

Closes #4815 if merged.