### PR TITLE
Fix `quick-repo-deletion` red background

### DIFF
--- a/source/features/quick-repo-deletion.tsx
+++ b/source/features/quick-repo-deletion.tsx
@@ -36,11 +36,10 @@ function handleToggle(event: delegate.Event<Event, HTMLDetailsElement>): void {
 	setTimeout(start, 1, event.delegateTarget);
 }
 
-async function verifyScopesWhileWaiting(abortController: AbortController): Promise<void> {
+async function verifyScopes(): Promise<boolean> {
 	try {
 		await api.expectTokenScope('delete_repo');
 	} catch (error: unknown) {
-		abortController.abort();
 		addNotice([
 			'Could not delete the repository. ',
 			parseBackticks((error as Error).message),
@@ -52,7 +51,9 @@ async function verifyScopesWhileWaiting(abortController: AbortController): Promi
 				</a>
 			),
 		});
+		return false
 	}
+	return true
 }
 
 async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boolean> {
@@ -64,7 +65,10 @@ async function buttonTimeout(buttonContainer: HTMLDetailsElement): Promise<boole
 		buttonContainer.open = false;
 	}, {once: true});
 
-	void verifyScopesWhileWaiting(abortController);
+	if(!await verifyScopes()) {
+		document.body.click()
+		return false
+	}
 
 	let secondsLeft = 5;
 	const button = select('.btn', buttonContainer)!;


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

In the case when token without `delete_repo` scope is provided the Delete Fork button will just result in `Could not delete the repository` message. The problem is that this doesn't actually close the details of this button and the whole website just stays with a red cover until user closes it manually.

![main](https://user-images.githubusercontent.com/23432278/135722176-3d7fbe82-b59c-49ab-9af1-75fe065df52d.gif)

This PR fixes it

![new](https://user-images.githubusercontent.com/23432278/135722214-90754c9d-32f4-4998-9d8a-bfd8e53dfc14.gif)

