### PR TITLE
Avoid duplicate `copy-file` button

### DIFF
--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -47,6 +47,7 @@ function init(): void {
 void features.add(__filebasename, {
 	asLongAs: [
 		() => select.exists('table.highlight'), // Rendered page
+		() => select.exists('remote-clipboard-copy'), // Native copy button #4802
 	],
 	include: [
 		pageDetect.isSingleFile,

--- a/source/features/copy-file.tsx
+++ b/source/features/copy-file.tsx
@@ -47,7 +47,7 @@ function init(): void {
 void features.add(__filebasename, {
 	asLongAs: [
 		() => select.exists('table.highlight'), // Rendered page
-		() => select.exists('remote-clipboard-copy'), // Native copy button #4802
+		() => !select.exists('remote-clipboard-copy'), // Native copy button #4802
 	],
 	include: [
 		pageDetect.isSingleFile,


### PR DESCRIPTION
The ideal solution to the new button would be to make the button faster:

-  https://github.com/sindresorhus/refined-github/issues/4802#issuecomment-932558832

but for now let's just hide our duplicate button.

## Test

https://github.com/sindresorhus/refined-github/blob/main/.gitignore

## Before

<img width="350" alt="Screen Shot 16" src="https://user-images.githubusercontent.com/1402241/135686339-3a5ed889-a26d-47a7-bb44-a73a143f1443.png">

## After
<img width="283" alt="Screen Shot 17" src="https://user-images.githubusercontent.com/1402241/135686337-949798ab-6e21-437b-977b-830641da1fc3.png">


