### PR TITLE
Meta: show screenshots in options page

### DIFF
--- a/distribution/options.html
+++ b/distribution/options.html
@@ -40,6 +40,10 @@
 		<p>
 			<label>
 				<strong class="features-header">Features</strong>
+				<label class="show-screenshots-label">
+					<input id="show-screenshots" type="checkbox" />
+					Show all screenshots
+				</label>
 				<input id="filter-features" type="text" placeholder="Find features" />
 			</label>
 		</p>

--- a/source/options.css
+++ b/source/options.css
@@ -155,3 +155,14 @@ li[data-validation] {
 #debugging p:last-child {
 	margin-bottom: 0;
 }
+
+.show-screenshots-label {
+	float: right;
+}
+
+img {
+	max-width: 100%;
+	margin-top: 0.5em;
+	border: 1px solid #d1d5da;
+	border-radius: 0.2em;
+}

--- a/source/options.tsx
+++ b/source/options.tsx
@@ -107,6 +107,10 @@ function buildFeatureCheckbox({id, description, screenshot}: FeatureMeta): HTMLE
 	const descriptionElement = domify.one(description)!;
 	descriptionElement.className = 'description';
 
+	if (screenshot) {
+		descriptionElement.append(<img hidden data-src={screenshot} loading="lazy"/>);
+	}
+
 	return (
 		<div className="feature" data-text={`${id} ${description}`.toLowerCase()}>
 			<input type="checkbox" name={`feature:${id}`} id={id}/>
@@ -147,6 +151,16 @@ async function findFeatureHandler(event: Event): Promise<void> {
 	}, 10_000);
 
 	select('#find-feature-message')!.hidden = false;
+}
+
+function showScreenshotsHandler(): void {
+	for (const screenshot of select.all('img')) {
+		if (!screenshot.hasAttribute('src')) {
+			screenshot.setAttribute('src', screenshot.getAttribute('data-src')!);
+		}
+
+		screenshot.hidden = !screenshot.hidden;
+	}
 }
 
 function featuresFilterHandler(event: Event): void {
@@ -236,6 +250,9 @@ function addEventListeners(): void {
 	// Improve textareas editing
 	fitTextarea.watch('textarea');
 	indentTextarea.watch('textarea');
+
+	// Toggle screenshots
+	select('#show-screenshots')!.addEventListener('change', showScreenshotsHandler);
 
 	// Filter feature list
 	select('#filter-features')!.addEventListener('input', featuresFilterHandler);


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Resolve #4810

## Test URLs

chrome://extensions/?options=balgliakcbamepammkbcjdepogihccmj (😄)

## Screenshot

![](https://user-images.githubusercontent.com/44045911/134818579-b114916b-4ffb-47cd-a44d-db1e421d9bc0.png)