### PR TITLE
Improve reliability of `reactions-avatar`

### DIFF
--- a/source/features/reactions-avatars.tsx
+++ b/source/features/reactions-avatars.tsx
@@ -7,8 +7,8 @@ import {flatZip} from 'flat-zip';
 import * as pageDetect from 'github-url-detection';
 
 import features from '.';
-import onReplacedElement from '../helpers/on-replaced-element';
 import {getUsername} from '../github-helpers';
+import onElementRemoval from '../helpers/on-element-removal';
 
 const arbitraryAvatarLimit = 36;
 const approximateHeaderLength = 3; // Each button header takes about as much as 3 avatars
@@ -67,9 +67,8 @@ async function showAvatarsOn(commentReactions: Element): Promise<void> {
 		);
 	}
 
-	const trackableElement = commentReactions.closest<HTMLElement>('[data-body-version]')!;
-	const trackingSelector = `[data-body-version="${trackableElement.dataset.bodyVersion!}"]`;
-	await onReplacedElement(trackingSelector, init);
+	await onElementRemoval(commentReactions.closest('.comment-reactions')!);
+	init();
 }
 
 const viewportObserver = new IntersectionObserver(changes => {


### PR DESCRIPTION
Fixes #4845 
Fixes #4591 

## Test URLs
* [Discussion](https://github.com/sindresorhus/refined-github/pull/4819)
* [Releases](https://github.com/sindresorhus/refined-github/releases)

## Screenshot
https://user-images.githubusercontent.com/46634000/135746945-b6f80b95-4616-4359-bcc3-b99cf9963590.mp4

@fregante feel free to close this if it's not the right solution. I just don't get why `onReplacedElement` was used in the first place, when the tracked element ins't even used in the callback :shrug: 