### PR TITLE
Clean up more `parse-backticks` selectors

### DIFF
--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -35,14 +35,6 @@ function init(): void {
 			parseBackticks(element);
 		},
 	});
-
-	// `isRepoSearch` might highlight keywords inside backticks, breaking the regular dom-formatter #3509
-	observe('.codesearch-results .f4:not(.rgh-backticks-already-parsed)', {
-		add(element) {
-			element.classList.add('rgh-backticks-already-parsed');
-			zipTextNodes(element, parseBackticksCore(element.textContent!));
-		},
-	});
 }
 
 void features.add(__filebasename, {

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -10,9 +10,8 @@ import parseBackticksCore from '../github-helpers/parse-backticks';
 function init(): void {
 	const selectors = [
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
-		'.Box-row .mb-1 a', // `isCompare` open Pull Request title
 		'.release-header', // `isReleasesOrTags` Headers
-		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR
+		'.Box-row .mb-1 a', // `isCompare` with existing PR
 		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE #4021)
 		'#pull-requests a.Link--primary', // `isPulse` issue and PR title
 		'[id^="check_suite"] a.link-gray-dark', // `isRepositoryActions` (GHE #4021)

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -8,6 +8,9 @@ import {parseBackticks} from '../github-helpers/dom-formatters';
 function init(): void {
 	const selectors = [
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
+		'.js-commits-list-item pre', // `isCommitList` commit description
+		'.js-commit-group .pr-1 code', // `isPRConversation` commit message
+		'.js-commit-group pre', // `isPRConversation` commit description
 		'.release-header', // `isReleasesOrTags` Headers
 		'.Box-row .mb-1 a', // `isCompare` with existing PR
 		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE #4021)

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -18,7 +18,7 @@ function init(): void {
 		'[id^="check_suite"] a.Link--primary', // `isRepositoryActions`
 		'.checks-summary-conclusion + .flex-auto .f3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
-		'.wiki-wrapper .gh-header-title', // `isWiki` page title
+		'#wiki-wrapper .gh-header-title', // `isWiki` page title
 		'.js-recent-activity-container .text-bold', // `isDashboard` "Recent activity" titles
 		'.issues_labeled .text-gray-dark > a', // `isDashboard` "help wanted" event titles (GHE #4021)
 		'.issues_labeled .color-text-primary > a', // `isDashboard` "help wanted" event titles

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -1,11 +1,9 @@
 import './parse-backticks.css';
 import onetime from 'onetime';
 import {observe} from 'selector-observer';
-import zipTextNodes from 'zip-text-nodes';
 
 import features from '.';
 import {parseBackticks} from '../github-helpers/dom-formatters';
-import parseBackticksCore from '../github-helpers/parse-backticks';
 
 function init(): void {
 	const selectors = [

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -16,7 +16,7 @@ function init(): void {
 		'#pull-requests a.Link--primary', // `isPulse` issue and PR title
 		'[id^="check_suite"] a.link-gray-dark', // `isRepositoryActions` (GHE #4021)
 		'[id^="check_suite"] a.Link--primary', // `isRepositoryActions`
-		'.checks-summary-conclusion + .flex-auto .f3', // `isActions` run
+		'.js-socket-channel[data-url*="/header_partial"] h3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
 		'#wiki-wrapper .gh-header-title', // `isWiki` page title
 		'.js-recent-activity-container .text-bold', // `isDashboard` "Recent activity" titles

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -19,7 +19,6 @@ function init(): void {
 		'#wiki-wrapper .gh-header-title', // `isWiki` page title
 		'.issues_labeled .text-gray-dark > a', // `isDashboard` "help wanted" event titles (GHE #4021)
 		'.issues_labeled .color-text-primary > a', // `isDashboard` "help wanted" event titles
-		'.commits blockquote', // `isDashboard` newsfeed commits
 		'#user-repositories-list [itemprop="description"]', // `isUserProfileRepoTab` repository description
 		'.js-hovercard-content > .Popover-message .link-gray-dark', // Hovercard (GHE #4021)
 		'.js-hovercard-content > .Popover-message .Link--primary', // Hovercard

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -19,7 +19,6 @@ function init(): void {
 		'.js-socket-channel[data-url*="/header_partial"] h3', // `isActions` run
 		'.js-wiki-sidebar-toggle-display a', // `isWiki` sidebar pages title
 		'#wiki-wrapper .gh-header-title', // `isWiki` page title
-		'.js-recent-activity-container .text-bold', // `isDashboard` "Recent activity" titles
 		'.issues_labeled .text-gray-dark > a', // `isDashboard` "help wanted" event titles (GHE #4021)
 		'.issues_labeled .color-text-primary > a', // `isDashboard` "help wanted" event titles
 		'.commits blockquote', // `isDashboard` newsfeed commits

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -10,22 +10,10 @@ import parseBackticksCore from '../github-helpers/parse-backticks';
 function init(): void {
 	const selectors = [
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
-		'.js-commits-list-item .mb-1', // `isCommitList` commit message
-		'.js-commits-list-item pre', // `isCommitList` commit description
-		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.link-gray-dark', // `isRepoRoot` commit message (GHE #4021)
-		'.Details[data-issue-and-pr-hovercards-enabled] .d-none a.Link--primary', // `isRepoRoot` commit message
-		'.commit-title', // `isCommit` commit message
-		'.commit-desc', // `isCommit` commit description
-		'.js-commit .pr-1 > code', // `isPRConversation` pushed commits
-		'.js-details-container .pr-1 > code', // `isCompare` pushed commits
 		'.Box-row .mb-1 a', // `isCompare` open Pull Request title
-		'.blame-commit-message', // `isBlame` commit message
 		'[id^=ref-issue-]', // `isIssue` issue and PR references
 		'[id^=ref-pullrequest-]', // `isPRConversation` issue and PR references
 		'[aria-label="Link issues"] a', // `isIssue`, `isPRConversation` linked issue and PR
-		'.Box-header.Details .link-gray', // `isSingleFile` commit message (GHE #4021)
-		'.Box-header.Details .Link--secondary', // `isSingleFile` commit message
-		'.Box-header.Details pre', // `isSingleFile` commit description
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR
 		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE #4021)

--- a/source/features/parse-backticks.tsx
+++ b/source/features/parse-backticks.tsx
@@ -11,9 +11,6 @@ function init(): void {
 	const selectors = [
 		'.BorderGrid--spacious .f4.mt-3', // `isRepoHome` repository description
 		'.Box-row .mb-1 a', // `isCompare` open Pull Request title
-		'[id^=ref-issue-]', // `isIssue` issue and PR references
-		'[id^=ref-pullrequest-]', // `isPRConversation` issue and PR references
-		'[aria-label="Link issues"] a', // `isIssue`, `isPRConversation` linked issue and PR
 		'.release-header', // `isReleasesOrTags` Headers
 		'.existing-pull-contents .list-group-item-link', // `isCompare` with existing PR
 		'#pull-requests a.link-gray-dark', // `isPulse` issue and PR title (GHE #4021)


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Related #4135
We only cleaned up the selectors a little bit in [`5e40087` (#4361)](https://github.com/sindresorhus/refined-github/pull/4361/commits/5e400878bdb49d747430584017547b8b16fbf1ea) but there's plenty more to deal with. I started with removing all "commit" related selector since they should all be native now.

## Test URLs

(Too many places 🤷‍♀️ just test and see if there are places left out)

- Commits: https://github.com/sindresorhus/refined-github/commits/main
- `isActions` run: https://github.com/sindresorhus/refined-github/actions/runs/1272877098
- `isRepoSearch`: https://github.com/sindresorhus/refined-github/search?q=latest+reliable+button+is%3Aissue&type=Issues

## Screenshot
