### PR TITLE
Fix `unfinished-comments` feature

### DIFF
--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -13,10 +13,7 @@ function hasDraftComments(): boolean {
 		&& (
       !select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
       || 
-      (
-        select.exists('input[aria-label="Title"]', textarea.form!)
-        && !(select('input[aria-label="Title"]', textarea.form!))?.value // Exclude forms doesn't fill in required title but have draft comments
-      )
+      select.exists('input[aria-label="Title"]', textarea.form!) // Exclude forms doesn't fill in required title but have draft comments
     )
 	);
 }

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -10,7 +10,14 @@ function hasDraftComments(): boolean {
 	// `[id^="convert-to-issue-body"]` excludes the hidden pre-filled textareas created when opening the dropdown menu of review comments
 	return select.all('textarea:not([disabled], [id^="convert-to-issue-body"])').some(textarea =>
 		textarea.value !== textarea.textContent // Exclude comments being edited but not yet changed (and empty comment fields)
-		&& !select.exists('.btn-primary[disabled]', textarea.form!), // Exclude forms being submitted
+		&& (
+      !select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
+      || 
+      (
+        select.exists('input[aria-label="Title"]', textarea.form!)
+        && !(select('input[aria-label="Title"]', textarea.form!))?.value // Exclude forms doesn't fill in required title but have draft comments
+      )
+    )
 	);
 }
 

--- a/source/features/unfinished-comments.tsx
+++ b/source/features/unfinished-comments.tsx
@@ -11,10 +11,9 @@ function hasDraftComments(): boolean {
 	return select.all('textarea:not([disabled], [id^="convert-to-issue-body"])').some(textarea =>
 		textarea.value !== textarea.textContent // Exclude comments being edited but not yet changed (and empty comment fields)
 		&& (
-      !select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
-      || 
-      select.exists('input[aria-label="Title"]', textarea.form!) // Exclude forms doesn't fill in required title but have draft comments
-    )
+			!select.exists('.btn-primary[disabled]', textarea.form!) // Exclude forms being submitted
+			|| select.exists('input[aria-label="Title"]', textarea.form!) // Exclude forms doesn't fill in required title but have draft comments
+		),
 	);
 }
 


### PR DESCRIPTION
fix #4737 


## Test URLs
https://github.com/sindresorhus/refined-github/issues/new?assignees=&labels=under+discussion&template=3_discussion.md


## Screenshot
before:
![before](https://user-images.githubusercontent.com/35054329/134853085-4c2742c8-3772-45f7-b059-080ebe6fe89e.gif)

after:
![after](https://user-images.githubusercontent.com/35054329/134853120-ec656343-04d0-4e64-b595-fe9b1792be15.gif)