### PR TITLE
Run `show-whitespace` on code blocks but not diff headers

### DIFF
--- a/source/features/show-whitespace.tsx
+++ b/source/features/show-whitespace.tsx
@@ -62,7 +62,13 @@ const viewportObserver = new IntersectionObserver(changes => {
 });
 
 function init(): void {
-	for (const line of select.all('.blob-code-inner:not(.rgh-observing-whitespace)')) {
+	const selectors = [
+		'.blob-code-inner', // Code lines
+		'.highlight pre', // Highlighted code blocks in comments
+		'.snippet-clipboard-content pre', // Not highlighted code blocks in comments
+	].join(',');
+
+	for (const line of select.all(`:is(${selectors}):not(.rgh-observing-whitespace, .blob-code-hunk)`)) {
 		line.classList.add('rgh-observing-whitespace');
 		viewportObserver.observe(line);
 	}


### PR DESCRIPTION
<!--

Thanks for contributing! 🍄 Do not ignore this template, plz.

1. Does this PR close/fix an existing issue? Write something like `Closes #10`

Help us test and visualize this PR:

2. What pages does this PR affect? Include some REAL URLs where you tested the code
3. If applicable, add demonstrative screenshots or gifs

Lastly:

4. Open the PR as draft and review it yourself first. Fix what you find and explain weird code, if necessary.

-->

Fix #4843

Also runs `show-whitespace` on code blocks now:

```
	A
	Block
	Without
	Highlight
```

```html
	<A Block>
		With Highlight
	</A>
```

## Test URLs

https://github.com/sindresorhus/refined-github/commit/e8ec186217ffc42f351983b22187ee14efb9251b#diff-6a8348ff857b16e455a52ddd651b49f31cd05895459c37301051a0e30bcf077c

## Screenshot

Before:

![image](https://user-images.githubusercontent.com/44045911/135727073-8f9d7aab-3b47-44d4-8757-6a263c4dafc2.png)

![image](https://user-images.githubusercontent.com/44045911/135727094-3006dbae-7720-4326-bf5c-3316bb6b5ea1.png)


After:

![image](https://user-images.githubusercontent.com/44045911/135727076-b0ab2b91-4de1-435c-b98b-cccf0603e305.png)

![image](https://user-images.githubusercontent.com/44045911/135727114-56ed0d9c-e28b-4253-a5a9-66adf4bd4dfa.png)
