### PR TITLE
Disable `view-markdown-source` where it already exists

### DIFF
--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -6,6 +6,10 @@ import {CodeIcon, FileIcon} from '@primer/octicons-react';
 import features from '.';
 
 async function init(): Promise<void> {
+	if (select.exists('[href^="?plain=1"]')) {
+		throw new Error('GitHub has implemented this feature. Please report this issue here https://github.com/sindresorhus/refined-github/pull/4837');
+	}
+
 	select('#raw-url')!.closest('.d-flex')!.prepend(
 		<div className="BtnGroup rgh-view-markdown-source">
 			<a
@@ -39,7 +43,6 @@ void features.add(__filebasename, {
 	],
 	asLongAs: [
 		() => /\.(mdx|mdwn|litcoffee|rst)$/.test(location.pathname),
-		() => !select.exists('[href^="?plain=1"]'),
 	],
 	deduplicate: '.rgh-view-markdown-source', // #3945
 	init,

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -6,28 +6,30 @@ import {CodeIcon, FileIcon} from '@primer/octicons-react';
 import features from '.';
 
 async function init(): Promise<void> {
-	const isPlain = new URLSearchParams(location.search).get('plain') === '1';
 	select('#raw-url')!.closest('.d-flex')!.prepend(
-		<div className="BtnGroup rgh-view-markdown-source mr-1">
+		<div className="BtnGroup rgh-view-markdown-source">
 			<a
 				href="?plain=1"
-				data-pjax="#repo-content-pjax-container"
-				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
-				aria-label="Display the source"
+				aria-label="Display the source blob"
+				role="button"
+				data-view-component="true"
+				className="source tooltipped tooltipped tooltipped-n  btn-sm btn BtnGroup-item"
 			>
 				<CodeIcon/>
 			</a>
 			<a
 				href={location.pathname}
-				data-pjax="#repo-content-pjax-container"
-				className="btn btn-sm BtnGroup-item tooltipped tooltipped-nw"
-				aria-label="Display the rendered file"
+				aria-label="Display the rendered blob"
+				role="button"
+				data-view-component="true"
+				className="rendered tooltipped tooltipped tooltipped-n btn-sm btn BtnGroup-item"
 			>
 				<FileIcon/>
 			</a>
 		</div>,
 	);
 
+	const isPlain = new URLSearchParams(location.search).get('plain') === '1';
 	select('.rgh-view-markdown-source')!.children[isPlain ? 0 : 1].classList.add('selected');
 }
 

--- a/source/features/view-markdown-source.tsx
+++ b/source/features/view-markdown-source.tsx
@@ -33,7 +33,11 @@ async function init(): Promise<void> {
 
 void features.add(__filebasename, {
 	include: [
-		() => pageDetect.isSingleFile() && /\.(mdx?|mkdn?|mdwn|mdown|markdown|litcoffee|rst)$/.test(location.pathname),
+		pageDetect.isSingleFile,
+	],
+	asLongAs: [
+		() => /\.(mdx|mdwn|litcoffee|rst)$/.test(location.pathname),
+		() => !select.exists('[href^="?plain=1"]'),
 	],
 	deduplicate: '.rgh-view-markdown-source', // #3945
 	init,


### PR DESCRIPTION
- Closes https://github.com/sindresorhus/refined-github/issues/4834


# Test 

## Native


<img width="413" alt="Screen Shot 7" src="https://user-images.githubusercontent.com/1402241/135581940-af42ff01-0200-49da-8406-e8eead579914.png">

https://github.com/sindresorhus/refined-github/blob/main/readme.md

More URLs in https://github.com/sindresorhus/refined-github/issues/4834#issuecomment-931400778


## Our feature
<img width="451" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/135581966-ee21fa48-4d76-4086-beb8-e4ef17fad516.png">


https://github.com/iamandrewluca/issue-view-markdown-source/blob/main/file.mdwn
https://github.com/iamandrewluca/issue-view-markdown-source/blob/main/file.mdx
https://github.com/iamandrewluca/issue-view-markdown-source/blob/main/file.litcoffee
https://github.com/iamandrewluca/issue-view-markdown-source/blob/main/file.rst