### PR TITLE
Follow the user’s tab-size setting where possible

### DIFF
--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -23,6 +23,11 @@ ttps://stackoverflow.com/a/40815884
 	--tab-size: 12;
 }
 
+.ghe * {
+	-moz-tab-size: 4 !important;
+	tab-size: 4 !important;
+}
+
 [data-rgh-whitespace] {
 	line-height: 1em;
 	background-clip: border-box;

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,5 +1,26 @@
+/*
+Can't use this because attributes are strings and calc() won't cast them
+ttps://stackoverflow.com/a/40815884
+
 [data-tab-size] {
 	--tab-size: attr(data-tab-size);
+}
+*/
+
+[data-tab-size="2"] {
+	--tab-size: 2;
+}
+[data-tab-size="4"] {
+	--tab-size: 4;
+}
+[data-tab-size="8"] {
+	--tab-size: 8;
+}
+[data-tab-size="10"] {
+	--tab-size: 10;
+}
+[data-tab-size="12"] {
+	--tab-size: 12;
 }
 
 [data-rgh-whitespace] {

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -7,25 +7,24 @@ ttps://stackoverflow.com/a/40815884
 }
 */
 
-[data-tab-size="2"] {
+[data-tab-size='2'] {
 	--tab-size: 2;
 }
-[data-tab-size="4"] {
+
+[data-tab-size='4'] {
 	--tab-size: 4;
 }
-[data-tab-size="8"] {
+
+[data-tab-size='8'] {
 	--tab-size: 8;
 }
-[data-tab-size="10"] {
+
+[data-tab-size='10'] {
 	--tab-size: 10;
 }
-[data-tab-size="12"] {
-	--tab-size: 12;
-}
 
-.ghe * {
-	-moz-tab-size: 4 !important;
-	tab-size: 4 !important;
+[data-tab-size='12'] {
+	--tab-size: 12;
 }
 
 [data-rgh-whitespace] {

--- a/source/features/show-whitespace.css
+++ b/source/features/show-whitespace.css
@@ -1,3 +1,7 @@
+[data-tab-size] {
+	--tab-size: attr(data-tab-size);
+}
+
 [data-rgh-whitespace] {
 	line-height: 1em;
 	background-clip: border-box;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -7,7 +7,7 @@
 
 /* Make tab indented code more readable on GitHub and Gist */
 :root, /* GHE, drop in February 2022 */
-.comment-body [data-tab-size] { /* User setting is ignored in comments #4833 */
+.comment-body [data-tab-size="8"] { /* User setting is ignored in comments #4833 */
 	--tab-size: 4;
 }
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -5,12 +5,6 @@
 	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 
-/* Make tab indented code more readable on GitHub and Gist */
-* {
-	-moz-tab-size: 4 !important;
-	tab-size: 4 !important;
-}
-
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
 #js-issues-toolbar .table-list-header-toggle details {
 	padding: 0 !important;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -7,7 +7,7 @@
 
 /* Make tab indented code more readable on GitHub and Gist */
 :root, /* GHE, drop in February 2022 */
-.comment-body [data-tab-size="8"] { /* User setting is ignored in comments #4833 */
+.comment-body [data-tab-size='8'] { /* User setting is ignored in comments #4833 */
 	--tab-size: 4;
 }
 

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -5,6 +5,17 @@
 	--github-border-color: var(--color-border-primary, #e1e4e8);
 }
 
+/* Make tab indented code more readable on GitHub and Gist */
+:root, /* GHE, drop in February 2022 */
+.comment-body [data-tab-size] { /* User setting is ignored in comments #4833 */
+	--tab-size: 4;
+}
+
+* {
+	-moz-tab-size: var(--tab-size) !important;
+	tab-size: var(--tab-size) !important;
+}
+
 /* For `open-all-selected` and `pr-filters`: set a reduced padding for all buttons for #1830 and #1904 */
 #js-issues-toolbar .table-list-header-toggle details {
 	padding: 0 !important;


### PR DESCRIPTION
- Fixes #4832 
- Fixes https://github.com/sindresorhus/refined-github/issues/4806

## What

- In files, follow the user’s setting
- In comments, stick to 4 characters because GitHub is ignoring the setting
- Preserves support in `show-whitespace`

## Test


### Working natively

- https://github.com/sindresorhus/refined-github/blob/a52decfe2d0b5cd4617c08055bcf4a0a23812e4e/package.json
- https://github.com/sindresorhus/refined-github/pull/4833/files


### GitHub bugs…

GitHub ignores the user setting in comments and just sets `data-tab-size="8"` in the DOM 🤷‍♂️  so I will force it in this case.

- Review: https://github.com/sindresorhus/refined-github/pull/4833#discussion_r719986599

- Inlined code:

	https://github.com/sindresorhus/refined-github/blob/a52decfe2d0b5cd4617c08055bcf4a0a23812e4e/package.json#L1-L6

- Code block
	  
	```js
	{
		no: "support"
	}
	```
- Try editing a comment and press <kbd>tab</tab>

# Screenshot 1

> <img width="321" alt="Screen Shot 2" src="https://user-images.githubusercontent.com/1402241/135579301-e0da9037-35ca-4013-a999-3e1b91902a63.png">


# Screenshot 2
 
> <img width="297" alt="Screen Shot 3" src="https://user-images.githubusercontent.com/1402241/135579366-c8f37e5c-3a93-4c86-ac59-ae4811298070.png">
 