### PR TITLE
Fix `hide-low-quality-comments` style

### DIFF
--- a/source/features/hide-low-quality-comments.css
+++ b/source/features/hide-low-quality-comments.css
@@ -11,3 +11,7 @@
 .rgh-hidden-comment .timeline-comment--caret::before {
 	background-color: var(--github-red);
 }
+
+.rgh-hidden-comment .timeline-comment--caret::after {
+	left: -7px; /* make caret border 1px */
+}

--- a/source/features/hide-low-quality-comments.css
+++ b/source/features/hide-low-quality-comments.css
@@ -7,3 +7,7 @@
 .rgh-hidden-comment .timeline-comment {
 	border-color: var(--github-red);
 }
+
+.rgh-hidden-comment .timeline-comment--caret::before {
+	background-color: var(--github-red);
+}

--- a/source/options.css
+++ b/source/options.css
@@ -12,7 +12,13 @@
 }
 
 :root {
-	--github-red: #cb2431;
+	--github-red: #cf222e;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--github-red: #f85149;
+	}
 }
 
 p {

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -4,14 +4,6 @@
 	--github-border-color: var(--color-border-muted, #d8dee4);
 }
 
-@media (prefers-color-scheme: dark) {
-	:root {
-		--github-green: var(--color-success-fg, #3fb950);
-		--github-red: var(--color-danger-fg, #f85149);
-		--github-border-color: var(--color-border-muted, #21262d);
-	}
-}
-
 /* Make tab indented code more readable on GitHub and Gist */
 :root, /* GHE, drop in February 2022 */
 .comment-body [data-tab-size='8'] { /* User setting is ignored in comments #4833 */

--- a/source/refined-github.css
+++ b/source/refined-github.css
@@ -1,8 +1,15 @@
 :root {
-	/* 2020-12-15: these variables only exist for GHE #3798 */
-	--github-green: var(--color-text-success, #28a745);
-	--github-red: var(--color-text-danger, #cb2431);
-	--github-border-color: var(--color-border-muted, #e1e4e8);
+	--github-green: var(--color-success-fg, #1a7f37);
+	--github-red: var(--color-danger-fg, #cf222e);
+	--github-border-color: var(--color-border-muted, #d8dee4);
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--github-green: var(--color-success-fg, #3fb950);
+		--github-red: var(--color-danger-fg, #f85149);
+		--github-border-color: var(--color-border-muted, #21262d);
+	}
 }
 
 /* Make tab indented code more readable on GitHub and Gist */


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4849

NOTE: `highest-rated-comment` got a similar style fix in #4554

## Test URLs

https://github.com/jerone/UserScripts/issues/1#issuecomment-162996100

## Screenshot

Before: ![image](https://user-images.githubusercontent.com/44045911/135723289-1d61fb38-76e9-4476-8671-2ac1b9f03b3a.png)

After: 
![image](https://user-images.githubusercontent.com/44045911/135728796-2462639e-7348-443a-868d-e6abca96604a.png)
