### PR TITLE
Fix: Many features don't work until you refresh the page

### DIFF
--- a/source/features/avoid-accidental-submissions.tsx
+++ b/source/features/avoid-accidental-submissions.tsx
@@ -65,6 +65,7 @@ void features.add(__filebasename, {
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	shortcuts: {

--- a/source/features/batch-mark-files-as-viewed.tsx
+++ b/source/features/batch-mark-files-as-viewed.tsx
@@ -78,6 +78,7 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 	deinit,
 });

--- a/source/features/bypass-checks.tsx
+++ b/source/features/bypass-checks.tsx
@@ -38,5 +38,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init: onetime(init),
 });

--- a/source/features/clean-conversation-headers.tsx
+++ b/source/features/clean-conversation-headers.tsx
@@ -84,5 +84,6 @@ void features.add(__filebasename, {
 		onConversationHeaderUpdate,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init: initPR,
 });

--- a/source/features/clean-header-search-field.tsx
+++ b/source/features/clean-header-search-field.tsx
@@ -14,5 +14,6 @@ void features.add(__filebasename, {
 		pageDetect.isGlobalConversationList,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init: onetime(init),
 });

--- a/source/features/clear-pr-merge-commit-message.tsx
+++ b/source/features/clear-pr-merge-commit-message.tsx
@@ -29,5 +29,6 @@ void features.add(__filebasename, {
 	],
 	onlyAdditionalListeners: true,
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/collapsible-content-button.tsx
+++ b/source/features/collapsible-content-button.tsx
@@ -48,5 +48,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.hasRichTextEditor,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/comment-on-draft-pr-indicator.tsx
+++ b/source/features/comment-on-draft-pr-indicator.tsx
@@ -33,5 +33,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRConversation,
 		pageDetect.isPRFiles,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/conflict-marker.tsx
+++ b/source/features/conflict-marker.tsx
@@ -78,5 +78,6 @@ void features.add(__filebasename, {
 	exclude: [
 		() => select.exists('.blankslate'),
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/convert-pr-to-draft-improvements.tsx
+++ b/source/features/convert-pr-to-draft-improvements.tsx
@@ -38,5 +38,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init: onetime(init),
 });

--- a/source/features/cross-deleted-pr-branches.tsx
+++ b/source/features/cross-deleted-pr-branches.tsx
@@ -42,5 +42,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/dim-bots.tsx
+++ b/source/features/dim-bots.tsx
@@ -35,5 +35,6 @@ void features.add(__filebasename, {
 		pageDetect.isCommitList,
 		pageDetect.isConversationList,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/easy-toggle-files.tsx
+++ b/source/features/easy-toggle-files.tsx
@@ -25,5 +25,6 @@ void features.add(__filebasename, {
 		pageDetect.isCompare,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/esc-to-cancel.tsx
+++ b/source/features/esc-to-cancel.tsx
@@ -27,5 +27,6 @@ void features.add(__filebasename, {
 		pageDetect.isPR,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/esc-to-deselect-line.tsx
+++ b/source/features/esc-to-deselect-line.tsx
@@ -28,5 +28,6 @@ void features.add(__filebasename, {
 		pageDetect.hasCode,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init: onetime(init),
 });

--- a/source/features/extend-diff-expander.tsx
+++ b/source/features/extend-diff-expander.tsx
@@ -22,5 +22,6 @@ void features.add(__filebasename, {
 		pageDetect.isCommit,
 		pageDetect.isCompare,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/first-published-tag-for-merged-pr.tsx
+++ b/source/features/first-published-tag-for-merged-pr.tsx
@@ -53,5 +53,6 @@ void features.add(__filebasename, {
 	additionalListeners: [
 		onConversationHeaderUpdate,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/fit-textareas.tsx
+++ b/source/features/fit-textareas.tsx
@@ -52,6 +52,7 @@ void features.add(__filebasename, {
 	exclude: [
 		isSafari,
 	],
+	deduplicate: 'has-rgh-inner',
 	init() {
 		onPrMergePanelOpen(fitPrCommitMessageBox);
 	},

--- a/source/features/hidden-review-comments-indicator.tsx
+++ b/source/features/hidden-review-comments-indicator.tsx
@@ -74,5 +74,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/hide-diff-signs.tsx
+++ b/source/features/hide-diff-signs.tsx
@@ -3,4 +3,4 @@ import * as pageDetect from 'github-url-detection';
 
 import features from '.';
 
-void features.addCssFeature(__filebasename, [pageDetect.hasCode]);
+void features.addCssFeature(__filebasename, [pageDetect.hasCode], 'has-rgh-inner');

--- a/source/features/hide-inactive-deployments.tsx
+++ b/source/features/hide-inactive-deployments.tsx
@@ -23,5 +23,6 @@ void features.add(__filebasename, {
 	additionalListeners: [
 		onNewComments,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/highlight-deleted-and-added-files-in-diffs.tsx
+++ b/source/features/highlight-deleted-and-added-files-in-diffs.tsx
@@ -72,6 +72,7 @@ void features.add(__filebasename, {
 		pageDetect.isPRCommit404,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 	deinit,
 });

--- a/source/features/highlight-non-default-base-branch.tsx
+++ b/source/features/highlight-non-default-base-branch.tsx
@@ -77,5 +77,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isRepoConversationList,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/jump-to-change-requested-comment.tsx
+++ b/source/features/jump-to-change-requested-comment.tsx
@@ -25,5 +25,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init: onetime(init),
 });

--- a/source/features/linkify-commit-sha.tsx
+++ b/source/features/linkify-commit-sha.tsx
@@ -16,5 +16,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRCommit,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/no-duplicate-list-update-time.tsx
+++ b/source/features/no-duplicate-list-update-time.tsx
@@ -23,5 +23,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isConversationList,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/no-unnecessary-split-diff-view.tsx
+++ b/source/features/no-unnecessary-split-diff-view.tsx
@@ -41,5 +41,6 @@ void features.add(__filebasename, {
 	additionalListeners: [
 		onDiffFileLoad,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/open-ci-details-in-new-tab.tsx
+++ b/source/features/open-ci-details-in-new-tab.tsx
@@ -15,5 +15,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/patch-diff-links.tsx
+++ b/source/features/patch-diff-links.tsx
@@ -27,5 +27,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isPRCommit404,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/pr-branch-auto-delete.tsx
+++ b/source/features/pr-branch-auto-delete.tsx
@@ -24,5 +24,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/pr-commit-lines-changed.tsx
+++ b/source/features/pr-commit-lines-changed.tsx
@@ -47,5 +47,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRCommit,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/pr-jump-to-first-non-viewed-file.tsx
+++ b/source/features/pr-jump-to-first-non-viewed-file.tsx
@@ -27,5 +27,6 @@ void features.add(__filebasename, {
 	exclude: [
 		pageDetect.isPRFile404,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/previous-next-commit-buttons.tsx
+++ b/source/features/previous-next-commit-buttons.tsx
@@ -20,5 +20,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles,
 		pageDetect.isPRCommit,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/quick-pr-diff-options.tsx
+++ b/source/features/quick-pr-diff-options.tsx
@@ -115,6 +115,7 @@ void features.add(__filebasename, {
 	shortcuts: {
 		'd w': 'Show/hide whitespaces in diffs',
 	},
+	deduplicate: 'has-rgh-inner',
 	init: initPR,
 }, {
 	include: [

--- a/source/features/quick-review-buttons.tsx
+++ b/source/features/quick-review-buttons.tsx
@@ -94,5 +94,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPR,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/quick-review-comment-deletion.tsx
+++ b/source/features/quick-review-comment-deletion.tsx
@@ -46,6 +46,7 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init,
 	deinit,
 });

--- a/source/features/quick-review.tsx
+++ b/source/features/quick-review.tsx
@@ -54,6 +54,7 @@ void features.add(__filebasename, {
 		},
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init: addSidebarReviewButton,
 }, {
 	shortcuts: {
@@ -63,5 +64,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles,
 	],
 	awaitDomReady: false,
+	deduplicate: 'has-rgh-inner',
 	init: initReviewButtonEnhancements,
 });

--- a/source/features/raw-file-link.tsx
+++ b/source/features/raw-file-link.tsx
@@ -30,5 +30,6 @@ void features.add(__filebasename, {
 		pageDetect.isPRFiles,
 		pageDetect.isCompare,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/submit-review-as-single-comment.tsx
+++ b/source/features/submit-review-as-single-comment.tsx
@@ -112,5 +112,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRFiles,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/suggest-commit-title-limit.tsx
+++ b/source/features/suggest-commit-title-limit.tsx
@@ -25,6 +25,7 @@ void features.add(__filebasename, {
 		pageDetect.isEditingFile,
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 }, {
 	include: [
@@ -36,5 +37,6 @@ void features.add(__filebasename, {
 		onPrMergePanelOpen,
 	],
 	onlyAdditionalListeners: true,
+	deduplicate: 'has-rgh-inner',
 	init: validateInput,
 });

--- a/source/features/sync-pr-commit-title.tsx
+++ b/source/features/sync-pr-commit-title.tsx
@@ -105,5 +105,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/toggle-everything-with-alt.tsx
+++ b/source/features/toggle-everything-with-alt.tsx
@@ -73,5 +73,6 @@ void features.add(__filebasename, {
 		pageDetect.isCommit,
 		pageDetect.isCompare,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/update-pr-from-base-branch.tsx
+++ b/source/features/update-pr-from-base-branch.tsx
@@ -97,5 +97,6 @@ void features.add(__filebasename, {
 		pageDetect.isClosedPR,
 		() => select('.head-ref')!.title === 'This repository has been deleted',
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/view-last-pr-deployment.tsx
+++ b/source/features/view-last-pr-deployment.tsx
@@ -36,5 +36,6 @@ void features.add(__filebasename, {
 	additionalListeners: [
 		onConversationHeaderUpdate,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/wait-for-build.tsx
+++ b/source/features/wait-for-build.tsx
@@ -106,5 +106,6 @@ void features.add(__filebasename, {
 	include: [
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });

--- a/source/features/warning-for-disallow-edits.tsx
+++ b/source/features/warning-for-disallow-edits.tsx
@@ -42,5 +42,6 @@ void features.add(__filebasename, {
 		pageDetect.isCompare,
 		pageDetect.isPRConversation,
 	],
+	deduplicate: 'has-rgh-inner',
 	init,
 });


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4695 
Fix #4692 

## Test URLs
Go to the options and check "Show the features enabled on each page"

* For PR files features (`batch-mark-files-as-viewed`, `easy-toggle-files`, etc.):
  1. Go to the PR list and reload the page
  2. Navigate to a PR
  3. Go to the "Files" tab
* For the PR conversation features (`clean-conversation-headers`, `cross-deleted-pr-branches`, etc.):
  1. Go to the "Files" tab of this PR
  2. Reload the page
  3. Got to the "Conversation" tab

## Screenshot
https://user-images.githubusercontent.com/46634000/134921002-64795a2e-d98b-456c-bebc-997b89dfe8fa.mp4
(↑ this only shows a few features in the "Files" tab)

I went through all the remaining features with no explicit deduplication (`rg --files-without-match 'deduplicate:' source/features/*.tsx | sort`) and checked each one. Basically every feature with `isPrFile` or `isPrConversation` needs `has-rgh-inner`.

Opening this as draft in case I've missed some.