### PR TITLE
Fix `clean-dashboard`’s background color

### DIFF
--- a/source/features/clean-dashboard.css
+++ b/source/features/clean-dashboard.css
@@ -16,7 +16,7 @@
 
 /* Add background and border Whole list */
 .rgh-clean-dashboard .news > .f4 + div {
-	background-color: var(--color-bg-canvas, #fff);
+	background-color: var(--color-canvas-default, var(--color-bg-canvas));
 	border: 1px solid var(--github-border-color);
 	border-radius: 6px;
 	margin-top: 8px !important;

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -2,7 +2,7 @@
 	/* 2020-12-15: these variables only exist for GHE #3798 */
 	--github-green: var(--color-text-success, #28a745);
 	--github-red: var(--color-text-danger, #cb2431);
-	--github-border-color: var(--color-border-primary, #e1e4e8);
+	--github-border-color: var(--color-border-muted, #e1e4e8);
 }
 
 /* Make tab indented code more readable on GitHub and Gist */


### PR DESCRIPTION
- Fixes #4841

## Test URLs

https://github.com/

## Before
<img width="677" alt="Screen Shot" src="https://user-images.githubusercontent.com/1402241/135692881-e6720cdc-7241-44bf-a070-27f8a94600dc.png">
## After
<img width="639" alt="Screen Shot 1" src="https://user-images.githubusercontent.com/1402241/135692876-809b23ef-7c5b-40de-bbe2-f5332fa96939.png">

